### PR TITLE
Fix tiny typo in log message

### DIFF
--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -161,7 +161,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		return fmt.Errorf("add cmd: failed to assign an IP address to container")
 	}
 
-	log.Infof("Received add network response for pod %s namespace %s container %s: %s, table %d ,external-SNAT: %v, vpcCIDR: %v",
+	log.Infof("Received add network response for pod %s namespace %s container %s: %s, table %d, external-SNAT: %v, vpcCIDR: %v",
 		string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID),
 		r.IPv4Addr, r.DeviceNumber, r.UseExternalSNAT, r.VPCcidrs)
 


### PR DESCRIPTION
Consistently use '<comma><space>' to separate values in log messages, not '<space><comma>'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
