### PR TITLE
Use device number 0 for primary device in unit test

### DIFF
--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -46,8 +46,8 @@ const (
 	eniID            = "eni-5731da78"
 	primaryMAC       = "12:ef:2a:98:e5:5a"
 	secMAC           = "12:ef:2a:98:e5:5b"
-	primaryDevice    = 2
-	secDevice        = 0
+	primaryDevice    = 0
+	secDevice        = 2
 	primarySubnet    = "10.10.10.0/24"
 	secSubnet        = "10.10.20.0/24"
 	ipaddr01         = "10.10.10.11"


### PR DESCRIPTION
*Description of changes:*

This patch makes very tiny change in unit test.

According to the comment below in pkg/awsutils/awsutils.go,
DeviceNumer 0 means primary interface.

https://github.com/aws/amazon-vpc-cni-k8s/blob/07363123942c6fa03da6a7737a2d15817a7c2f8e/pkg/awsutils/awsutils.go#L167-L168

Hence, this patch changes to set primaryDevice to 0 and secDevice to 2 in
unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
