### PR TITLE
support pass in kubeconfig and master to client-go by flag

### DIFF
--- a/cni-metrics-helper/cni-metrics-helper.go
+++ b/cni-metrics-helper/cni-metrics-helper.go
@@ -46,6 +46,7 @@ func main() {
 	flags.Lookup("logtostderr").DefValue = "true"
 	flags.Lookup("logtostderr").NoOptDefVal = "true"
 	flags.BoolVar(&options.submitCW, "cloudwatch", true, "a bool")
+	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Path to a kubeconfig file, specifying how to connect to the API server.")
 
 	flags.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
@@ -79,7 +80,7 @@ func main() {
 
 	glog.Infof("Starting CNIMetricsHelper. Sending metrics to CloudWatch: %v", options.submitCW)
 
-	kubeClient, err := k8sapi.CreateKubeClient()
+	kubeClient, err := k8sapi.CreateKubeClient(options.kubeconfig, "")
 	if err != nil {
 		glog.Errorf("Failed to create client: %v", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"flag"
 	"io"
 	"os"
 
@@ -31,8 +32,15 @@ const (
 )
 
 var (
-	version string
+	version    string
+	kubeconfig string
+	master     string
 )
+
+func init() {
+	flag.StringVar(&master, "master", "", "The address of the Kubernetes API server (overrides any value in kubeconfig).")
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
+}
 
 func main() {
 	os.Exit(_main())
@@ -40,11 +48,12 @@ func main() {
 
 func _main() int {
 	defer log.Flush()
+	flag.Parse()
 	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
 
 	log.Infof("Starting L-IPAMD %s  ...", version)
 
-	kubeClient, err := k8sapi.CreateKubeClient()
+	kubeClient, err := k8sapi.CreateKubeClient(kubeconfig, master)
 	if err != nil {
 		log.Errorf("Failed to create client: %v", err)
 		return 1


### PR DESCRIPTION
Now we can talk to apiserver by specifying `--kubeconfig` or `--master` flag other than default in-cluster config, so we can remove the dependence on kube-proxy, that is to say, `aws-k8s-agent` can start successfully without kube-proxy.

Have verified in our aws environment and everything works fine.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
