### PR TITLE
Use InClusterConfig when CreateKubeClient() was called without args

### DIFF
--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -72,7 +73,13 @@ func NewController(clientset kubernetes.Interface) *Controller {
 
 // CreateKubeClient creates a k8s client
 func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
-	config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+	var config *rest.Config
+	var err error
+	if apiserver == "" && kubeconfig == "" {
+		config, err = rest.InClusterConfig()
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When `BuildConfigFromFlags(apiserver, kubeconfig)` was called with
empty apiserver and kubeconfig, it fallbacks to
rest.InClusterConfig(). When it happened, amazon-k8s-agent outputs
following error/warning message.

```
ERROR: logging before flag.Parse: W1217 10:37:25.707719      13 client_config.go:533] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
```

Although this error is harmless, it causes some confusion.

Hence this patch changes to use `InClusterConfig()` when
`BuildConfigFromFlags` was called with empty args.

P.S `logging before flag.Parse` is also solved by this patch, as glog
is not called.

Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/270

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
