### PR TITLE
Revert back to v1.5.4

### DIFF
--- a/config/v1.5/aws-k8s-cni-1.10.yaml
+++ b/config/v1.5/aws-k8s-cni-1.10.yaml
@@ -69,7 +69,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -81,7 +81,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678


### PR DESCRIPTION
This reverts commit fb2fd20f

*Description of changes:*
The issue with DNS lookups is the same on v1.5.3 and v1.5.4. #641

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
