### PR TITLE
Reconcile eni and ip addresses info from instance's metadata service

### DIFF
--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -31,6 +31,18 @@ const (
 
 	// DuplicateIPError is an error when caller tries to add an duplicate IP address to data store
 	DuplicateIPError = "datastore: duplicated IP"
+
+	// UnknownIPError is an error when caller tries to delele an IP which is unknown to data store
+	UnknownIPError = "datastore: unknown IP"
+
+	// IPInUseError is an error when caller tries to delete an IP where IP is still assigned to a Pod
+	IPInUseError = "datastore: IP is used and can not be deleted"
+
+	// ENIInUseError is an error when caller tries to delete an ENI where there are IP still assigned to a pod
+	ENIInUseError = "datastore: ENI is used and can not be deleted"
+
+	// UnknownENIError is an error when caller tries to access an ENI which is unknown to datastore
+	UnknownENIError = "datastore: unknown ENI"
 )
 
 // ErrUnknownPod is an error when there is no pod in data store matching pod name, namespace, container id
@@ -151,6 +163,37 @@ func (ds *DataStore) AddENIIPv4Address(eniID string, ipv4 string) error {
 	curENI.IPv4Addresses[ipv4] = &AddressInfo{address: ipv4, Assigned: false}
 
 	log.Infof("Added ENI(%s)'s IP %s to datastore", eniID, ipv4)
+
+	return nil
+}
+
+// DelENIIPv4Address delete an IP of ENI from datastore
+func (ds *DataStore) DelENIIPv4Address(eniID string, ipv4 string) error {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	log.Debugf("Deleting ENI(%s)'s IPv4 address %s from datastore", eniID, ipv4)
+	log.Debugf("IP Address Pool stats: total: %d, assigned: %d",
+		ds.total, ds.assigned)
+
+	curENI, ok := ds.eniIPPools[eniID]
+	if !ok {
+		return errors.New(UnknownENIError)
+	}
+
+	ipAddr, ok := curENI.IPv4Addresses[ipv4]
+	if !ok {
+		return errors.New(UnknownIPError)
+	}
+
+	if ipAddr.Assigned {
+		return errors.New(IPInUseError)
+	}
+
+	ds.total--
+
+	delete(curENI.IPv4Addresses, ipv4)
+
+	log.Infof("Deleted ENI(%s)'s IP %s from datastore", eniID, ipv4)
 
 	return nil
 }
@@ -284,6 +327,28 @@ func (ds *DataStore) FreeENI() (string, error) {
 	return deletedENI, nil
 }
 
+// DeleteENI free a ENI.
+func (ds *DataStore) DeleteENI(eni string) error {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+
+	_, ok := ds.eniIPPools[eni]
+	if !ok {
+		return errors.New(UnknownENIError)
+	}
+
+	if ds.eniIPPools[eni].AssignedIPv4Addresses != 0 {
+		return errors.New(ENIInUseError)
+	}
+
+	ds.total -= len(ds.eniIPPools[eni].IPv4Addresses)
+	log.Infof("DeleteENI %s: IP address pool stats: free %d addresses, total: %d, assigned: %d",
+		eni, len(ds.eniIPPools[eni].IPv4Addresses), ds.total, ds.assigned)
+	delete(ds.eniIPPools, eni)
+
+	return nil
+}
+
 // UnAssignPodIPv4Address a) find out the IP address based on PodName and PodNameSpace
 // b)  mark IP address as unassigned c) returns IP address, ENI's device number, error
 func (ds *DataStore) UnAssignPodIPv4Address(k8sPod *k8sapi.K8SPodInfo) (string, int, error) {
@@ -358,4 +423,24 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 		eniInfos.ENIIPPools[eni] = *eniInfo
 	}
 	return &eniInfos
+}
+
+// GetENIIPPools returns eni's IP address list
+func (ds *DataStore) GetENIIPPools(eni string) (map[string]*AddressInfo, error) {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+
+	eniIPPool, ok := ds.eniIPPools[eni]
+
+	if !ok {
+		return nil, errors.New(UnknownENIError)
+	}
+
+	var ipPool = make(map[string]*AddressInfo, len(eniIPPool.IPv4Addresses))
+
+	for ip, ipAddr := range eniIPPool.IPv4Addresses {
+		ipPool[ip] = ipAddr
+	}
+
+	return ipPool, nil
 }

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -49,6 +49,7 @@ type IPAMContext struct {
 
 	currentMaxAddrsPerENI int
 	maxAddrsPerENI        int
+	primaryIP             map[string]string
 }
 
 // New retrieves IP address usage information from Instance MetaData service and Kubelet
@@ -77,6 +78,8 @@ func New() (*IPAMContext, error) {
 
 //TODO need to break this function down(comments from CR)
 func (c *IPAMContext) nodeInit() error {
+	c.primaryIP = make(map[string]string)
+
 	enis, err := c.awsClient.GetAttachedENIs()
 	if err != nil {
 		log.Error("Failed to retrive ENI info")
@@ -144,6 +147,8 @@ func (c *IPAMContext) StartNodeIPPoolManager() {
 	for {
 		time.Sleep(ipPoolMonitorInterval)
 		c.updateIPPoolIfRequired()
+		// TODO what trigger nodeIPPoolReconcile()
+		c.nodeIPPoolReconcile()
 	}
 }
 
@@ -221,15 +226,18 @@ func (c *IPAMContext) setupENI(eni string, eniMetadata awsutils.ENIMetadata) err
 		}
 	}
 
-	c.addENIaddressesToDataStore(ec2Addrs, eni)
+	c.primaryIP[eni] = c.addENIaddressesToDataStore(ec2Addrs, eni)
 
 	return nil
 
 }
 
-func (c *IPAMContext) addENIaddressesToDataStore(ec2Addrs []*ec2.NetworkInterfacePrivateIpAddress, eni string) {
+// return primary ip address on the interface
+func (c *IPAMContext) addENIaddressesToDataStore(ec2Addrs []*ec2.NetworkInterfacePrivateIpAddress, eni string) string {
+	var primaryIP string
 	for _, ec2Addr := range ec2Addrs {
 		if aws.BoolValue(ec2Addr.Primary) {
+			primaryIP = aws.StringValue(ec2Addr.PrivateIpAddress)
 			continue
 		}
 		err := c.dataStore.AddENIIPv4Address(eni, aws.StringValue(ec2Addr.PrivateIpAddress))
@@ -239,6 +247,8 @@ func (c *IPAMContext) addENIaddressesToDataStore(ec2Addrs []*ec2.NetworkInterfac
 			// TODO need to add health stats for err
 		}
 	}
+
+	return primaryIP
 }
 
 // returns all addresses on eni, the primary adderss on eni, error
@@ -305,5 +315,91 @@ func (c *IPAMContext) nodeIPPoolTooHigh() bool {
 		total, used, c.currentMaxAddrsPerENI, c.maxAddrsPerENI)
 
 	return (total-used > 2*c.currentMaxAddrsPerENI)
+
+}
+
+// nodeIPPoolReconcile reconcile ENI and IP info from metadata service and IP addresses in datastore
+func (c *IPAMContext) nodeIPPoolReconcile() error {
+	log.Debug("Reconciling IP pool info...")
+	attachedENIs, err := c.awsClient.GetAttachedENIs()
+
+	if err != nil {
+		log.Error("ip pool reconcile: Failed to get attached eni info", err.Error())
+		errors.Wrap(err, "ip pool reconcile: failed to get attached eni")
+	}
+
+	curENIs := c.dataStore.GetENIInfos()
+
+	// mark phase
+	for _, attachedENI := range attachedENIs {
+		eniIPPool, err := c.dataStore.GetENIIPPools(attachedENI.ENIID)
+
+		if err == nil {
+			log.Debugf("Reconcile existing ENI %s IP pool", attachedENI.ENIID)
+			// reconcile IP pool
+			c.eniIPPoolReconcile(eniIPPool, attachedENI, attachedENI.ENIID)
+
+			// mark action= remove this eni from curENIs list
+			delete(curENIs.ENIIPPools, attachedENI.ENIID)
+			continue
+		}
+
+		// add new ENI
+		log.Debugf("Reconcile and add a new eni %s", attachedENI)
+		err = c.setupENI(attachedENI.ENIID, attachedENI)
+		if err != nil {
+			log.Errorf("ip pool reconcile: Failed to setup eni %s network: %v", attachedENI.ENIID, err)
+			//TODO should continue if having trouble with ONLY 1 eni, instead of bailout here?
+			return errors.Wrapf(err, "ip pool reconcile: failed to setup eni %v", attachedENI.ENIID)
+		}
+
+	}
+
+	// sweep phase: since the marked eni have been removed, the remaining ones needs to be sweeped
+	for eni := range curENIs.ENIIPPools {
+		log.Infof("Reconcile and delete detached eni %s", eni)
+		c.dataStore.DeleteENI(eni)
+	}
+
+	return nil
+}
+
+func (c *IPAMContext) eniIPPoolReconcile(ipPool map[string]*datastore.AddressInfo, attachENI awsutils.ENIMetadata, eni string) error {
+
+	for _, localIP := range attachENI.LocalIPv4s {
+		if localIP == c.primaryIP[eni] {
+			log.Debugf("Reconcile and skip primary IP %s on eni %s", localIP, eni)
+			continue
+		}
+
+		err := c.dataStore.AddENIIPv4Address(eni, localIP)
+
+		if err != nil && err.Error() == datastore.DuplicateIPError {
+			log.Debugf("Reconciled IP %s on eni %s", localIP, eni)
+			// mark action = remove it from eniPool
+			delete(ipPool, localIP)
+			continue
+		}
+
+		if err != nil {
+			log.Errorf("Failed to reconcile IP %s on eni %s", localIP, eni)
+			return errors.Wrapf(err, "ip pool reconcile: failed to reconcile ip %s on eni %s", localIP, eni)
+		}
+
+	}
+
+	// sweep phase, delete remaining IPs
+
+	for existingIP := range ipPool {
+		log.Debugf("Reconcile and delete ip %s on eni %s", existingIP, eni)
+		err := c.dataStore.DelENIIPv4Address(eni, existingIP)
+		if err != nil {
+			log.Errorf("Failed to reconcile and delete IP %s on eni %s, %v", existingIP, eni, err)
+			//TODO should contine instead of bailout due to one ip ?
+			return errors.Wrapf(err, "ip pool reconcile: failed to reconcile and delete IP %s on eni %s", existingIP, eni)
+		}
+	}
+
+	return nil
 
 }

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -44,8 +44,10 @@ const (
 	secSubnet        = "10.10.20.0/24"
 	ipaddr01         = "10.10.10.11"
 	ipaddr02         = "10.10.10.12"
+	ipaddr03         = "10.10.10.13"
 	ipaddr11         = "10.10.20.11"
 	ipaddr12         = "10.10.20.12"
+	ipaddr13         = "10.10.20.13"
 	vpcCIDR          = "10.10.0.0/16"
 )
 
@@ -185,4 +187,74 @@ func TestIncreaseIPPool(t *testing.T) {
 
 	mockContext.increaseIPPool()
 
+}
+
+func TestNodeIPPoolReconcile(t *testing.T) {
+	ctrl, mockAWS, mockK8S, mockNetwork := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:     mockAWS,
+		k8sClient:     mockK8S,
+		networkClient: mockNetwork,
+		primaryIP:     make(map[string]string),
+	}
+
+	mockContext.dataStore = datastore.NewDataStore()
+
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+		awsutils.ENIMetadata{
+			ENIID:          primaryENIid,
+			MAC:            primaryMAC,
+			DeviceNumber:   primaryDevice,
+			SubnetIPv4CIDR: primarySubnet,
+			LocalIPv4s:     []string{ipaddr01, ipaddr02},
+		},
+	}, nil)
+
+	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+
+	primary := true
+	notPrimary := false
+	attachmentID := testAttachmentID
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	mockAWS.EXPECT().DescribeENI(primaryENIid).Return(
+		[]*ec2.NetworkInterfacePrivateIpAddress{
+			&ec2.NetworkInterfacePrivateIpAddress{
+				PrivateIpAddress: &testAddr1, Primary: &primary},
+			&ec2.NetworkInterfacePrivateIpAddress{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary}}, &attachmentID, nil)
+	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+
+	mockContext.nodeIPPoolReconcile()
+
+	curENIs := mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 1)
+	assert.Equal(t, curENIs.TotalIPs, 1)
+
+	// remove 1 IP
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+		awsutils.ENIMetadata{
+			ENIID:          primaryENIid,
+			MAC:            primaryMAC,
+			DeviceNumber:   primaryDevice,
+			SubnetIPv4CIDR: primarySubnet,
+			LocalIPv4s:     []string{ipaddr01},
+		},
+	}, nil)
+
+	mockContext.nodeIPPoolReconcile()
+	curENIs = mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 1)
+	assert.Equal(t, curENIs.TotalIPs, 0)
+
+	// remove eni
+	mockAWS.EXPECT().GetAttachedENIs().Return(nil, nil)
+
+	mockContext.nodeIPPoolReconcile()
+	curENIs = mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 0)
+	assert.Equal(t, curENIs.TotalIPs, 0)
 }

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -139,6 +139,7 @@ func TestIncreaseIPPool(t *testing.T) {
 		awsClient:     mockAWS,
 		k8sClient:     mockK8S,
 		networkClient: mockNetwork,
+		primaryIP:     make(map[string]string),
 	}
 
 	mockContext.dataStore = datastore.NewDataStore()


### PR DESCRIPTION
### Summary

* query instance's metadata service and get up-to-date eni and IP addresses information
* then reconcile this up-to-date eni/IP information with local cache in L-IPAMD

### Testing Done

```
make unit-test
make lint
make vet
```