### PR TITLE
set iptables FORWARD rules  ACCEPT for inside VPC traffic

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -331,6 +331,20 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 			rule: []string{
 				"!", "-d", cidr.cidr, "-m", "comment", "--comment", comment, "-j", nextChain,
 			}})
+
+		// ACCEPT FORWARD rules for inside VPC traffic
+		log.Debugf("Setup Host Network: iptables -A FORWARD -d %s -t filter -j ACCEPT", cidr)
+		iptableRules = append(iptableRules, iptablesRule{
+			name:        "AWS CNI FORWARD",
+			shouldExist: true,
+			table:       "filter",
+			chain:       "FORWARD",
+			rule: []string{
+				"-s", cidr.cidr,
+				"-m", "comment", "--comment", "AWS CNI FORWARD",
+				"-j", "ACCEPT",
+			},
+		})
 	}
 
 	// Prepare the Desired Rule for SNAT Rule

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -378,6 +378,14 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
 				},
 			},
+			"filter": {
+				"FORWARD": [][]string{
+					{"-s", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.12.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.13.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+				},
+			},
 		}, mockIptables.dataplaneState)
 }
 
@@ -437,6 +445,12 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
 				},
 			},
+			"filter": {
+				"FORWARD": [][]string{
+					{"-s", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+				},
+			},
 		}, mockIptables.dataplaneState)
 }
 
@@ -494,6 +508,14 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 				"PREROUTING": [][]string{
 					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
 					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+			"filter": {
+				"FORWARD": [][]string{
+					{"-s", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.12.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
+					{"-s", "10.13.0.0/16", "-m", "comment", "--comment", "AWS CNI FORWARD", "-j", "ACCEPT"},
 				},
 			},
 		}, mockIptables.dataplaneState)


### PR DESCRIPTION

*Description of changes:*
For some AMI doesn't ACCEPT FORWARD traffic by default, this will enable those traffic FORWARD in VPC CIDR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
