### PR TITLE
Add hostPort support #144

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS ?= -X main.version=$(VERSION)
 
+# Download portmap plugin
+download-portmap:
+	mkdir -p tmp/downloads
+	mkdir -p tmp/plugins
+	curl -L -o tmp/downloads/cni-plugins-amd64.tgz https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
+	tar -vxf tmp/downloads/cni-plugins-amd64.tgz -C tmp/plugins
+	cp tmp/plugins/portmap .
+	rm -rf tmp
+
 # Default to build the Linux binary
 build-linux:
 	GOOS=linux CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "$(LDFLAGS)"
@@ -26,7 +35,7 @@ docker-build:
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
 		--env GOPATH=/usr/src/app \
-		golang:1.10 make build-linux
+		golang:1.10 make build-linux && make download-portmap
 
 
 # Build docker image
@@ -64,3 +73,4 @@ vet:
 clean:
 	rm -f aws-k8s-agent
 	rm -f aws-cni
+	rm -f portmap

--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -1,0 +1,15 @@
+{
+  "name": "aws-cni",
+  "plugins": [
+    {
+      "name": "aws-cni",
+      "type": "aws-cni",
+      "vethPrefix": "__VETHPREFIX__"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    }
+  ]
+}

--- a/misc/aws.conf
+++ b/misc/aws.conf
@@ -1,5 +1,0 @@
-{
-"type": "aws-cni",
-"name": "aws-cni",
-"vethPrefix": "__VETHPREFIX__"
-}

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -6,7 +6,9 @@ RUN yum update -y && \
 WORKDIR /app
 
 COPY aws-cni /app 
-COPY misc/aws.conf /app
+COPY misc/10-aws.conflist /app
+
+COPY portmap /app
 
 COPY aws-k8s-agent  /app
 COPY scripts/aws-cni-support.sh /app

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 echo "=====Starting installing AWS-CNI ========="
-sed -i s/__VETHPREFIX__/${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}/g /app/aws.conf
+sed -i s/__VETHPREFIX__/${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}/g /app/10-aws.conflist
 cp /app/aws-cni /host/opt/cni/bin/
+cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
-cp /app/aws.conf /host/etc/cni/net.d/
+cp /app/10-aws.conflist /host/etc/cni/net.d/
+
+if [[ -f /host/etc/cni/net.d/aws.conf ]]; then
+    rm /host/etc/cni/net.d/aws.conf
+fi
+
 echo "=====Starting amazon-k8s-agent ==========="
 /app/aws-k8s-agent


### PR DESCRIPTION
* Issue: #144 *

This PR adds support to hostPort.

### Design decisions to de discussed:
1. Not sure if hostPort support should be offered by `amazon-vpc-cni-k8s` image itself or by modifying amazon-vpc-cni manifests on Kops, adding a new image to perform a slightly different installation, for instance.
2. Portmap plugin is downloaded from `github.com/containernetworking/plugins/releases` 