### PR TITLE
Allow configuring docker image when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 .PHONY: build-linux clean docker docker-build lint unit-test vet
 
+IMAGE   ?= amazon/amazon-k8s-cni
 VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS ?= -X main.version=$(VERSION)
 
@@ -31,8 +32,8 @@ docker-build:
 
 # Build docker image
 docker: docker-build
-	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-k8s-cni:$(VERSION)" .
-	@echo "Built Docker image \"amazon/amazon-k8s-cni:$(VERSION)\""
+	@docker build -f scripts/dockerfiles/Dockerfile.release -t "$(IMAGE):$(VERSION)" .
+	@echo "Built Docker image \"$(IMAGE):$(VERSION)\""
 
 # unit-test
 unit-test:


### PR DESCRIPTION
*Description of changes:*

This allows setting `IMAGE` when running `make docker`
e.g.:

```sh
$ IMAGE=mikkeloscar/amazon-k8s-cni make docker
```

This makes it easier to build a custom image for testing. If you don't specify
the custom variable, the behavior is the same as before.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.