### PR TITLE
Fixed typos in json types for ENIConfig

### DIFF
--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -23,8 +23,8 @@ type ENIConfig struct {
 
 type ENIConfigSpec struct {
 	// Fill me
-	SecurityGroups []string `json:"securitygroups"`
-	Subnet         string   `json: "subnet"`
+	SecurityGroups []string `json:"securityGroups"`
+	Subnet         string   `json:"subnet"`
 }
 type ENIConfigStatus struct {
 	// Fill me


### PR DESCRIPTION
TL;DR this is necessary in order for CNI Custom Networking to work in 1.4.

*Description of changes:*
With the new crd updates, json fields are case sensitive. A space turned `subnet` to be capitalized, and the docs expect `securityGroup`. This resulted in the subnet and security groups not be found so the ENI wasn't created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
