### PR TITLE
Set mainENIRule mask

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -241,6 +241,7 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 	// reversed so, to the routing table, it looks like the traffic is pod traffic instead of NodePort traffic.
 	mainENIRule := n.netLink.NewRule()
 	mainENIRule.Mark = int(n.mainENIMark)
+	mainENIRule.Mask = int(n.mainENIMark)
 	mainENIRule.Table = mainRoutingTable
 	mainENIRule.Priority = hostRulePriority
 	// If this is a restart, cleanup previous rule first


### PR DESCRIPTION
- Re-add the mask for the mainENIRule. Without this calico breaks NodePort traffic on secondary ENIs, as whilst the traffic is correctly marked by iptables, the ip rule that forces the traffic out of the primary ENI is impacted by other bits sets by calico in the mask

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
