### PR TITLE
Revert "Remove globalfelixconfigs and globalbgpconfigs from calico config"

### DIFF
--- a/config/v1.4/calico.yaml
+++ b/config/v1.4/calico.yaml
@@ -362,8 +362,10 @@ rules:
       - list
   - apiGroups: ["crd.projectcalico.org"]
     resources:
+      - globalfelixconfigs
       - felixconfigurations
       - bgppeers
+      - globalbgpconfigs
       - bgpconfigurations
       - ippools
       - globalnetworkpolicies


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-k8s#421, fixed #450

Put the permissions back. For more details, see #421