### PR TITLE
Add config option for number of ENIs get preallocated

### DIFF
--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -50,7 +50,7 @@ var (
 	enis = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "eni_allocated",
-			Help: "The number of ENI allocated",
+			Help: "The number of ENIs allocated",
 		},
 	)
 	totalIPs = prometheus.NewGauge(
@@ -62,7 +62,7 @@ var (
 	assignedIPs = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "assigned_ip_addresses",
-			Help: "The number of IP addresses assigned",
+			Help: "The number of IP addresses assigned to pods",
 		},
 	)
 	prometheusRegistered = false

--- a/misc/cni_metrics_helper.yaml
+++ b/misc/cni_metrics_helper.yaml
@@ -77,6 +77,9 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 694065802095.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:0.1.0
+      - image: 694065802095.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:0.1.1
         imagePullPolicy: Always
         name: cni-metrics-helper
+        env:
+          - name: USE_CLOUDWATCH
+            value: "no"

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -73,14 +73,14 @@ var (
 	awsAPIErr = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aws_api_error_count",
-			Help: "the number of times AWS API returns an err",
+			Help: "The number of times AWS API returns an error",
 		},
 		[]string{"api", "error"},
 	)
 	awsUtilsErr = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aws_utils_error_count",
-			Help: " the number of errors not handled in awsutils library",
+			Help: "The number of errors not handled in awsutils library",
 		},
 		[]string{"fn", "error"},
 	)


### PR DESCRIPTION
## Description of changes

**Current Behavior**
Today, ipamD dynamically allocate and free ENIs based on the number Pods running on the node.
It allocates one more ENI when the number of available IP addresses goes below the per ENI's  secondary IP limit.  It can free an ENI when the number of available IP addresses grows more than 2 * per ENI's secondary IP limit.  

 For example, for c3.xlarge, each ENI have 14 secondary IPs.   When there is one ENI attached to the instance(e.g. when the instance is first booted) and after 8 pods just get scheduled to run on this node. The available IPs becomes 6 (14-8) and this will trigger ipamD allocating a new ENI.

**Requirements**
There are 3 different deployment scenarios requires 3 different triggering threshold:

* scenario-1: default and same as today's behavior. Let ipamD dynamically allocate and free one ENI at time based on the available IPs
* scenario-2:  allocate all available ENIs and IPs right after the  instance is initialized.  Once all ENIs are allocated on all nodes, there will be no delay on Pod deployment (compare to scenario-1, that some pods may have to wait for nodes to get new ENI and  IPs)
* scenario-3: do NOT allocate any ENI.  And only use secondary IPs from instance's primary ENI. 

**New Behavior**
This PR add config option which allow user to define the number of ENIs get allocated.  If the config option is not defined, it is default to today's behavior 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
