### PR TITLE
Bump CNI to latest 1.3 version

### DIFF
--- a/config/v1.3/aws-k8s-cni.yaml
+++ b/config/v1.3/aws-k8s-cni.yaml
@@ -68,7 +68,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.3.0
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.3.2
         imagePullPolicy: Always
         ports:
         - containerPort: 61678


### PR DESCRIPTION
The 1.3 branch points to the old CNI #321

*Description of changes:*
Use the latest v1.3.2 tag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
