### PR TITLE
Update Calico version to v3.8.1

### DIFF
--- a/config/v1.5/calico.yaml
+++ b/config/v1.5/calico.yaml
@@ -1,6 +1,6 @@
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -154,7 +154,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -205,7 +208,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
@@ -219,7 +225,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: BGPPeer
     plural: bgppeers
@@ -233,7 +242,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IPPool
     plural: ippools
@@ -360,7 +372,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
@@ -461,7 +473,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -476,7 +488,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -485,6 +497,9 @@ metadata:
     k8s-app: calico-typha
 spec:
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -565,7 +580,7 @@ spec:
       k8s-app: calico-typha
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: typha-cpha
@@ -580,7 +595,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: typha-cpha
@@ -615,7 +630,7 @@ data:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha-horizontal-autoscaler
@@ -623,6 +638,9 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
 spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   replicas: 1
   template:
     metadata:
@@ -652,7 +670,7 @@ spec:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: typha-cpha
@@ -675,7 +693,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: typha-cpha

--- a/config/v1.5/calico.yaml
+++ b/config/v1.5/calico.yaml
@@ -37,7 +37,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.3.6
+          image: quay.io/calico/node:v3.8.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -159,6 +159,42 @@ spec:
     kind: FelixConfiguration
     plural: felixconfigurations
     singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
 
 ---
 
@@ -295,6 +331,24 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset
+
+---
+
 # Create the ServiceAccount and roles necessary for Calico.
 
 apiVersion: v1
@@ -323,6 +377,12 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
   - apiGroups: [""]
     resources:
       - pods
@@ -369,9 +429,11 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
       - networkpolicies
+      - networksets
       - clusterinformations
       - hostendpoints
     verbs:
@@ -379,6 +441,22 @@ rules:
       - get
       - list
       - update
+      - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
       - watch
 
 ---
@@ -424,7 +502,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-        - image: quay.io/calico/typha:v3.3.6
+        - image: quay.io/calico/typha:v3.8.1
           name: calico-typha
           ports:
             - containerPort: 5473
@@ -457,19 +535,17 @@ spec:
             - name: FELIX_IPTABLESMANGLEALLOWACTION
               value: Return
           livenessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - liveness
+            httpGet:
+              path: /liveness
+              port: 9098
+              host: localhost
             periodSeconds: 30
             initialDelaySeconds: 30
           readinessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - readiness
+            httpGet:
+              path: /readiness
+              port: 9098
+              host: localhost
             periodSeconds: 10
 
 ---


### PR DESCRIPTION
*Description of changes:*

* Update Calico image tags from `v3.3.6` to `v3.8.1`
* Add required RBAC changes and CRDs for `v3.8.1`
* Remove deprecated apiVersions and fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
