### PR TITLE
Collect rp_filter from all network interface in aws-cni-support.sh

### DIFF
--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -66,7 +66,7 @@ ip route show table all >> $LOG_DIR/$ROUTE_OUTPUT
 
 # dump relevant sysctls
 echo "================== sysctls ==================" > ${LOG_DIR}/sysctls.out
-for f in /proc/sys/net/ipv4/conf/{all,default,eth0}/rp_filter; do
+for f in /proc/sys/net/ipv4/conf/*/rp_filter; do
   echo "$f = $(cat $f)" >> ${LOG_DIR}/sysctls.out
 done
 


### PR DESCRIPTION
### Description of changes:

Currently `aws-cni-support.sh` outputs rp_filter from `eth0`. Although
`eth0` is fixed value, some env have different name such as `ens5`,
so the script fails on non-eth0 env.

This patch changes the script to collect rp_filter from all interface on
the host.

### Issue

Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/213

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Additional Note
I considered to collect only specific interfaces, but I changed to
collect rp_filter from all interface with these reasons:

- To collect rp_filter from only primary interface, the script becomes complicated to read.
- Even if dumping `rp_filter` from all ENI, the lines are less than 100.
- All dump may find some unusual settings from other interfaces. So it still has some value.

