### PR TITLE
Make sure that goimports is available in the docker image

### DIFF
--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -13,5 +13,6 @@ COPY go.sum .
 
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download
+RUN go get -u golang.org/x/tools/cmd/goimports
 
 COPY . .


### PR DESCRIPTION
Before this commit:
```
> make docker-unit-test
.
.
.
goimports: command not found
```
Change was added in https://github.com/aws/amazon-vpc-cni-k8s/pull/520/commits/5355b9052f2a986eabfd14fa3d7ba1eec399015d

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
