### PR TITLE
Stop wrapping and returning nil

### DIFF
--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -592,7 +592,7 @@ func (c *IPAMContext) getENIaddresses(eni string) ([]*ec2.NetworkInterfacePrivat
 		}
 	}
 
-	return nil, "", errors.Wrapf(err, "faind to find eni's primary address for eni %s", eni)
+	return nil, "", errors.Errorf("failed to find eni's primary address for eni %s", eni)
 }
 
 func (c *IPAMContext) waitENIAttached(eni string) (awsutils.ENIMetadata, error) {

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -117,11 +117,12 @@ func TestNodeInit(t *testing.T) {
 	testAddr1 := ipaddr01
 	testAddr2 := ipaddr02
 	primary := true
+	notPrimary := false
 	eniResp := []*ec2.NetworkInterfacePrivateIpAddress{
 		{
 			PrivateIpAddress: &testAddr1, Primary: &primary},
 		{
-			PrivateIpAddress: &testAddr2, Primary: &primary}}
+			PrivateIpAddress: &testAddr2, Primary: &notPrimary}}
 	mockAWS.EXPECT().GetENIipLimit().Return(int64(56), nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	mockAWS.EXPECT().DescribeENI(primaryENIid).Return(eniResp, &attachmentID, nil)
@@ -131,12 +132,11 @@ func TestNodeInit(t *testing.T) {
 	attachmentID = testAttachmentID
 	testAddr11 := ipaddr11
 	testAddr12 := ipaddr12
-	primary = false
 	eniResp = []*ec2.NetworkInterfacePrivateIpAddress{
 		{
 			PrivateIpAddress: &testAddr11, Primary: &primary},
 		{
-			PrivateIpAddress: &testAddr12, Primary: &primary}}
+			PrivateIpAddress: &testAddr12, Primary: &notPrimary}}
 	mockAWS.EXPECT().GetENIipLimit().Return(int64(56), nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	mockAWS.EXPECT().DescribeENI(secENIid).Return(eniResp, &attachmentID, nil)
@@ -253,7 +253,8 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 	mockAWS.EXPECT().GetENIipLimit().Return(int64(5), nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 
-	primary := false
+	primary := true
+	notPrimary := false
 	attachmentID := testAttachmentID
 	testAddr11 := ipaddr11
 	testAddr12 := ipaddr12
@@ -263,7 +264,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 			{
 				PrivateIpAddress: &testAddr11, Primary: &primary},
 			{
-				PrivateIpAddress: &testAddr12, Primary: &primary}}, &attachmentID, nil)
+				PrivateIpAddress: &testAddr12, Primary: &notPrimary}}, &attachmentID, nil)
 
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)


### PR DESCRIPTION
*Description of changes:*

Currently `err` in arg of the second `errors.Wrapf()` in getENIaddresses() will never
receive error except for nil value.

- L#584 checks `err != nil` and return, hence L#595 will never get err except for nil.
https://github.com/aws/amazon-vpc-cni-k8s/blob/07363123942c6fa03da6a7737a2d15817a7c2f8e/ipamd/ipamd.go#L583-L595

When `errors.Wrapf()` is called with nil in first arg, the new message
is not wrapped. To make matters worse, `getENIaddresses()` returns
error as `nil` so the logic of code after the method could be collapsed.

Hence, this patch uses `errors.Errorf()` instead `errors.Wrapf()`.

Also, current unit tests for ipamd use two primary IPs for one
ENI. This patch fixes it as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
