### PR TITLE
Use versions instead of version for Calico CRDs

### DIFF
--- a/config/v1.5/calico.yaml
+++ b/config/v1.5/calico.yaml
@@ -154,7 +154,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -169,7 +172,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
@@ -183,7 +189,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: BGPPeer
     plural: bgppeers
@@ -197,7 +206,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IPPool
     plural: ippools


### PR DESCRIPTION
*Description of changes:*

`versions` only work with Kubernetes 1.11 and later, but `version` is deprecated. Moved all CRDs over to the current format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
