### PR TITLE
Remove unneeded spec entry in v1.3 manifest

### DIFF
--- a/config/v1.3/aws-k8s-cni.yaml
+++ b/config/v1.3/aws-k8s-cni.yaml
@@ -122,7 +122,6 @@ spec:
   group: crd.k8s.amazonaws.com
   version: v1alpha1
   names:
-    scope: Cluster
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove unknown field in v1.3 manifest. This line can cause validation failure on Kubernetes 1.11:

```
error validating data: ValidationError(CustomResourceDefinition.spec.names): unknown field "scope" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
