### PR TITLE
Wait until the discover controller cache is synced

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,12 @@ func _main() int {
 		return 1
 	}
 
-	discoverController := k8sapi.NewController(kubeClient)
+	discoverController, err := k8sapi.NewController(kubeClient)
+	if err != nil {
+		log.Errorf("Failed to create new Discover Controller: %v", err)
+		return 1
+	}
+
 	go discoverController.DiscoverK8SPods()
 
 	eniConfigController := eniconfig.NewENIConfigController()
@@ -59,7 +64,6 @@ func _main() int {
 	}
 
 	ipamContext, err := ipamd.New(discoverController, eniConfigController)
-
 	if err != nil {
 		log.Errorf("Initialization failure: %v", err)
 		return 1


### PR DESCRIPTION
https://github.com/aws/amazon-vpc-cni-k8s/issues/711

This change makes sure we don't have a race condition when the ipamD agent initially starts. In the current state, without these changes, there is a possibility that ipamD would start assigning IPs to pods before its internal state is synced

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
