### PR TITLE
Remove globalfelixconfigs and globalbgpconfigs from calico config

### DIFF
--- a/config/v1.4/calico.yaml
+++ b/config/v1.4/calico.yaml
@@ -362,10 +362,8 @@ rules:
       - list
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - globalfelixconfigs
       - felixconfigurations
       - bgppeers
-      - globalbgpconfigs
       - bgpconfigurations
       - ippools
       - globalnetworkpolicies


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removed globalfelixconfigs and globalbgpconfigs from calico config following conversation https://github.com/aws/amazon-vpc-cni-k8s/pull/406#issuecomment-487150036

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
