### PR TITLE
Use priorityClassName for pod priority

### DIFF
--- a/config/v1.5/calico.yaml
+++ b/config/v1.5/calico.yaml
@@ -18,13 +18,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -412,9 +407,9 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -552,9 +547,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:


### PR DESCRIPTION
*Issue #, if available:* 

Follow up to #496 

`scheduler.alpha.kubernetes.io/critical-pod: ''` is being [deprecated in 1.13](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical)

*Description of changes:*
* Add `system-node-critical` to `calico-node`
* Add `system-cluster-critical` to `calico-typha` and `calico-typha-autoscaler`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
