### PR TITLE
Choose correct VPC CIDR block even when more than 1 VPC CIDR block exists 

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -28,25 +28,28 @@ import (
 )
 
 const (
-	az           = "us-east-1a"
-	localIP      = "10.0.0.10"
-	instanceID   = "i-0e1f3b9eb950e4980"
-	instanceType = "c1.medium"
-	primaryMAC   = "12:ef:2a:98:e5:5a"
-	eni2MAC      = "12:ef:2a:98:e5:5b"
-	sg1          = "sg-2e080f50"
-	sg2          = "sg-2e080f51"
-	sgs          = sg1 + " " + sg2
-	subnetID     = "subnet-6b245523"
-	vpcCIDR      = "10.0.0.0/16"
-	subnetCIDR   = "10.0.1.0/24"
-	accountID    = "694065802095"
-	primaryeniID = "eni-00000000"
-	eniID        = "eni-5731da78"
-	eniAttachID  = "eni-attach-beb21856"
-	eni1Device   = "0"
-	eni2Device   = "2"
-	ownerID      = "i-0946d8a24922d2852"
+	az                 = "us-east-1a"
+	localIP            = "10.0.0.10"
+	localIPInSecondary = "10.2.0.10"
+	instanceID         = "i-0e1f3b9eb950e4980"
+	instanceType       = "c1.medium"
+	primaryMAC         = "12:ef:2a:98:e5:5a"
+	eni2MAC            = "12:ef:2a:98:e5:5b"
+	sg1                = "sg-2e080f50"
+	sg2                = "sg-2e080f51"
+	sgs                = sg1 + " " + sg2
+	subnetID           = "subnet-6b245523"
+	primaryVpcCIDR     = "10.0.0.0/16"
+	secondaryVpcCIDR   = "10.2.0.0/16"
+	vpcCIDRS           = primaryVpcCIDR + " " + secondaryVpcCIDR
+	subnetCIDR         = "10.0.1.0/24"
+	accountID          = "694065802095"
+	primaryeniID       = "eni-00000000"
+	eniID              = "eni-5731da78"
+	eniAttachID        = "eni-attach-beb21856"
+	eni1Device         = "0"
+	eni2Device         = "2"
+	ownerID            = "i-0946d8a24922d2852"
 )
 
 func setup(t *testing.T) (*gomock.Controller,
@@ -73,7 +76,7 @@ func TestInitWithEC2metadata(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCCidrs).Return(vpcCIDRS, nil)
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 
@@ -86,10 +89,36 @@ func TestInitWithEC2metadata(t *testing.T) {
 	assert.Equal(t, ins.primaryENImac, primaryMAC)
 	assert.Equal(t, len(ins.securityGroups), 2)
 	assert.Equal(t, subnetID, ins.subnetID)
-	assert.Equal(t, vpcCIDR, ins.vpcIPv4CIDR)
+	assert.Equal(t, primaryVpcCIDR, ins.vpcIPv4CIDR)
 }
 
-func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
+func TestInitWithEC2metadataVPCSecondaryCidr (t *testing.T) {
+	ctrl, mockMetadata, _ := setup(t)
+	defer ctrl.Finish()
+
+	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIPInSecondary, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCCidrs).Return(vpcCIDRS, nil)
+
+	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
+
+	err := ins.initWithEC2Metadata()
+
+	assert.NoError(t, err)
+	assert.Equal(t, localIPInSecondary, ins.localIPv4)
+	assert.Equal(t, secondaryVpcCIDR, ins.vpcIPv4CIDR)
+}
+
+func TestInitWithEC2metadataVPCCidrErr(t *testing.T) {
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -104,7 +133,7 @@ func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, errors.New("Error on VPCcidr"))
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCCidrs).Return(vpcCIDRS, errors.New("Error on VPCcidr"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #35 

*Description of changes:*

Changes aim to make sure node level network configuration is set up in the correct VPC CIDR
- use "/vpc-ipv4-cidr-blocks/" instead of "/vpc-ipv4-cidr-block/" to get all VPC CIDR blocks, not just primary
- store CIDR blocks into string array
- loop through array and find correct VPC CIDR, based on localIP of EC2
- getter now always returns correct VPC CIDR, based on localIP 
- tests to confirm correct CIDR is chosen and not just primary every time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
