### PR TITLE
Error when newly required env var is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Type: Boolean
 Default: `false`
 Specifies whether prometeus metrics endpoints are enabled on a worker node.
 
+`MY_NODE_NAME`
+Type: String
+Default: Unset
+Specifies the local node name to use when filtering pods from the kubernetes API.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server. If it can **not** reach

--- a/cni-metrics-helper/cni-metrics-helper.go
+++ b/cni-metrics-helper/cni-metrics-helper.go
@@ -85,7 +85,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	discoverController := k8sapi.NewController(kubeClient)
+	discoverController, err := k8sapi.NewController(kubeClient)
+	if err != nil {
+		glog.Errorf("Failed to create controller: %v", err)
+		os.Exit(1)
+	}
 	go discoverController.DiscoverK8SPods()
 
 	var cw publisher.Publisher

--- a/main.go
+++ b/main.go
@@ -49,7 +49,11 @@ func _main() int {
 		return 1
 	}
 
-	discoverController := k8sapi.NewController(kubeClient)
+	discoverController, err := k8sapi.NewController(kubeClient)
+	if err != nil {
+		log.Error("Initialization failure ", err)
+		return 1
+	}
 	go discoverController.DiscoverK8SPods()
 
 	eniConfigController := eniconfig.NewENIConfigController()

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -72,11 +72,14 @@ type Controller struct {
 }
 
 // NewController creates a new DiscoveryController
-func NewController(clientset kubernetes.Interface) *Controller {
+func NewController(clientset kubernetes.Interface) (*Controller, error) {
+	if os.Getenv("MY_NODE_NAME") == "" {
+		return nil, errors.New("env var MY_NODE_NAME must not be blank")
+	}
 	return &Controller{kubeClient: clientset,
 		myNodeName: os.Getenv("MY_NODE_NAME"),
 		cniPods:    make(map[string]string),
-		workerPods: make(map[string]*K8SPodInfo)}
+		workerPods: make(map[string]*K8SPodInfo)}, nil
 }
 
 // CreateKubeClient creates a k8s client


### PR DESCRIPTION
https://github.com/aws/amazon-vpc-cni-k8s/commit/463e880d06c850246374838a384355d87506de8c swapped discovery of local running pods from the docker daemon to the k8s API. In doing so it now requires the `MY_NODE_NAME` environment variable -- which was both (1) not documented and (2) no error if it is not set. In the case that the variable wasn't set the local daemon would then attempt to add *all* pods that aren't assigned to any node (as the node name would be "").

This patch (1) adds an entry in readme about this option and (2) returns
an error if it is not set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
