### PR TITLE
eni reconcile

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,7 +37,7 @@ You can verify if you are in this situation by example cni metrics
 ![](images/cni-metrics-inprogress.png)
 **ipamdActionInProgress**: the total number of nodes whose ipamD is in the middle of ENI operation.
 
-To avoid Pod deployment delay, you can configure ipamD to have a higher [**WARM-ENI-TARGET**](https://github.com/aws/amazon-vpc-cni-k8s/pull/68).
+To avoid Pod deployment delay, you can configure ipamD to have a higher [**WARM\_ENI\_TARGET**](https://github.com/aws/amazon-vpc-cni-k8s/pull/68).
 
 ## Troubleshooting CNI/ipamD at node level
 

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -16,7 +16,6 @@ package ipamd
 import (
 	"net"
 	"testing"
-	//"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/ipamd/datastore"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
@@ -44,8 +43,10 @@ const (
 	secSubnet        = "10.10.20.0/24"
 	ipaddr01         = "10.10.10.11"
 	ipaddr02         = "10.10.10.12"
+	ipaddr03         = "10.10.10.13"
 	ipaddr11         = "10.10.20.11"
 	ipaddr12         = "10.10.20.12"
+	ipaddr13         = "10.10.20.13"
 	vpcCIDR          = "10.10.0.0/16"
 )
 
@@ -85,6 +86,7 @@ func TestNodeInit(t *testing.T) {
 		LocalIPv4s:     []string{ipaddr11, ipaddr12},
 	}
 	mockAWS.EXPECT().GetENILimit().Return(4, nil)
+	mockAWS.EXPECT().GetENIipLimit().Return(int64(56), nil)
 	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1, eni2}, nil)
 	mockAWS.EXPECT().GetVPCIPv4CIDR().Return(vpcCIDR)
 	mockAWS.EXPECT().GetLocalIPv4().Return(ipaddr01)
@@ -140,6 +142,7 @@ func TestIncreaseIPPool(t *testing.T) {
 		awsClient:     mockAWS,
 		k8sClient:     mockK8S,
 		networkClient: mockNetwork,
+		primaryIP:     make(map[string]string),
 	}
 
 	mockContext.dataStore = datastore.NewDataStore()
@@ -186,4 +189,74 @@ func TestIncreaseIPPool(t *testing.T) {
 
 	mockContext.increaseIPPool()
 
+}
+
+func TestNodeIPPoolReconcile(t *testing.T) {
+	ctrl, mockAWS, mockK8S, mockNetwork := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:     mockAWS,
+		k8sClient:     mockK8S,
+		networkClient: mockNetwork,
+		primaryIP:     make(map[string]string),
+	}
+
+	mockContext.dataStore = datastore.NewDataStore()
+
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+		awsutils.ENIMetadata{
+			ENIID:          primaryENIid,
+			MAC:            primaryMAC,
+			DeviceNumber:   primaryDevice,
+			SubnetIPv4CIDR: primarySubnet,
+			LocalIPv4s:     []string{ipaddr01, ipaddr02},
+		},
+	}, nil)
+
+	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+
+	primary := true
+	notPrimary := false
+	attachmentID := testAttachmentID
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	mockAWS.EXPECT().DescribeENI(primaryENIid).Return(
+		[]*ec2.NetworkInterfacePrivateIpAddress{
+			&ec2.NetworkInterfacePrivateIpAddress{
+				PrivateIpAddress: &testAddr1, Primary: &primary},
+			&ec2.NetworkInterfacePrivateIpAddress{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary}}, &attachmentID, nil)
+	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+
+	mockContext.nodeIPPoolReconcile(0)
+
+	curENIs := mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 1)
+	assert.Equal(t, curENIs.TotalIPs, 1)
+
+	// remove 1 IP
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+		awsutils.ENIMetadata{
+			ENIID:          primaryENIid,
+			MAC:            primaryMAC,
+			DeviceNumber:   primaryDevice,
+			SubnetIPv4CIDR: primarySubnet,
+			LocalIPv4s:     []string{ipaddr01},
+		},
+	}, nil)
+
+	mockContext.nodeIPPoolReconcile(0)
+	curENIs = mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 1)
+	assert.Equal(t, curENIs.TotalIPs, 0)
+
+	// remove eni
+	mockAWS.EXPECT().GetAttachedENIs().Return(nil, nil)
+
+	mockContext.nodeIPPoolReconcile(0)
+	curENIs = mockContext.dataStore.GetENIInfos()
+	assert.Equal(t, len(curENIs.ENIIPPools), 0)
+	assert.Equal(t, curENIs.TotalIPs, 0)
 }


### PR DESCRIPTION
*Issue #66 , if available:*

### Summary

* query instance's metadata service and get up-to-date eni and IP addresses information
* then reconcile this up-to-date eni/IP information into local cache in L-IPAMD

### Testing Done

```
make unit-test
make lint
make vet
```
In addition, manually tested following:

* Manually remove worker node's IAM permission for EC2's CreateNetworkInterface/AttachNetworkInterface/DeleteNetworkInterface/DetachNetworkInterface/AssignPrivateIpAddresses
* Use AWS console and manually add and attach ENI and IP addresses to a worker node
* Verify cni-ipamD dynamically reconcile this ENI and IP address to its data store
* Use AWS console and manually detach and free ENI and IP addresses from a worker node
* Verify cni-ipamD dynamically reconcile and delete this ENI and its IP addresses from its data store


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
