### PR TITLE
cherry-pick: Restrict p3dn.24xlarge to 31 ips per interface.

### DIFF
--- a/pkg/awsutils/vpc_ip_resource_limit.go
+++ b/pkg/awsutils/vpc_ip_resource_limit.go
@@ -275,7 +275,7 @@ var InstanceIPsAvailable = map[string]int64{
 	"p3.2xlarge":    15,
 	"p3.8xlarge":    30,
 	"p3.16xlarge":   30,
-	"p3dn.24xlarge": 50,
+	"p3dn.24xlarge": 31,
 	"r3.large":      10,
 	"r3.xlarge":     15,
 	"r3.2xlarge":    15,


### PR DESCRIPTION
While some instance types allow for more than 30 secondary IPs on ENIs,
there is an issue where the 32 IP forward will not be able to access
instance metadata, VPC DNS and Time Sync services.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
