### PR TITLE
Configure MTU of ENI and veths to match primary interface

### DIFF
--- a/ipamd/datastore/data_store_test.go
+++ b/ipamd/datastore/data_store_test.go
@@ -23,14 +23,15 @@ import (
 
 func TestAddENI(t *testing.T) {
 	ds := NewDataStore()
+	testMTU := 9001
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, testMTU)
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-1", 1, true)
+	err = ds.AddENI("eni-1", 1, true, testMTU)
 	assert.Error(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, testMTU)
 	assert.NoError(t, err)
 
 	assert.Equal(t, len(ds.eniIPPools), 2)
@@ -41,14 +42,15 @@ func TestAddENI(t *testing.T) {
 
 func TestDeleteENI(t *testing.T) {
 	ds := NewDataStore()
+	testMTU := 9001
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, testMTU)
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, testMTU)
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-3", 3, false)
+	err = ds.AddENI("eni-3", 3, false, testMTU)
 	assert.NoError(t, err)
 
 	eniInfos := ds.GetENIInfos()
@@ -69,11 +71,12 @@ func TestDeleteENI(t *testing.T) {
 
 func TestAddENIIPv4Address(t *testing.T) {
 	ds := NewDataStore()
+	testMTU := 9001
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, testMTU)
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, testMTU)
 	assert.NoError(t, err)
 
 	err = ds.AddENIIPv4Address("eni-1", "1.1.1.1")
@@ -107,11 +110,12 @@ func TestAddENIIPv4Address(t *testing.T) {
 
 func TestGetENIIPPools(t *testing.T) {
 	ds := NewDataStore()
+	testMTU := 9001
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, testMTU)
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, testMTU)
 	assert.NoError(t, err)
 
 	err = ds.AddENIIPv4Address("eni-1", "1.1.1.1")
@@ -140,7 +144,9 @@ func TestGetENIIPPools(t *testing.T) {
 
 func TestDelENIIPv4Address(t *testing.T) {
 	ds := NewDataStore()
-	err := ds.AddENI("eni-1", 1, true)
+	testMTU := 9001
+
+	err := ds.AddENI("eni-1", 1, true, testMTU)
 	assert.NoError(t, err)
 
 	err = ds.AddENIIPv4Address("eni-1", "1.1.1.1")
@@ -172,10 +178,11 @@ func TestDelENIIPv4Address(t *testing.T) {
 
 func TestPodIPv4Address(t *testing.T) {
 	ds := NewDataStore()
+	testMTU := 9001
 
-	ds.AddENI("eni-1", 1, true)
+	ds.AddENI("eni-1", 1, true, testMTU)
 
-	ds.AddENI("eni-2", 2, false)
+	ds.AddENI("eni-2", 2, false, testMTU)
 
 	ds.AddENIIPv4Address("eni-1", "1.1.1.1")
 
@@ -189,7 +196,7 @@ func TestPodIPv4Address(t *testing.T) {
 		IP:        "1.1.1.1",
 	}
 
-	ip, _, err := ds.AssignPodIPv4Address(&podInfo)
+	ip, _, _, err := ds.AssignPodIPv4Address(&podInfo)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
@@ -197,7 +204,7 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, 2, len(ds.eniIPPools["eni-1"].IPv4Addresses))
 	assert.Equal(t, 1, ds.eniIPPools["eni-1"].AssignedIPv4Addresses)
 
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip, _, _, err = ds.AssignPodIPv4Address(&podInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 
@@ -205,7 +212,7 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, len(*podsInfos), 1)
 
 	// duplicate add
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip, _, _, err = ds.AssignPodIPv4Address(&podInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.1")
 	assert.Equal(t, ds.total, 3)
@@ -219,7 +226,7 @@ func TestPodIPv4Address(t *testing.T) {
 		IP:        "1.1.2.10",
 	}
 
-	_, _, err = ds.AssignPodIPv4Address(&podInfo)
+	_, _, _, err = ds.AssignPodIPv4Address(&podInfo)
 	assert.Error(t, err)
 
 	podInfo = k8sapi.K8SPodInfo{
@@ -228,7 +235,7 @@ func TestPodIPv4Address(t *testing.T) {
 		IP:        "1.1.2.2",
 	}
 
-	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(&podInfo)
+	ip, pod1Ns2Device, _, err := ds.AssignPodIPv4Address(&podInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.2.2")
 	assert.Equal(t, ds.total, 3)
@@ -245,7 +252,7 @@ func TestPodIPv4Address(t *testing.T) {
 		Container: "container-1",
 	}
 
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip, _, _, err = ds.AssignPodIPv4Address(&podInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.2")
 	assert.Equal(t, ds.total, 3)
@@ -259,7 +266,7 @@ func TestPodIPv4Address(t *testing.T) {
 		Namespace: "ns-3",
 	}
 
-	_, _, err = ds.AssignPodIPv4Address(&podInfo)
+	_, _, _, err = ds.AssignPodIPv4Address(&podInfo)
 	assert.Error(t, err)
 	// Unassign unknown Pod
 	_, _, err = ds.UnAssignPodIPv4Address(&podInfo)

--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -43,13 +43,13 @@ func (s *server) AddNetwork(ctx context.Context, in *pb.AddNetworkRequest) (*pb.
 	log.Infof("Received AddNetwork for NS %s, Pod %s, NameSpace %s, Container %s, ifname %s",
 		in.Netns, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID, in.IfName)
 
-	addr, deviceNumber, err := s.ipamContext.dataStore.AssignPodIPv4Address(&k8sapi.K8SPodInfo{
+	addr, deviceNumber, mtu, err := s.ipamContext.dataStore.AssignPodIPv4Address(&k8sapi.K8SPodInfo{
 		Name:      in.K8S_POD_NAME,
 		Namespace: in.K8S_POD_NAMESPACE,
 		Container: in.K8S_POD_INFRA_CONTAINER_ID})
 	log.Infof("Send AddNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", addr, deviceNumber, err)
 	addIPCnt.Inc()
-	return &pb.AddNetworkReply{Success: err == nil, IPv4Addr: addr, IPv4Subnet: "", DeviceNumber: int32(deviceNumber)}, nil
+	return &pb.AddNetworkReply{Success: err == nil, IPv4Addr: addr, IPv4Subnet: "", DeviceNumber: int32(deviceNumber), MTU: int32(mtu)}, nil
 }
 
 func (s *server) DelNetwork(ctx context.Context, in *pb.DelNetworkRequest) (*pb.DelNetworkReply, error) {

--- a/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
+++ b/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
@@ -158,6 +158,18 @@ func (mr *MockNetLinkMockRecorder) LinkSetUp(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetUp", reflect.TypeOf((*MockNetLink)(nil).LinkSetUp), arg0)
 }
 
+// LinkSetMTU mocks base method
+func (m *MockNetLink) LinkSetMTU(arg0 netlink.Link, arg1 int) error {
+	ret := m.ctrl.Call(m, "LinkSetMTU", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LinkSetMTU indicates an expected call of LinkSetMTU
+func (mr *MockNetLinkMockRecorder) LinkSetMTU(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetMTU", reflect.TypeOf((*MockNetLink)(nil).LinkSetMTU), arg0, arg1)
+}
+
 // NeighAdd mocks base method
 func (m *MockNetLink) NeighAdd(arg0 *netlink.Neigh) error {
 	ret := m.ctrl.Call(m, "NeighAdd", arg0)

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -46,6 +46,8 @@ type NetLink interface {
 	NewRule() *netlink.Rule
 	RuleDel(rule *netlink.Rule) error
 	RuleAdd(rule *netlink.Rule) error
+	// LinkSetMTU is equivalent to `ip link set dev $link mtu $mtu`
+	LinkSetMTU(link netlink.Link, mtu int) error
 }
 
 type netLink struct {
@@ -121,4 +123,8 @@ func (*netLink) RuleDel(rule *netlink.Rule) error {
 
 func (*netLink) RuleAdd(rule *netlink.Rule) error {
 	return netlink.RuleAdd(rule)
+}
+
+func (*netLink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -48,25 +48,25 @@ func (m *MockNetworkAPIs) EXPECT() *MockNetworkAPIsMockRecorder {
 }
 
 // SetupENINetwork mocks base method
-func (m *MockNetworkAPIs) SetupENINetwork(arg0, arg1 string, arg2 int, arg3 string) error {
-	ret := m.ctrl.Call(m, "SetupENINetwork", arg0, arg1, arg2, arg3)
+func (m *MockNetworkAPIs) SetupENINetwork(arg0, arg1 string, arg2 int, arg3 string, arg4 int) error {
+	ret := m.ctrl.Call(m, "SetupENINetwork", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupENINetwork indicates an expected call of SetupENINetwork
-func (mr *MockNetworkAPIsMockRecorder) SetupENINetwork(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupENINetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupENINetwork), arg0, arg1, arg2, arg3)
+func (mr *MockNetworkAPIsMockRecorder) SetupENINetwork(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupENINetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupENINetwork), arg0, arg1, arg2, arg3, arg4)
 }
 
 // SetupHostNetwork mocks base method
-func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 string, arg2 *net.IP) error {
-	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2)
+func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 string, arg2 *net.IP, arg3 *int) error {
+	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupHostNetwork indicates an expected call of SetupHostNetwork
-func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2)
+func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2, arg3)
 }

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -161,9 +161,9 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		return fmt.Errorf("add cmd: failed to assign an IP address to container")
 	}
 
-	log.Infof("Received add network response for pod %s namespace %s container %s: %s, table %d ",
+	log.Infof("Received add network response for pod %s namespace %s container %s: %s, table %d, mtu %d",
 		string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID),
-		r.IPv4Addr, r.DeviceNumber)
+		r.IPv4Addr, r.DeviceNumber, r.MTU)
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(r.IPv4Addr),
@@ -174,7 +174,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	// Note: the maximum length for linux interface name is 15
 	hostVethName := generateHostVethName(conf.VethPrefix, string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 
-	err = driverClient.SetupNS(hostVethName, args.IfName, args.Netns, addr, int(r.DeviceNumber))
+	err = driverClient.SetupNS(hostVethName, args.IfName, args.Netns, addr, int(r.DeviceNumber), int(r.MTU))
 
 	if err != nil {
 		log.Errorf("Failed SetupPodNetwork for pod %s namespace %s container %s: %v",

--- a/plugins/routed-eni/driver/driver_test.go
+++ b/plugins/routed-eni/driver/driver_test.go
@@ -43,6 +43,7 @@ const (
 	testeniIP        = "10.10.10.20"
 	testeniMAC       = "01:23:45:67:89:ab"
 	testeniSubnet    = "10.10.0.0/16"
+	testMTU          = 9001
 )
 
 func setup(t *testing.T) (*gomock.Controller,
@@ -69,6 +70,7 @@ func TestRun(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -128,6 +130,7 @@ func TestRunLinkAddErr(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	mockNS := mock_ns.NewMockNetNS(ctrl)
@@ -153,6 +156,7 @@ func TestRunErrLinkByNameHost(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	mockNS := mock_ns.NewMockNetNS(ctrl)
@@ -180,6 +184,7 @@ func TestRunErrSetup(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	mockHostVeth := mock_netlink.NewMockLink(ctrl)
@@ -210,6 +215,7 @@ func TestRunErrLinkByNameCont(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	mockHostVeth := mock_netlink.NewMockLink(ctrl)
@@ -243,6 +249,7 @@ func TestRunErrRouteAdd(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -288,6 +295,7 @@ func TestRunErrAddDefaultRoute(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -334,6 +342,7 @@ func TestRunErrAddrAdd(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -383,6 +392,7 @@ func TestRunErrNeighAdd(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -437,6 +447,7 @@ func TestRunErrLinkSetNsFd(t *testing.T) {
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
 		},
+		mtu:          testMTU,
 	}
 
 	hwAddr, err := net.ParseMAC(testMAC)
@@ -528,7 +539,7 @@ func TestSetupPodNetwork(t *testing.T) {
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS, testMTU)
 
 	assert.NoError(t, err)
 
@@ -548,7 +559,7 @@ func TestSetupPodNetworkErrLinkByName(t *testing.T) {
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS, testMTU)
 
 	assert.Error(t, err)
 
@@ -570,7 +581,7 @@ func TestSetupPodNetworkErrLinkSetup(t *testing.T) {
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS, testMTU)
 
 	assert.Error(t, err)
 
@@ -603,7 +614,7 @@ func TestSetupPodNetworkErrRouteAdd(t *testing.T) {
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, mockNetLink, mockNS, testMTU)
 
 	assert.Error(t, err)
 }
@@ -649,7 +660,7 @@ func TestSetupPodNetworkPrimaryIntf(t *testing.T) {
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, mockNetLink, mockNS, testMTU)
 
 	assert.NoError(t, err)
 

--- a/plugins/routed-eni/driver/mocks/driver_mocks.go
+++ b/plugins/routed-eni/driver/mocks/driver_mocks.go
@@ -48,15 +48,15 @@ func (m *MockNetworkAPIs) EXPECT() *MockNetworkAPIsMockRecorder {
 }
 
 // SetupNS mocks base method
-func (m *MockNetworkAPIs) SetupNS(arg0, arg1, arg2 string, arg3 *net.IPNet, arg4 int) error {
-	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4)
+func (m *MockNetworkAPIs) SetupNS(arg0, arg1, arg2 string, arg3 *net.IPNet, arg4, arg5 int) error {
+	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupNS indicates an expected call of SetupNS
-func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4)
+func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // TeardownNS mocks base method

--- a/rpc/rpc.pb.go
+++ b/rpc/rpc.pb.go
@@ -88,6 +88,7 @@ type AddNetworkReply struct {
 	IPv4Addr     string `protobuf:"bytes,2,opt,name=IPv4Addr" json:"IPv4Addr,omitempty"`
 	IPv4Subnet   string `protobuf:"bytes,3,opt,name=IPv4Subnet" json:"IPv4Subnet,omitempty"`
 	DeviceNumber int32  `protobuf:"varint,4,opt,name=DeviceNumber" json:"DeviceNumber,omitempty"`
+	MTU          int32  `protobuf:"varint,5,opt,name=MTU" json:"MTU,omitempty"`
 }
 
 func (m *AddNetworkReply) Reset()                    { *m = AddNetworkReply{} }
@@ -119,6 +120,13 @@ func (m *AddNetworkReply) GetIPv4Subnet() string {
 func (m *AddNetworkReply) GetDeviceNumber() int32 {
 	if m != nil {
 		return m.DeviceNumber
+	}
+	return 0
+}
+
+func (m *AddNetworkReply) GetMTU() int32 {
+	if m != nil {
+		return m.MTU
 	}
 	return 0
 }

--- a/rpc/rpc.proto
+++ b/rpc/rpc.proto
@@ -25,6 +25,7 @@ message  AddNetworkReply{
   string IPv4Addr = 2;
   string IPv4Subnet = 3;
   int32 DeviceNumber = 4;
+  int32 MTU = 5;
 }
 
 message DelNetworkRequest {


### PR DESCRIPTION
*Issue #, if available:*

#167 

*Description of changes:*

Get MTU of primary interface and apply the same MTU to attached ENIs and created veths.
* Set primary interface MTU in IPAM context in host network setup
* Set MTU of ENI from IPAM context
* Send MTU in add network response for veth configuration
* Update test for changes to methods

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
