### PR TITLE
Use dockershim.sock for CRI

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -101,7 +101,7 @@ spec:
             - name: AWS_VPC_K8S_CNI_VETHPREFIX
               value: eni
             - name: AWS_VPC_K8S_CNI_MTU
-              value: 9001
+              value: "9001"
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -120,6 +120,8 @@ spec:
               name: log-dir
             - mountPath: /var/run/docker.sock
               name: dockersock
+            - mountPath: /var/run/dockershim.sock
+              name: dockershim
       volumes:
         - name: cni-bin-dir
           hostPath:
@@ -133,6 +135,9 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
+        - name: dockershim
+          hostPath:
+            path: /var/run/dockershim.sock
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
-	github.com/onsi/ginkgo v1.8.0
-	github.com/onsi/gomega v1.5.0
+	github.com/onsi/ginkgo v1.8.0 // indirect
+	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/operator-framework/operator-sdk v0.0.7
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
@@ -40,7 +40,6 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293

--- a/ipamd/datastore/data_store.go
+++ b/ipamd/datastore/data_store.go
@@ -470,7 +470,7 @@ func (ds *DataStore) UnassignPodIPv4Address(k8sPod *k8sapi.K8SPodInfo) (ip strin
 	}
 	ipAddr, ok := ds.podsIP[podKey]
 	if !ok {
-		log.Warnf("UnassignPodIPv4Address: Failed to find pod %s namespace %s Sandbox %s",
+		log.Warnf("UnassignPodIPv4Address: Failed to find pod %s namespace %q, sandbox %q",
 			k8sPod.Name, k8sPod.Namespace, k8sPod.Sandbox)
 		return "", 0, ErrUnknownPod
 	}

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -334,7 +334,6 @@ func (c *IPAMContext) nodeInit() error {
 		}
 	}
 	localPods, err := c.getLocalPodsWithRetry()
-	log.Debugf("getLocalPodsWithRetry() found %d local pods", len(localPods))
 	if err != nil {
 		log.Warnf("During ipamd init, failed to get Pod information from Kubernetes API Server %v", err)
 		ipamdErrInc("nodeInitK8SGetLocalPodIPsFailed")
@@ -342,6 +341,7 @@ func (c *IPAMContext) nodeInit() error {
 		// TODO  need to add node health stats here
 		return errors.Wrap(err, "failed to get running pods!")
 	}
+	log.Debugf("getLocalPodsWithRetry() found %d local pods", len(localPods))
 
 	rules, err := c.networkClient.GetRuleList()
 	if err != nil {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 
 AGENT_LOG_PATH=${AGENT_LOG_PATH:-aws-k8s-agent.log}
 HOST_CNI_BIN_PATH=${HOST_CNI_BIN_PATH:-/host/opt/cni/bin}
-HOST_CNI_CONFDIR_PATH=${HOST_CNI_CONFDIR_PATH:-/host/opt/cni/net.d}
+HOST_CNI_CONFDIR_PATH=${HOST_CNI_CONFDIR_PATH:-/host/etc/cni/net.d}
 
 # Checks for IPAM connectivity on localhost port 50051, retrying connectivity
 # check with a timeout of 36 seconds
@@ -53,7 +53,7 @@ wait_for_ipam() {
 }
 
 echo -n "starting IPAM daemon in background ... "
-./aws-k8s-agent > $AGENT_LOG_PATH 2>&1 &
+./aws-k8s-agent > "$AGENT_LOG_PATH" 2>&1 &
 echo "ok."
 
 echo -n "checking for IPAM connectivity ... "
@@ -68,13 +68,13 @@ echo "ok."
 
 echo -n "copying CNI plugin binaries and config files ... "
 
-cp portmap $HOST_CNI_BIN_PATH
-cp aws-cni $HOST_CNI_BIN_PATH$
-cp aws-cni-support.sh $HOST_CNI_BIN_PATH
+cp portmap "$HOST_CNI_BIN_PATH"
+cp aws-cni "$HOST_CNI_BIN_PATH"
+cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"
 
 sed -i s/__VETHPREFIX__/"${AWS_VPC_K8S_CNI_VETHPREFIX:-"eni"}"/g 10-aws.conflist
 sed -i s/__MTU__/"${AWS_VPC_ENI_MTU:-"9001"}"/g 10-aws.conflist
-cp 10-aws.conflist $HOST_CNI_CONFDIR_PATH
+cp 10-aws.conflist "$HOST_CNI_CONFDIR_PATH"
 
 echo " ok."
 
@@ -84,8 +84,8 @@ fi
 
 # bring the aws-k8s-agent process back into the foreground
 echo "foregrounding IPAM daemon ... "
-fg %1 >/dev/null 2>&1 || $(echo "failed (process terminated)" && cat $AGENT_LOG_PATH && exit 1)
+fg %1 >/dev/null 2>&1 || $(echo "failed (process terminated)" && cat "$AGENT_LOG_PATH" && exit 1)
 
 # Best practice states we should send the container's CMD output to stdout, so
 # let's tee back up the log file into stdout
-cat $AGENT_LOG_PATH
+cat "$AGENT_LOG_PATH"


### PR DESCRIPTION
*Issue #714 related*

*Description of changes:*
In the original commit, we only checked `/var/run/cri.sock` to get the Sandbox ID. This works fine for CRI-O or containerd with the CRI plugin, as long as the socket is mounted correctly, but when using docker we need the `/var/run/dockershim.sock` created by Kubelet, since it talks gRPC with the CRI API, while `/var/run/docker.sock` is http only.

* Use `dockershim.sock` provided by kubelet to get a gRPC CRI to call. (Follow up in #752)
* Fix entrypoint script
* ~~Fix delete check of pod that failed to start~~ (Merged #750 first)
* Log empty sandbox id using quotes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
