### PR TITLE
add an environment variable to limit the number of ENIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ unit-test:
 	GOOS=linux CGO_ENABLED=1 go test -v -cover -race -timeout 10s ./pkg/networkutils/...
 	GOOS=linux CGO_ENABLED=1 go test -v -cover -race -timeout 10s ./ipamd/...
 
+docker-unit-test:
+	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
+		--workdir=/usr/src/app/src/github.com/aws/amazon-vpc-cni-k8s \
+		--env GOPATH=/usr/src/app \
+		golang:1.10 make unit-test
+
 # golint
 # To install: go get -u golang.org/x/lint/golint
 lint:

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Default: None
 Specifies the number of free IP addresses that the `ipamD` daemon should attempt to keep available for pod assignment on the node\. For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times\. If the elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces until `WARM_IP_TARGET` free IP addresses are available\.  
 This environment variable overrides `WARM_ENI_TARGET` behavior\.
 
-`MAX_ENI`
-Type: Integer
-Default: `-1`
-Specifies the maximum number of ENIs that will be attached to the node. When MAX_ENI is <= 1 (i.e., the default), the setting is not used, and the maximum number of ENIs is always equal to the maximum number for the instance type in question. Even when MAX_ENI is a positive number, it is limited by the maximum number for the instance type.
+`MAX_ENI`  
+Type: Integer  
+Default: None  
+Specifies the maximum number of ENIs that will be attached to the node. When MAX_ENI is unset or 0 (or lower), the setting is not used, and the maximum number of ENIs is always equal to the maximum number for the instance type in question. Even when MAX_ENI is a positive number, it is limited by the maximum number for the instance type.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Default: None
 Specifies the number of free IP addresses that the `ipamD` daemon should attempt to keep available for pod assignment on the node\. For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times\. If the elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces until `WARM_IP_TARGET` free IP addresses are available\.  
 This environment variable overrides `WARM_ENI_TARGET` behavior\.
 
+`MAX_ENI`
+Type: Integer
+Default: `-1`
+Specifies the maximum number of ENIs that will be attached to the node. When MAX_ENI is <= 1 (i.e., the default), the setting is not used, and the maximum number of ENIs is always equal to the maximum number for the instance type in question. Even when MAX_ENI is a positive number, it is limited by the maximum number for the instance type.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server.  If it can **not** reach kubernetes API server, ipamD will exit and CNI will not be able to get any IP address for Pods.  Here is a way to confirm if `L-IPAMD` has access to the kubernetes API server.

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -201,7 +201,6 @@ func New(k8sapiClient k8sapi.K8SAPIs, eniConfig *eniconfig.ENIConfigController) 
 func (c *IPAMContext) nodeInit() error {
 	ipamdActionsInprogress.WithLabelValues("nodeInit").Add(float64(1))
 	defer ipamdActionsInprogress.WithLabelValues("nodeInit").Sub(float64(1))
-	var err error
 
 	// If MAX_ENI is set, the maximum number of ENIs may be no more than that
 	// number (but might be less, depending on instance type.) If MAX_ENI is < 1,

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -364,17 +364,35 @@ func TestGetMaxENI(t *testing.T) {
 	ctrl, _, _, _, _, _ := setup(t)
 	defer ctrl.Finish()
 
+	// MaxENI 5 is less than lower bound of 10, so 5
 	os.Setenv("MAX_ENI", "5")
-	maxENI := getMaxENI()
+	maxENI := getMaxENI(10)
 	assert.Equal(t, maxENI, 5)
 
-	os.Unsetenv("MAX_ENI")
-	maxENI = getMaxENI()
-	assert.Equal(t, maxENI, defaultMaxENI)
+	// MaxENI 5 is greater than lower bound of 4, so 4
+	os.Setenv("MAX_ENI", "5")
+	maxENI = getMaxENI(4)
+	assert.Equal(t, maxENI, 4)
 
+	// MaxENI 0 is 0, which means disabled; so use lower bound
+	os.Setenv("MAX_ENI", "0")
+	maxENI = getMaxENI(4)
+	assert.Equal(t, maxENI, 4)
+
+	// MaxENI 1 is less than lower bound of 4, so 1.
+	os.Setenv("MAX_ENI", "1")
+	maxENI = getMaxENI(4)
+	assert.Equal(t, maxENI, 1)
+
+	// Empty MaxENI means disabled, so use lower bound
+	os.Unsetenv("MAX_ENI")
+	maxENI = getMaxENI(10)
+	assert.Equal(t, maxENI, 10)
+
+	// Invalid MaxENI means disabled, so use lower bound
 	os.Setenv("MAX_ENI", "non-integer-string")
-	maxENI = getMaxENI()
-	assert.Equal(t, maxENI, defaultMaxENI)
+	maxENI = getMaxENI(10)
+	assert.Equal(t, maxENI, 10)
 }
 
 func TestGetCurWarmIPTarget(t *testing.T) {

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -360,6 +360,23 @@ func TestGetWarmENITarget(t *testing.T) {
 	assert.Equal(t, warmIPTarget, noWarmIPTarget)
 }
 
+func TestGetMaxENI(t *testing.T) {
+	ctrl, _, _, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	os.Setenv("MAX_ENI", "5")
+	maxENI := getMaxENI()
+	assert.Equal(t, maxENI, 5)
+
+	os.Unsetenv("MAX_ENI")
+	maxENI = getMaxENI()
+	assert.Equal(t, maxENI, defaultMaxENI)
+
+	os.Setenv("MAX_ENI", "non-integer-string")
+	maxENI = getMaxENI()
+	assert.Equal(t, maxENI, defaultMaxENI)
+}
+
 func TestGetCurWarmIPTarget(t *testing.T) {
 	ctrl, mockAWS, mockK8S, _, mockNetwork, _ := setup(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds an environment variable to limit the number of ENIs assigned to a node. For the time being we're interested in only using one ENI per node, and this setting makes it possible to _ensure_ that this is the case.

(I also add a Make target to run tests in the same docker container used for building, but, you know, take it or leave it.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
