### PR TITLE
Introduce a minimum target for ENI IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,26 @@ Specifies the number of free IP addresses that the `ipamD` daemon should attempt
 For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times. If the
 elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces
 until `WARM_IP_TARGET` free IP addresses are available.
+If both `WARM_IP_TARGET` and `MINIMUM_WARM_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.
+
+`MINIMUM_IP_TARGET`
+Type: Integer
+Default: None
+
+Specifies the number of total IP addresses that the `ipamD` daemon should attempt to allocate for pod assignment on the node.
+`MINIMUM_IP_TARGET` behaves identically to `WARM_IP_TARGET` except that instead of setting a target number of free IP
+addresses to keep available at all times, it sets a target number for a floor on how many total IP addresses are allocated.
+
+`MINIMUM_IP_TARGET` is for pre-scaling, `WARM_IP_TARGET` is for dynamic scaling. For example, suppose a cluster has an
+expected pod density of approximately 30 pods per node. If `WARM_IP_TARGET` is set to 30 to ensure there are enough IPs
+allocated up front by the CNI, then 30 pods are deployed to the node, the CNI will allocate an additional 30 IPs, for
+a total of 60, accelerating IP exhaustion in the relevant subnets. If instead `MINIMUM_IP_TARGET` is set to 30 and
+`WARM_IP_TARGET` to 2, after the 30 pods are deployed the CNI would allocate an additional 2 IPs. This still provides
+elasticity, but uses roughly half as many IPs as using WARM_IP_TARGET alone (32 IPs vs 60 IPs).
+
+This also improves reliability of the EKS cluster by reducing the number of calls necessary to allocate or deallocate
+private IPs, which may be throttled, especially at scaling-related times.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Specifies the number of free IP addresses that the `ipamD` daemon should attempt
 For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times. If the
 elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces
 until `WARM_IP_TARGET` free IP addresses are available.
-If both `WARM_IP_TARGET` and `MINIMUM_WARM_TARGET` are set, `ipamD` will attempt to meet both constraints.
+If both `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.
 
 `MINIMUM_IP_TARGET`

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -71,10 +71,10 @@ const (
 	// This environment variable is used to specify the desired minimum number of total IPs.
 	// When it is not set, ipamd defaults to 0.
 	// For example, for a m4.4xlarge node,
-	//     If WARM-IP-TARGET is set to 1 and MINIMUM_IP_TARGET is set to 12, and there are 9 pods running on the node,
+	//     If WARM_IP_TARGET is set to 1 and MINIMUM_IP_TARGET is set to 12, and there are 9 pods running on the node,
 	//     ipamd will make the "warm pool" have 12 IP addresses with 9 being assigned to pods and 3 free IPs.
 	//
-	//     If "MINIMUM-WARM-IP-TARGET is not set, it will default to 0, which causes WARM-IP-TARGET settings to be the
+	//     If "MINIMUM_IP_TARGET is not set, it will default to 0, which causes WARM_IP_TARGET settings to be the
 	//	   only settings considered.
 	envMinimumIPTarget = "MINIMUM_IP_TARGET"
 	noMinimumIPTarget  = 0


### PR DESCRIPTION
Adds a MINIMUM_IP_TARGET environment variable to inform the AWS CNI that a particular number of total IPs is anticipated for use with a particular node. This is useful to ensure a sufficient supply of IPs on a node up-front without the 2x IP usage overhead of setting WARM_IP_TARGET to the same value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
