### PR TITLE
Fix introspection port in troubleshooting docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,7 +82,7 @@ ipamd.log.2018-05-16-01  ipamd.log.2018-05-16-06  ipamd.log.2018-05-16-11  ipamd
 
 ```
 // get enis info
-[root@ip-192-168-188-7 bin]# curl http://localhost:61678/v1/enis | python -m json.tool
+[root@ip-192-168-188-7 bin]# curl http://localhost:61679/v1/enis | python -m json.tool
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  2589    0  2589    0     0   2589      0 --:--:-- --:--:-- --:--:--  505k
@@ -137,7 +137,7 @@ ipamd.log.2018-05-16-01  ipamd.log.2018-05-16-06  ipamd.log.2018-05-16-11  ipamd
 
 ```
 // get IP assignment info
-[root@ip-192-168-188-7 bin]# curl http://localhost:61678/v1/pods | python -m json.tool
+[root@ip-192-168-188-7 bin]# curl http://localhost:61679/v1/pods | python -m json.tool
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  6688    0  6688    0     0   6688      0 --:--:-- --:--:-- --:--:-- 1306k


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
The port in the default value of `INTROSPECTION_BIND_ADDRESS` is 61679, not 61678 (which is the metrics port). Attempting to fetch the introspection URLs as written with the default configuration yields an error:

```shell
$ curl http://localhost:61678/v1/enis | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19  100    19    0     0   4750      0 --:--:-- --:--:-- --:--:--  4750
Extra data: line 1 column 5 - line 2 column 1 (char 4 - 19)
$ curl http://localhost:61678/v1/enis 
404 page not found
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.