### PR TITLE
Adding additional CRD for Calico that was missing.

### DIFF
--- a/config/v1.4/calico.yaml
+++ b/config/v1.4/calico.yaml
@@ -176,6 +176,19 @@ spec:
     singular: bgpconfiguration
 
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+---
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
*Description of changes:*

Cherry picked https://github.com/aws/amazon-vpc-cni-k8s/pull/406 to the release-1.4 branch.

(cherry picked from commit 92b46e1f8e8445370a72bdc68e880195fcb00c79)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
