### PR TITLE
Remove unExpectedMaxENIAttached error case

### DIFF
--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -449,10 +449,6 @@ func (c *IPAMContext) increaseIPPool() {
 		return
 	}
 	if (c.maxENI > 0) && (c.maxENI == c.dataStore.GetENIs()) {
-		if c.maxENI < maxENIs {
-			errString := "desired: " + strconv.FormatInt(int64(maxENIs), 10) + "current: " + strconv.FormatInt(int64(c.maxENI), 10)
-			ipamdErrInc("unExpectedMaxENIAttached", errors.New(errString))
-		}
 		log.Debugf("Skipping increase IP pool due to max ENI already attached to the instance : %d", c.maxENI)
 		return
 	}


### PR DESCRIPTION
Currently only a metric is emitted.  This should be removed because
I don't think we care when this happens and it's clutter.

The case is true when the discovered c.maxENI (which happens when
an ENI fails to be allocated due to maxENIs already present on the
instance) is less than maxENIs (either the env var or the maximum
allowed by the instance).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
