### PR TITLE
Add milliseconds to log format

### DIFF
--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -34,7 +34,7 @@ const (
   %s
  </outputs>
  <formats>
-  <format id="main" format="%%UTCDate(2006-01-02T15:04:05Z07:00) [%%LEVEL]%%t%%Msg%%n" />
+  <format id="main" format="%%UTCDate(2006-01-02T15:04:05.000Z07:00) [%%LEVEL]%%t%%Msg%%n" />
  </formats>
 </seelog>
 `


### PR DESCRIPTION
*Description of changes:*
Adding milliseconds to help troubleshoot events that could relate with other services that has this measure in their logs, like calico.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
