### PR TITLE
Bump TravisCI to use 1.11 (released 2018/08/24)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ language: go
 # Only the last two Go releases are supported by the Go team with security updates.
 # Any older versions are considered deprecated.
 go:
+  - "1.11.x"
   - "1.10.x"
-  - "1.9.x"
 
 # Only clone the most recent commit.
 git:


### PR DESCRIPTION
#242

*Run TravisCI on 1.10 and 1.11*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
