### PR TITLE
Revert back to v1.5.3 to mitigate #641

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -82,7 +82,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
           imagePullPolicy: Always
           ports:
             - containerPort: 61678


### PR DESCRIPTION
*Issue #641 

*Description of changes:*
* Revert to v1.5.3 to avoid issues caused by deleted `ip route`s

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
