### PR TITLE
Update kubeconfig lookup order for eksctl nodegroups

### DIFF
--- a/scripts/aws-cni-support.sh
+++ b/scripts/aws-cni-support.sh
@@ -34,11 +34,11 @@ curl http://localhost:61678/metrics 2>&1 > ${LOG_DIR}/metrics.out
 # Collecting kubelet introspection data
 if [[ -n "${KUBECONFIG:-}" ]]; then
     command -v kubectl > /dev/null && kubectl get --kubeconfig=${KUBECONFIG} --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
+elif [[ -f /etc/eksctl/kubeconfig.yaml ]]; then
+    command -v kubectl > /dev/null && kubectl get --kubeconfig=/etc/eksctl/kubeconfig.yaml --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
 elif [[ -f /etc/systemd/system/kubelet.service ]]; then
     KUBECONFIG=`grep kubeconfig /etc/systemd/system/kubelet.service | awk '{print $2}'`
     command -v kubectl > /dev/null && kubectl get --kubeconfig=${KUBECONFIG} --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
-elif [[ -f /etc/eksctl/kubeconfig.yaml ]]; then
-    command -v kubectl > /dev/null && kubectl get --kubeconfig=/etc/eksctl/kubeconfig.yaml --raw=/api/v1/pods > ${LOG_DIR}/kubelet.out
 else
     echo "======== Unable to find KUBECONFIG, IGNORING POD DATA ========="
 fi


### PR DESCRIPTION
During eksctl bootstrap, the `/etc/systemd/system/kubelet.service` file still exists, although `kubelet.service.d/10-eksclt.al2.conf` and `/etc/eksctl/kubeconfig.yaml` are created and used [1].

This causes errors when running the `aws-cni-support.sh` script due to the precedence of looking up the kubeconfig file.

`error: unable to read certificate-authority /etc/kubernetes/pki/ca.crt for kubernetes due to open /etc/kubernetes/pki/ca.crt: no such file or directory`

[1] https://github.com/weaveworks/eksctl/blob/master/pkg/nodebootstrap/userdata_al2.go

*Issue #, if available:*

*Description of changes:*

Reversed the lookup to first match eksctl bootstrapped nodes to avoid errors retrieving introspection data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
