### PR TITLE
Avoid unbound variable error

### DIFF
--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -32,7 +32,7 @@ curl http://localhost:61678/v1/eni-configs  > ${LOG_DIR}/eni-configs.out
 curl http://localhost:61678/metrics 2>&1 > ${LOG_DIR}/metrics.out
 
 # Collecting kubelet introspection data
-if [[ -n "${KUBECONFIG}" ]]; then
+if [[ -n "${KUBECONFIG:-}" ]]; then
     command -v kubectl > /dev/null && kubectl get --kubeconfig=${KUBECONFIG} --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
 elif [[ -f /etc/systemd/system/kubelet.service ]]; then
     KUBECONFIG=`grep kubeconfig /etc/systemd/system/kubelet.service | awk '{print $2}'`


### PR DESCRIPTION
/opt/cni/bin/aws-cni-support.sh: line 35: KUBECONFIG: unbound variable
set -u will abort here so see if the parameter is set and non-empty using an empty default value.

Pull request #382

(cherry picked from commit a34eae12dfcf8f275449e8f204e2f8cbc2d3c23c)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
