### PR TITLE
Version cni plugin, ipamD, cni docker image with git tag and hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,13 @@
 
 .PHONY: build-linux clean docker docker-build lint unit-test vet
 
+VERSION ?= $(shell git describe --tags --always --dirty)
+LDFLAGS ?= -X main.version=$(VERSION)
+
 # Default to build the Linux binary
 build-linux:
-	GOOS=linux CGO_ENABLED=0 go build -o aws-k8s-agent
-	GOOS=linux CGO_ENABLED=0 go build -o aws-cni ./plugins/routed-eni/
+	GOOS=linux CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "$(LDFLAGS)"
+	GOOS=linux CGO_ENABLED=0 go build -o aws-cni -ldflags "$(LDFLAGS)" ./plugins/routed-eni/
 
 docker-build:
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
@@ -28,8 +31,8 @@ docker-build:
 
 # Build docker image
 docker: docker-build
-	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:latest" .
-	@echo "Built Docker image \"amazon/amazon-k8s-cni:latest\""
+	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:$(VERSION)" .
+	@echo "Built Docker image \"amazon/amazon-k8s-cni:$(VERSION)\""
 
 # unit-test
 unit-test:

--- a/main.go
+++ b/main.go
@@ -26,7 +26,10 @@ import (
 
 const (
 	defaultLogFilePath = "/host/var/log/aws-routed-eni/ipamd.log"
-	version            = "1.0.0"
+)
+
+var (
+	version string
 )
 
 func main() {

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -18,10 +18,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"net"
 	"runtime"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	log "github.com/cihub/seelog"
 
@@ -44,6 +45,10 @@ import (
 const (
 	ipamDAddress       = "localhost:50051"
 	defaultLogFilePath = "/var/log/aws-routed-eni/plugin.log"
+)
+
+var (
+	version string
 )
 
 // NetConf stores the common network config for the CNI plugin
@@ -273,6 +278,8 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 func main() {
 	defer log.Flush()
 	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
+
+	log.Infof("Starting CNI Plugin %s  ...", version)
 
 	skel.PluginMain(cmdAdd, cmdDel, cniSpecVersion.All)
 }


### PR DESCRIPTION
*Issue #, if available:* Fixes #90.

*Description of changes:*
Use the git tag and hash of the current commit as the version number for IPAMD, CNI Plugin and Docker image.
The calculated version number can be overridden via the `VERSION` environment variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
