### PR TITLE
Fix metrics watcher

### DIFF
--- a/cni-metrics-helper/cni-metrics-helper.go
+++ b/cni-metrics-helper/cni-metrics-helper.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	discoverController := k8sapi.NewController(kubeClient)
-	go discoverController.DiscoverK8SPods()
+	go discoverController.DiscoverCNIK8SPods()
 
 	var cw publisher.Publisher
 

--- a/cni-metrics-helper/metrics/cni_metrics.go
+++ b/cni-metrics-helper/metrics/cni_metrics.go
@@ -86,6 +86,20 @@ var InterestingCNIMetrics = map[string]metricsConvert{
 				actionFunc: metricsAdd,
 				data:       &dataPoints{},
 				logToFile:  true}}},
+	"awscni_force_removed_enis": {
+		actions: []metricsAction{
+			{cwMetricName: "forceRemoveENI",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{},
+				logToFile:  true}}},
+	"awscni_force_removed_ips": {
+		actions: []metricsAction{
+			{cwMetricName: "forceRemoveIPs",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{},
+				logToFile:  true}}},
 	"awscni_ipamd_action_inprogress": {
 		actions: []metricsAction{
 			{cwMetricName: "ipamdActionInProgress",

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func _main() int {
 	}
 
 	discoverController := k8sapi.NewController(kubeClient)
-	go discoverController.DiscoverK8SPods()
+	go discoverController.DiscoverLocalK8SPods()
 
 	eniConfigController := eniconfig.NewENIConfigController()
 	if ipamd.UseCustomNetworkCfg() {

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -117,11 +117,20 @@ func (d *Controller) GetCNIPods() []string {
 	return cniPods
 }
 
-// DiscoverK8SPods discovers Pods running in the cluster
-func (d *Controller) DiscoverK8SPods() {
+// DiscoverLocalK8SPods discovers CNI pods, aws-node, running in the cluster
+func (d *Controller) DiscoverCNIK8SPods() {
 	// create the pod watcher
-	podListWatcher := cache.NewListWatchFromClient(d.kubeClient.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", d.myNodeName))
+	d.DiscoverK8SPods(cache.NewListWatchFromClient(d.kubeClient.CoreV1().RESTClient(), "pods", metav1.NamespaceSystem, fields.Everything()))
+}
 
+// DiscoverLocalK8SPods discovers local pods running on the node
+func (d *Controller) DiscoverLocalK8SPods() {
+	// create the pod watcher
+	d.DiscoverK8SPods(cache.NewListWatchFromClient(d.kubeClient.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", d.myNodeName)))
+}
+
+// DiscoverK8SPods takes a watcher and updates the Controller cache
+func (d *Controller) DiscoverK8SPods(podListWatcher *cache.ListWatch) {
 	// create the workqueue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 


### PR DESCRIPTION
*Issue #717*

*Description of changes:*
* Modify watcher to only look at `kube-system` (Follow up to #716)
* Add the force detach metrics (`awscni_force_removed_enis` and `awscni_force_removed_ips `), added in #733 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
