### PR TITLE
Explicitly set the IP on secondary ENIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ verify-network
 .idea/
 *.iml
 .DS_Store
+portmap

--- a/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
+++ b/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
@@ -59,6 +59,18 @@ func (mr *MockNetLinkMockRecorder) AddrAdd(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddrAdd", reflect.TypeOf((*MockNetLink)(nil).AddrAdd), arg0, arg1)
 }
 
+// AddrDel mocks base method
+func (m *MockNetLink) AddrDel(arg0 netlink.Link, arg1 *netlink.Addr) error {
+	ret := m.ctrl.Call(m, "AddrDel", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddrDel indicates an expected call of AddrDel
+func (mr *MockNetLinkMockRecorder) AddrDel(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddrDel", reflect.TypeOf((*MockNetLink)(nil).AddrDel), arg0, arg1)
+}
+
 // AddrList mocks base method
 func (m *MockNetLink) AddrList(arg0 netlink.Link, arg1 int) ([]netlink.Addr, error) {
 	ret := m.ctrl.Call(m, "AddrList", arg0, arg1)

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -25,6 +25,8 @@ type NetLink interface {
 	ParseAddr(s string) (*netlink.Addr, error)
 	// AddrAdd is equivalent to `ip addr add $addr dev $link`
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	// AddrDel is equivalent to `ip addr del $addr dev $link`
+	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	// AddrList is equivalent to `ip addr show `
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
 	// LinkAdd is equivalent to `ip link add`
@@ -77,6 +79,10 @@ func (*netLink) ParseAddr(s string) (*netlink.Addr, error) {
 
 func (*netLink) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
 	return netlink.AddrAdd(link, addr)
+}
+
+func (*netLink) AddrDel(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrDel(link, addr)
 }
 
 func (*netLink) LinkSetUp(link netlink.Link) error {

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -524,7 +524,7 @@ func setupENINetwork(eniIP string, eniMAC string, eniTable int, eniSubnetCIDR st
 	// ip add del <eniIP> dev <link> (if necessary)
 	// ip add add <eniIP> dev <link>
 	log.Debugf("Setting up ENI's primary IP %s", eniIP)
-	addrs, err := netlink.AddrList(link, unix.AF_INET)
+	addrs, err := netLink.AddrList(link, unix.AF_INET)
 	if err != nil {
 		return errors.Wrap(err, "eni network setup: failed to list IP addrs for ENI")
 	}

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -518,6 +518,32 @@ func setupENINetwork(eniIP string, eniMAC string, eniTable int, eniSubnetCIDR st
 		return errors.Wrapf(err, "eni network setup: failed to define gateway address from %v", ipnet.IP)
 	}
 
+	// Explicitly set the IP on the device if not already set.
+	// Required for older kernels.
+	// ip addr show
+	// ip add del <eniIP> dev <link> (if necessary)
+	// ip add add <eniIP> dev <link>
+	log.Debugf("Setting up ENI's primary IP %s", eniIP)
+	addrs, err := netlink.AddrList(link, unix.AF_INET)
+	if err != nil {
+		return errors.Wrap(err, "eni network setup: failed to list IP addrs for ENI")
+	}
+
+	for _, addr := range addrs {
+		log.Debugf("Deleting existing IP address %s", addr.String())
+		if err = netLink.AddrDel(link, &addr); err != nil {
+			return errors.Wrap(err, "eni network setup: failed to delete IP addr from ENI")
+		}
+	}
+	eniAddr := &net.IPNet{
+		IP:   net.ParseIP(eniIP),
+		Mask: ipnet.Mask,
+	}
+	log.Debugf("Adding IP address %s", eniAddr.String())
+	if err = netLink.AddrAdd(link, &netlink.Addr{IPNet: eniAddr}); err != nil {
+		return errors.Wrap(err, "eni network setup: failed to add IP addr to ENI")
+	}
+
 	log.Debugf("Setting up ENI's default gateway %v", gw)
 
 	for _, r := range []netlink.Route{

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	mocks_ip "github.com/aws/amazon-vpc-cni-k8s/pkg/ipwrapper/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mock_netlink"
@@ -97,6 +98,14 @@ func TestSetupENINetwork(t *testing.T) {
 	// eth1's device
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
+
+	// eth1's IP address
+	testeniAddr := &net.IPNet{
+		IP:   net.ParseIP(testeniIP),
+		Mask: testENINetIPNet.Mask,
+	}
+	mockNetLink.EXPECT().AddrList(gomock.Any(), unix.AF_INET).Return([]netlink.Addr{}, nil)
+	mockNetLink.EXPECT().AddrAdd(gomock.Any(), &netlink.Addr{IPNet: testeniAddr}).Return(nil)
 
 	mockNetLink.EXPECT().RouteDel(gomock.Any())
 	mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil)


### PR DESCRIPTION
Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/219.

Verified on Amazon Linux 2 and stock CentOS 7.

```console
$ cat /etc/centos-release
CentOS Linux release 7.5.1804 (Core)
$ uname -r
3.10.0-862.14.4.el7.x86_64
```