### PR TITLE
Adding additional CRD for Calico that was missing.

### DIFF
--- a/config/v1.4/calico.yaml
+++ b/config/v1.4/calico.yaml
@@ -175,6 +175,19 @@ spec:
     singular: bgpconfiguration
 
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+---
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Description of changes: The Calico deployment was missing a CRD causing it to have errors. I have added the missing CRD to remove the errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
