### PR TITLE
Configure MTU of ENI and veths to 9001

### DIFF
--- a/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
+++ b/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
@@ -165,6 +165,18 @@ func (m *MockNetLink) NeighAdd(arg0 *netlink.Neigh) error {
 	return ret0
 }
 
+// LinkSetMTU mocks base method
+func (m *MockNetLink) LinkSetMTU(arg0 netlink.Link, arg1 int) error {
+	ret := m.ctrl.Call(m, "LinkSetMTU", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LinkSetMTU indicates an expected call of LinkSetMTU
+func (mr *MockNetLinkMockRecorder) LinkSetMTU(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetMTU", reflect.TypeOf((*MockNetLink)(nil).LinkSetMTU), arg0, arg1)
+}
+
 // NeighAdd indicates an expected call of NeighAdd
 func (mr *MockNetLinkMockRecorder) NeighAdd(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighAdd", reflect.TypeOf((*MockNetLink)(nil).NeighAdd), arg0)

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -46,6 +46,8 @@ type NetLink interface {
 	NewRule() *netlink.Rule
 	RuleDel(rule *netlink.Rule) error
 	RuleAdd(rule *netlink.Rule) error
+	// LinkSetMTU is equivalent to `ip link set dev $link mtu $mtu`
+	LinkSetMTU(link netlink.Link, mtu int) error
 }
 
 type netLink struct {
@@ -121,4 +123,8 @@ func (*netLink) RuleDel(rule *netlink.Rule) error {
 
 func (*netLink) RuleAdd(rule *netlink.Rule) error {
 	return netlink.RuleAdd(rule)
+}
+
+func (*netLink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -70,6 +70,9 @@ const (
 	// - kube-proxy uses 0x0000c000
 	// - Calico uses 0xffff0000.
 	defaultConnmark = 0x80
+
+	// MTU of ENI - veth MTU defined in plugins/routed-eni/driver/driver.go
+	ethernetMTU = 9001
 )
 
 // NetworkAPIs defines the host level and the eni level network related operations
@@ -406,6 +409,10 @@ func setupENINetwork(eniIP string, eniMAC string, eniTable int, eniSubnetCIDR st
 	link, err := LinkByMac(eniMAC, netLink)
 	if err != nil {
 		return errors.Wrapf(err, "eni network setup: failed to find the link which uses mac address %s", eniMAC)
+	}
+
+	if err = netLink.LinkSetMTU(link, ethernetMTU); err != nil {
+		return errors.Wrapf(err, "eni network setup: failed to set MTU for %s", eniIP)
 	}
 
 	if err = netLink.LinkSetUp(link); err != nil {

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -44,6 +44,9 @@ const (
 	testeniIP        = "10.10.10.20"
 	testeniMAC       = "01:23:45:67:89:ab"
 	testeniSubnet    = "10.10.0.0/16"
+	// Default MTU of ENI and veth
+	// defined in plugins/routed-eni/driver/driver.go, pkg/networkutils/network.go
+	testMTU          = 9001
 )
 
 var (
@@ -88,6 +91,7 @@ func TestSetupENINetwork(t *testing.T) {
 	lo.EXPECT().Attrs().Return(mockLinkAttrs1)
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
 
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	mockNetLink.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
 
 	// eth1's device

--- a/plugins/routed-eni/driver/driver.go
+++ b/plugins/routed-eni/driver/driver.go
@@ -37,8 +37,8 @@ const (
 
 	// TODO need to test all distros use this number
 	mainRouteTable = 254
-
-	ethernetMTU = 1500
+	// MTU of veth - ENI MTU defined in pkg/networkutils/network.go
+	ethernetMTU = 9001
 )
 
 // NetworkAPIs defines network API calls


### PR DESCRIPTION
*Issue #, if available:*
#167 

*Description of changes:*
* Add LinkSetMTU wrapper and  mocks
* Add LinkSetMTU call to ENI setup and network test
* Change hardcoded veth MTU to 9001

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
