### PR TITLE
Add support for listening on unix socket for introspection endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Default: `127.0.0.1:61679`
 
 Specifies the bind address for the introspection endpoint.
 
+A Unix Domain Socket can be specified with the `unix:` prefix before the socket path.
+
 ---
 
 `DISABLE_INTROSPECTION`


### PR DESCRIPTION
*Description of changes:*
Add support for listening on unix socket for introspection endpoint. This can be locked down to appropriate readers easier than a listening port can be.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.