### PR TITLE
t3a.small only have 2 ENIs

### DIFF
--- a/pkg/awsutils/vpc_ip_resource_limit.go
+++ b/pkg/awsutils/vpc_ip_resource_limit.go
@@ -203,7 +203,7 @@ var InstanceENIsAvailable = map[string]int{
 	"t3.2xlarge":    4,
 	"t3a.nano":      2,
 	"t3a.micro":     2,
-	"t3a.small":     3,
+	"t3a.small":     2,
 	"t3a.medium":    3,
 	"t3a.large":     3,
 	"t3a.xlarge":    4,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/262#issuecomment-514714392

*Description of changes:*
* t3a.small only have 2 ENIs
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
