### PR TITLE
Exit early if MAC address doesn't match

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -91,7 +91,7 @@ const (
 	// number of attempts to find an ENI by MAC address after it is attached
 	maxAttemptsLinkByMac = 5
 
-	retryLinkByMacInterval = 5 * time.Second
+	retryLinkByMacInterval = 3 * time.Second
 )
 
 // NetworkAPIs defines the host level and the eni level network related operations
@@ -541,7 +541,6 @@ func LinkByMac(mac string, netLink netlinkwrapper.NetLink, retryInterval time.Du
 		lastErr = errors.Errorf("no interface found which uses mac address %s (attempt %d/%d)", mac, attempt, maxAttemptsLinkByMac)
 		log.Debugf(lastErr.Error())
 	}
-
 }
 
 // SetupENINetwork adds default route to route table (eni-<eni_table>)


### PR DESCRIPTION
*Description of changes:*
* Change `retryLinkByMacInterval` from `5` to `3` seconds.
* Don't add an ENI to the datastore if we fail to describe it.
* If we fail on `find the link which uses MAC address`, don't retry for that ENI.
* Removed some unneeded casts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
