### PR TITLE
Add toleration for NoExecute and NoSchedule taints

### DIFF
--- a/config/v1.0/aws-k8s-cni.yaml
+++ b/config/v1.0/aws-k8s-cni.yaml
@@ -59,6 +59,9 @@ spec:
       hostNetwork: true
       tolerations:
       - operator: Exists
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
         name: aws-node


### PR DESCRIPTION
Added to ensure the aws-node pod is started when taints exist. If the pod is not started, this will result in the container runtime network not being ready, and the node 'NotReady'.

*Description of changes:*

Added toleration to the Pod spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
