### PR TITLE
Avoid unbound variable error in CNI 1.4 RC1

### DIFF
--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -32,7 +32,7 @@ curl http://localhost:61678/v1/eni-configs  > ${LOG_DIR}/eni-configs.out
 curl http://localhost:61678/metrics 2>&1 > ${LOG_DIR}/metrics.out
 
 # Collecting kubelet introspection data
-if [[ -n "${KUBECONFIG}" ]]; then
+if [[ -n "${KUBECONFIG:-}" ]]; then
     command -v kubectl > /dev/null && kubectl get --kubeconfig=${KUBECONFIG} --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
 elif [[ -f /etc/systemd/system/kubelet.service ]]; then
     KUBECONFIG=`grep kubeconfig /etc/systemd/system/kubelet.service | awk '{print $2}'`


### PR DESCRIPTION
After upgrading to the latest release candidate, SSHing into the host machines, running as root /opt/cni/bin/aws-cni-support.sh gets the following error:
```
/opt/cni/bin/aws-cni-support.sh: line 35: KUBECONFIG: unbound variable
```
`set -u` will abort here so in the bracket test, see if the parameter is set and non-empty using an empty default value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
