### PR TITLE
Updated version of Calico image to 3.0.6

### DIFF
--- a/misc/aws-k8s-cni-calico.yaml
+++ b/misc/aws-k8s-cni-calico.yaml
@@ -434,7 +434,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.6.1
+      - image: quay.io/calico/typha:v0.6.4
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/misc/aws-k8s-cni-calico.yaml
+++ b/misc/aws-k8s-cni-calico.yaml
@@ -93,7 +93,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.0.2
+          image: quay.io/calico/node:v3.0.6
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE


### PR DESCRIPTION
*Issue #, if available:*
Old version of Calico image was causing the pods to fail.  The following errors appeared in the Calico logs: 
```
2018-04-23 19:21:28.042 [INFO][10] startup.go 248: Early log level set to info
2018-04-23 19:21:28.044 [INFO][10] startup.go 278: Checking datastore connection
2018-04-23 19:21:28.061 [INFO][10] startup.go 302: Datastore connection verified
2018-04-23 19:21:28.061 [INFO][10] startup.go 99: Datastore is ready
2018-04-23 19:21:28.066 [WARNING][10] migrate.go 723: Unable to parse Calico version :  is not in dotted-tri format
2018-04-23 19:21:28.066 [ERROR][10] migrate.go 665: Could not parse CalicoVersion  in ClusterInformation: Error converting version
2018-04-23 19:21:28.066 [ERROR][10] startup.go 106: Unable to ensure datastore is migrated. error=Error converting version
2018-04-23 19:21:28.066 [WARNING][10] startup.go 1007: Terminating
```
*Description of changes:*
Updated the image to 3.0.6
See https://github.com/projectcalico/typha/issues/151#issuecomment-383717821 for additional information. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
