### PR TITLE
Update aws-k8s-cni.yaml

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -79,7 +79,10 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-        - operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
       containers:
         - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.5
           imagePullPolicy: Always


### PR DESCRIPTION
*Issue #, if available:*
when i try to create kops cluster with vpc-cni network plugin,  the master node has these taints, so 
pod is not scheduled to master node.

*Description of changes:*
Add toleration to daemonset can fix this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
