### PR TITLE
Add logic to dynamically discover primary interface name

### DIFF
--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -218,7 +218,7 @@ func (c *IPAMContext) nodeInit() error {
 
 	primaryIP := net.ParseIP(c.awsClient.GetLocalIPv4())
 
-	err = c.networkClient.SetupHostNetwork(vpcCIDR, &primaryIP)
+	err = c.networkClient.SetupHostNetwork(vpcCIDR, c.awsClient.GetPrimaryENImac(), &primaryIP)
 	if err != nil {
 		log.Error("Failed to setup host network", err)
 		return errors.Wrap(err, "ipamd init: failed to setup host network")

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -105,7 +105,8 @@ func TestNodeInit(t *testing.T) {
 
 	_, vpcCIDR, _ := net.ParseCIDR(vpcCIDR)
 	primaryIP := net.ParseIP(ipaddr01)
-	mockNetwork.EXPECT().SetupHostNetwork(vpcCIDR, &primaryIP).Return(nil)
+	mockAWS.EXPECT().GetPrimaryENImac().Return("")
+	mockNetwork.EXPECT().SetupHostNetwork(vpcCIDR, "", &primaryIP).Return(nil)
 
 	//primaryENIid
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -124,6 +124,8 @@ type APIs interface {
 
 	// GetENILimit returns the number of enis can be attached to an instance
 	GetENILimit() (int, error)
+	// GetPrimaryENImac returns the mac address of the primary eni
+	GetPrimaryENImac() string
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -938,4 +940,9 @@ func (cache *EC2InstanceMetadataCache) GetLocalIPv4() string {
 // GetPrimaryENI returns the primary ENI
 func (cache *EC2InstanceMetadataCache) GetPrimaryENI() string {
 	return cache.primaryENI
+}
+
+// GetPrimaryENIMAC returns the mac address of primary eni
+func (cache *EC2InstanceMetadataCache) GetPrimaryENImac() string {
+	return cache.primaryENImac
 }

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -186,6 +186,18 @@ func (mr *MockAPIsMockRecorder) GetPrimaryENI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryENI", reflect.TypeOf((*MockAPIs)(nil).GetPrimaryENI))
 }
 
+// GetPrimaryENImac mocks base method
+func (m *MockAPIs) GetPrimaryENImac() string {
+	ret := m.ctrl.Call(m, "GetPrimaryENImac")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrimaryENImac indicates an expected call of GetPrimaryENImac
+func (mr *MockAPIsMockRecorder) GetPrimaryENImac() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryENImac", reflect.TypeOf((*MockAPIs)(nil).GetPrimaryENImac))
+}
+
 // GetVPCIPv4CIDR mocks base method
 func (m *MockAPIs) GetVPCIPv4CIDR() string {
 	ret := m.ctrl.Call(m, "GetVPCIPv4CIDR")

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -60,13 +60,13 @@ func (mr *MockNetworkAPIsMockRecorder) SetupENINetwork(arg0, arg1, arg2, arg3 in
 }
 
 // SetupHostNetwork mocks base method
-func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 *net.IP) error {
-	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1)
+func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 string, arg2 *net.IP) error {
+	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupHostNetwork indicates an expected call of SetupHostNetwork
-func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1)
+func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2)
 }

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -136,7 +136,7 @@ func TestSetupHostNetworkNodePortDisabled(t *testing.T) {
 	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)
 
-	err := ln.SetupHostNetwork(testENINetIPNet, &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, "", &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]map[string][][]string{
@@ -181,7 +181,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)
 	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
 
-	err := ln.SetupHostNetwork(testENINetIPNet, &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, "", &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]map[string][][]string{
@@ -241,7 +241,7 @@ func (ipt *mockIptables) Delete(table, chainName string, rulespec ...string) err
 		}
 		updatedChain = append(updatedChain, r)
 	}
-	if ! found {
+	if !found {
 		return errors.New("not found")
 	}
 	ipt.dataplaneState[table][chainName] = updatedChain


### PR DESCRIPTION
*Issue #171 , if available:*

*Description of changes:*
* use metadata service to find out the mac address on primary interface
* go through all the interfaces and find the interface which has same mac address as primary interface's mac.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
