### PR TITLE
Revert "Calling the veth interfaces eni is confusing"

### DIFF
--- a/ipamd/rpc_handler_test.go
+++ b/ipamd/rpc_handler_test.go
@@ -47,7 +47,7 @@ func TestServer_AddNetwork(t *testing.T) {
 		K8S_POD_NAME:               "pod",
 		K8S_POD_NAMESPACE:          "ns",
 		K8S_POD_INFRA_CONTAINER_ID: "cid",
-		IfName:                     "veth",
+		IfName:                     "eni",
 	}
 
 	vpcCIDRs := []*string{aws.String(vpcCIDR)}

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -115,7 +115,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 	// Default the host-side veth prefix to 'eni'.
 	if conf.VethPrefix == "" {
-		conf.VethPrefix = "veth"
+		conf.VethPrefix = "eni"
 	}
 	if len(conf.VethPrefix) > 4 {
 		return errors.New("conf.VethPrefix can be at most 4 characters long")

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "====== Installing AWS-CNI ======"
-sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"veth"}"/g /app/10-aws.conflist
+sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
 cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-k8s#674

Pains me to revert this since having it called `eni` doesn't feel right at all, but changing it now will probably cause more trouble than it's worth.