### PR TITLE
Use primary interface to add iptables for connmark entry

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -207,9 +207,10 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 		return errors.Wrapf(err, "host network setup: failed to delete old host rule")
 	}
 
+	primaryIntf := "eth0"
 	if n.nodePortSupportEnabled {
 
-		primaryIntf, err := findPrimaryInterfaceName(primaryMAC)
+		primaryIntf, err = findPrimaryInterfaceName(primaryMAC)
 
 		if err != nil {
 			return errors.Wrapf(err, "failed to SetupHostNetwork")
@@ -350,7 +351,7 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 		chain:       "PREROUTING",
 		rule: []string{
 			"-m", "comment", "--comment", "AWS, primary ENI",
-			"-i", "eth0",
+			"-i", primaryIntf,
 			"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
 			"-j", "CONNMARK", "--set-mark", fmt.Sprintf("%#x/%#x", n.mainENIMark, n.mainENIMark),
 		},

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -230,7 +230,7 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 		log.Debugf("Setting RPF for primary interface: %s", primaryIntfRPFilter)
 		err = n.setProcSys(primaryIntfRPFilter, rpFilterLoose)
 		if err != nil {
-			return errors.Wrapf(err, "failed to configure eth0 RPF check")
+			return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
 		}
 	}
 

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -255,7 +255,12 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
 
 	var vpcCIDRs []*string
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+
+	// loopback for primary device is a little bit hacky. But the test is stable and it should be
+	// OK for test purpose.
+	LoopBackMac := ""
+
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, LoopBackMac, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]map[string][][]string{
@@ -263,7 +268,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 			"PREROUTING": [][]string{
 				{
 					"-m", "comment", "--comment", "AWS, primary ENI",
-					"-i", "eth0",
+					"-i", "lo",
 					"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
 					"-j", "CONNMARK", "--set-mark", "0x80/0x80",
 				},


### PR DESCRIPTION
*Description of changes:*

Currently iptables for CONNMARK entry always uses `eth0`, even though
AWS EC2 instance does not always use eth0.

This fix uses primary interface name which was discovered dynamically.

Please also refer to https://github.com/aws/amazon-vpc-cni-k8s/pull/196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
