### PR TITLE
Update start script to wait for ipamd health check

### DIFF
--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,14 +1,42 @@
 #!/usr/bin/env bash
-echo "===== Starting installing AWS-CNI ========="
-sed -i s/__VETHPREFIX__/${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}/g /app/10-aws.conflist
-cp /app/aws-cni /host/opt/cni/bin/
-cp /app/portmap /host/opt/cni/bin/
-cp /app/aws-cni-support.sh /host/opt/cni/bin/
-cp /app/10-aws.conflist /host/etc/cni/net.d/
 
-if [[ -f /host/etc/cni/net.d/aws.conf ]]; then
+grpcHealthCheck () {
+  /app/grpc_health_probe -addr 127.0.0.1:50051
+}
+
+waitIPamDServing () {
+   until grpcHealthCheck; do
+    echo "Waiting for ipamd health check";
+    sleep 1;
+  done
+}
+
+main () {
+  # Remove old config files that might have been baked into older AMIs
+  if [[ -f /host/etc/cni/net.d/aws.conf ]]; then
     rm /host/etc/cni/net.d/aws.conf
-fi
+  fi
 
-echo "===== Starting amazon-k8s-agent ==========="
-/app/aws-k8s-agent
+  # Copy standard files
+  cp /app/aws-cni-support.sh /host/opt/cni/bin/
+  cp /app/portmap /host/opt/cni/bin/
+
+  echo "===== Starting amazon-k8s-agent ==========="
+  /app/aws-k8s-agent &
+
+  # Check ipamd health
+  echo "Checking if ipamd is serving"
+  waitIPamDServing
+
+  echo "===== Copying AWS CNI plugin and config ========="
+  sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
+  cp /app/aws-cni /host/opt/cni/bin/
+  cp /app/10-aws.conflist /host/etc/cni/net.d/
+
+  # Check that ipamd is healthy, exit if the check fails
+  while grpcHealthCheck; do
+      sleep 10;
+  done
+}
+
+main


### PR DESCRIPTION
*Issue #, if available:* #282 

*Description of changes:*
* Update start script to wait for ipamd health check to return SERVING before copying in the CNI binary and config file, making the node Ready.
* Tested by scheduling pods with 0 worker nodes in the ASG, then scaling up. The nodes do not become ready until ipamd is running.

This is a quick fix for the release-1.5 branch. It will also add additional log lines to the aws-node stdout logs. The long term goal will probably be to move the set up into go instead and have ipamd copy the files once it's ready.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
