### PR TITLE
Improve setup advice in project README around ENI / IP address limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Download the latest version of the [yaml](./config/) and apply it the cluster.
 kubectl apply -f aws-k8s-cni.yaml
 ```
 
-Launch kubelet with network plugins set to cni (`--network-plugin=cni`), the cni directories configured (`--cni-config-dir` and `--cni-bin-dir`) and node ip set to the primary IPv4 address of the primary ENI for the instance (`--node-ip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)`).  It is also recommended to set `--max-pods` equal to (the number of ENIs for the instance type * (the number of IPs per ENI - 1)) + 2 [see](./pkg/awsutils/vpc_ip_resource_limit.go) to prevent scheduling that exceeds the IP resources available to the kubelet.
+Launch kubelet with network plugins set to cni (`--network-plugin=cni`), the cni directories configured (`--cni-config-dir` and `--cni-bin-dir`) and node ip set to the primary IPv4 address of the primary ENI for the instance (`--node-ip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)`).
+It is also recommended to set `--max-pods` equal to _(the number of ENIs for the instance type * (the number of IPs per ENI - 1)) + 2_; for details, see [vpc_ip_resource_limit.go][] to prevent scheduling that exceeds the IP resources available to the kubelet.
+
+[vpc_ip_resource_limit.go]: ./pkg/awsutils/vpc_ip_resource_limit.go
 
 The default manifest expects `--cni-conf-dir=/etc/cni/net.d` and `--cni-bin-dir=/opt/cni/bin`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kubectl apply -f aws-k8s-cni.yaml
 ```
 
 Launch kubelet with network plugins set to cni (`--network-plugin=cni`), the cni directories configured (`--cni-config-dir` and `--cni-bin-dir`) and node ip set to the primary IPv4 address of the primary ENI for the instance (`--node-ip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)`).
-It is also recommended to set `--max-pods` equal to _(the number of ENIs for the instance type * (the number of IPs per ENI - 1)) + 2_; for details, see [vpc_ip_resource_limit.go][] to prevent scheduling that exceeds the IP resources available to the kubelet.
+It is also recommended to set `--max-pods` equal to _(the number of ENIs for the instance type × (the number of IPs per ENI - 1)) + 2_; for details, see [vpc_ip_resource_limit.go][]. Setting `--max-pods` will prevent scheduling that exceeds the IP address resources available to the kubelet.
 
 [vpc_ip_resource_limit.go]: ./pkg/awsutils/vpc_ip_resource_limit.go
 


### PR DESCRIPTION
*Issue #, if available:* _n/a_ (can make one if needed)

*Description of changes:* The [current README](https://github.com/aws/amazon-vpc-cni-k8s/blob/fb2d96af3f31af7c68c2cdc81eeb07691843efc3/README.md#setup) on `master` mentions [https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/awsutils/vpc_ip_resource_limit.go](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/awsutils/vpc_ip_resource_limit.go), and it looks like the link text is meant to show that filename. At the moment the link text renders as just “see”. This PR changes the rendered page to show the filename, and also rewords that paragraph for clarity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
