### PR TITLE
Add changes to support multiple platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,20 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS ?= -X main.version=$(VERSION)
 
+ARCH ?= $(shell uname -m)
+
+ifeq ($(ARCH),aarch64)
+  ARCH = arm64
+else ($(ARCH),x86_64)
+  ARCH = amd64
+endif
+
 # Download portmap plugin
 download-portmap:
 	mkdir -p tmp/downloads
 	mkdir -p tmp/plugins
-	curl -L -o tmp/downloads/cni-plugins-amd64.tgz https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
-	tar -vxf tmp/downloads/cni-plugins-amd64.tgz -C tmp/plugins
+	curl -L -o tmp/downloads/cni-plugins-$(ARCH).tgz https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-$(ARCH)-v0.6.0.tgz
+	tar -vxf tmp/downloads/cni-plugins-$(ARCH).tgz -C tmp/plugins
 	cp tmp/plugins/portmap .
 	rm -rf tmp
 


### PR DESCRIPTION
AMD64 and ARM64 Support

*Issue #, if available:*

*Description of changes:*
Change the download-portmap target in the makefile to be platform aware, so it can download the arm64 or amd64 binaries depending on the target platform where the code is being compiled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
