### PR TITLE
Avoid calling EC2 to allocate ENIs when instance's ENIs limit reached

### DIFF
--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -359,3 +359,10 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 	}
 	return &eniInfos
 }
+
+// GetENIs provides the number of ENI in the datastore
+func (ds *DataStore) GetENIs() int {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	return len(ds.eniIPPools)
+}


### PR DESCRIPTION
To address #36 ,  this PR does following:

- discover the maximum number of ENIs can be attached to the instance
- avoid calling EC2 to allocate ENIs when the number of ENIs attached to instance reaches the limit

### Tests done
- create a cluster which contains 3 worker nodes that uses t2-medium type
- create 40 pods on the cluster
- verify L-IPAMD will create 3 ENIs and will not  trying to allocate 4th ENI after that
- delete 40 pods from the cluster
- verify L-IPAMD will free extra ENIs
- then add back 40 pods 
- verify L-IPAMD will create up to 3 ENIs for each node and will NOT trying to allocate 4th ENI after that 
 