### PR TITLE
Setting SourceDestCheck to false in AllocENI

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -555,6 +555,9 @@ func (cache *EC2InstanceMetadataCache) AllocENI(useCustomCfg bool, sg []*string,
 			DeleteOnTermination: aws.Bool(true),
 		},
 		NetworkInterfaceId: aws.String(eniID),
+		SourceDestCheck: &ec2.AttributeBooleanValue{
+			Value: aws.Bool(false),
+		},
 	}
 
 	start := time.Now()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-vpc-cni-k8s/issues/231

*Description of changes:*
This disables the SourceDestCheck on the ENIs that are created by AllocENI so that packets are not dropped in the case where a NodePort service's backend pods have IPs allocated from a secondary interface. The NodePort traffic enters on eth0 and is then dropped by the secondary interface (e.g. eth1) when the source/destination check is true, as per the default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
