### PR TITLE
Cherry pick fixes over to 1.6 branch from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,18 @@ is not used, and the maximum number of ENIs is always equal to the maximum numbe
 
 ---
 
+`AWS_VPC_K8S_CNI_LOGLEVEL`
+
+Type: String
+
+Default: `DEBUG`
+
+Valid Values: `trace`, `debug`, `info`, `warn`, `error`, `critical` or `off`. (Not case sensitive)
+
+Specifies the loglevel for ipamd.
+
+---
+
 `AWS_VPC_K8S_CNI_LOG_FILE`
 
 Type: String

--- a/README.md
+++ b/README.md
@@ -234,7 +234,26 @@ Specifies the number of free IP addresses that the `ipamD` daemon should attempt
 For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times. If the
 elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces
 until `WARM_IP_TARGET` free IP addresses are available.
+If both `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.
+
+`MINIMUM_IP_TARGET`
+Type: Integer
+Default: None
+
+Specifies the number of total IP addresses that the `ipamD` daemon should attempt to allocate for pod assignment on the node.
+`MINIMUM_IP_TARGET` behaves identically to `WARM_IP_TARGET` except that instead of setting a target number of free IP
+addresses to keep available at all times, it sets a target number for a floor on how many total IP addresses are allocated.
+
+`MINIMUM_IP_TARGET` is for pre-scaling, `WARM_IP_TARGET` is for dynamic scaling. For example, suppose a cluster has an
+expected pod density of approximately 30 pods per node. If `WARM_IP_TARGET` is set to 30 to ensure there are enough IPs
+allocated up front by the CNI, then 30 pods are deployed to the node, the CNI will allocate an additional 30 IPs, for
+a total of 60, accelerating IP exhaustion in the relevant subnets. If instead `MINIMUM_IP_TARGET` is set to 30 and
+`WARM_IP_TARGET` to 2, after the 30 pods are deployed the CNI would allocate an additional 2 IPs. This still provides
+elasticity, but uses roughly half as many IPs as using WARM_IP_TARGET alone (32 IPs vs 60 IPs).
+
+This also improves reliability of the EKS cluster by reducing the number of calls necessary to allocate or deallocate
+private IPs, which may be throttled, especially at scaling-related times.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -237,8 +237,12 @@ until `WARM_IP_TARGET` free IP addresses are available.
 If both `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.
 
+---
+
 `MINIMUM_IP_TARGET`
+
 Type: Integer
+
 Default: None
 
 Specifies the number of total IP addresses that the `ipamD` daemon should attempt to allocate for pod assignment on the node.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/amazon-vpc-cni-k8s
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.21.7
+	github.com/aws/aws-sdk-go v1.23.13
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
 	github.com/containernetworking/cni v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
-github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.13 h1:l/NG+mgQFRGG3dsFzEj0jw9JIs/zYdtU6MXhY1WIDmM=
+github.com/aws/aws-sdk-go v1.23.13/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf h1:XI2tOTCBqEnMyN2j1yPBI07yQHeywUSCEf8YWqf0oKw=

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -68,6 +68,17 @@ const (
 	envWarmIPTarget = "WARM_IP_TARGET"
 	noWarmIPTarget  = 0
 
+	// This environment variable is used to specify the desired minimum number of total IPs.
+	// When it is not set, ipamd defaults to 0.
+	// For example, for a m4.4xlarge node,
+	//     If WARM_IP_TARGET is set to 1 and MINIMUM_IP_TARGET is set to 12, and there are 9 pods running on the node,
+	//     ipamd will make the "warm pool" have 12 IP addresses with 9 being assigned to pods and 3 free IPs.
+	//
+	//     If "MINIMUM_IP_TARGET is not set, it will default to 0, which causes WARM_IP_TARGET settings to be the
+	//	   only settings considered.
+	envMinimumIPTarget = "MINIMUM_IP_TARGET"
+	noMinimumIPTarget  = 0
+
 	// This environment is used to specify the desired number of free ENIs along with all of its IP addresses
 	// always available in "warm pool".
 	// When it is not set, it is default to 1.
@@ -159,6 +170,7 @@ type IPAMContext struct {
 	maxENI               int
 	warmENITarget        int
 	warmIPTarget         int
+	minimumIPTarget      int
 	primaryIP            map[string]string
 	lastNodeIPPoolAction time.Time
 	lastDecreaseIPPool   time.Time
@@ -238,6 +250,7 @@ func New(k8sapiClient k8sapi.K8SAPIs, eniConfig *eniconfig.ENIConfigController) 
 	c.reconcileCooldownCache.cache = make(map[string]time.Time)
 	c.warmENITarget = getWarmENITarget()
 	c.warmIPTarget = getWarmIPTarget()
+	c.minimumIPTarget = getMinimumIPTarget()
 	c.useCustomNetworking = UseCustomNetworkCfg()
 
 	err = c.nodeInit()
@@ -463,7 +476,7 @@ func (c *IPAMContext) tryFreeENI() {
 		return
 	}
 
-	eni := c.dataStore.RemoveUnusedENIFromStore(c.warmIPTarget)
+	eni := c.dataStore.RemoveUnusedENIFromStore(c.warmIPTarget, c.minimumIPTarget)
 	if eni == "" {
 		return
 	}
@@ -1046,10 +1059,27 @@ func getWarmIPTarget() int {
 	return noWarmIPTarget
 }
 
-// ipTargetState determines the number of IPs `short` or `over` our WARM_IP_TARGET
+func getMinimumIPTarget() int {
+	inputStr, found := os.LookupEnv(envMinimumIPTarget)
+
+	if !found {
+		return noMinimumIPTarget
+	}
+
+	if input, err := strconv.Atoi(inputStr); err == nil {
+		if input >= 0 {
+			log.Debugf("Using MINIMUM_IP_TARGET %v", input)
+			return input
+		}
+	}
+	return noMinimumIPTarget
+}
+
+// ipTargetState determines the number of IPs `short` or `over` our WARM_IP_TARGET,
+// accounting for the MINIMUM_IP_TARGET
 func (c *IPAMContext) ipTargetState() (short int, over int, enabled bool) {
-	if c.warmIPTarget == noWarmIPTarget {
-		// there is no WARM_IP_TARGET defined, fallback to use all IP addresses on ENI
+	if c.warmIPTarget == noWarmIPTarget && c.minimumIPTarget == noMinimumIPTarget {
+		// there is no WARM_IP_TARGET defined and no MINIMUM_IP_TARGET, fallback to use all IP addresses on ENI
 		return 0, 0, false
 	}
 
@@ -1059,8 +1089,14 @@ func (c *IPAMContext) ipTargetState() (short int, over int, enabled bool) {
 	// short is greater than 0 when we have fewer available IPs than the warm IP target
 	short = max(c.warmIPTarget-available, 0)
 
+	// short is greater than the warm IP target alone when we have fewer total IPs than the minimum target
+	short = max(short, c.minimumIPTarget-total)
+
 	// over is the number of available IPs we have beyond the warm IP target
 	over = max(available-c.warmIPTarget, 0)
+
+	// over is less than the warm IP target alone if it would imply reducing total IPs below the minimum target
+	over = max(min(over, total-c.minimumIPTarget), 0)
 
 	log.Tracef("Current warm IP stats: target: %d, total: %d, assigned: %d, available: %d, short: %d, over %d", c.warmIPTarget, total, assigned, available, short, over)
 	return short, over, true

--- a/ipamd/rpc_handler_test.go
+++ b/ipamd/rpc_handler_test.go
@@ -47,7 +47,7 @@ func TestServer_AddNetwork(t *testing.T) {
 		K8S_POD_NAME:               "pod",
 		K8S_POD_NAMESPACE:          "ns",
 		K8S_POD_INFRA_CONTAINER_ID: "cid",
-		IfName:                     "veth",
+		IfName:                     "eni",
 	}
 
 	vpcCIDRs := []*string{aws.String(vpcCIDR)}

--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -5,7 +5,8 @@
     {
       "name": "aws-cni",
       "type": "aws-cni",
-      "vethPrefix": "__VETHPREFIX__"
+      "vethPrefix": "__VETHPREFIX__",
+      "mtu": "__MTU__"
     },
     {
       "type": "portmap",

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 const (
+	loopback      = ""
 	testMAC1      = "01:23:45:67:89:a0"
 	testMAC2      = "01:23:45:67:89:a1"
 	testTable     = 10
@@ -72,17 +73,14 @@ func TestSetupENINetwork(t *testing.T) {
 
 	hwAddr, err := net.ParseMAC(testMAC1)
 	assert.NoError(t, err)
-
 	mockLinkAttrs1 := &netlink.LinkAttrs{
 		HardwareAddr: hwAddr,
 	}
 	hwAddr, err = net.ParseMAC(testMAC2)
 	assert.NoError(t, err)
-
 	mockLinkAttrs2 := &netlink.LinkAttrs{
 		HardwareAddr: hwAddr,
 	}
-
 	lo := mock_netlink.NewMockLink(ctrl)
 	eth1 := mock_netlink.NewMockLink(ctrl)
 	// Emulate a delay attaching the ENI so a retry is necessary
@@ -94,14 +92,11 @@ func TestSetupENINetwork(t *testing.T) {
 	lo.EXPECT().Attrs().Return(mockLinkAttrs1)
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
 	gomock.InOrder(firstlistSet, secondlistSet)
-
 	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	mockNetLink.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
-
 	// eth1's device
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
 	eth1.EXPECT().Attrs().Return(mockLinkAttrs2)
-
 	// eth1's IP address
 	testeniAddr := &net.IPNet{
 		IP:   net.ParseIP(testeniIP),
@@ -150,14 +145,16 @@ func TestSetupHostNetworkNodePortDisabled(t *testing.T) {
 
 	ln := &linuxNetwork{
 		mainENIMark: 0x80,
-
-		netLink: mockNetLink,
-		ns:      mockNS,
+		mtu:         testMTU,
+		netLink:     mockNetLink,
+		ns:          mockNS,
 		newIptables: func() (iptablesIface, error) {
 			return mockIptables, nil
 		},
 	}
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -166,8 +163,17 @@ func TestSetupHostNetworkNodePortDisabled(t *testing.T) {
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)
 
 	var vpcCIDRs []*string
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
+}
+
+func mockPrimaryInterfaceLookup(ctrl *gomock.Controller, mockNetLink *mock_netlinkwrapper.MockNetLink) {
+	lo := mock_netlink.NewMockLink(ctrl)
+	mockLinkAttrs1 := &netlink.LinkAttrs{
+		HardwareAddr: net.HardwareAddr{},
+	}
+	mockNetLink.EXPECT().LinkList().Return([]netlink.Link{lo}, nil)
+	lo.EXPECT().Attrs().AnyTimes().Return(mockLinkAttrs1)
 }
 
 func TestUpdateRuleListBySrc(t *testing.T) {
@@ -267,6 +273,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 		useExternalSNAT:        true,
 		nodePortSupportEnabled: true,
 		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -278,6 +285,9 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 		},
 	}
 
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
+
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -288,11 +298,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 
 	var vpcCIDRs []*string
 
-	// loopback for primary device is a little bit hacky. But the test is stable and it should be
-	// OK for test purpose.
-	LoopBackMac := ""
-
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, LoopBackMac, &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]map[string][][]string{
@@ -316,17 +322,17 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 
 func TestLoadMTUFromEnvTooLow(t *testing.T) {
 	_ = os.Setenv(envMTU, "1")
-	assert.Equal(t, GetEthernetMTU(), minimumMTU)
+	assert.Equal(t, GetEthernetMTU(""), minimumMTU)
 }
 
 func TestLoadMTUFromEnv1500(t *testing.T) {
 	_ = os.Setenv(envMTU, "1500")
-	assert.Equal(t, GetEthernetMTU(), 1500)
+	assert.Equal(t, GetEthernetMTU(""), 1500)
 }
 
 func TestLoadMTUFromEnvTooHigh(t *testing.T) {
 	_ = os.Setenv(envMTU, "65536")
-	assert.Equal(t, GetEthernetMTU(), maximumMTU)
+	assert.Equal(t, GetEthernetMTU(""), maximumMTU)
 }
 
 func TestLoadExcludeSNATCIDRsFromEnv(t *testing.T) {
@@ -347,6 +353,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		excludeSNATCIDRs:       []string{"10.12.0.0/16", "10.13.0.0/16"},
 		nodePortSupportEnabled: true,
 		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -358,6 +365,9 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		},
 	}
 
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
+
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -368,7 +378,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 
 	var vpcCIDRs []*string
 	vpcCIDRs = []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 	assert.Equal(t,
 		map[string]map[string][][]string{
@@ -398,6 +408,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 		excludeSNATCIDRs:       nil,
 		nodePortSupportEnabled: true,
 		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -408,7 +419,9 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 			return &mockRPFilter, nil
 		},
 	}
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -426,7 +439,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
 
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -457,6 +470,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 		excludeSNATCIDRs:       []string{"10.12.0.0/16", "10.13.0.0/16"},
 		nodePortSupportEnabled: true,
 		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -467,7 +481,9 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 			return &mockRPFilter, nil
 		},
 	}
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -485,7 +501,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 
 	// remove exclusions
 	vpcCIDRs := []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -515,6 +531,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 		useExternalSNAT:        true,
 		nodePortSupportEnabled: true,
 		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -525,7 +542,9 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 			return &mockRPFilter, nil
 		},
 	}
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 	var hostRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&hostRule)
 	mockNetLink.EXPECT().RuleDel(&hostRule)
@@ -536,7 +555,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 
 	var vpcCIDRs []*string
 	vpcCIDRs = []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, "", &testENINetIP)
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
 

--- a/plugins/routed-eni/cni.go
+++ b/plugins/routed-eni/cni.go
@@ -115,7 +115,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 	// Default the host-side veth prefix to 'eni'.
 	if conf.VethPrefix == "" {
-		conf.VethPrefix = "veth"
+		conf.VethPrefix = "eni"
 	}
 	if len(conf.VethPrefix) > 4 {
 		return errors.New("conf.VethPrefix can be at most 4 characters long")

--- a/plugins/routed-eni/driver/driver_test.go
+++ b/plugins/routed-eni/driver/driver_test.go
@@ -43,6 +43,7 @@ const (
 	testeniIP        = "10.10.10.20"
 	testeniMAC       = "01:23:45:67:89:ab"
 	testeniSubnet    = "10.10.0.0/16"
+	mtu              = 9001
 )
 
 func setup(t *testing.T) (*gomock.Controller,
@@ -529,7 +530,7 @@ func TestSetupPodNetwork(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu)
 	assert.NoError(t, err)
 }
 
@@ -548,7 +549,7 @@ func TestSetupPodNetworkErrLinkByName(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu)
 
 	assert.Error(t, err)
 }
@@ -570,7 +571,7 @@ func TestSetupPodNetworkErrLinkSetup(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu)
 
 	assert.Error(t, err)
 }
@@ -603,7 +604,7 @@ func TestSetupPodNetworkErrRouteReplace(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu)
 
 	assert.Error(t, err)
 }
@@ -651,7 +652,7 @@ func TestSetupPodNetworkPrimaryIntf(t *testing.T) {
 	}
 
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, cidrs, false, mockNetLink, mockNS)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, cidrs, false, mockNetLink, mockNS, mtu)
 
 	assert.NoError(t, err)
 }

--- a/plugins/routed-eni/driver/mocks/driver_mocks.go
+++ b/plugins/routed-eni/driver/mocks/driver_mocks.go
@@ -48,15 +48,15 @@ func (m *MockNetworkAPIs) EXPECT() *MockNetworkAPIsMockRecorder {
 }
 
 // SetupNS mocks base method
-func (m *MockNetworkAPIs) SetupNS(arg0, arg1, arg2 string, arg3 *net.IPNet, arg4 int, arg5 []string, arg6 bool) error {
-	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (m *MockNetworkAPIs) SetupNS(arg0, arg1, arg2 string, arg3 *net.IPNet, arg4 int, arg5 []string, arg6 bool, arg7 int) error {
+	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupNS indicates an expected call of SetupNS
-func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // TeardownNS mocks base method

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "====== Installing AWS-CNI ======"
-sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"veth"}"/g /app/10-aws.conflist
+sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
 cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 

--- a/scripts/install-aws.sh
+++ b/scripts/install-aws.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 echo "====== Installing AWS-CNI ======"
 sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g /app/10-aws.conflist
+sed -i s/__MTU__/"${AWS_VPC_ENI_MTU:-"9001"}"/g /app/10-aws.conflist
 cp /app/portmap /host/opt/cni/bin/
 cp /app/aws-cni-support.sh /host/opt/cni/bin/
 


### PR DESCRIPTION
*Description of changes:*
* Revert "Calling the veth bridge eni is confusing" #680, @mogren
* Bump `aws-sdk-go` to v1.23.13 #681, @mogren
* Introduce a minimum target for ENI IPs #612, @asheldon 
* Fix Readme.md formatting around `MINIMUM_IP_TARGET` #683, @asheldon 
* Add MTU to the plugin config #676, @mogren 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
