### PR TITLE
Add build outputs to .dockerignore to reduce size of docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+aws-cni
+aws-k8s-agent
+portmap
+cni-metrics-helper/cni-metrics-helper


### PR DESCRIPTION
*Description of changes:*
With this change, locally build binaries will not be sent to docker daemon during build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
