### PR TITLE
Return the err from f.Close()

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -381,12 +381,13 @@ func (n *linuxNetwork) setProcSys(key, value string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	_, err = f.WriteString(value)
 	if err != nil {
+		// If the write failed, just close
+		_ = f.Close()
 		return err
 	}
-	return nil
+	return f.Close()
 }
 
 type iptablesRule struct {


### PR DESCRIPTION
In the case of an EIO (IO Exception) the error from the write would be lost because of the use of defer.

See https://www.joeshaw.org/dont-defer-close-on-writable-files/

*Description of changes:*
Return the return value of `f.Close()` for a successful `f.WriteString` in case of an EIO.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
