### PR TITLE
Fix warning message from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ ARCH ?= $(shell uname -m)
 
 ifeq ($(ARCH),aarch64)
   ARCH = arm64
-else ($(ARCH),x86_64)
+else
+endif
+ifeq ($(ARCH),x86_64)
   ARCH = amd64
 endif
 


### PR DESCRIPTION
Currently `make arg` produces following error:

```
Makefile:24: extraneous text after 'else' directive
```

Please also refer to previous travis build log - https://travis-ci.org/aws/amazon-vpc-cni-k8s/jobs/480537040#L474
This patch fixes this warning message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
