### PR TITLE
 Add support for a 'no manage' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,17 +375,17 @@ This plugin interacts with the following tags on ENIs:
 * `node.k8s.amazonaws.com/instance_id`
 * `node.k8s.amazonaws.com/no_manage`.
 
-### Cluster Name tag
+#### Cluster Name tag
 
 The tag `cluster.k8s.amazonaws.com/name` will be set to the cluster name of the
 aws-node daemonset which created the ENI.
 
-### Instance ID tag
+#### Instance ID tag
 
 The tag `node.k8s.amazonaws.com/instance_id` will be set to the instance ID of
 the aws-node instance that allocated this ENI.
 
-### No Manage tag
+#### No Manage tag
 
 The tag `node.k8s.amazonaws.com/no_manage` is read by the aws-node daemonset to
 determine whether an ENI attached to the machine should not be configured or

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ This plugin interacts with the following tags on ENIs:
 
 * `cluster.k8s.amazonaws.com/name`
 * `node.k8s.amazonaws.com/instance_id`
-* `node.k8s.amazonaws.com/no_manage`.
+* `node.k8s.amazonaws.com/no_manage`
 
 #### Cluster Name tag
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The default manifest expects `--cni-conf-dir=/etc/cni/net.d` and `--cni-bin-dir=
 
 L-IPAM requires following [IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html):
 
-```      
+```
  {
      "Effect": "Allow",
      "Action": [
@@ -353,9 +353,52 @@ Default: `{}`
 
 Example values: `{"tag_key": "tag_val"}`
 
-Metadata applied to ENI help you categorize and organize your resources for billing or other purposes. Each tag consists of a custom-defined key and an optional value. Tag keys can have a maximum character length of 128 characters. Tag values can have a maximum length of 256 characters. These tags will be added to all ENIs on the host. 
+Metadata applied to ENI help you categorize and organize your resources for billing or other purposes. Each tag consists of a custom-defined key and an optional value. Tag keys can have a maximum character length of 128 characters. Tag values can have a maximum length of 256 characters. These tags will be added to all ENIs on the host.
 
 Important: Custom tags should not contain `k8s.amazonaws.com` prefix as it is reserved. If the tag has `k8s.amazonaws.com` string, tag addition will ignored.
+
+---
+
+`CLUSTER_NAME`
+
+Type: String
+
+Default: `""`
+
+Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag" section below.
+
+### ENI tags related to Allocation
+
+This plugin interacts with the following tags on ENIs:
+
+* `cluster.k8s.amazonaws.com/name`
+* `node.k8s.amazonaws.com/instance_id`
+* `node.k8s.amazonaws.com/no_manage`.
+
+### Cluster Name tag
+
+The tag `cluster.k8s.amazonaws.com/name` will be set to the cluster name of the
+aws-node daemonset which created the ENI.
+
+### Instance ID tag
+
+The tag `node.k8s.amazonaws.com/instance_id` will be set to the instance ID of
+the aws-node instance that allocated this ENI.
+
+### No Manage tag
+
+The tag `node.k8s.amazonaws.com/no_manage` is read by the aws-node daemonset to
+determine whether an ENI attached to the machine should not be configured or
+used for private IPs.
+
+This tag is not set by the cni plugin itself, but rather may be set by a user
+to indicate that an ENI is intended for host networking pods, or for some other
+process unrelated to Kubernetes.
+
+*Note*: Attaching an ENI with the `no_manage` tag will result in an incorrect
+value for the Kubelet's `--max-pods` configuration option. Consider also
+updating the `MAX_ENI` and `--max-pods` configuration options on this plugin
+and the kubelet respectively if you are making use of this tag.
 
 ### Notes
 

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -107,6 +107,10 @@ const (
 	// This environment is used to specify whether Pods need to use a security group and subnet defined in an ENIConfig CRD.
 	// When it is NOT set or set to false, ipamd will use primary interface security group and subnet for Pod network.
 	envCustomNetworkCfg = "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG"
+
+	// eniNoManageTagKey is the tag that may be set on an ENI to indicate ipamd
+	// should not manage it in any form.
+	eniNoManageTagKey = "node.k8s.amazonaws.com/no_manage"
 )
 
 var (
@@ -128,6 +132,12 @@ var (
 		prometheus.GaugeOpts{
 			Name: "awscni_eni_max",
 			Help: "The maximum number of ENIs that can be attached to the instance",
+		},
+	)
+	unmanagedENIs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "awscni_eni_unmanaged",
+			Help: "The number of ENIs that are unmanaged on this instance",
 		},
 	)
 	ipMax = prometheus.NewGauge(
@@ -271,25 +281,24 @@ func (c *IPAMContext) nodeInit() error {
 
 	log.Debugf("Start node init")
 
-	c.maxENI, err = c.getMaxENI()
+	allENIs, err := c.awsClient.GetAttachedENIs()
+	if err != nil {
+		log.Error("Failed to retrieve ENI info")
+		return errors.New("ipamd init: failed to retrieve attached ENIs info")
+	}
+	enis, numUnmanaged := filterUnmanagedENIs(allENIs)
+	nodeMaxENI, err := c.getMaxENI()
 	if err != nil {
 		log.Error("Failed to get ENI limit")
 		return err
 	}
-	enisMax.Set(float64(c.maxENI))
-
+	c.maxENI = nodeMaxENI
 	c.maxIPsPerENI, err = c.awsClient.GetENIipLimit()
 	if err != nil {
 		log.Error("Failed to get IPs per ENI limit")
 		return err
 	}
-	ipMax.Set(float64(c.maxIPsPerENI * c.maxENI))
-
-	enis, err := c.awsClient.GetAttachedENIs()
-	if err != nil {
-		log.Error("Failed to retrieve ENI info")
-		return errors.New("ipamd init: failed to retrieve attached ENIs info")
-	}
+	c.updateIPStats(numUnmanaged)
 
 	_, vpcCIDR, err := net.ParseCIDR(c.awsClient.GetVPCIPv4CIDR())
 	if err != nil {
@@ -390,6 +399,11 @@ func (c *IPAMContext) nodeInit() error {
 		c.updateLastNodeIPPoolAction()
 	}
 	return err
+}
+
+func (c *IPAMContext) updateIPStats(unmanaged int) {
+	ipMax.Set(float64(c.maxIPsPerENI * (c.maxENI - unmanaged)))
+	unmanagedENIs.Set(float64(unmanaged))
 }
 
 func (c *IPAMContext) getLocalPodsWithRetry() ([]*k8sapi.K8SPodInfo, error) {
@@ -786,7 +800,7 @@ func (c *IPAMContext) addENIaddressesToDataStore(ec2Addrs []*ec2.NetworkInterfac
 
 // returns all addresses on ENI, the primary address on ENI, error
 func (c *IPAMContext) getENIaddresses(eni string) ([]*ec2.NetworkInterfacePrivateIpAddress, string, error) {
-	ec2Addrs, _, err := c.awsClient.DescribeENI(eni)
+	ec2Addrs, _, _, err := c.awsClient.DescribeENI(eni)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to find ENI addresses for ENI %s", eni)
 	}
@@ -941,13 +955,14 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 	}
 
 	log.Debug("Reconciling ENI/IP pool info...")
-	attachedENIs, err := c.awsClient.GetAttachedENIs()
-
+	allENIs, err := c.awsClient.GetAttachedENIs()
 	if err != nil {
 		log.Errorf("IP pool reconcile: Failed to get attached ENI info: %v", err.Error())
 		ipamdErrInc("reconcileFailedGetENIs")
 		return
 	}
+	attachedENIs, numUnmanaged := filterUnmanagedENIs(allENIs)
+	c.updateIPStats(numUnmanaged)
 
 	curENIs := c.dataStore.GetENIInfos()
 
@@ -1104,6 +1119,20 @@ func getMinimumIPTarget() int {
 		}
 	}
 	return noMinimumIPTarget
+}
+
+func filterUnmanagedENIs(enis []awsutils.ENIMetadata) ([]awsutils.ENIMetadata, int) {
+	numFiltered := 0
+	ret := make([]awsutils.ENIMetadata, 0, len(enis))
+	for _, eni := range enis {
+		if eni.Tags[eniNoManageTagKey] == "true" {
+			log.Debugf("skipping ENI %s: tagged with %s", eni.ENIID, eniNoManageTagKey)
+			numFiltered++
+			continue
+		}
+		ret = append(ret, eni)
+	}
+	return ret, numFiltered
 }
 
 // ipTargetState determines the number of IPs `short` or `over` our WARM_IP_TARGET,

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -134,12 +134,6 @@ var (
 			Help: "The maximum number of ENIs that can be attached to the instance",
 		},
 	)
-	unmanagedENIs = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "awscni_eni_unmanaged",
-			Help: "The number of ENIs that are unmanaged on this instance",
-		},
-	)
 	ipMax = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "awscni_ip_max",
@@ -403,7 +397,6 @@ func (c *IPAMContext) nodeInit() error {
 
 func (c *IPAMContext) updateIPStats(unmanaged int) {
 	ipMax.Set(float64(c.maxIPsPerENI * (c.maxENI - unmanaged)))
-	unmanagedENIs.Set(float64(unmanaged))
 }
 
 func (c *IPAMContext) getLocalPodsWithRetry() ([]*k8sapi.K8SPodInfo, error) {

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -127,7 +127,7 @@ func TestNodeInit(t *testing.T) {
 		{
 			PrivateIpAddress: &testAddr2, Primary: &notPrimary}}
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	mockAWS.EXPECT().DescribeENI(primaryENIid).Return(eniResp, &attachmentID, nil)
+	mockAWS.EXPECT().DescribeENI(primaryENIid).Return(eniResp, map[string]string{}, &attachmentID, nil)
 
 	//secENIid
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
@@ -140,7 +140,7 @@ func TestNodeInit(t *testing.T) {
 		{
 			PrivateIpAddress: &testAddr12, Primary: &notPrimary}}
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	mockAWS.EXPECT().DescribeENI(secENIid).Return(eniResp, &attachmentID, nil)
+	mockAWS.EXPECT().DescribeENI(secENIid).Return(eniResp, map[string]string{}, &attachmentID, nil)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	mockAWS.EXPECT().GetLocalIPv4().Return(ipaddr01)
@@ -161,7 +161,7 @@ func TestNodeInit(t *testing.T) {
 	mockNetwork.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any(), gomock.Any(), true)
 	// Add IPs
 	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
-	mockAWS.EXPECT().DescribeENI(gomock.Any()).Return(eniResp, &attachmentID, nil)
+	mockAWS.EXPECT().DescribeENI(gomock.Any()).Return(eniResp, map[string]string{}, &attachmentID, nil)
 
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)
@@ -248,7 +248,8 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 			{PrivateIpAddress: &testAddr12, Primary: &notPrimary},
 			{PrivateIpAddress: &testAddr12, Primary: &notPrimary},
 		},
-		&attachmentID, nil)
+		map[string]string{}, &attachmentID, nil,
+	)
 
 	mockContext.increaseIPPool()
 }
@@ -313,8 +314,7 @@ func TestTryAddIPToENI(t *testing.T) {
 			{PrivateIpAddress: &testAddr11, Primary: &primary},
 			{PrivateIpAddress: &testAddr12, Primary: &notPrimary},
 			{PrivateIpAddress: &testAddr12, Primary: &notPrimary},
-		},
-		&attachmentID, nil)
+		}, map[string]string{}, &attachmentID, nil)
 
 	mockContext.increaseIPPool()
 }
@@ -356,7 +356,9 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 			{
 				PrivateIpAddress: &testAddr1, Primary: &primary},
 			{
-				PrivateIpAddress: &testAddr2, Primary: &notPrimary}}, &attachmentID, nil)
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary,
+			},
+		}, map[string]string{}, &attachmentID, nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 
 	mockContext.nodeIPPoolReconcile(0)

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -98,12 +98,13 @@ func (mr *MockAPIsMockRecorder) DeallocIPAddresses(arg0, arg1 interface{}) *gomo
 }
 
 // DescribeENI mocks base method
-func (m *MockAPIs) DescribeENI(arg0 string) ([]*ec2.NetworkInterfacePrivateIpAddress, *string, error) {
+func (m *MockAPIs) DescribeENI(arg0 string) ([]*ec2.NetworkInterfacePrivateIpAddress, map[string]string, *string, error) {
 	ret := m.ctrl.Call(m, "DescribeENI", arg0)
 	ret0, _ := ret[0].([]*ec2.NetworkInterfacePrivateIpAddress)
-	ret1, _ := ret[1].(*string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(map[string]string)
+	ret2, _ := ret[2].(*string)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // DescribeENI indicates an expected call of DescribeENI

--- a/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
+++ b/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
@@ -18,9 +18,9 @@
 package mock_ec2wrapper
 
 import (
+	context "context"
 	reflect "reflect"
 
-	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
@@ -167,7 +167,7 @@ func (mr *MockEC2MockRecorder) ModifyNetworkInterfaceAttribute(arg0 interface{})
 }
 
 // UnassignPrivateIpAddressesWithContext mocks base method
-func (m *MockEC2) UnassignPrivateIpAddressesWithContext(arg0 aws.Context, arg1 *ec2.UnassignPrivateIpAddressesInput, arg2 ...request.Option) (*ec2.UnassignPrivateIpAddressesOutput, error) {
+func (m *MockEC2) UnassignPrivateIpAddressesWithContext(arg0 context.Context, arg1 *ec2.UnassignPrivateIpAddressesInput, arg2 ...request.Option) (*ec2.UnassignPrivateIpAddressesOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)

--- a/pkg/netlinkwrapper/mock_netlink/link_mocks.go
+++ b/pkg/netlinkwrapper/mock_netlink/link_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
+++ b/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -231,18 +231,6 @@ func (mr *MockNetLinkMockRecorder) RouteAdd(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteAdd", reflect.TypeOf((*MockNetLink)(nil).RouteAdd), arg0)
 }
 
-// RouteReplace mocks base method
-func (m *MockNetLink) RouteReplace(arg0 *netlink.Route) error {
-	ret := m.ctrl.Call(m, "RouteReplace", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RouteReplace indicates an expected call of RouteReplace
-func (mr *MockNetLinkMockRecorder) RouteReplace(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockNetLink)(nil).RouteReplace), arg0)
-}
-
 // RouteDel mocks base method
 func (m *MockNetLink) RouteDel(arg0 *netlink.Route) error {
 	ret := m.ctrl.Call(m, "RouteDel", arg0)
@@ -266,6 +254,18 @@ func (m *MockNetLink) RouteList(arg0 netlink.Link, arg1 int) ([]netlink.Route, e
 // RouteList indicates an expected call of RouteList
 func (mr *MockNetLinkMockRecorder) RouteList(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteList", reflect.TypeOf((*MockNetLink)(nil).RouteList), arg0, arg1)
+}
+
+// RouteReplace mocks base method
+func (m *MockNetLink) RouteReplace(arg0 *netlink.Route) error {
+	ret := m.ctrl.Call(m, "RouteReplace", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteReplace indicates an expected call of RouteReplace
+func (mr *MockNetLinkMockRecorder) RouteReplace(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockNetLink)(nil).RouteReplace), arg0)
 }
 
 // RuleAdd mocks base method

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -58,6 +58,18 @@ func (m *MockNetworkAPIs) DeleteRuleListBySrc(arg0 net.IPNet) error {
 // DeleteRuleListBySrc indicates an expected call of DeleteRuleListBySrc
 func (mr *MockNetworkAPIsMockRecorder) DeleteRuleListBySrc(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRuleListBySrc", reflect.TypeOf((*MockNetworkAPIs)(nil).DeleteRuleListBySrc), arg0)
+}
+
+// GetExcludeSNATCIDRs mocks base method
+func (m *MockNetworkAPIs) GetExcludeSNATCIDRs() []string {
+	ret := m.ctrl.Call(m, "GetExcludeSNATCIDRs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetExcludeSNATCIDRs indicates an expected call of GetExcludeSNATCIDRs
+func (mr *MockNetworkAPIsMockRecorder) GetExcludeSNATCIDRs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExcludeSNATCIDRs", reflect.TypeOf((*MockNetworkAPIs)(nil).GetExcludeSNATCIDRs))
 }
 
 // GetRuleList mocks base method
@@ -132,16 +144,4 @@ func (m *MockNetworkAPIs) UseExternalSNAT() bool {
 // UseExternalSNAT indicates an expected call of UseExternalSNAT
 func (mr *MockNetworkAPIsMockRecorder) UseExternalSNAT() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseExternalSNAT", reflect.TypeOf((*MockNetworkAPIs)(nil).UseExternalSNAT))
-}
-
-// GetExcludeSNATCIDRs mocks base method
-func (m *MockNetworkAPIs) GetExcludeSNATCIDRs() []string {
-	ret := m.ctrl.Call(m, "GetExcludeSNATCIDRs")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetExcludeSNATCIDRs indicates an expected call of GetExcludeSNATCIDRs
-func (mr *MockNetworkAPIsMockRecorder) GetExcludeSNATCIDRs() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExcludeSNATCIDRs", reflect.TypeOf((*MockNetworkAPIs)(nil).GetExcludeSNATCIDRs))
 }

--- a/pkg/utils/ttime/mocks/time_mocks.go
+++ b/pkg/utils/ttime/mocks/time_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/rpc/mocks/rpc_mocks.go
+++ b/rpc/mocks/rpc_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -18,11 +18,11 @@
 package mock_rpc
 
 import (
+	context "context"
 	reflect "reflect"
 
 	rpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
 	gomock "github.com/golang/mock/gomock"
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
One possible solution for #725 

This tag results in an ENI being unmanaged by the ipamd plugin. This
allows someone to create an ENI, associate it with an instance, and then
use eks per normal while also using that ENI for whatever.