### PR TITLE
Retry LinkByMac when link not found

### DIFF
--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -15,10 +15,12 @@ package networkutils
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -86,10 +88,15 @@ func TestSetupENINetwork(t *testing.T) {
 
 	lo := mock_netlink.NewMockLink(ctrl)
 	eth1 := mock_netlink.NewMockLink(ctrl)
-	mockNetLink.EXPECT().LinkList().Return([]netlink.Link([]netlink.Link{lo, eth1}), nil)
-	// 2 links
+	// Emulate a delay attaching the ENI so a retry is necessary
+	// First attempt gets one links
+	firstlistSet := mockNetLink.EXPECT().LinkList().Return([]netlink.Link([]netlink.Link{lo}), nil)
+	lo.EXPECT().Attrs().Return(mockLinkAttrs1)
+	// Second attempt gets both links
+	secondlistSet := mockNetLink.EXPECT().LinkList().Return([]netlink.Link([]netlink.Link{lo, eth1}), nil)
 	lo.EXPECT().Attrs().Return(mockLinkAttrs1)
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
+	gomock.InOrder(firstlistSet, secondlistSet)
 
 	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	mockNetLink.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
@@ -105,16 +112,30 @@ func TestSetupENINetwork(t *testing.T) {
 	mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil)
 
 	mockNetLink.EXPECT().RouteDel(gomock.Any()).Return(nil)
-	err = setupENINetwork(testeniIP, testMAC2, testTable, testeniSubnet, mockNetLink)
+	err = setupENINetwork(testeniIP, testMAC2, testTable, testeniSubnet, mockNetLink, 0*time.Second)
 
 	assert.NoError(t, err)
+}
+
+func TestSetupENINetworkMACFail(t *testing.T) {
+	ctrl, mockNetLink, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	// Emulate a delay attaching the ENI so a retry is necessary
+	// First attempt gets one links
+	for i := 0; i < maxAttemptsLinkByMac; i++ {
+		mockNetLink.EXPECT().LinkList().Return(nil, fmt.Errorf("simulated failure"))
+	}
+	err := setupENINetwork(testeniIP, testMAC2, testTable, testeniSubnet, mockNetLink, 0*time.Second)
+
+	assert.Errorf(t, err, "simulated failure")
 }
 
 func TestSetupENINetworkPrimary(t *testing.T) {
 	ctrl, mockNetLink, _, _, _ := setup(t)
 	defer ctrl.Finish()
 
-	err := setupENINetwork(testeniIP, testMAC2, 0, testeniSubnet, mockNetLink)
+	err := setupENINetwork(testeniIP, testMAC2, 0, testeniSubnet, mockNetLink, 0*time.Second)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Fix for #204 

*Description of changes:*

We have observed that the first time `LinkByMac` is run after attaching a new ENI, there is a timing condition where can fail to find the ENI. An error is reported in the logs, but processing on the node continues. The routing table for that ENI never get set up, although IP addresses associated with the ENI are included in the IPAM pool. Example logs showing the IPs being allocated to the failed ENI.

```
2019-03-10T13:11:16Z [INFO] Successfully created and attached a new eni eni-0a975df1b2b06bc79 to instance
2019-03-10T13:11:16Z [INFO] Trying to allocate 14 IP address on eni eni-0a975df1b2b06bc79
2019-03-10T13:11:16Z [DEBUG] Found eni: eni-0a975df1b2b06bc79, mac 02:5a:96:2b:9b:a2, device 3
2019-03-10T13:11:16Z [DEBUG] DataStore Add an ENI eni-0a975df1b2b06bc79
2019-03-10T13:11:16Z [DEBUG] AssignPodIPv4Address, skip ENI eni-0a975df1b2b06bc79 that does not have available addresses
2019-03-10T13:11:17Z [ERROR] Failed to increase pool size: failed to setup eni eni-0a975df1b2b06bc79 network: eni network setup: failed to find the link which uses mac address 02:5a:96:2b:9b:a2: no interface found which uses mac address 02:5a:96:2b:9b:a2 
2019-03-10T13:11:22Z [DEBUG] AssignPodIPv4Address, skip ENI eni-0a975df1b2b06bc79 that does not have available addresses
2019-03-10T13:11:22Z [DEBUG] Found eni eni-0a975df1b2b06bc79 that have less IP address allocated: cur=0, max=14
2019-03-10T13:11:22Z [DEBUG] Attempt again to allocate IP address for eni :eni-0a975df1b2b06bc79
2019-03-10T13:11:22Z [INFO] Trying to allocate 14 IP address on eni eni-0a975df1b2b06bc79
2019-03-10T13:11:22Z [DEBUG] Adding ENI(eni-0a975df1b2b06bc79)'s IPv4 address 10.10.79.106 to datastore
```

This means that any pods scheduled with IPs on that ENI fail to perform networking. They are unable to talk to the internet through a NAT gateway (we use `AWS_VPC_K8S_CNI_EXTERNALSNAT`), or with other pods in the local k8s cluster.

This manifests as difficult to diagnose and at first inspection quite random networking failures in the cluster.  Hopefully, it is root cause for all of the various symptoms reported in #204.

The simple fix proposed here, is to follow the pattern of other functions in `network.go` and perform retry. To allow efficient unit testing, the retry delay `retryLinkByMacInterval ` is set as a code-configurable constant for callers from outside of the package, but passed as a parameter in the call so the unit test can set it to zero.

In our environment, we have a pipeline for our fork and have installed it into a number of test clusters. As of 14th March we are continuing to soak test, but have already encountered one example where the retry was required and succeeded after the first 5s retry, hence raising the PR:
```
2019-03-14T03:46:32Z [DEBUG] no interface found which uses mac address 02:bd:cf:ff:a6:e6 (attempt 1/5)
2019-03-14T03:46:37Z [DEBUG] Found the Link that uses mac address 02:bd:cf:ff:a6:e6 and its index is 13 (attempt 2/5)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
