### PR TITLE
Use simple filename check in entrypoint script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 IMAGE   ?= amazon/amazon-k8s-cni
 VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS ?= -X main.version=$(VERSION)
-
+DOCKER_ARGS ?=
 ALLPKGS := $(shell go list ./...)
 
 ARCH ?= $(shell uname -m)
@@ -47,11 +47,11 @@ download-portmap:
 
 # Build CNI Docker image
 docker:
-	@docker build --build-arg arch="$(ARCH)" -f scripts/dockerfiles/Dockerfile.release -t "$(IMAGE):$(VERSION)" .
+	@docker build $(DOCKER_ARGS) --build-arg arch="$(ARCH)" -f scripts/dockerfiles/Dockerfile.release -t "$(IMAGE):$(VERSION)" .
 	@echo "Built Docker image \"$(IMAGE):$(VERSION)\""
 
 docker-func-test: docker
-	docker run -it "$(IMAGE):$(VERSION)"
+	docker run $(DOCKER_ARGS) -it "$(IMAGE):$(VERSION)"
 
 # unit-test
 unit-test:

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,12 +25,12 @@
 set -m
 
 # Check for all the required binaries before we go forward
-if [ ! -x $(command -v aws-k8s-agent) ]; then
+if [ ! -f aws-k8s-agent ]; then
     echo "Required aws-k8s-agent executable not found."
     exit 1
 fi
-if [ ! -x $(command -v grp_health_probe) ]; then
-    echo "Required grp_health_probe executable not found."
+if [ ! -f grpc_health_probe ]; then
+    echo "Required grpc_health_probe executable not found."
     exit 1
 fi
 


### PR DESCRIPTION
The `[ ! -x $(command -v grp_health_probe) ]` check contained a typo
(grp instead of grpc) but the `command -v` check was always returning 0
for some reason. This meant the executable check wasn't working but the
entrypoint script was executing properly anyway.

This patch fixes the typo and replaces the command -v check with a
simpler bash `if [ -f $FILE ]` check instead.

Also adds a DOCKER_ARGS envvar to facilitate local testing in
environments that don't handle Docker non-host networking well.

Closes Issue #748

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
