### PR TITLE
Update metrics-helper link and readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ ifeq ($(ARCH),x86_64)
   ARCH = amd64
 endif
 
+# Default to build the Linux binary
+build-linux:
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "$(LDFLAGS)"
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-cni -ldflags "$(LDFLAGS)" ./plugins/routed-eni/
+
 # Download portmap plugin
 download-portmap:
 	mkdir -p tmp/downloads
@@ -36,11 +41,6 @@ download-portmap:
 	tar -vxf tmp/downloads/cni-plugins-$(ARCH).tgz -C tmp/plugins
 	cp tmp/plugins/portmap .
 	rm -rf tmp
-
-# Default to build the Linux binary
-build-linux:
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "$(LDFLAGS)"
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-cni -ldflags "$(LDFLAGS)" ./plugins/routed-eni/
 
 # Build CNI Docker image
 docker:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ L-IPAM requires following [IAM policy](https://docs.aws.amazon.com/IAM/latest/Us
          "ec2:DescribeNetworkInterfaces",
          "ec2:DescribeInstances",
          "ec2:ModifyNetworkInterfaceAttribute",
-         "ec2:AssignPrivateIpAddresses"
+         "ec2:AssignPrivateIpAddresses",
+         "ec2:UnassignPrivateIpAddresses"
      ],
      "Resource": [
          "*"
@@ -58,9 +59,10 @@ L-IPAM requires following [IAM policy](https://docs.aws.amazon.com/IAM/latest/Us
 ## Building
 
 * `make` defaults to `make build-linux` that builds the Linux binaries.
-* `make docker-build` uses a docker container (golang:1.10) to build the binaries.
-* `make docker` will create a docker container using the docker-build with the finished binaries, with a tag of `amazon/amazon-k8s-cni:latest`
 * `unit-test`, `lint` and `vet` provide ways to run the respective tests/tools and should be run before submitting a PR.
+* `make docker` will create a docker container using the docker-build with the finished binaries, with a tag of `amazon/amazon-k8s-cni:latest`
+* `make docker-build` uses a docker container (golang:1.12) to build the binaries.
+* `make docker-unit-tests` uses a docker container (golang:1.12) to run all unit tests.
 
 ## Components
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ As described in [Proposal: CNI plugin for Kubernetes networking over AWS VPC](./
 A node, based on the instance type ([Limit](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI)), can have up to N ENIs and M addresses. The maximum number of IP addresses available to Pods on this node is min((N*M -N), subnet's free IP)
 
 ### Tip: Make sure subnet have enough available addresses
- If a subnet runs out of IP addresses, ipamD will not able to get secondary IP addresses.  When this happens, pods assigned to this node may not able to get an IP and get stucked in ** ContainerCreating**.
+If a subnet runs out of IP addresses, ipamD will not able to get secondary IP addresses. When this happens, pods assigned to this node may not able to get an IP and get stucked in ** ContainerCreating**.
 
 You can check the available IP addresses in AWS console:
 ![](images/subnet.png)
@@ -16,7 +16,7 @@ You can check the available IP addresses in AWS console:
 
 ### Tip: Make sure there are enough ENIs and IPs for Pods in the cluster
 
-We provide a tool [**cni-metrics-helper**](../misc/cni_metrics_helper.yaml) which can show aggregated ENIs and IPs information at the cluster level.  
+We provide a tool [**cni-metrics-helper**](../config/v1.4/cni-metrics-helper.yaml) which can show aggregated ENIs and IPs information at the cluster level.
 
 You can optionally push them to cloudwatch.  For example:
 


### PR DESCRIPTION
*Issue #, if available:* #465, #476

*Description of changes:*
* Make `build-linux` the default target
* Update build instructions in readme
* Update link to `cni-metrics-helper.yaml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
