### PR TITLE
rev calico version

### DIFF
--- a/config/v1.0/aws-k8s-cni-calico.yaml
+++ b/config/v1.0/aws-k8s-cni-calico.yaml
@@ -1,100 +1,4 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: aws-node
-rules:
-- apiGroups: [""]
-  resources:
-  - pods
-  - namespaces
-  verbs: ["list", "watch", "get"]
-- apiGroups: ["extensions"]
-  resources:
-  - daemonsets
-  verbs: ["list", "watch"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aws-node
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
-  namespace: kube-system
---- 
-kind: DaemonSet
-apiVersion: extensions/v1beta1
-metadata:
-  name: aws-node
-  namespace: kube-system
-  labels:
-    k8s-app: aws-node
-spec:
-  updateStrategy:
-    type: RollingUpdate
-  selector:
-    matchLabels:
-      k8s-app: aws-node
-  template:
-    metadata:
-      labels:
-        k8s-app: aws-node
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
-      serviceAccountName: aws-node
-      hostNetwork: true
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
-      containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
-        name: aws-node
-        env:
-          - name: AWS_VPC_K8S_CNI_LOGLEVEL
-            value: DEBUG
-          - name: AWS_VPC_K8S_CNI_VETHPREFIX
-            value: cali
-        resources:
-          requests:
-            cpu: 10m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cni-bin-dir
-        - mountPath: /host/etc/cni/net.d
-          name: cni-net-dir
-        - mountPath: /host/var/log
-          name: log-dir
-      volumes:
-      - name: cni-bin-dir
-        hostPath:
-          path: /opt/cni/bin
-      - name: cni-net-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: log-dir
-        hostPath:
-          path: /var/log
-
----
-
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -131,11 +35,14 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.0.6
+          image: quay.io/calico/node:v3.1.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            # Use eni not cali for interface prefix
+            - name: FELIX_INTERFACEPREFIX
+              value: "eni"
             # Enable felix info logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
@@ -181,6 +88,7 @@ spec:
             httpGet:
               path: /liveness
               port: 9099
+              host: localhost
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -472,7 +380,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.6.4
+      - image: quay.io/calico/typha:v0.7.4
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/config/v1.0/aws-k8s-cni-calico.yaml
+++ b/config/v1.0/aws-k8s-cni-calico.yaml
@@ -387,6 +387,9 @@ spec:
           name: calico-typha
           protocol: TCP
         env:
+          # Use eni not cali for interface prefix
+          - name: FELIX_INTERFACEPREFIX
+            value: "eni"
           - name: TYPHA_LOGFILEPATH
             value: "none"
           - name: TYPHA_LOGSEVERITYSYS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump Calico version to current v3.1.3 which supports changing FELIX_INTERFACEPREFIX.

Calico pods are now launched with `eni` as the interface instead of `cali` Because of this we removed the `aws-node` components from the calico manifest.

Non-EKS users should now apply both `aws-k8s-cni.yaml` and `aws-k8s-cni-calico.yaml` manifests. EKS users should continue to follow the instructions of just installing the `aws-k8s-cni-calico.yaml` manifest which no longer makes changes to the existing `aws-node` components in their EKS cluster.

*Validation:*
* successfully applied and walked through the EKS Getting started Launch a Guest Book Application demo after applying this change
* successfully applied and walked through the EKS Networking: Installing Calico Stars Policy Demo after applying this change
* confirmed new EKS cluster successfully applied this manifest. `ip route` `ifconfig` also show `eni` in-use and not `cali`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
