### PR TITLE
Fix typo in IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The details can be found in [Proposal: CNI plugin for Kubernetes networking over
          "ec2:DetachNetworkInterface",
          "ec2:DescribeNetworkInterfaces",
          “ec2:DescribeInstances”,
-         “ec2.ModifyNetworkIntefaceAttribute”,
+         “ec2:ModifyNetworkInterfaceAttribute”,
          "ec2:AssignPrivateIpAddresses"
      ],
      "Resource": [


### PR DESCRIPTION
The README specifies `{"Action": "ec2.ModifyNetworkIntefaceAttribute"}`. This should be `ec2:` instead of `ec2.`, and it should be `Interface` instead of `Inteface`.