### PR TITLE
Collect iptables -nvL -t mangle by support script

### DIFF
--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -48,6 +48,9 @@ iptables -nvL > $LOG_DIR/iptables.out
 # iptables -nvL -t nat
 iptables -nvL -t nat > $LOG_DIR/iptables-nat.out
 
+# iptables -nvL -t mangle
+iptables -nvL -t mangle > $LOG_DIR/iptables-mangle.out
+
 # dump cni config
 mkdir -p $LOG_DIR/cni
 cp /etc/cni/net.d/* $LOG_DIR/cni


### PR DESCRIPTION
*Description of changes:*

aws-k8s-agent adds iptables for CONNMARK target to magle table.

e.g
```
# iptables -nvL -t mangle 
Chain PREROUTING (policy ACCEPT 25324 packets, 8496K bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 CONNMARK   all  --  ens5   *       0.0.0.0/0            0.0.0.0/0            /* AWS, primary ENI */ ADDRTYPE match dst-type LOCAL limit-in CONNMARK or 0x80
    0     0 CONNMARK   all  --  eni+   *       0.0.0.0/0            0.0.0.0/0            /* AWS, primary ENI */ CONNMARK restore mask 0x80
```

To collect mangle tables info, this patch adds `iptables -nvL -t mangle`
to aws-cni-support.sh.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
