### PR TITLE
Add prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,12 @@
   version = "v1.12.14"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/cihub/seelog"
   packages = ["."]
   revision = "d2c6e5aa9fbfdd1c624e140287063c7730654115"
@@ -145,6 +151,12 @@
   revision = "3fd5e860b68f3cc81671ece2e226c78a6bbf54d3"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -155,6 +167,30 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [".","internal/util","nfs","xfs"]
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -243,6 +279,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b6c35664386e0bd1130101921cf7b02047e942892491d64f3bac3507f9146f02"
+  inputs-digest = "b30165eb426f9047bf1d10b600fcd805df18a24a9a91fb2f5bb44cb48650f6db"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ipamd/introspect.go
+++ b/ipamd/introspect.go
@@ -21,13 +21,14 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils"
 )
 
 const (
 	// IntrospectionPort is the port for ipamd introspection
-	IntrospectionPort = 51678
+	IntrospectionPort = 61678
 )
 
 type rootResponse struct {
@@ -91,6 +92,7 @@ func (c *IPAMContext) setupServer() *http.Server {
 	for key, fn := range serverFunctions {
 		serveMux.HandleFunc(key, fn)
 	}
+	serveMux.Handle("/metrics", promhttp.Handler())
 
 	// Log all requests and then pass through to serveMux
 	loggingServeMux := http.NewServeMux()
@@ -127,5 +129,11 @@ func podV1RequestHandler(ipam *IPAMContext) func(http.ResponseWriter, *http.Requ
 			return
 		}
 		w.Write(responseJSON)
+	}
+}
+
+func metricsHandler(ipam *IPAMContext) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		promhttp.Handler()
 	}
 }

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -84,6 +84,7 @@ func TestNodeInit(t *testing.T) {
 		SubnetIPv4CIDR: secSubnet,
 		LocalIPv4s:     []string{ipaddr11, ipaddr12},
 	}
+	mockAWS.EXPECT().GetENILimit().Return(4, nil)
 	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1, eni2}, nil)
 	mockAWS.EXPECT().GetVPCIPv4CIDR().Return(vpcCIDR)
 	mockAWS.EXPECT().GetLocalIPv4().Return(ipaddr01)
@@ -145,6 +146,7 @@ func TestIncreaseIPPool(t *testing.T) {
 
 	eni2 := secENIid
 
+	mockAWS.EXPECT().GetENILimit().Return(4, nil)
 	mockAWS.EXPECT().AllocENI().Return(eni2, nil)
 
 	mockAWS.EXPECT().AllocAllIPAddress(eni2)

--- a/misc/cni_metrics_helper.yaml
+++ b/misc/cni_metrics_helper.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cni-metrics-helper
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - pods/proxy
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch", "get"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cni-metrics-helper
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cni-metrics-helper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cni-metrics-helper
+subjects:
+- kind: ServiceAccount
+  name: cni-metrics-helper
+  namespace: kube-system
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: cni-metrics-helper
+  namespace: kube-system
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      serviceAccountName: cni-metrics-helper
+      containers:
+      - image: 694065802095.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:0.1.0
+        imagePullPolicy: Always
+        name: cni-metrics-helper

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -124,6 +124,19 @@ func (mr *MockAPIsMockRecorder) GetAttachedENIs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttachedENIs", reflect.TypeOf((*MockAPIs)(nil).GetAttachedENIs))
 }
 
+// GetENILimit mocks base method
+func (m *MockAPIs) GetENILimit() (int, error) {
+	ret := m.ctrl.Call(m, "GetENILimit")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetENILimit indicates an expected call of GetENILimit
+func (mr *MockAPIsMockRecorder) GetENILimit() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENILimit", reflect.TypeOf((*MockAPIs)(nil).GetENILimit))
+}
+
 // GetENIipLimit mocks base method
 func (m *MockAPIs) GetENIipLimit() (int64, error) {
 	ret := m.ctrl.Call(m, "GetENIipLimit")

--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -21,10 +21,13 @@ set -e
 LOG_DIR="/var/log/aws-routed-eni"
 
 # collecting L-IPAMD introspection data
-curl http://localhost:51678/v1/enis  > ${LOG_DIR}/eni.output
-curl http://localhost:51678/v1/pods  > ${LOG_DIR}/pod.output
+curl http://localhost:61678/v1/enis  > ${LOG_DIR}/eni.output
+curl http://localhost:61678/v1/pods  > ${LOG_DIR}/pod.output
 
-# collecting kubeleet introspection data
+# metrics TODO not able to use LOG_DIR
+curl http://localhost:61678/metrics 2>&1 > /var/log/aws-routed-eni/metrics.output
+
+# collecting kubelet introspection data
 curl http://localhost:10255/pods  > ${LOG_DIR}/kubelet.output
 
 # ifconfig
@@ -32,6 +35,22 @@ ifconfig > ${LOG_DIR}/ifconig.output
 
 # ip rule show
 ip rule show > ${LOG_DIR}/iprule.output
+
+# iptables-save
+iptables-save > $LOG_DIR/iptables-save.out
+
+# iptables -nvL
+iptables -nvL > $LOG_DIR/iptables.out
+
+# iptables -nvL -t nat
+iptables -nvL -t nat > $LOG_DIR/iptables-nat.out
+
+# dump cni config
+mkdir -p $LOG_DIR/cni
+cp /etc/cni/net.d/* $LOG_DIR/cni
+
+# collect kubelet log
+cp /var/log/messages $LOG_DIR/
 
 # dump out route table
 ROUTE_OUTPUT="route.output"


### PR DESCRIPTION
*Descriptions:*

Add following prometheus metrics which provide metrics at ***localhost:61678/metrics***

* aws_api_lantency_ms
* aws_api_error_count
* eni_allocated
* total_ip_addresses
* assigned_ip_addresses

Also add a tool ***cni-metrics-helper*** which can collect CNI  prometheus metrics from all nodes in the cluster by 
```
# deploying
kubectl apply -f cni_metrics_helper.yaml

#exam metrics by
kubectl logs cni-metrics-helper-xxx -n kube-system
```

*Tests Performed*
Deployed 4000 busybox pods over 80 nodes.  Verify the prometheus metrics from all 80 nodes, that aggregated eni_allocated is 320, aggregated total_ip_addresses is 4.48k, assigned_ip_addresses is 4k


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
