### PR TITLE
Ensure that logs are flushed when exiting on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,10 @@ const (
 )
 
 func main() {
+	os.Exit(_main())
+}
+
+func _main() int {
 	defer log.Flush()
 	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
 
@@ -36,10 +40,12 @@ func main() {
 
 	if err != nil {
 		log.Error("initialization failure", err)
-		os.Exit(1)
+		return 1
 	}
 
 	go aws_k8s_agent.StartNodeIPPoolManager()
 	go aws_k8s_agent.SetupHTTP()
 	aws_k8s_agent.RunRPCHandler()
+
+	return 0
 }


### PR DESCRIPTION
*Description of changes:*

Fixes #57

The defer clause does not apply when using os.Exit() so logs are not flushed on initialization errors, which makes debugging hard. 

This fix ensures that logs are flushed before exiting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
