### PR TITLE
Scope watch on "pods" to only pods associated with the local node

### DIFF
--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -120,7 +120,7 @@ func (d *Controller) GetCNIPods() []string {
 // DiscoverK8SPods discovers Pods running in the cluster
 func (d *Controller) DiscoverK8SPods() {
 	// create the pod watcher
-	podListWatcher := cache.NewListWatchFromClient(d.kubeClient.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.Everything())
+	podListWatcher := cache.NewListWatchFromClient(d.kubeClient.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", d.myNodeName))
 
 	// create the workqueue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())


### PR DESCRIPTION
Prior to this patch the aws-cni plugin would create a watch for *all*
pods in the cluster to then client-side filter them to only the ones
assigned to the node. This is not only wasteful of resources (as we're
throwing away the majority of data once we get it) this causes some
significant performance/capacity issues on sizeable clusters. In some
cases we've seen the initial `watch` call return ~500MB! This is a
significant savings of space and resources (both client and server side)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
