### PR TITLE
Reduce image layers and strip debug flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ endif
 
 # Default to build the Linux binary
 build-linux:
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "$(LDFLAGS)"
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-cni -ldflags "$(LDFLAGS)" ./plugins/routed-eni/
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o grpc_health_probe -ldflags "$(LDFLAGS)" ./client/health-check/
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-k8s-agent -ldflags "-s -w $(LDFLAGS)"
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o aws-cni -ldflags " -s -w $(LDFLAGS)" ./plugins/routed-eni/
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o grpc_health_probe -ldflags "-s -w $(LDFLAGS)" ./client/health-check/
 
 # Download portmap plugin
 download-portmap:
@@ -73,7 +73,7 @@ docker-unit-test: build-docker-test
 
 # Build metrics
 build-metrics:
-	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -o cni-metrics-helper/cni-metrics-helper cni-metrics-helper/cni-metrics-helper.go
+	GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags="-s -w" -o cni-metrics-helper/cni-metrics-helper cni-metrics-helper/cni-metrics-helper.go
 
 # Build metrics Docker image
 docker-metrics:

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -19,19 +19,18 @@ RUN make build-linux && make download-portmap
 
 FROM amazonlinux:2
 RUN yum update -y && \
-    yum install -y iproute && \
     yum install -y iptables && \
+    yum install -y iproute && \
     yum clean all
 
 WORKDIR /app
 
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni /app
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist /app
+COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/portmap \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent  \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/grpc_health_probe \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/aws-cni-support.sh \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/install-aws.sh /app/
 
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/portmap /app
-
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent  /app
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/grpc_health_probe /app
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/aws-cni-support.sh /app
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/install-aws.sh /app
 ENTRYPOINT /app/install-aws.sh


### PR DESCRIPTION
*Description of changes:*
* Strip debug info from the binaries
* Copy all files in one layer

The `aws-cni` binary went from 34 Mb to 15 Mb. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
