### PR TITLE
Force ENI/IP reconciliation to delete from the datastore

### DIFF
--- a/ipamd/datastore/data_store_test.go
+++ b/ipamd/datastore/data_store_test.go
@@ -67,7 +67,7 @@ func TestDeleteENI(t *testing.T) {
 	assert.Equal(t, len(eniInfos.ENIIPPools), 2)
 
 	// Add an IP and assign a pod.
-	err = ds.AddIPv4AddressFromStore("eni-1", "1.1.1.1")
+	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	assert.NoError(t, err)
 	podInfo := &k8sapi.K8SPodInfo{
 		Name:      "pod-1",

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -552,8 +552,7 @@ func (c *IPAMContext) tryUnassignIPsFromAll() {
 			for _, toDelete := range ips {
 				// Don't force the delete, since a freeable IP might have been assigned to a pod
 				// before we get around to deleting it.
-				const force = false
-				err := c.dataStore.DelIPv4AddressFromStore(eniID, toDelete, force)
+				err := c.dataStore.DelIPv4AddressFromStore(eniID, toDelete, false /* force */)
 				if err != nil {
 					log.Warnf("Failed to delete IP %s on ENI %s from datastore: %s", toDelete, eniID, err)
 					ipamdErrInc("decreaseIPPool")
@@ -996,8 +995,7 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 		log.Infof("Reconcile and delete detached ENI %s", eni)
 		// Force the delete, since aws local metadata has told us that this ENI is no longer
 		// attached, so any IPs assigned from this ENI will no longer work.
-		const force = true
-		err = c.dataStore.RemoveENIFromDataStore(eni, force)
+		err = c.dataStore.RemoveENIFromDataStore(eni, true /* force */)
 		if err != nil {
 			log.Errorf("IP pool reconcile: Failed to delete ENI during reconcile: %v", err)
 			ipamdErrInc("eniReconcileDel")
@@ -1071,8 +1069,7 @@ func (c *IPAMContext) eniIPPoolReconcile(ipPool map[string]*datastore.AddressInf
 		log.Debugf("Reconcile and delete IP %s on ENI %s", existingIP, eni)
 		// Force the delete, since aws local metadata has told us that this ENI is no longer
 		// attached, so any IPs assigned from this ENI will no longer work.
-		const force = true
-		err := c.dataStore.DelIPv4AddressFromStore(eni, existingIP, force)
+		err := c.dataStore.DelIPv4AddressFromStore(eni, existingIP, true /* force */)
 		if err != nil {
 			log.Errorf("Failed to reconcile and delete IP %s on ENI %s, %v", existingIP, eni, err)
 			ipamdErrInc("ipReconcileDel")

--- a/ipamd/ipamd.go
+++ b/ipamd/ipamd.go
@@ -550,7 +550,10 @@ func (c *IPAMContext) tryUnassignIPsFromAll() {
 			// Delete IPs from datastore
 			var deletedIPs []string
 			for _, toDelete := range ips {
-				err := c.dataStore.DelIPv4AddressFromStore(eniID, toDelete)
+				// Don't force the delete, since a freeable IP might have been assigned to a pod
+				// before we get around to deleting it.
+				const force = false
+				err := c.dataStore.DelIPv4AddressFromStore(eniID, toDelete, force)
 				if err != nil {
 					log.Warnf("Failed to delete IP %s on ENI %s from datastore: %s", toDelete, eniID, err)
 					ipamdErrInc("decreaseIPPool")
@@ -991,7 +994,10 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 	// Sweep phase: since the marked ENI have been removed, the remaining ones needs to be sweeped
 	for eni := range curENIs.ENIIPPools {
 		log.Infof("Reconcile and delete detached ENI %s", eni)
-		err = c.dataStore.RemoveENIFromDataStore(eni)
+		// Force the delete, since aws local metadata has told us that this ENI is no longer
+		// attached, so any IPs assigned from this ENI will no longer work.
+		const force = true
+		err = c.dataStore.RemoveENIFromDataStore(eni, force)
 		if err != nil {
 			log.Errorf("IP pool reconcile: Failed to delete ENI during reconcile: %v", err)
 			ipamdErrInc("eniReconcileDel")
@@ -1063,7 +1069,10 @@ func (c *IPAMContext) eniIPPoolReconcile(ipPool map[string]*datastore.AddressInf
 	// Sweep phase, delete remaining IPs
 	for existingIP := range ipPool {
 		log.Debugf("Reconcile and delete IP %s on ENI %s", existingIP, eni)
-		err := c.dataStore.DelIPv4AddressFromStore(eni, existingIP)
+		// Force the delete, since aws local metadata has told us that this ENI is no longer
+		// attached, so any IPs assigned from this ENI will no longer work.
+		const force = true
+		err := c.dataStore.DelIPv4AddressFromStore(eni, existingIP, force)
 		if err != nil {
 			log.Errorf("Failed to reconcile and delete IP %s on ENI %s, %v", existingIP, eni, err)
 			ipamdErrInc("ipReconcileDel")


### PR DESCRIPTION
Fixes #732

The ENI/IP reconciliation logic fails to delete from the datastore, if any IPs are already assigned to pods. This is wrong; the AWS local metadata is the source of truth for what ENIs/IPs are actually attached to the EC2 instance. By failing to delete from the datastore, ipamd will assign IPs from ENIs that aren't actually attached to the EC2 instance.

This PR fixes this by forcing the reconciliation logic to delete from the datastore. I've also added prometheus counters to track how often this force-deletion is occurring, to aid debugging.

The unittests pass, and I've been running an image built from this on my clusters, and have seen that it fixes the problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.