### PR TITLE
Adjust veth name generation to be compatible with Calico

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	defaultLogFilePath = "/host/var/log/aws-routed-eni/ipamd.log"
-	version            = "0.1.1"
+	version            = "0.1.2"
 )
 
 func main() {

--- a/misc/aws-k8s-cni-calico.yaml
+++ b/misc/aws-k8s-cni-calico.yaml
@@ -1,0 +1,307 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    k8s-app: aws-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        k8s-app: aws-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:latest
+        name: aws-node
+        env:
+          - name: ECS_CNI_LOGLEVEL
+            value: DEBUG
+          - name: ECS_CNI_VETHPREFIX
+            value: cali
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /host/var/log
+          name: log-dir
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: log-dir
+        hostPath:
+          path: /var/log
+
+---
+
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: calico-node
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v2.6.3
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix info logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,ecs"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+
+---
+
+# Create all the CustomResourceDefinitions needed for
+# Calico policy-only mode.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Felix Configuration
+kind: CustomResourceDefinition
+metadata:
+   name: globalfelixconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalFelixConfig
+    plural: globalfelixconfigs
+    singular: globalfelixconfig
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global BGP Configuration
+kind: CustomResourceDefinition
+metadata:
+  name: globalbgpconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalBGPConfig
+    plural: globalbgpconfigs
+    singular: globalbgpconfig
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico IP Pools
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+# Create the ServiceAccount and roles necessary for Calico.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - bgppeers
+      - globalbgpconfigs
+      - ippools
+      - globalnetworkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system

--- a/misc/aws-k8s-cni-calico.yaml
+++ b/misc/aws-k8s-cni-calico.yaml
@@ -28,7 +28,7 @@ spec:
         env:
           - name: ECS_CNI_LOGLEVEL
             value: DEBUG
-          - name: ECS_CNI_VETHPREFIX
+          - name: EKS_CNI_VETHPREFIX
             value: cali
         resources:
           requests:

--- a/misc/aws.conf
+++ b/misc/aws.conf
@@ -1,4 +1,5 @@
 {
 "type": "aws-cni",
-"name": "aws-cni"
+"name": "aws-cni",
+"vethPrefix": "__VETHPREFIX__"
 }

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -57,6 +57,11 @@ type NetConf struct {
 
 	// Type is the plugin type
 	Type string `json:"type"`
+
+	// VethPrefix is the prefix to use when constructing the host-side
+	// veth device name. It should be no more than four characters, and
+	// defaults to 'eni'.
+	VethPrefix string `json:"vethPrefix"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -101,6 +106,14 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	if err := cniTypes.LoadArgs(args.Args, &k8sArgs); err != nil {
 		log.Errorf("Failed to load k8s config from arg: %v", err)
 		return errors.Wrap(err, "add cmd: failed to load k8s config from arg")
+	}
+
+	// Default the host-side veth prefix to 'eni'.
+	if conf.VethPrefix == "" {
+		conf.VethPrefix = "eni"
+	}
+	if len(conf.VethPrefix) > 4 {
+		return errors.New("conf.VethPrefix must be less than 4 characters long")
 	}
 
 	cniVersion := conf.CNIVersion
@@ -154,9 +167,8 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	}
 
 	// build hostVethName
-	// hostVethName := "cali" + sha1(namespace.name)[:11]
 	// Note: the maximum length for linux interface name is 15
-	hostVethName := generateHostVethName(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+	hostVethName := generateHostVethName(conf.VethPrefix, string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 
 	err = driverClient.SetupNS(hostVethName, args.IfName, args.Netns, addr, int(r.DeviceNumber))
 
@@ -181,12 +193,10 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 }
 
 // generateHostVethName returns a name to be used on the host-side veth device.
-// The veth name is generated such that it aligns with the value expected
-// by Calico for NetworkPolicy enforcement.
-func generateHostVethName(namespace, podname string) string {
+func generateHostVethName(prefix, namespace, podname string) string {
 	h := sha1.New()
 	h.Write([]byte(fmt.Sprintf("%s.%s", namespace, podname)))
-	return fmt.Sprintf("cali%s", hex.EncodeToString(h.Sum(nil))[:11])
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,5 +1,5 @@
 echo "=====Starting installing AWS-CNI ========="
-sed -i s/__VETHPREFIX__/${ECS_CNI_VETHPREFIX:-"eni"}/g /app/aws.conf
+sed -i s/__VETHPREFIX__/${EKS_CNI_VETHPREFIX:-"eni"}/g /app/aws.conf
 cp /app/aws-cni /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 cp /app/aws.conf /host/etc/cni/net.d/

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,4 +1,5 @@
 echo "=====Starting installing AWS-CNI ========="
+sed -i s/__VETHPREFIX__/${ECS_CNI_VETHPREFIX:-"eni"}/g /app/aws.conf
 cp /app/aws-cni /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 cp /app/aws.conf /host/etc/cni/net.d/


### PR DESCRIPTION

Pulling in commits from https://github.com/aws/amazon-vpc-cni-k8s/pull/17 and applying review feedback to it since @caseydavenport is on vacation.

CC @liwenwu-amazon @eswarbala @lilida @lstoll

Original description:
------------------------------
This PR adjusts the calculation used to generate the host-side veth name such that it aligns with the value expected by Calico.

See [here](https://github.com/projectcalico/libcalico-go/blob/v1.7.3/lib/backend/k8s/conversion.go#L43-L51) for the corresponding calculation in Calico.

This is the groundwork for allowing Calico to be installed as a DaemonSet for network policy enforcement.

Posting this to get feedback as to the approach