### PR TITLE
Don't ignore Gopkg.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ aws-k8s-agent
 aws-cni
 verify-aws
 verify-network
-Gopkg.lock


### PR DESCRIPTION
Gopkg.lock shouldn't be in .gitignore.

Signed-off-by: Nick Turner <nic@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
