### PR TITLE
Calling the veth interfaces eni is confusing

### DIFF
--- a/ipamd/rpc_handler_test.go
+++ b/ipamd/rpc_handler_test.go
@@ -47,7 +47,7 @@ func TestServer_AddNetwork(t *testing.T) {
 		K8S_POD_NAME:               "pod",
 		K8S_POD_NAMESPACE:          "ns",
 		K8S_POD_INFRA_CONTAINER_ID: "cid",
-		IfName:                     "eni",
+		IfName:                     "veth",
 	}
 
 	vpcCIDRs := []*string{aws.String(vpcCIDR)}

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -115,7 +115,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 	// Default the host-side veth prefix to 'eni'.
 	if conf.VethPrefix == "" {
-		conf.VethPrefix = "eni"
+		conf.VethPrefix = "veth"
 	}
 	if len(conf.VethPrefix) > 4 {
 		return errors.New("conf.VethPrefix can be at most 4 characters long")

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "====== Installing AWS-CNI ======"
-sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
+sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"veth"}"/g /app/10-aws.conflist
 cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 


### PR DESCRIPTION
*Description of changes:*
* Rename the veth interfaces to `vethxxxxx` instead of `enixxxxx`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
