### PR TITLE
Make sure calico  aws-node gets scheduled on all nodes.

### DIFF
--- a/config/v1.0/aws-k8s-cni.yaml
+++ b/config/v1.0/aws-k8s-cni.yaml
@@ -58,10 +58,7 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
+      - operator: Exists
       containers:
       - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
         name: aws-node

--- a/config/v1.0/calico.yaml
+++ b/config/v1.0/calico.yaml
@@ -114,13 +114,7 @@ spec:
             path: /var/run/calico
       tolerations:
         # Make sure calico/node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
+      - operator: Exists
 
 ---
 
@@ -375,8 +369,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      - operator: Exists
       hostNetwork: true
       serviceAccountName: calico-node
       containers:


### PR DESCRIPTION
changed tolerations for calico-node and calico-typha to be sure it gets deployed also to nodes with custom taints like NoExecute and NoSchedule

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
