### PR TITLE
Feature: ENIConfig set by custom annotation or label names

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,14 @@ Specifies that your pods may use subnets and security groups that are independen
 `ENI_CONFIG_ANNOTATION_DEF`
 Type: String
 Default: k8s.amazonaws.com/eniConfig
-Specifies node annotation key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name.
+Specifies node annotation key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name. See ENI_CONFIG_LABEL_DEF for examples.
 
 `ENI_CONFIG_LABEL_DEF`
 Type: String
 Default: k8s.amazonaws.com/eniConfig
-Specifies node label key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name.
-For example if you set ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone, the node that is deployed in `us-east-1a` would have it set to that zone and CNI would use eniConfig named `us-east-1a`.
+Specifies node label key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom label value will be used to set eniConfig name. Note that annotations will take precedence over labels. To use labels, ensure default annotation k8s.amazonaws.com/eniConfig is not set on node and ENI_CONFIG_ANNOTATION_DEF is not used.
+For example, you can use custom node label key _example.com/eniConfig_ by setting ENI_CONFIG_LABEL_DEF=example.com/eniConfig. Then you can set that label on node with value of your custom eniConfig name like `eniConfig-us-east-1a`.
+In other example if your node has label _failure-domain.beta.kubernetes.io/zone_ and its value is set to availability zone `us-east-1a`, you can set ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone. In such case eniConfig would be set to availability zone name `us-east-1a`, and you could use it to differentiate configs between zones.
 
 `AWS_VPC_K8S_CNI_EXTERNALSNAT`  
 Type: Boolean  

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Type: Boolean
 Default: `false`  
 Specifies that your pods may use subnets and security groups that are independent of your worker node's VPC configuration\. By default, pods share the same subnet and security groups as the worker node's primary interface\. Setting this variable to `true` causes `ipamD` to use the security groups and VPC subnet in a worker node's `ENIConfig` for elastic network interface allocation\. You must create an `ENIConfig` custom resource definition for each subnet that your pods will reside in, and then annotate each worker node to use a specific `ENIConfig` \(multiple worker nodes can be annotated with the same `ENIConfig`\)\. Worker nodes can only be annotated with a single `ENIConfig` at a time, and the subnet in the `ENIConfig` must belong to the same Availability Zone that the worker node resides in\. For more information, see [https://github.com/aws/amazon-vpc-cni-k8s/pull/165](https://github.com/aws/amazon-vpc-cni-k8s/pull/165)\.
 
+`ENI_CONFIG_ANNOTATION_DEF`
+Type: String
+Default: k8s.amazonaws.com/eniConfig
+Specifies node annotation key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name.
+
+`ENI_CONFIG_LABEL_DEF`
+Type: String
+Default: k8s.amazonaws.com/eniConfig
+Specifies node label key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name.
+For example if you set ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone, the node that is deployed in `us-east-1a` would have it set to that zone and CNI would use eniConfig named `us-east-1a`.
+
 `AWS_VPC_K8S_CNI_EXTERNALSNAT`  
 Type: Boolean  
 Default: `false`  

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -59,10 +59,12 @@ var ErrNoENIConfig = errors.New("eniconfig: eniconfig is not available")
 
 // ENIConfigController defines global context for ENIConfig controller
 type ENIConfigController struct {
-	eni        map[string]*v1alpha1.ENIConfigSpec
-	myENI      string
-	eniLock    sync.RWMutex
-	myNodeName string
+	eni                    map[string]*v1alpha1.ENIConfigSpec
+	myENI                  string
+	eniLock                sync.RWMutex
+	myNodeName             string
+	eniConfigAnnotationDef string
+	eniConfigLabelDef      string
 }
 
 // ENIConfigInfo returns locally cached ENIConfigs
@@ -77,6 +79,8 @@ func NewENIConfigController() *ENIConfigController {
 		myNodeName: os.Getenv("MY_NODE_NAME"),
 		eni:        make(map[string]*v1alpha1.ENIConfigSpec),
 		myENI:      eniConfigDefault,
+		eniConfigAnnotationDef: getEniConfigAnnotationDef(),
+		eniConfigLabelDef:      getEniConfigLabelDef(),
 	}
 }
 
@@ -119,9 +123,8 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 		// Get annotations if not found get labels if not found fallback use default
 		if h.controller.myNodeName == o.GetName() {
 			annotation := o.GetAnnotations()
-			annotationDef := getEniConfigAnnotationDef()
 
-			val, ok := annotation[annotationDef]
+			val, ok := annotation[h.controller.eniConfigAnnotationDef]
 			if ok {
 				h.controller.eniLock.Lock()
 				defer h.controller.eniLock.Unlock()
@@ -130,9 +133,8 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 			} else {
 
 				label := o.GetLabels()
-				labelDef := getEniConfigLabelDef()
 
-				val, ok := label[labelDef]
+				val, ok := label[h.controller.eniConfigLabelDef]
 				if ok {
 					h.controller.eniLock.Lock()
 					defer h.controller.eniLock.Unlock()

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -122,32 +122,19 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 		log.Infof("Handle corev1.Node: %s, %v, %v", o.GetName(), o.GetAnnotations(), o.GetLabels())
 		// Get annotations if not found get labels if not found fallback use default
 		if h.controller.myNodeName == o.GetName() {
-			annotation := o.GetAnnotations()
 
-			val, ok := annotation[h.controller.eniConfigAnnotationDef]
-			if ok {
-				h.controller.eniLock.Lock()
-				defer h.controller.eniLock.Unlock()
-				h.controller.myENI = val
-				log.Infof(" Setting myENI to: %s", val)
-			} else {
-
-				label := o.GetLabels()
-
-				val, ok := label[h.controller.eniConfigLabelDef]
-				if ok {
-					h.controller.eniLock.Lock()
-					defer h.controller.eniLock.Unlock()
-					h.controller.myENI = val
-					log.Infof(" Setting myENI to: %s", val)
-				} else {
-
-					h.controller.eniLock.Lock()
-					defer h.controller.eniLock.Unlock()
-					h.controller.myENI = eniConfigDefault
-					log.Infof(" Setting myENI to: %s", eniConfigDefault)
+			val, ok := o.GetAnnotations()[h.controller.eniConfigAnnotationDef]
+			if !ok {
+				val, ok = o.GetLabels()[h.controller.eniConfigLabelDef]
+				if !ok {
+					val = eniConfigDefault
 				}
 			}
+
+			h.controller.eniLock.Lock()
+			defer h.controller.eniLock.Unlock()
+			h.controller.myENI = val
+			log.Infof(" Setting myENI to: %s", val)
 		}
 	}
 	return nil

--- a/pkg/eniconfig/eniconfig_test.go
+++ b/pkg/eniconfig/eniconfig_test.go
@@ -60,6 +60,7 @@ func updateNodeAnnotation(hdlr sdk.Handler, nodeName string, configName string, 
 		Deleted: toDelete,
 	}
 	eniAnnotations := make(map[string]string)
+	eniConfigAnnotationDef := getEniConfigAnnotationDef()
 
 	if !toDelete {
 		eniAnnotations[eniConfigAnnotationDef] = configName
@@ -87,6 +88,7 @@ func updateNodeLabel(hdlr sdk.Handler, nodeName string, configName string, toDel
 		Deleted: toDelete,
 	}
 	eniLabels := make(map[string]string)
+	eniConfigLabelDef := getEniConfigLabelDef()
 
 	if !toDelete {
 		eniLabels[eniConfigLabelDef] = configName
@@ -211,4 +213,28 @@ func TestNodeENIConfigLabel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCfg, *outputCfg)
 
+}
+
+func TestGetEniConfigAnnotationDefDefault(t *testing.T) {
+	os.Unsetenv(envEniConfigAnnotationDef)
+	eniConfigAnnotationDef := getEniConfigAnnotationDef()
+	assert.Equal(t, eniConfigAnnotationDef, defaultEniConfigAnnotationDef)
+}
+
+func TestGetEniConfigAnnotationlDefCustom(t *testing.T) {
+	os.Setenv(envEniConfigAnnotationDef, "k8s.amazonaws.com/eniConfigCustom")
+	eniConfigAnnotationDef := getEniConfigAnnotationDef()
+	assert.Equal(t, eniConfigAnnotationDef, "k8s.amazonaws.com/eniConfigCustom")
+}
+
+func TestGetEniConfigLabelDefDefault(t *testing.T) {
+	os.Unsetenv(envEniConfigLabelDef)
+	eniConfigLabelDef := getEniConfigLabelDef()
+	assert.Equal(t, eniConfigLabelDef, defaultEniConfigLabelDef)
+}
+
+func TestGetEniConfigLabelDefCustom(t *testing.T) {
+	os.Setenv(envEniConfigLabelDef, "k8s.amazonaws.com/eniConfigCustom")
+	eniConfigLabelDef := getEniConfigLabelDef()
+	assert.Equal(t, eniConfigLabelDef, "k8s.amazonaws.com/eniConfigCustom")
 }


### PR DESCRIPTION
This feature enables user to set custom annotation or label key to define ENIConfig name. One use case if you have nodes in different failure domains. By default AWS deployments set node label failure-domain.beta.kubernetes.io/zone and its value is availability zone name. We can use availability zone name as ENIConfig to map to proper subnets.
Added 2 new environmental variables:
ENI_CONFIG_ANNOTATION_DEF
ENI_CONFIG_LABEL_DEF

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
