### PR TITLE
Document AWS_VPC_K8S_CNI_VETHPREFIX #298

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,12 @@ information we can get from the node when running the `aws-cni-support.sh` scrip
 `DISABLE_METRICS`
 Type: Boolean
 Default: `false`
-Specifies whether prometeus metrics endpoints are enabled on a worker node.
+Specifies whether the prometheus metrics endpoint is disabled or not for ipamd.
+
+`AWS_VPC_K8S_CNI_VETHPREFIX`
+Type: String
+Default: `eni`
+Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long.
 
 ### Notes
 

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -118,7 +118,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		conf.VethPrefix = "eni"
 	}
 	if len(conf.VethPrefix) > 4 {
-		return errors.New("conf.VethPrefix must be less than 4 characters long")
+		return errors.New("conf.VethPrefix can be at most 4 characters long")
 	}
 
 	cniVersion := conf.CNIVersion

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "====== Installing AWS-CNI ======"
-sed -i s/__VETHPREFIX__/${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}/g /app/10-aws.conflist
+sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
 cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 


### PR DESCRIPTION
*Issue #, if available:* #298

*Description of changes:*
* Document how `AWS_VPC_K8S_CNI_VETHPREFIX` used to name the veth device 
* Fix spelling of prometheus
* Use quotes in bash script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
