### PR TITLE
Use UID for pod/container matching and only consider running containers

### DIFF
--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -135,8 +135,10 @@ func TestNodeInit(t *testing.T) {
 	mockK8S.EXPECT().K8SGetLocalPodIPs().Return([]*k8sapi.K8SPodInfo{&k8sapi.K8SPodInfo{Name: "pod1",
 		Namespace: "default", UID: "pod-uid", IP: ipaddr02}}, nil)
 
-	mockDocker.EXPECT().GetRunningContainers().Return([]*docker.ContainerInfo{&docker.ContainerInfo{ID: "docker-id",
-		Name: k8sName, K8SUID: "pod-uid"}}, nil)
+	var dockerList = make(map[string]*docker.ContainerInfo, 0)
+	dockerList["pod-uid"] = &docker.ContainerInfo{ID: "docker-id",
+		Name: k8sName, K8SUID: "pod-uid"}
+	mockDocker.EXPECT().GetRunningContainers().Return(dockerList, nil)
 
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defaultLogFilePath = "/host/var/log/aws-routed-eni/ipamd.log"
-	version            = "0.2.3"
+	version            = "0.2.4"
 )
 
 func main() {

--- a/misc/aws-k8s-cni-calico.yaml
+++ b/misc/aws-k8s-cni-calico.yaml
@@ -63,7 +63,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.2.3
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.2.4
         name: aws-node
         env:
           - name: AWS_VPC_K8S_CNI_LOGLEVEL

--- a/misc/aws-k8s-cni.yaml
+++ b/misc/aws-k8s-cni.yaml
@@ -63,7 +63,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.2.3
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.2.4
         name: aws-node
         env:
           - name: AWS_VPC_K8S_CNI_LOGLEVEL

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -5,6 +5,8 @@ import (
 	"github.com/docker/docker/client"
 	"golang.org/x/net/context"
 
+	"github.com/pkg/errors"
+
 	log "github.com/cihub/seelog"
 )
 
@@ -17,7 +19,7 @@ type ContainerInfo struct {
 
 // APIs provides Docker API
 type APIs interface {
-	GetRunningContainers() ([]*ContainerInfo, error)
+	GetRunningContainers() (map[string]*ContainerInfo, error)
 }
 
 type Client struct{}
@@ -26,8 +28,8 @@ func New() *Client {
 	return &Client{}
 }
 
-func (c *Client) GetRunningContainers() ([]*ContainerInfo, error) {
-	var containerInfos []*ContainerInfo
+func (c *Client) GetRunningContainers() (map[string]*ContainerInfo, error) {
+	var containerInfos = make(map[string]*ContainerInfo)
 
 	cli, err := client.NewEnvClient()
 	if err != nil {
@@ -41,13 +43,48 @@ func (c *Client) GetRunningContainers() ([]*ContainerInfo, error) {
 	}
 
 	for _, container := range containers {
-		log.Infof("GetRunningContainers: Discovered running docker: %s %s %s",
-			container.ID, container.Names[0], container.Labels["io.kubernetes.pod.uid"])
-		containerInfos = append(containerInfos,
-			&ContainerInfo{
+		log.Infof("GetRunningContainers: Discovered running docker: %s %s %s State: %s Status: %s ",
+			container.ID, container.Names[0], container.Labels["io.kubernetes.pod.uid"], container.State, container.Status)
+
+		containerType, ok := container.Labels["io.kubernetes.docker.type"]
+		if !ok {
+			log.Infof("GetRunningContainers: skip non pause container")
+			continue
+		}
+
+		if containerType != "podsandbox" {
+			log.Infof("GetRunningContainers: skip container type: %s", containerType)
+			continue
+		}
+
+		log.Debugf("GetRunningContainers: containerType %s", containerType)
+
+		if container.State != "running" {
+			log.Infof("GetRunningContainers: skip container who is not running")
+			continue
+		}
+
+		uid := container.Labels["io.kubernetes.pod.uid"]
+		_, ok = containerInfos[uid]
+		if !ok {
+			containerInfos[uid] = &ContainerInfo{
 				ID:     container.ID,
 				Name:   container.Names[0],
-				K8SUID: container.Labels["io.kubernetes.pod.uid"]})
+				K8SUID: uid}
+			continue
+		}
+
+		if container.Names[0] != containerInfos[uid].Name {
+			log.Infof("GetRunningContainers: same uid matched by container:%s, %s container id %s",
+				containerInfos[uid].Name, container.Names[0], container.ID)
+			continue
+		}
+
+		if container.Names[0] == containerInfos[uid].Name {
+			log.Errorf("GetRunningContainers: Conflict container id %s for container %s",
+				container.ID, containerInfos[uid].Name)
+			return nil, errors.New("conflict docker runtime info")
+		}
 	}
 
 	return containerInfos, nil

--- a/pkg/docker/mocks/docker_mocks.go
+++ b/pkg/docker/mocks/docker_mocks.go
@@ -48,9 +48,9 @@ func (m *MockAPIs) EXPECT() *MockAPIsMockRecorder {
 }
 
 // GetRunningContainers mocks base method
-func (m *MockAPIs) GetRunningContainers() ([]*docker.ContainerInfo, error) {
+func (m *MockAPIs) GetRunningContainers() (map[string]*docker.ContainerInfo, error) {
 	ret := m.ctrl.Call(m, "GetRunningContainers")
-	ret0, _ := ret[0].([]*docker.ContainerInfo)
+	ret0, _ := ret[0].(map[string]*docker.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -200,7 +200,7 @@ func (d *Controller) handlePodUpdate(key string) error {
 	}
 
 	if !exists {
-		log.Infof(" Pods deleted on my node: %s", key)
+		log.Infof(" Pods deleted on my node: %v", key)
 		d.workerPodsLock.Lock()
 		defer d.workerPodsLock.Unlock()
 		delete(d.workerPods, key)


### PR DESCRIPTION
*Description of changes*
When ipamD restart, it needs to discover currently running Pods on the node and reserves the IP addresses used by these running Pods in datastore.

there are 2 changes

* To find out the container ID of a Pod, the original code was using **name**.  The **name** could change if the pod got restarted. So, modify the logic to use UID. 
* Change logic to not consider non-running container/pod.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
