### PR TITLE
Added liveness and readiness probes

### DIFF
--- a/config/v1.4/aws-k8s-cni-1.10.yaml
+++ b/config/v1.4/aws-k8s-cni-1.10.yaml
@@ -89,6 +89,24 @@ spec:
         resources:
           requests:
             cpu: 10m
+        livenessProbe:
+          tcpSocket:
+            host: 127.0.0.1
+            port: 50051
+          initialDelaySeconds: 5
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            host: 127.0.0.1
+            port: 50051
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+          failureThreshold: 3
         securityContext:
           privileged: true
         volumeMounts:

--- a/config/v1.4/aws-k8s-cni.yaml
+++ b/config/v1.4/aws-k8s-cni.yaml
@@ -90,6 +90,24 @@ spec:
         resources:
           requests:
             cpu: 10m
+        livenessProbe:
+          tcpSocket:
+            host: 127.0.0.1
+            port: 50051
+          initialDelaySeconds: 5
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            host: 127.0.0.1
+            port: 50051
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+          failureThreshold: 3
         securityContext:
           privileged: true
         volumeMounts:

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -101,6 +101,24 @@ spec:
           resources:
             requests:
               cpu: 10m
+          livenessProbe:
+            tcpSocket:
+              host: 127.0.0.1
+              port: 50051
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              host: 127.0.0.1
+              port: 50051
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+            failureThreshold: 3
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-vpc-cni-k8s/issues/330

*Description of changes:*

Added a liveness and readiness probe to see if the application is up and running. This can help with the above issue. However this is still not a full solution, since the application can be up but it could be it is still not ready to distribute ip adresses.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
