### PR TITLE
Detach ENI before deleting

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -572,7 +572,7 @@ func (cache *EC2InstanceMetadataCache) AllocENI(useCustomCfg bool, sg []*string,
 	awsAPILatency.WithLabelValues("ModifyNetworkInterfaceAttribute", fmt.Sprint(err != nil)).Observe(msSince(start))
 	if err != nil {
 		awsAPIErrInc("ModifyNetworkInterfaceAttribute", err)
-		err := cache.deleteENI(eniID)
+		err := cache.FreeENI(eniID)
 		if err != nil {
 			awsUtilsErrInc("ENICleanupUponModifyNetworkErr", err)
 		}


### PR DESCRIPTION
Fix for issue #537.

Try to detach ENI before deleting it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
