### PR TITLE
update calico version and add v3.3 required changes

### DIFF
--- a/config/v1.2/calico.yaml
+++ b/config/v1.2/calico.yaml
@@ -25,6 +25,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
@@ -35,7 +37,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.1.3
+          image: quay.io/calico/node:v3.3.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -93,14 +95,18 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
@@ -112,6 +118,10 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
       tolerations:
         # Make sure calico/node gets scheduled on all nodes.
       - operator: Exists
@@ -259,6 +269,7 @@ rules:
   - apiGroups: [""]
     resources:
       - namespaces
+      - serviceaccounts
     verbs:
       - get
       - list
@@ -267,7 +278,7 @@ rules:
     resources:
       - pods/status
     verbs:
-      - update
+      - patch
   - apiGroups: [""]
     resources:
       - pods
@@ -275,7 +286,6 @@ rules:
       - get
       - list
       - watch
-      - patch
   - apiGroups: [""]
     resources:
       - services
@@ -359,13 +369,16 @@ spec:
         k8s-app: calico-typha
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        cluster-autoscaler.kuberentes.io/safe-to-evict: 'true'
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       tolerations:
       - operator: Exists
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.7.4
+      - image: quay.io/calico/typha:v3.3.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -398,15 +411,19 @@ spec:
           name: etc-calico
           readOnly: true
         livenessProbe:
-          httpGet:
-            path: /liveness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - liveness
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - readiness
           periodSeconds: 10
       volumes:
       - name: etc-calico
@@ -416,6 +433,21 @@ spec:
 
 ---
 
+# This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
+
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Rev calico to v3.3.1

# validation
* Fresh EKS cluster install w/calico-v3.3.1 completes w/out errors
* Guestbook-app demo completes w/out errors
* Stars-demo completes w/out errors
* Kubernetes e2e run w/NetworkPolicy focus passes w/out failures/errors
* Rolling upgrade EKS cluster w/calico-3.1.3 to calico-3.3.1 completes w/out errors
