### PR TITLE
dnsPolicy should be set to ClusterFirstWithHostNet for hostNetwork pod

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -78,6 +78,7 @@ spec:
                       - amd64
       serviceAccountName: aws-node
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
*Issue #, if available:*
aws-node pod with default ClusterFirst policy picks up `/etc/resolv.conf` from the host (?), it couldn't resolve kube-apiserver cluster ip.

*Description of changes:*
add `dnsPolicy: ClusterFirstWithHostNet` so it could resolve kube-apiserver cluster ip from coredns.

From [kubernetes](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy):
> For Pods running with hostNetwork, you should explicitly set its DNS policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
