### PR TITLE
Make logging consistent with metrics/endpoints handlers

### DIFF
--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -91,6 +91,8 @@ func (s *server) DelNetwork(ctx context.Context, in *pb.DelNetworkRequest) (*pb.
 
 // RunRPCHandler handles request from gRPC
 func (c *IPAMContext) RunRPCHandler() error {
+	log.Info("Serving RPC Handler on ", ipamdgRPCaddress)
+
 	lis, err := net.Listen("tcp", ipamdgRPCaddress)
 	if err != nil {
 		log.Errorf("Failed to listen gRPC port: %v", err)


### PR DESCRIPTION
Log staring of gRPC Handler to be consistent with other endpoints and get better visibility when endpoint starts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
