### PR TITLE
Added retryNbackoff for tagENI method

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -328,6 +328,35 @@ func TestDescribeENI(t *testing.T) {
 	}
 }
 
+func TestTagEni(t *testing.T) {
+	ctrl, mockMetadata, mockEC2 := setup(t)
+	defer ctrl.Finish()
+	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(vpcCIDR, nil)
+
+	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
+	err := ins.initWithEC2Metadata()
+	assert.NoError(t, err)
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, nil)
+	ins.tagENI(eniID)
+	assert.NoError(t, err)
+}
+
 func TestAllocENI(t *testing.T) {
 	ctrl, _, mockEC2 := setup(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
*Issue #, if available:*
#610 

*Description of changes:*
Added retryNbackoff for tagENI method 

*Build result*
```
1569459583921084000 [Warn] Failed to tag the newly created ENI eni-5731da78: Tagging Failed
1569459585170221000 [Warn] Failed to tag the newly created ENI eni-5731da78: Tagging Failed
1569459588656214000 [Warn] Failed to tag the newly created ENI eni-5731da78: Tagging Failed
1569459599823924000 [Warn] Failed to tag the newly created ENI eni-5731da78: Tagging Failed
1569459627965153000 [Debug] Successfully tagged ENI: eni-5731da78
PASS
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
