### PR TITLE
Bump golang version to 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.13-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       GO111MODULE: "on"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ language: go
 # Only the last two Go releases are supported by the Go team with security updates.
 # Any older versions are considered deprecated.
 go:
+  - "1.13.x"
   - "1.12.x"
-  - "1.11.x"
-
 
 # Only clone the most recent commit.
 git:

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch as builder
+FROM golang:1.13-stretch as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 
 ARG arch
@@ -6,6 +6,7 @@ ENV ARCH=$arch
 
 # Force the go compiler to use modules.
 ENV GO111MODULE=on
+ENV GOPROXY=direct
 
 # go.mod and go.sum go into their own layers.
 COPY go.mod .

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch as builder
+FROM golang:1.13-stretch as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 
 ARG arch
@@ -6,6 +6,7 @@ ENV ARCH=$arch
 
 # Force the go compiler to use modules.
 ENV GO111MODULE=on
+ENV GOPROXY=direct
 
 # go.mod and go.sum go into their own layers.
 COPY go.mod .

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.13-stretch
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 
 ARG arch
@@ -6,6 +6,7 @@ ENV ARCH=$arch
 
 # Force the go compiler to use modules.
 ENV GO111MODULE=on
+ENV GOPROXY=direct
 
 # Add goimports
 RUN go get -u golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
*Description of changes:*
* Bump go version to 1.13
* Disable the proxy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
