### PR TITLE
Use `unix.RT_TABLE_MAIN` for main routing table number in driver

### DIFF
--- a/plugins/routed-eni/driver/driver.go
+++ b/plugins/routed-eni/driver/driver.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -36,8 +37,8 @@ const (
 	// 1024 is reserved for (ip rule not to <vpc's subnet> table main)
 	fromContainerRulePriority = 1536
 
-	// TODO need to test all distros use this number
-	mainRouteTable = 254
+	// main routing table number
+	mainRouteTable = unix.RT_TABLE_MAIN
 	// MTU of veth - ENI MTU defined in pkg/networkutils/network.go
 	ethernetMTU = 9001
 )


### PR DESCRIPTION
*Description of changes:*

This patch is same fix with https://github.com/aws/amazon-vpc-cni-k8s/pull/269 but another code. It changes to
unix.RT_TABLE_MAIN from fixed value 254(0xfe).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
