### PR TITLE
Revert "Revert back to v1.5.4"

### DIFF
--- a/config/v1.5/aws-k8s-cni-1.10.yaml
+++ b/config/v1.5/aws-k8s-cni-1.10.yaml
@@ -69,7 +69,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -81,7 +81,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
           imagePullPolicy: Always
           ports:
             - containerPort: 61678


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-k8s#660

#641 seems to mainly be caused by #623, reverting back to v1.5.3 to avoid `ip rule` issues.

Will work to get a v1.5.5 out soon without this change, but with the new instance types.