### PR TITLE
Remove deprecated session.New method

### DIFF
--- a/pkg/ec2metadata/client.go
+++ b/pkg/ec2metadata/client.go
@@ -25,7 +25,10 @@ type EC2Metadata interface {
 	Region() (string, error)
 }
 
-// NewEC2Metadata creates a new EC2Metadata object
+// New creates a new EC2Metadata object
 func New() EC2Metadata {
-	return ec2metadatasvc.New(session.New(), aws.NewConfig().WithMaxRetries(10))
+	awsSession := session.Must(session.NewSession(aws.NewConfig().
+		WithMaxRetries(10),
+	))
+	return ec2metadatasvc.New(awsSession)
 }

--- a/pkg/ec2metadatawrapper/ec2metadatawrapper.go
+++ b/pkg/ec2metadatawrapper/ec2metadatawrapper.go
@@ -1,4 +1,4 @@
-// package ecmetadatawrapper is used to retrieve data from EC2 IMDS
+// Package ec2metadatawrapper is used to retrieve data from EC2 IMDS
 package ec2metadatawrapper
 
 import (
@@ -32,10 +32,12 @@ type ec2MetadataClientImpl struct {
 // New creates an ec2metadata client to retrieve metadata
 func New(client HttpClient) EC2MetadataClient {
 	if client == nil {
-		return &ec2MetadataClientImpl{client: ec2metadata.New(session.New(), aws.NewConfig().WithMaxRetries(metadataRetries))}
-	} else {
-		return &ec2MetadataClientImpl{client: client}
+		awsSession := session.Must(session.NewSession(aws.NewConfig().
+			WithMaxRetries(metadataRetries),
+		))
+		return &ec2MetadataClientImpl{client: ec2metadata.New(awsSession)}
 	}
+	return &ec2MetadataClientImpl{client: client}
 }
 
 // InstanceIdentityDocument returns instance identity documents


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
As per this [comment](https://github.com/aws/aws-sdk-go/issues/2828#issuecomment-533649525), session.New() is deprecated. We call this method in multiple places which is replaced with session.NewSession() instead. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
