### PR TITLE
Not returning error when unassign called on pod without IP

### DIFF
--- a/ipamd/rpc_handler.go
+++ b/ipamd/rpc_handler.go
@@ -97,6 +97,14 @@ func (s *server) DelNetwork(ctx context.Context, in *pb.DelNetworkRequest) (*pb.
 		ip, deviceNumber, err = s.ipamContext.dataStore.UnassignPodIPv4Address(&k8sapi.K8SPodInfo{
 			Name:      in.K8S_POD_NAME,
 			Namespace: in.K8S_POD_NAMESPACE})
+
+		// if a pod gets scheduled to a node when the aws cni is restarting,
+		// kubelet would kill and recreate pod. When kubelet tries to kill
+		// the container initially, this block would make sure the ipamD agent would
+		// make sure we dont return an error.
+		if err == datastore.ErrUnknownPod {
+			err = nil
+		}
 	}
 	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)
 


### PR DESCRIPTION
https://github.com/aws/amazon-vpc-cni-k8s/issues/739

As described in the above issues, the current code for UnassignIP returns an error on ipamD when UnassignIP is called on pods that dont have an IP assigned yet. This fix makes this idempotent and does not return an error when a pod without Ip goes through UnassignIP flow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
