### PR TITLE
Fix #164 issue

### DIFF
--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -276,9 +276,9 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	}
 
 	if !r.Success {
-		log.Errorf("Failed to process delete request for pod %s namespace %s container %s: %v",
-			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID), err)
-		return errors.Wrap(err, "del cmd: failed to process delete request")
+		log.Errorf("Failed to process delete request for pod %s namespace %s container %s: Success == false",
+			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID))
+		return errors.New("del cmd: failed to process delete request")
 	}
 
 	addr := &net.IPNet{


### PR DESCRIPTION
From issue #164

> This code block logs and wraps an err that was proven nil in the block above, so it ends up providing no context.

The `DelNetworkReply` has very limited information. (Removed the annotations for clarity)
```
type DelNetworkReply struct {
	Success      bool 
	IPv4Addr     string 
	DeviceNumber int32
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
