### PR TITLE
Revert "dnsPolicy should be set to ClusterFirstWithHostNet for hostNetwork pod"

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -78,7 +78,6 @@ spec:
                       - amd64
       serviceAccountName: aws-node
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-k8s#664

Having tested this, it works fine when upgrading, but not when starting new nodes, since that means CoreDNS is not yet running. Reverting.