### PR TITLE
Some cleanups related to #234

### DIFF
--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -726,15 +726,11 @@ func (c *IPAMContext) nodeIPPoolTooHigh() bool {
 		return false
 	}
 
-	return (int64(available) >= (int64(warmENITarget)+1)*c.maxAddrsPerENI)
+	return int64(available) >= (int64(warmENITarget)+1)*c.maxAddrsPerENI
 }
 
 func ipamdErrInc(fn string, err error) {
 	ipamdErr.With(prometheus.Labels{"fn": fn, "error": err.Error()}).Inc()
-}
-
-func ipamdActionsInprogressSet(fn string, curNum int) {
-	ipamdActionsInprogress.WithLabelValues(fn).Set(float64(curNum))
 }
 
 // nodeIPPoolReconcile reconcile ENI and IP info from metadata service and IP addresses in datastore
@@ -839,7 +835,7 @@ func (c *IPAMContext) eniIPPoolReconcile(ipPool map[string]*datastore.AddressInf
 	}
 }
 
-// UseCustomerNetworkCfg() return whether Pods needs to use pod specific config
+// UseCustomNetworkCfg returns whether Pods needs to use pod specific configuration or not.
 func UseCustomNetworkCfg() bool {
 	defaultValue := false
 	if strValue := os.Getenv(envCustomNetworkCfg); strValue != "" {

--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -71,7 +71,6 @@ func (s *server) AddNetwork(ctx context.Context, in *pb.AddNetworkRequest) (*pb.
 func (s *server) DelNetwork(ctx context.Context, in *pb.DelNetworkRequest) (*pb.DelNetworkReply, error) {
 	log.Infof("Received DelNetwork for IP %s, Pod %s, Namespace %s, Container %s",
 		in.IPv4Addr, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID)
-
 	delIPCnt.With(prometheus.Labels{"reason": in.Reason}).Inc()
 
 	ip, deviceNumber, err := s.ipamContext.dataStore.UnAssignPodIPv4Address(&k8sapi.K8SPodInfo{

--- a/plugins/routed-eni/driver/driver.go
+++ b/plugins/routed-eni/driver/driver.go
@@ -56,8 +56,10 @@ type linuxNetwork struct {
 
 // New creates linuxNetwork object
 func New() NetworkAPIs {
-	return &linuxNetwork{netLink: netlinkwrapper.NewNetLink(),
-		ns: nswrapper.NewNS()}
+	return &linuxNetwork{
+		netLink: netlinkwrapper.NewNetLink(),
+		ns:      nswrapper.NewNS(),
+	}
 }
 
 // createVethPairContext wraps the parameters and the method to create the
@@ -70,11 +72,7 @@ type createVethPairContext struct {
 	ip           ipwrapper.IP
 }
 
-func newCreateVethPairContext(
-	contVethName string,
-	hostVethName string,
-	addr *net.IPNet) *createVethPairContext {
-
+func newCreateVethPairContext(contVethName string, hostVethName string, addr *net.IPNet) *createVethPairContext {
 	return &createVethPairContext{
 		contVethName: contVethName,
 		hostVethName: hostVethName,
@@ -168,11 +166,9 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 	return nil
 }
 
-// SetupNS wiresup linux networking for Pod's network
+// SetupNS wires up linux networking for Pod's network
 func (os *linuxNetwork) SetupNS(hostVethName string, contVethName string, netnsPath string, addr *net.IPNet, table int, vpcCIDRs []string, useExternalSNAT bool) error {
-	log.Debugf("SetupNS: hostVethName=%s,contVethName=%s, netnsPath=%s table=%d\n",
-		hostVethName, contVethName, netnsPath, table)
-
+	log.Debugf("SetupNS: hostVethName=%s,contVethName=%s, netnsPath=%s table=%d\n", hostVethName, contVethName, netnsPath, table)
 	return setupNS(hostVethName, contVethName, netnsPath, addr, table, vpcCIDRs, useExternalSNAT, os.netLink, os.ns)
 }
 
@@ -258,12 +254,9 @@ func setupNS(hostVethName string, contVethName string, netnsPath string, addr *n
 				if podRule.Dst != nil {
 					toDst = podRule.Dst.String()
 				}
-
 				log.Infof("Successfully added pod rule[%v] to %s", podRule, toDst)
-
 			}
 		}
-
 	}
 	return nil
 }
@@ -285,11 +278,9 @@ func addContainerRule(netLink netlinkwrapper.NetLink, isToContainer bool, addr *
 	}
 
 	err = netLink.RuleAdd(containerRule)
-
 	if err != nil {
 		return errors.Wrapf(err, "add NS network: failed to add container rule  for %s", addr.String())
 	}
-
 	return nil
 }
 
@@ -300,7 +291,6 @@ func (os *linuxNetwork) TeardownNS(addr *net.IPNet, table int) error {
 }
 
 func tearDownNS(addr *net.IPNet, table int, netLink netlinkwrapper.NetLink) error {
-
 	// remove to-pod rule
 	toContainerRule := netLink.NewRule()
 	toContainerRule.Dst = addr
@@ -333,7 +323,6 @@ func tearDownNS(addr *net.IPNet, table int, netLink netlinkwrapper.NetLink) erro
 		Dst:   addrHostAddr}); err != nil {
 		log.Errorf("delete NS network: failed to delete host route for %s, %v", addr.String(), err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Two small bug fixes in the error handling when deleting rules, otherwise no functional changes.

Follow up to #234

*Description of changes:*
* The biggest change is in network.go where I extended the link creation loop to add the last chain link instead of creating it explicitly. I also save the names of the chains instead of rebuilding them.
* Two if-statments checked the wrong `err` to verify the result of `netLink.RuleDel`.
* Removed unused methods `ipamdActionsInprogressSet` and `isDuplicateRuleAdd `.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
