### PR TITLE
Removing redundant rbac permissions in a role in 1.2 config

### DIFF
--- a/config/v1.2/aws-k8s-cni.yaml
+++ b/config/v1.2/aws-k8s-cni.yaml
@@ -9,7 +9,7 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaecs
+  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]


### PR DESCRIPTION
*Description of changes:*
Removing redundant rbac permissions in a role in 1.2 config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
