### PR TITLE
Remove error message from Prometheus labels

### DIFF
--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -98,7 +98,7 @@ var (
 			Name: "awscni_ipamd_error_count",
 			Help: "The number of errors encountered in ipamd",
 		},
-		[]string{"fn", "error"},
+		[]string{"fn"},
 	)
 	ipamdActionsInprogress = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -807,7 +807,7 @@ func (c *IPAMContext) nodeIPPoolTooHigh() bool {
 }
 
 func ipamdErrInc(fn string, err error) {
-	ipamdErr.With(prometheus.Labels{"fn": fn, "error": err.Error()}).Inc()
+	ipamdErr.With(prometheus.Labels{"fn": fn}).Inc()
 }
 
 // nodeIPPoolReconcile reconcile ENI and IP info from metadata service and IP addresses in datastore


### PR DESCRIPTION
Fixes #112 

Remove error message from Prometheus labels to limit the number of unique labels, in line with [best practice](https://prometheus.io/docs/practices/naming/#labels)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
