### PR TITLE
Add docker-build target and use amazonlinux:2 for cni.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ static:
 	go build verify-aws.go
 	go build verify-network.go
 
-# need to bundle certificates
-certs: misc/certs/ca-certificates.crt
-misc/certs/ca-certificates.crt:
-	docker build -t "amazon/amazon-k8s-cert-source:make" misc/certs/
-	docker run "amazon/amazon-k8s-cert-source:make" cat /etc/ssl/certs/ca-certificates.crt > misc/certs/ca-certificates.crt
+docker-build:
+	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
+		--workdir=/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
+		--env GOPATH=/usr/src/app \
+		golang:1.10 make static
 
 
 # build docker image
-docker: certs
+docker: docker-build
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:latest" .
 	@echo "Built Docker image \"amazon/amazon-k8s-cni:latest\""
 

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,17 +1,11 @@
-FROM debian:latest
-
-RUN apt-get update && \
-    apt-get install -y iproute2 && \
-    apt-get install -y iptables
+FROM amazonlinux:2
+RUN yum update -y && \
+    yum install -y iproute && \
+    yum install -y iptables
 
 WORKDIR /app
 
 COPY aws-cni /app 
-COPY misc/aws.conf /app
-
-# Copy our bundled certs to the first place go will check: see 
-# https://golang.org/src/pkg/crypto/x509/root_unix.go
-COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ADD aws-k8s-agent  /app
 ADD scripts/aws-cni-support.sh /app


### PR DESCRIPTION
Add a build target for doing the build with docker.

Use amazonlinux:2 as the basis for the cni container.

Tested by building container and deploying to cluster then running conformance tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
