### PR TITLE
Additional tags to ENI

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,20 @@ Default: `eni`
 
 Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long.
 
+---
+
+`ADDITIONAL_ENI_TAGS`
+
+Type: String
+
+Default: `{}`
+
+Example values: `{"tag_key": "tag_val"}`
+
+Metadata applied to ENI help you categorize and organize your resources for billing or other purposes. Each tag consists of a custom-defined key and an optional value. Tag keys can have a maximum character length of 128 characters. Tag values can have a maximum length of 256 characters. These tags will be added to all ENIs on the host. 
+
+Important: Custom tags should not contain `k8s.amazonaws.com` prefix as it is reserved. If the tag has `k8s.amazonaws.com` string, tag addition will ignored.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server. If it can **not** reach

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -15,6 +15,8 @@ package awsutils
 
 import (
 	"errors"
+	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -355,6 +357,55 @@ func TestTagEni(t *testing.T) {
 	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, nil)
 	ins.tagENI(eniID)
 	assert.NoError(t, err)
+}
+
+func TestAdditionalTagsEni(t *testing.T) {
+	ctrl, _, mockEC2 := setup(t)
+	defer ctrl.Finish()
+	os.Setenv(additionalEniTagsEnvVar, `{"testKey": "testing"}`)
+	cureniID := eniID
+	//result key
+	tagKey1 := "testKey"
+	//result value
+	tagValue1 := "testing"
+	tag := ec2.Tag{
+		Key:   &tagKey1,
+		Value: &tagValue1}
+	result := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []*ec2.NetworkInterface{{TagSet: []*ec2.Tag{&tag}}}}
+
+	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, nil)
+	ins.tagENI(cureniID)
+
+	// Verify the tags are registered.
+	assert.Equal(t, aws.StringValue(result.NetworkInterfaces[0].TagSet[0].Key), tagKey1)
+	assert.Equal(t, aws.StringValue(result.NetworkInterfaces[0].TagSet[0].Value), tagValue1)
+}
+
+func TestMapToTags(t *testing.T) {
+	tagKey1 := "tagKey1"
+	tagKey2 := "tagKey2"
+	tagValue1 := "tagValue1"
+	tagValue2 := "tagValue2"
+	tagKey3 := "cluster.k8s.amazonaws.com/name"
+	tagValue3 := "clusterName"
+	tagsMap := map[string]string{
+		tagKey1: tagValue1,
+		tagKey2: tagValue2,
+		tagKey3: tagValue3,
+	}
+	tags := make([]*ec2.Tag, 0)
+	tags = mapToTags(tagsMap, tags)
+	assert.Equal(t, 2, len(tags))
+	sort.Slice(tags, func(i, j int) bool {
+		return aws.StringValue(tags[i].Key) < aws.StringValue(tags[j].Key)
+	})
+
+	assert.Equal(t, aws.StringValue(tags[0].Key), tagKey1)
+	assert.Equal(t, aws.StringValue(tags[0].Value), tagValue1)
+	assert.Equal(t, aws.StringValue(tags[1].Key), tagKey2)
+	assert.Equal(t, aws.StringValue(tags[1].Value), tagValue2)
 }
 
 func TestAllocENI(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#643 

*Description of changes:*

This feature allows you to add additional tags to ENIs created. Metadata applied to ENI help you categorize and organize your resources for billing or other purposes. Each tag consists of a custom-defined key and an optional value. Tag keys can have a maximum character length of 128 characters. Tag values can have a maximum length of 256 characters.
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
