### PR TITLE
Add IPs to the first ENI on startup

### DIFF
--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -148,6 +148,9 @@ func TestNodeInit(t *testing.T) {
 	mockAWS.EXPECT().GetVPCIPv4CIDRs().Return(cidrs)
 	mockNetwork.EXPECT().UseExternalSNAT().Return(false)
 	mockNetwork.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any(), gomock.Any(), true)
+	// Add IPs
+	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
+	mockAWS.EXPECT().DescribeENI(gomock.Any()).Return(eniResp, &attachmentID, nil)
 
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)


### PR DESCRIPTION
*Description of changes:*
* Make sure we have IPs available before making the node ready
* This change will add a 400 - 600ms delay before marking a node as *Ready*
* For new nodes, this saves at least 2.5 seconds before IPs are available

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
