### PR TITLE
Add flag to disable metrics and introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ Default: Unset
 Valid Values: stdout or a file path
 Specifies where to write the logging output. Either to stdout or to override the default file.
 
+`DISABLE_INTROSPECTION`
+Type: Boolean
+Default: `false`
+Specifies whether introspection endpoints are disabled on a worker node. Setting this to `true` will reduce the debugging 
+information we can get from the node when running the `aws-cni-support.sh` script.
+
+`DISABLE_METRICS`
+Type: Boolean
+Default: `false`
+Specifies whether prometeus metrics endpoints are enabled on a worker node.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server.  If it can **not** reach kubernetes API server, ipamD will exit and CNI will not be able to get any IP address for Pods.  Here is a way to confirm if `L-IPAMD` has access to the kubernetes API server.

--- a/config/v1.3/aws-k8s-cni.yaml
+++ b/config/v1.3/aws-k8s-cni.yaml
@@ -69,7 +69,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.3.3
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.3.4
         imagePullPolicy: Always
         ports:
         - containerPort: 61678
@@ -126,5 +126,3 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-
-

--- a/ipamd/metrics.go
+++ b/ipamd/metrics.go
@@ -1,0 +1,72 @@
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils"
+)
+
+const (
+	// metricsPort is the port for prometheus metrics
+	metricsPort = 61678
+
+	// Environment variable to disable the metrics endpoint on 61678
+	envDisableMetrics = "DISABLE_METRICS"
+)
+
+// ServeMetrics sets up ipamd metrics and introspection endpoints
+func (c *IPAMContext) ServeMetrics() {
+	if disableMetrics() {
+		log.Info("Metrics endpoint disabled")
+		return
+	}
+
+	log.Info("Serving metrics on port ", metricsPort)
+	server := c.setupMetricsServer()
+	for {
+		once := sync.Once{}
+		_ = utils.RetryWithBackoff(utils.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
+			err := server.ListenAndServe()
+			once.Do(func() {
+				log.Error("Error running http API: ", err)
+			})
+			return err
+		})
+	}
+}
+
+func (c *IPAMContext) setupMetricsServer() *http.Server {
+	serveMux := http.NewServeMux()
+	serveMux.Handle("/metrics", promhttp.Handler())
+	server := &http.Server{
+		Addr:         ":" + strconv.Itoa(metricsPort),
+		Handler:      serveMux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+	return server
+}
+
+// disableMetrics returns true if we should disable metrics
+func disableMetrics() bool {
+	return getEnvBoolWithDefault(envDisableMetrics, false)
+}

--- a/main.go
+++ b/main.go
@@ -60,13 +60,24 @@ func _main() int {
 	awsK8sAgent, err := ipamd.New(discoverController, eniConfigController)
 
 	if err != nil {
-		log.Error("initialization failure", err)
+		log.Error("Initialization failure ", err)
 		return 1
 	}
 
+	// Pool manager
 	go awsK8sAgent.StartNodeIPPoolManager()
-	go awsK8sAgent.SetupHTTP()
-	awsK8sAgent.RunRPCHandler()
+
+	// Prometheus metrics
+	go awsK8sAgent.ServeMetrics()
+
+	// CNI introspection endpoints
+	go awsK8sAgent.ServeIntrospection()
+
+	err = awsK8sAgent.RunRPCHandler()
+	if err != nil {
+		log.Error("Failed to set up gRPC handler ", err)
+		return 1
+	}
 
 	return 0
 }

--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -17,18 +17,18 @@
 # Set language to C to make sorting consistent among different environments.
 export LANG=C
 
-set -euo pipefail
+set -uo pipefail
 LOG_DIR="/var/log/aws-routed-eni"
 mkdir -p ${LOG_DIR}
 
-# collecting L-IPAMD introspection data
-curl http://localhost:61678/v1/enis         > ${LOG_DIR}/eni.out
-curl http://localhost:61678/v1/pods         > ${LOG_DIR}/pod.out
-curl http://localhost:61678/v1/networkutils-env-settings > ${LOG_DIR}/networkutils-env.out
-curl http://localhost:61678/v1/ipamd-env-settings > ${LOG_DIR}/ipamd-env.out
-curl http://localhost:61678/v1/eni-configs  > ${LOG_DIR}/eni-configs.out
+# Collecting L-IPAMD introspection data
+curl http://localhost:61679/v1/enis         > ${LOG_DIR}/eni.out
+curl http://localhost:61679/v1/pods         > ${LOG_DIR}/pod.out
+curl http://localhost:61679/v1/networkutils-env-settings > ${LOG_DIR}/networkutils-env.out
+curl http://localhost:61679/v1/ipamd-env-settings > ${LOG_DIR}/ipamd-env.out
+curl http://localhost:61679/v1/eni-configs  > ${LOG_DIR}/eni-configs.out
 
-# metrics
+# Metrics
 curl http://localhost:61678/metrics 2>&1 > ${LOG_DIR}/metrics.out
 
 # Collecting kubelet introspection data
@@ -80,4 +80,4 @@ for f in /proc/sys/net/ipv4/conf/*/rp_filter; do
   echo "$f = $(cat ${f})" >> ${LOG_DIR}/sysctls.out
 done
 
-tar -cvzf ${LOG_DIR}/aws-cni-support.tar.gz ${LOG_DIR}/
+tar --exclude 'aws-cni-support.tar.gz' -cvzf ${LOG_DIR}/aws-cni-support.tar.gz ${LOG_DIR}/


### PR DESCRIPTION
Issue #, if available:

Cherry pick of #433

Description of changes:

Adds the environment variables `DISABLE_INTROSPECTION` and `DISABLE_METRICS`
to make it possible to turn off metrics and debugging. Updates the log collector script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.