### PR TITLE
Version cni plugin, ipamD, cni docker image with git SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,17 @@
 # language governing permissions and limitations under the License.
 #
 
+.PHONY:	static docker-build docker unit-test lint vet
+.DEFAULT_GOAL := static
+
+#VERSION ?= $(shell git describe --tags --always --dirty)
+VERSION ?= $(shell git rev-parse --short HEAD)
+LDFLAGS ?= -X main.version=$(VERSION)
+
 # build binary
 static:
-	go build -o aws-k8s-agent main.go
-	go build -o aws-cni plugins/routed-eni/cni.go
+	go build -o aws-k8s-agent -ldflags "$(LDFLAGS)" main.go
+	go build -o aws-cni -ldflags "$(LDFLAGS)" plugins/routed-eni/cni.go
 	go build verify-aws.go
 	go build verify-network.go
 
@@ -28,8 +35,8 @@ docker-build:
 
 # build docker image
 docker: docker-build
-	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:latest" .
-	@echo "Built Docker image \"amazon/amazon-k8s-cni:latest\""
+	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:$(VERSION)" .
+	@echo "Built Docker image \"amazon/amazon-k8s-cni:$(VERSION)\""
 
 # unit-test
 unit-test:

--- a/main.go
+++ b/main.go
@@ -26,7 +26,10 @@ import (
 
 const (
 	defaultLogFilePath = "/host/var/log/aws-routed-eni/ipamd.log"
-	version            = "1.0.0"
+)
+
+var (
+	version string
 )
 
 func main() {

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -18,10 +18,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"net"
 	"runtime"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	log "github.com/cihub/seelog"
 
@@ -45,6 +46,10 @@ const (
 	ipamDAddress       = "localhost:50051"
 	defaultLogFilePath = "/var/log/aws-routed-eni/plugin.log"
 	maxVethNameLen     = 10
+)
+
+var (
+	version string
 )
 
 // NetConf stores the common network config for CNI plugin
@@ -274,6 +279,8 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 func main() {
 	defer log.Flush()
 	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
+
+	log.Infof("Starting CNI Plugin %s  ...", version)
 
 	skel.PluginMain(cmdAdd, cmdDel, cniSpecVersion.All)
 }


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/90

*Description of changes:*
Use the short SHA of the current commit as the version number for IPAMD, CNI Plugin and Docker image.
The calculated version number can be overridden via the `VERSION` environment variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
