### PR TITLE
Remove unused function

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -550,37 +550,6 @@ func TestAllocIPAddressOnErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestAllocAllIPAddress(t *testing.T) {
-	ctrl, _, mockEC2 := setup(t)
-	defer ctrl.Finish()
-
-	// the expected addresses for t2.nano
-	input := &ec2.AssignPrivateIpAddressesInput{
-		NetworkInterfaceId:             aws.String("eni-id"),
-		SecondaryPrivateIpAddressCount: aws.Int64(1),
-	}
-	mockEC2.EXPECT().AssignPrivateIpAddresses(input).Return(nil, nil)
-
-	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "t2.nano"}
-
-	err := ins.AllocAllIPAddress("eni-id")
-
-	assert.NoError(t, err)
-
-	// the expected addresses for c5n.18xlarge
-	input = &ec2.AssignPrivateIpAddressesInput{
-		NetworkInterfaceId:             aws.String("eni-id"),
-		SecondaryPrivateIpAddressCount: aws.Int64(49),
-	}
-	mockEC2.EXPECT().AssignPrivateIpAddresses(input).Return(nil, nil)
-
-	ins = &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "c5n.18xlarge"}
-
-	err = ins.AllocAllIPAddress("eni-id")
-
-	assert.NoError(t, err)
-}
-
 func TestAllocIPAddresses(t *testing.T) {
 	ctrl, _, mockEC2 := setup(t)
 	defer ctrl.Finish()
@@ -615,19 +584,4 @@ func TestAllocIPAddresses(t *testing.T) {
 	err = ins.AllocIPAddresses("eni-id", 0)
 
 	assert.NoError(t, err)
-}
-
-func TestAllocAllIPAddressOnErr(t *testing.T) {
-	ctrl, _, mockEC2 := setup(t)
-	defer ctrl.Finish()
-
-	// 2 addresses
-	mockEC2.EXPECT().AssignPrivateIpAddresses(gomock.Any()).Return(nil, nil)
-	mockEC2.EXPECT().AssignPrivateIpAddresses(gomock.Any()).Return(nil, errors.New("Error on AssignPrivateIpAddresses"))
-
-	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-
-	err := ins.AllocAllIPAddress("eni-id")
-
-	assert.Error(t, err)
 }

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -48,18 +48,6 @@ func (m *MockAPIs) EXPECT() *MockAPIsMockRecorder {
 	return m.recorder
 }
 
-// AllocAllIPAddress mocks base method
-func (m *MockAPIs) AllocAllIPAddress(arg0 string) error {
-	ret := m.ctrl.Call(m, "AllocAllIPAddress", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AllocAllIPAddress indicates an expected call of AllocAllIPAddress
-func (mr *MockAPIsMockRecorder) AllocAllIPAddress(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocAllIPAddress", reflect.TypeOf((*MockAPIs)(nil).AllocAllIPAddress), arg0)
-}
-
 // AllocENI mocks base method
 func (m *MockAPIs) AllocENI(arg0 bool, arg1 []*string, arg2 string) (string, error) {
 	ret := m.ctrl.Call(m, "AllocENI", arg0, arg1, arg2)


### PR DESCRIPTION
*Description of changes:*
* We had both `AllocAllIPAddress()` and `AllocIPAddresses()`, but only the later was ever used.
* The `err` parameter to the prometheus metrics is never used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
