### PR TITLE
adding note to AWS_VPC_K8S_CNI_RANDOMIZESNAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ To use pseudo random number generation rather than hash based (i.e. `--random-fu
 For old versions of `iptables` that do not support `--random-fully` this option will fall back to `--random`.
 Disable (`none`) this functionality if you rely on sequential port allocation for outgoing connections.
 
+*Note*: Any options other than `none` will cause outbound connections to be assigned a source port that's not necessarily part of the ephemeral port range set at the OS level (/proc/sys/net/ipv4/ip_local_port_range). This is relevant for any customers that might have NACLs restricting traffic based on the port range found in ip_local_port_range
+
 `WARM_ENI_TARGET`
 Type: Integer
 Default: `1`


### PR DESCRIPTION
AWS_VPC_K8S_CNI_RANDOMIZESNAT will cause netfilter to select a source port that's not necessarily part of sysctl setting ip_local_port_range, causing networking issues if NACLs are present.

*Issue #, if available:*
NA, I learned that by working a case that came through the AWS Support.

*Description of changes:*
Simply adding a note to let people know that once random is enabled for SNAT it will not honor the port range specified in /proc/sys/net/ipv4/ip_local_port_range

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
