### PR TITLE
Fixed max-IPs for p3dn.24xlarge

### DIFF
--- a/pkg/awsutils/vpc_ip_resource_limit.go
+++ b/pkg/awsutils/vpc_ip_resource_limit.go
@@ -275,7 +275,7 @@ var InstanceIPsAvailable = map[string]int64{
 	"p3.2xlarge":    15,
 	"p3.8xlarge":    30,
 	"p3.16xlarge":   30,
-	"p3dn.24xlarge": 31,
+	"p3dn.24xlarge": 50,
 	"r3.large":      10,
 	"r3.xlarge":     15,
 	"r3.2xlarge":    15,


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

p3dn.24xlarge do not have the limitation of on IPs that 16xlarges do for f1, g3, h1, i3, and r4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
