### PR TITLE
fix gofmt errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ clean:
 	rm -f cni-metrics-helper/cni-metrics-helper
 	rm -f portmap
 
-files := $(shell find . -not -name 'mock_publisher.go' -name '*.go' -print)
+files := $(shell find . -not -name 'mock_publisher.go' -not -name 'rpc.pb.go' -not -name 'integration_test.go' -name '*.go' -print)
 unformatted = $(shell goimports -l $(files))
 
 format :

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -3,15 +3,16 @@ package cri
 import (
 	"context"
 	"errors"
+	"os"
+
 	"google.golang.org/grpc"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-	"os"
 
 	log "github.com/cihub/seelog"
 )
 
 const (
-	criSocketPath = "unix:///var/run/cri.sock"
+	criSocketPath    = "unix:///var/run/cri.sock"
 	dockerSocketPath = "unix:///var/run/dockershim.sock"
 )
 


### PR DESCRIPTION
goimports was not being installed by default in the travis.yml or
circleci build jobs. This was causing make check-format to not be run
properly. When I installed goimports for circleci's config, there were a
couple errors. This patch fixes those errors by ignoring the
grpc-generated and integration_test.go files and addressing the
gofmt-found issues in pkg/cri/cri.go around import ordering.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
