### PR TITLE
update aws-cni to 1.5.5 and metrics helper to 1.5.5 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ verify-network
 .DS_Store
 cni-metrics-helper/cni-metrics-helper
 portmap
+grpc_health_probe

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -81,7 +81,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.5
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.5/cni-metrics-helper.yaml
+++ b/config/v1.5/cni-metrics-helper.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.5.0
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.5.5
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
bump amazon-k8s-cni:v1.5.3 to amazon-k8s-cni:v1.5.5
cni-metrics-helper:v1.5.0 to cni-metrics-helper:v1.5.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
