### PR TITLE
Output CIDR in correct format

### DIFF
--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -53,7 +53,7 @@ func (s *server) AddNetwork(ctx context.Context, in *pb.AddNetworkRequest) (*pb.
 	var pbVPCcidrs []string
 
 	for _, cidr := range vpcCIDRs {
-		log.Debugf("VPC CIDR %s", cidr)
+		log.Debugf("VPC CIDR %s", *cidr)
 		pbVPCcidrs = append(pbVPCcidrs, *cidr)
 	}
 


### PR DESCRIPTION
*Description of changes:*

This patch makes very tiny change which outputs CIDR in correct
format.

Currentl debug log output CIDR as blow:

```
2018-12-07T11:03:40Z [DEBUG] VPC CIDR %!s(*string=0xc420039040)
```

This patch fixes it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
