### PR TITLE
add support for stdout logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Type: Integer
 Default: None  
 Specifies the maximum number of ENIs that will be attached to the node. When MAX_ENI is unset or 0 (or lower), the setting is not used, and the maximum number of ENIs is always equal to the maximum number for the instance type in question. Even when MAX_ENI is a positive number, it is limited by the maximum number for the instance type.
 
+`AWS_VPC_K8S_CNI_LOG_FILE`
+Type: String
+Default: Unset
+Valid Values: stdout or a file path
+Specifies where to write the logging output. Either to stdout or to override the default file.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server.  If it can **not** reach kubernetes API server, ipamD will exit and CNI will not be able to get any IP address for Pods.  Here is a way to confirm if `L-IPAMD` has access to the kubernetes API server.

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	envLogLevel    = "AWS_VPC_K8S_CNI_LOGLEVEL"
-	envLogOutput   = "AWS_VPC_K8S_CNI_LOG_OUTPUT"
 	envLogFilePath = "AWS_VPC_K8S_CNI_LOG_FILE"
 	// logConfigFormat defines the seelog format, with a rolling file
 	// writer. We cannot do this in code and have to resort to using
@@ -71,7 +70,7 @@ func getLogLevel() string {
 }
 
 func getLogOutput(logFilePath string) string {
-	switch strings.ToLower(os.Getenv(envLogOutput)) {
+	switch logFilePath {
 	case "stdout":
 		return `<console />`
 	default:

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -58,15 +58,16 @@ func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
 	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
 }
 
-func TestLogOutputReturnsFileWhenEnvNotSet(t *testing.T) {
-	var expectedOutput = `<rollingfile filename="foo" type="date" datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />`
-	assert.Equal(t, expectedOutput, getLogOutput("foo"))
+func TestLogOutputReturnsFileWhenValueNotStdout(t *testing.T) {
+	path := "/tmp/foo"
+
+	var expectedOutput = `<rollingfile filename="/tmp/foo" type="date" datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />`
+	assert.Equal(t, expectedOutput, getLogOutput(path))
 }
 
 func TestLogOutputReturnsConsole(t *testing.T) {
-	os.Setenv(envLogOutput, "stdout")
-	defer os.Unsetenv(envLogOutput)
+	path := "stdout"
 
 	var expectedOutput = `<console />`
-	assert.Equal(t, expectedOutput, getLogOutput(""))
+	assert.Equal(t, expectedOutput, getLogOutput(path))
 }

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -57,3 +57,16 @@ func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
 	expectedLogLevel = log.InfoLvl
 	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
 }
+
+func TestLogOutputReturnsFileWhenEnvNotSet(t *testing.T) {
+	var expectedOutput = `<rollingfile filename="foo" type="date" datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />`
+	assert.Equal(t, expectedOutput, getLogOutput("foo"))
+}
+
+func TestLogOutputReturnsConsole(t *testing.T) {
+	os.Setenv(envLogOutput, "stdout")
+	defer os.Unsetenv(envLogOutput)
+
+	var expectedOutput = `<console />`
+	assert.Equal(t, expectedOutput, getLogOutput(""))
+}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-vpc-cni-k8s/issues/135

*Description of changes:*

- Add env var (`AWS_VPC_K8S_CNI_LOG_OUTPUT`) for log output (log file is default, stdout is only other option)

Note: I took the least-friction approach I could think of for adding this. If anyone has a better idea/design for this support, I'd be happy to give it a shot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
