### PR TITLE
Reinstate FELIX_IPTABLESMANGLEALLOWACTION and clear cpu req

### DIFF
--- a/config/v1.3/calico.yaml
+++ b/config/v1.3/calico.yaml
@@ -62,6 +62,10 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # This will make Felix honor AWS VPC CNI's mangle table
+            # rules.
+            - name: FELIX_IPTABLESMANGLEALLOWACTION
+              value: Return
             # Disable IPV6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
@@ -86,9 +90,6 @@ spec:
               value: "true"
           securityContext:
             privileged: true
-          resources:
-            requests:
-              cpu: 250m
           livenessProbe:
             httpGet:
               path: /liveness
@@ -423,6 +424,10 @@ spec:
               value: "1"
             - name: TYPHA_HEALTHENABLED
               value: "true"
+            # This will make Felix honor AWS VPC CNI's mangle table
+            # rules.
+            - name: FELIX_IPTABLESMANGLEALLOWACTION
+              value: Return              
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
*Description of changes:*

We hit two issues after the latest `config/v1.3/calico.yaml` configuration was picked up in our pipeline for v1.3 based dev environments.
The core changes to the YAML configs were to update Calico from `v3.1.3` to `v3.3.6`, but it was the ancillary changes that affected us.
Both had pretty obscure symptoms, which burned cycles to resolve, so I wanted to share the attached changes we had to make to recover the environments in case it's helpful to others.

1) The updated YAML added new `250m` CPU requests
  In our environments this stalls the rolling upgrade.
  We were left with nodes with no `calico-node` daemonset pods, which is a subtle symptom, as it only affects networking to pods scheduled on that node that requires Calico.
  Note a stalled update does not leave pods in `Pending` state for a Daemonset, so it's hard to spot.
  The root cause was there was no space to allocate the pods, because other pods were utilizing the available requests on the node.

2) The `FELIX_IPTABLESMANGLEALLOWACTION` env var was removed
  This resulted in dropped packets on certain routes through the cluster. The behaviour here is also very subtle as routing from Load Balancer -> Node -> kube-proxy -> Nginx -> Pod is a number of network hops. Only certain routes would fail, so the failures at first seem random.

I understand these changes might have been intentional to the v1.3 config, and maybe if we picked up other co-requisite to the Go code in v1.3 changes we might not have hit this. We're on a fork there because of another issue we had a fix for.

However, others might hit the same so I wanted to share back.