### PR TITLE
Renaming all prometheus metrics to comply with  convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See the [README](README.md) for additional information.
 * Bug Fix - [Add logic to dynamically discover primary interface name](https://github.com/aws/amazon-vpc-cni-k8s/pull/196)
 
 ## 1.3.0
+
 * Feature - [Add logic to handle multiple VPC CIDRs](https://github.com/aws/amazon-vpc-cni-k8s/pull/234)
 * Improvement - [Update instance types](https://github.com/aws/amazon-vpc-cni-k8s/pull/229)
 * Improvement - [Add retry for plumbing route entry](https://github.com/aws/amazon-vpc-cni-k8s/pull/223)
@@ -46,5 +47,14 @@ See the [README](README.md) for additional information.
 * Bug Fix - [cleanup the host route when perform CNI delete](https://github.com/aws/amazon-vpc-cni-k8s/pull/228)
 
 ## 1.3.1
+
 * Feature - [Add ENI entries for p3dn.24xlarge](https://github.com/aws/amazon-vpc-cni-k8s/pull/295)
 * Bug Fix - [Restrict p3dn.24xlarge to 31 IPs/ENI](https://github.com/aws/amazon-vpc-cni-k8s/pull/300)
+
+## 1.3.2
+
+* Bug Fix - [Bump CNI to latest 1.3 version](https://github.com/aws/amazon-vpc-cni-k8s/pull/333)
+
+## 1.3.3
+
+* Improvement - [Renaming Prometheus metrics with "awscni_" prefix](https://github.com/aws/amazon-vpc-cni-k8s/pull/348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,6 @@ See the [README](README.md) for additional information.
 
 * Bug Fix - [Bump CNI to latest 1.3 version](https://github.com/aws/amazon-vpc-cni-k8s/pull/333)
 
-## 1.3.3
+## 1.4.0
 
 * Improvement - [Renaming Prometheus metrics with "awscni_" prefix](https://github.com/aws/amazon-vpc-cni-k8s/pull/348)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -150,12 +150,12 @@ ipamd.log.2018-05-16-01  ipamd.log.2018-05-16-06  ipamd.log.2018-05-16-11  ipamd
 ```
 // get ipamD metrics
 root@ip-192-168-188-7 bin]# curl http://localhost:61678/metrics
-# HELP assigned_ip_addresses The number of IP addresses assigned
-# TYPE assigned_ip_addresses gauge
-assigned_ip_addresses 46
-# HELP eni_allocated The number of ENI allocated
-# TYPE eni_allocated gauge
-eni_allocated 4
+# HELP awscni_assigned_ip_addresses The number of IP addresses assigned
+# TYPE awscni_assigned_ip_addresses gauge
+awscni_assigned_ip_addresses 46
+# HELP awscni_eni_allocated The number of ENI allocated
+# TYPE awscni_eni_allocated gauge
+awscni_eni_allocated 4
 # HELP eni_max The number of maximum ENIs can be attached to the instance
 # TYPE eni_max gauge
 eni_max 4

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,9 +156,9 @@ awscni_assigned_ip_addresses 46
 # HELP awscni_eni_allocated The number of ENI allocated
 # TYPE awscni_eni_allocated gauge
 awscni_eni_allocated 4
-# HELP eni_max The number of maximum ENIs can be attached to the instance
-# TYPE eni_max gauge
-eni_max 4
+# HELP awscni_eni_max The number of maximum ENIs can be attached to the instance
+# TYPE awscni_eni_max gauge
+awscni_eni_max 4
 # HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary
 go_gc_duration_seconds{quantile="0"} 5.6955e-05

--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -61,19 +61,19 @@ var ErrUnknownPodIP = errors.New("datastore: pod using unknown IP address")
 var (
 	enis = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "eni_allocated",
+			Name: "awscni_eni_allocated",
 			Help: "The number of ENIs allocated",
 		},
 	)
 	totalIPs = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "total_ip_addresses",
+			Name: "awscni_total_ip_addresses",
 			Help: "The total number of IP addresses",
 		},
 	)
 	assignedIPs = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "assigned_ip_addresses",
+			Name: "awscni_assigned_ip_addresses",
 			Help: "The number of IP addresses assigned to pods",
 		},
 	)

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -105,7 +105,7 @@ var (
 	)
 	enisMax = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "eni_max",
+			Name: "awscni_eni_max",
 			Help: "The maximum number of ENIs that can be attached to the instance",
 		},
 	)

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -91,14 +91,14 @@ const (
 var (
 	ipamdErr = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ipamd_error_count",
+			Name: "awscni_ipamd_error_count",
 			Help: "The number of errors encountered in ipamd",
 		},
 		[]string{"fn", "error"},
 	)
 	ipamdActionsInprogress = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "ipamd_action_inprogress",
+			Name: "awscni_ipamd_action_inprogress",
 			Help: "The number of ipamd actions inprogress",
 		},
 		[]string{"fn"},
@@ -111,26 +111,26 @@ var (
 	)
 	ipMax = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ip_max",
+			Name: "awscni_ip_max",
 			Help: "The maximum number of IP addresses that can be allocated to the instance",
 		},
 	)
 	reconcileCnt = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "reconcile_count",
+			Name: "awscni_reconcile_count",
 			Help: "The number of times ipamD reconciles on ENIs and IP addresses",
 		},
 		[]string{"fn"},
 	)
 	addIPCnt = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "add_ip_req_count",
+			Name: "awscni_add_ip_req_count",
 			Help: "The number of add IP address request",
 		},
 	)
 	delIPCnt = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "del_ip_req_count",
+			Name: "awscni_del_ip_req_count",
 			Help: "The number of delete IP address request",
 		},
 		[]string{"reason"},

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -69,21 +69,21 @@ var ErrENINotFound = errors.New("ENI is not found")
 var (
 	awsAPILatency = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "aws_api_lantency_ms",
+			Name: "awscni_aws_api_lantency_ms",
 			Help: "AWS API call latency in ms",
 		},
 		[]string{"api", "error"},
 	)
 	awsAPIErr = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "aws_api_error_count",
+			Name: "awscni_aws_api_error_count",
 			Help: "The number of times AWS API returns an error",
 		},
 		[]string{"api", "error"},
 	)
 	awsUtilsErr = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "aws_utils_error_count",
+			Name: "awscni_aws_utils_error_count",
 			Help: "The number of errors not handled in awsutils library",
 		},
 		[]string{"fn", "error"},


### PR DESCRIPTION
Fixes https://github.com/aws/amazon-vpc-cni-k8s/issues/337

The current metric names are not very informative or consistent with [metric and label conventions](https://prometheus.io/docs/practices/naming/). Specifically:

> A metric name should have a (single-word) application prefix relevant to the domain the metric belongs to

So in this PR I am prepending them all with `awscni_`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
