### PR TITLE
Update logging format to align messages

### DIFF
--- a/cni-metrics-helper/metrics/metrics.go
+++ b/cni-metrics-helper/metrics/metrics.go
@@ -199,7 +199,7 @@ func postProcessingHistogram(convert metricsConvert) bool {
 	for _, action := range convert.actions {
 		numOfBuckets := len(action.bucket.curBucket)
 		if numOfBuckets == 0 {
-			glog.Info(" Post Histogram Processing: no bucket found")
+			glog.Info("Post Histogram Processing: no bucket found")
 			continue
 		}
 		for i := 1; i < numOfBuckets; i++ {

--- a/ipamd/introspect.go
+++ b/ipamd/introspect.go
@@ -44,7 +44,7 @@ type LoggingHandler struct {
 }
 
 func (lh LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Info("Handling http request: ", ", method: ", r.Method, ", from: ", r.RemoteAddr, ", URI: ", r.RequestURI)
+	log.Infof("Handling http request: %s, from: %s, URI: %s", r.Method, r.RemoteAddr, r.RequestURI)
 	lh.h.ServeHTTP(w, r)
 }
 

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -337,7 +337,7 @@ func (c *IPAMContext) nodeInit() error {
 		_, _, err = c.dataStore.AssignPodIPv4Address(ip)
 		if err != nil {
 			ipamdErrInc("nodeInitAssignPodIPv4AddressFailed", err)
-			log.Warnf("During ipamd init, failed to use pod ip %s returned from Kubelet %v", ip.IP, err)
+			log.Warnf("During ipamd init, failed to use pod IP %s returned from Kubelet %v", ip.IP, err)
 			// TODO continue, but need to add node health stats here
 			// TODO need to feed this to controller on the health of pod and node
 			// This is a bug among kubelet/cni-plugin/l-ipamd/ec2-metadata that this particular pod is using an non existent ip address.
@@ -452,7 +452,7 @@ func (c *IPAMContext) decreaseIPPool(interval time.Duration) {
 	logPoolStats(total, used, c.currentMaxAddrsPerENI, c.maxAddrsPerENI)
 }
 
-// tryFreeENI always trys to free one ENI
+// tryFreeENI always tries to free one ENI
 func (c *IPAMContext) tryFreeENI() {
 	warmIPTarget := getWarmIPTarget()
 
@@ -637,7 +637,7 @@ func (c *IPAMContext) tryAllocateENI() {
 
 	maxIPPerENI, err := c.awsClient.GetENIipLimit()
 	if err != nil {
-		log.Infof("Failed to retrieve ENI IP limit: %v", err)
+		log.Warnf("Failed to retrieve ENI IP limit: %v", err)
 		return
 	}
 
@@ -1009,7 +1009,7 @@ func (c *IPAMContext) eniIPPoolReconcile(ipPool map[string]*datastore.AddressInf
 					if isReallyAttachedToENI {
 						c.reconcileCooldownCache.Remove(localIP)
 					} else {
-						log.Warnf(" Skipping IP %s on ENI %s because it does not belong to this ENI!.", localIP, eni)
+						log.Warnf("Skipping IP %s on ENI %s because it does not belong to this ENI!.", localIP, eni)
 						continue
 					}
 				}

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -136,7 +136,7 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 			h.controller.eniLock.Lock()
 			defer h.controller.eniLock.Unlock()
 			h.controller.myENI = val
-			log.Infof(" Setting myENI to: %s", val)
+			log.Infof("Setting myENI to: %s", val)
 		}
 	}
 	return nil

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -220,7 +220,7 @@ func (d *Controller) handlePodUpdate(key string) error {
 	}
 
 	if !exists {
-		log.Infof(" Pods deleted on my node: %v", key)
+		log.Infof("Pods deleted on my node: %v", key)
 		d.workerPodsLock.Lock()
 		defer d.workerPodsLock.Unlock()
 		delete(d.workerPods, key)
@@ -253,12 +253,12 @@ func (d *Controller) handlePodUpdate(key string) error {
 			IP:        pod.Status.PodIP,
 		}
 
-		log.Infof(" Add/Update for Pod %s on my node, namespace = %s, IP = %s", podName, d.workerPods[key].Namespace, d.workerPods[key].IP)
+		log.Infof("Add/Update for Pod %s on my node, namespace = %s, IP = %s", podName, d.workerPods[key].Namespace, d.workerPods[key].IP)
 	} else if strings.HasPrefix(key, metav1.NamespaceSystem+"/"+cniPodName) {
 		d.cniPodsLock.Lock()
 		defer d.cniPodsLock.Unlock()
 
-		log.Infof(" Add/Update for CNI pod %s", podName)
+		log.Infof("Add/Update for CNI pod %s", podName)
 		d.cniPods[podName] = podName
 	}
 	return nil

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -34,7 +34,7 @@ const (
   %s
  </outputs>
  <formats>
-  <format id="main" format="%%UTCDate(2006-01-02T15:04:05Z07:00) [%%LEVEL] %%Msg%%n" />
+  <format id="main" format="%%UTCDate(2006-01-02T15:04:05Z07:00) [%%LEVEL]%%t%%Msg%%n" />
  </formats>
 </seelog>
 `
@@ -46,7 +46,6 @@ func GetLogFileLocation(defaultLogFilePath string) string {
 	if logFilePath == "" {
 		logFilePath = defaultLogFilePath
 	}
-
 	return logFilePath
 }
 
@@ -57,7 +56,11 @@ func SetupLogger(logFilePath string) {
 		fmt.Println("Error setting up logger: ", err)
 		return
 	}
-	log.ReplaceLogger(logger)
+	err = log.ReplaceLogger(logger)
+	if err != nil {
+		fmt.Println("Error replacing logger: ", err)
+		return
+	}
 }
 
 func getLogLevel() string {
@@ -65,7 +68,6 @@ func getLogLevel() string {
 	if !ok {
 		seelogLevel = log.InfoLvl
 	}
-
 	return seelogLevel.String()
 }
 


### PR DESCRIPTION
*Description of changes:*
Use a tab instead of a space after the log level. Example of log output:
```
2019-05-16T19:31:39Z [DEBUG]	Discovered ENI eni-053402f8bf3d6c1a7, trying to set it up
2019-05-16T19:31:39Z [DEBUG]	DataStore Add an ENI eni-053402f8bf3d6c1a7
2019-05-16T19:31:39Z [INFO]	Synced successfully with APIServer
2019-05-16T19:31:39Z [INFO]	Add/Update for Pod cni-metrics-helper-688f4747cf-chvvm on my node, namespace = kube-system, IP = 172.31.2.95
2019-05-16T19:31:39Z [INFO]	Add/Update for Pod coredns-7d77776957-hmj5p on my node, namespace = kube-system, IP = 172.31.3.20
2019-05-16T19:31:39Z [INFO]	Add/Update for CNI pod aws-node-p6htp
2019-05-16T19:31:39Z [INFO]	Add/Update for CNI pod aws-node-gp6j4
2019-05-16T19:31:39Z [INFO]	Add/Update for CNI pod aws-node-rqz2m
2019-05-16T19:31:39Z [INFO]	Add/Update for Pod coredns-7d77776957-cdpsc on my node, namespace = kube-system, IP = 172.31.10.37
2019-05-16T19:31:39Z [DEBUG]	Adding ENI(eni-053402f8bf3d6c1a7)'s IPv4 address 172.31.10.110 to datastore
2019-05-16T19:31:39Z [DEBUG]	IP Address Pool stats: total: 0, assigned: 0
2019-05-16T19:31:39Z [INFO]	Added ENI(eni-053402f8bf3d6c1a7)'s IP 172.31.10.110 to datastore
2019-05-16T19:31:39Z [DEBUG]	Adding ENI(eni-053402f8bf3d6c1a7)'s IPv4 address 172.31.3.254 to datastore
2019-05-16T19:31:39Z [DEBUG]	IP Address Pool stats: total: 1, assigned: 0
2019-05-16T19:31:39Z [INFO]	Added ENI(eni-053402f8bf3d6c1a7)'s IP 172.31.3.254 to datastore
2019-05-16T19:31:39Z [DEBUG]	Adding ENI(eni-053402f8bf3d6c1a7)'s IPv4 address 172.31.2.149 to datastore
2019-05-16T19:31:39Z [DEBUG]	IP Address Pool stats: total: 2, assigned: 0
2019-05-16T19:31:39Z [INFO]	Added ENI(eni-053402f8bf3d6c1a7)'s IP 172.31.2.149 to datastore
2019-05-16T19:31:39Z [INFO]	ENI eni-053402f8bf3d6c1a7 set up.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
