### PR TITLE
Add a nodeSelector to the calico autoscaler

### DIFF
--- a/config/v1.4/calico.yaml
+++ b/config/v1.4/calico.yaml
@@ -548,6 +548,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a `nodeSelector` to the Calico Typha cluster-proportional auto-scaler to make sure it only runs on Linux nodes.  The rest of the components have a `nodeSelector` but this one was missed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
