### PR TITLE
Add more error messages during initialization

### DIFF
--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -88,6 +88,9 @@ func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface,
 	log.Infof("Testing communication with server")
 	v, err := kubeClient.Discovery().ServerVersion()
 	if err != nil {
+		errMsg := "Failed to communicate with K8S Server. Please check instance security groups or http proxy setting"
+		log.Infof(errMsg)
+		fmt.Printf(errMsg)
 		return nil, fmt.Errorf("error communicating with apiserver: %v", err)
 	}
 	log.Infof("Running with Kubernetes cluster version: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",


### PR DESCRIPTION
*Issue #122 , if available:*

*Description of changes:*
One of the common scenario that CNI ipamD fails to start is that it can not communicate with K8S master. Here are 2  possible root causes:

* security groups  are not configured correctly on the across-account ENI attached to the master.
* or worker node HTTP proxy setting prevent ipamD communicate with master

This PR adds more error msgs when this happens.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
