### PR TITLE
Update containerPort in the spec

### DIFF
--- a/config/v1.2/aws-k8s-cni.yaml
+++ b/config/v1.2/aws-k8s-cni.yaml
@@ -71,7 +71,7 @@ spec:
       - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.2.1
         imagePullPolicy: Always
         ports:
-        - containerPort: 60000
+        - containerPort: 61678
           name: metrics
         name: aws-node
         env:


### PR DESCRIPTION
Update containerPort in the spec to match actual port used https://github.com/aws/amazon-vpc-cni-k8s/blob/master/ipamd/introspect.go#L32

*Description of changes:*

The metrics port in the deployment yaml is currently set to 60000, while ipamd is actually hardcoded to listen to 61678. This PR fixes that, allowing automated metrics collection by prometheus.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
