### PR TITLE
Make v1.5.1-rc1 the default and add set -uo pipefail

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -81,7 +81,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.0
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.1-rc1
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -uo pipefail
+
 grpcHealthCheck () {
   /app/grpc_health_probe -addr 127.0.0.1:50051
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Make v1.5.1-rc1 the default image
* Add `set -uo pipefail` to the bash script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
