### PR TITLE
Return with exit codes to call log.Flush()

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func _main() int {
 	kubeClient, err := k8sapi.CreateKubeClient("", "")
 	if err != nil {
 		log.Errorf("Failed to create client: %v", err)
-		os.Exit(1)
+		return 1
 	}
 
 	discoverController := k8sapi.NewController(kubeClient)


### PR DESCRIPTION
Before `os.Exit()` is fired, `github.cihub/seelog`'s log.Flush() needs to be
called. Otherwise, the log message was not output and we lost some
important logs.

This patch changes surely `returns 1` to call `defer log.Flush()` in
main().

Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/288

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
