### PR TITLE
Expose configuration variables via ipamD to make it debug friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ Type: Boolean
 Default: `false`  
 Specifies that your pods may use subnets and security groups that are independent of your worker node's VPC configuration\. By default, pods share the same subnet and security groups as the worker node's primary interface\. Setting this variable to `true` causes `ipamD` to use the security groups and VPC subnet in a worker node's `ENIConfig` for elastic network interface allocation\. You must create an `ENIConfig` custom resource definition for each subnet that your pods will reside in, and then annotate each worker node to use a specific `ENIConfig` \(multiple worker nodes can be annotated with the same `ENIConfig`\)\. Worker nodes can only be annotated with a single `ENIConfig` at a time, and the subnet in the `ENIConfig` must belong to the same Availability Zone that the worker node resides in\. For more information, see [https://github.com/aws/amazon-vpc-cni-k8s/pull/165](https://github.com/aws/amazon-vpc-cni-k8s/pull/165)\.
 
-`ENI_CONFIG_ANNOTATION_DEF`
-Type: String
-Default: k8s.amazonaws.com/eniConfig
-Specifies node annotation key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name. See ENI_CONFIG_LABEL_DEF for examples.
+`ENI_CONFIG_ANNOTATION_DEF`  
+Type: String  
+Default: `k8s.amazonaws.com/eniConfig`  
+Specifies node annotation key name\. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom annotation value will be used to set eniConfig name. See ENI_CONFIG_LABEL_DEF for examples.
 
-`ENI_CONFIG_LABEL_DEF`
-Type: String
-Default: k8s.amazonaws.com/eniConfig
-Specifies node label key name. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true. Custom label value will be used to set eniConfig name. Note that annotations will take precedence over labels. To use labels, ensure default annotation k8s.amazonaws.com/eniConfig is not set on node and ENI_CONFIG_ANNOTATION_DEF is not used.
-For example, you can use custom node label key _example.com/eniConfig_ by setting ENI_CONFIG_LABEL_DEF=example.com/eniConfig. Then you can set that label on node with value of your custom eniConfig name like `eniConfig-us-east-1a`.
-In other example if your node has label _failure-domain.beta.kubernetes.io/zone_ and its value is set to availability zone `us-east-1a`, you can set ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone. In such case eniConfig would be set to availability zone name `us-east-1a`, and you could use it to differentiate configs between zones.
+`ENI_CONFIG_LABEL_DEF`  
+Type: String  
+Default: `k8s.amazonaws.com/eniConfig`  
+Specifies node label key name\. This should be used when AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true\. Custom label value will be used to set eniConfig name\. Note that annotations will take precedence over labels\. To use labels, ensure default annotation k8s.amazonaws.com/eniConfig is not set on node and ENI_CONFIG_ANNOTATION_DEF is not used\.
+For example, you can use custom node label key _example.com/eniConfig_ by setting ENI_CONFIG_LABEL_DEF=example.com/eniConfig\. Then you can set that label on node with value of your custom eniConfig name like `eniConfig-us-east-1a`\.  
+In other example if your node has label _failure-domain.beta.kubernetes.io/zone_ and its value is set to availability zone `us-east-1a`, you can set ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone. In such case eniConfig would be set to availability zone name `us-east-1a`, and you could use it to differentiate configs between zones\.
 
 `AWS_VPC_K8S_CNI_EXTERNALSNAT`  
 Type: Boolean  
@@ -115,12 +115,12 @@ Specifies whether an external NAT gateway should be used to provide SNAT of seco
 Disable SNAT if you need to allow inbound communication to your pods from external VPNs, direct connections, and external VPCs, and your pods do not need to access the Internet directly via an Internet Gateway\. However, your nodes must be running in a private subnet and connected to the internet through an AWS NAT Gateway or another external NAT device\.
 
 `AWS_VPC_K8S_CNI_RANDOMIZESNAT`  
-Type: String 
-Default: `hashrandom` 
+Type: String  
+Default: `hashrandom`   
 Valid Values: `hashrandom`, `prng`, `none`
-Specifies weather the SNAT `iptables` rule should randomize the outgoing ports for connections. When enabled (`hashrandom`) the `--random` flag will be added to the SNAT `iptables` rule.
-To use pseudo random number generation rather than hash based (i.e. `--random-fully`) use `prng` for the environment variable. For old versions of `iptables` that do not support `--random-fully` this option will fall back to `--random`.
-Disable (`none`) this functionality if you rely on sequential port allocation for outgoing connections.
+Specifies weather the SNAT `iptables` rule should randomize the outgoing ports for connections\. When enabled (`hashrandom`) the `--random` flag will be added to the SNAT `iptables` rule\.  
+To use pseudo random number generation rather than hash based (i.e. `--random-fully`) use `prng` for the environment variable\. For old versions of `iptables` that do not support `--random-fully` this option will fall back to `--random`\.  
+Disable (`none`) this functionality if you rely on sequential port allocation for outgoing connections\.
 
 `WARM_ENI_TARGET`  
 Type: Integer  

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -69,16 +69,18 @@ type ENIConfigController struct {
 
 // ENIConfigInfo returns locally cached ENIConfigs
 type ENIConfigInfo struct {
-	ENI   map[string]v1alpha1.ENIConfigSpec
-	MyENI string
+	ENI                    map[string]v1alpha1.ENIConfigSpec
+	MyENI                  string
+	EniConfigAnnotationDef string
+	EniConfigLabelDef      string
 }
 
 // NewENIConfigController creates a new ENIConfig controller
 func NewENIConfigController() *ENIConfigController {
 	return &ENIConfigController{
-		myNodeName: os.Getenv("MY_NODE_NAME"),
-		eni:        make(map[string]*v1alpha1.ENIConfigSpec),
-		myENI:      eniConfigDefault,
+		myNodeName:             os.Getenv("MY_NODE_NAME"),
+		eni:                    make(map[string]*v1alpha1.ENIConfigSpec),
+		myENI:                  eniConfigDefault,
 		eniConfigAnnotationDef: getEniConfigAnnotationDef(),
 		eniConfigLabelDef:      getEniConfigLabelDef(),
 	}
@@ -174,6 +176,8 @@ func (eniCfg *ENIConfigController) Getter() *ENIConfigInfo {
 	defer eniCfg.eniLock.Unlock()
 
 	output.MyENI = eniCfg.myENI
+	output.EniConfigAnnotationDef = getEniConfigAnnotationDef()
+	output.EniConfigLabelDef = getEniConfigLabelDef()
 
 	for name, val := range eniCfg.eni {
 		output.ENI[name] = *val

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -448,6 +448,7 @@ func GetConfigForDebug() map[string]interface{} {
 		envExternalSNAT:    useExternalSNAT(),
 		envNodePortSupport: nodePortSupportEnabled(),
 		envConnmark:        getConnmark(),
+		envRandomizeSNAT:   typeOfSNAT(),
 	}
 }
 
@@ -483,7 +484,7 @@ func typeOfSNAT() snatType {
 		return randomHashSNAT
 	default:
 		// if we get to this point, the environment variable has an invalid value
-		log.Errorf("Failed to parse %s; using default: %s. Provided string was \"%s\"", envRandomizeSNAT, defaultString,
+		log.Errorf("Failed to parse %s; using default: %s. Provided string was %q", envRandomizeSNAT, defaultString,
 			strValue)
 		return defaultValue
 	}


### PR DESCRIPTION
After added some configuration variables, these are not exposed via
ipamD. This patch exposes following variables as introspection data.

- `AWS_VPC_K8S_CNI_RANDOMIZESNAT`
- `ENI_CONFIG_ANNOTATION_DEF`
- `ENI_CONFIG_LABEL_DEF`

c.f - After this patch:
```
{"AWS_VPC_CNI_NODE_PORT_SUPPORT":true,"AWS_VPC_K8S_CNI_CONNMARK":128,"AWS_VPC_K8S_CNI_EXTERNALSNAT":false,"AWS_VPC_K8S_CNI_RANDOMIZESNAT":1}

{"ENI":{},"MyENI":"default","EniConfigAnnotationDef":"k8s.amazonaws.com/eniConfig","EniConfigLabelDef":"k8s.amazonaws.com/eniConfig"}
```


*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
