### PR TITLE
Speed up tests using exponential backoff

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -310,7 +310,7 @@ func TestAWSGetFreeDeviceNumberOnErr(t *testing.T) {
 	defer ctrl.Finish()
 
 	// test error handling
-	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("Error on DescribeInstances"))
+	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("error on DescribeInstances"))
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
 	_, err := ins.awsGetFreeDeviceNumber()
@@ -399,20 +399,20 @@ func TestTagEni(t *testing.T) {
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
 	err := ins.initWithEC2Metadata()
 	assert.NoError(t, err)
-	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
-	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
-	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
-	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("Tagging Failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("tagging failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("tagging failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("tagging failed"))
+	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, errors.New("tagging failed"))
 	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, nil)
-	ins.tagENI(eniID)
+	ins.tagENI(eniID, time.Millisecond)
 	assert.NoError(t, err)
 }
 
 func TestAdditionalTagsEni(t *testing.T) {
 	ctrl, _, mockEC2 := setup(t)
 	defer ctrl.Finish()
-	os.Setenv(additionalEniTagsEnvVar, `{"testKey": "testing"}`)
-	cureniID := eniID
+	_ = os.Setenv(additionalEniTagsEnvVar, `{"testKey": "testing"}`)
+	currentENIID := eniID
 	//result key
 	tagKey1 := "testKey"
 	//result value
@@ -425,7 +425,7 @@ func TestAdditionalTagsEni(t *testing.T) {
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
 	mockEC2.EXPECT().CreateTags(gomock.Any()).Return(nil, nil)
-	ins.tagENI(cureniID)
+	ins.tagENI(currentENIID, time.Millisecond)
 
 	// Verify the tags are registered.
 	assert.Equal(t, aws.StringValue(result.NetworkInterfaces[0].TagSet[0].Key), tagKey1)
@@ -572,7 +572,7 @@ func TestFreeENI(t *testing.T) {
 	mockEC2.EXPECT().DeleteNetworkInterface(gomock.Any()).Return(nil, nil)
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	err := ins.freeENI("test-eni", time.Millisecond)
+	err := ins.freeENI("test-eni", time.Millisecond, time.Millisecond)
 	assert.NoError(t, err)
 }
 
@@ -592,7 +592,7 @@ func TestFreeENIRetry(t *testing.T) {
 	mockEC2.EXPECT().DeleteNetworkInterface(gomock.Any()).Return(nil, nil)
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	err := ins.freeENI("test-eni", time.Millisecond)
+	err := ins.freeENI("test-eni", time.Millisecond, time.Millisecond)
 	assert.NoError(t, err)
 }
 
@@ -612,7 +612,7 @@ func TestFreeENIRetryMax(t *testing.T) {
 	}
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	err := ins.freeENI("test-eni", time.Millisecond)
+	err := ins.freeENI("test-eni", time.Millisecond, time.Millisecond)
 	assert.Error(t, err)
 }
 

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -198,12 +198,6 @@ func TestPushWithMissingData(t *testing.T) {
 	assert.Empty(t, cloudwatchPublisher.localMetricData)
 }
 
-func TestPublisherNewWithoutClusterID(t *testing.T) {
-	cloudwatchPublisher, err := New(context.TODO())
-	assert.Error(t, err)
-	assert.Nil(t, cloudwatchPublisher)
-}
-
 func TestMin(t *testing.T) {
 	a, b := 1, 2
 


### PR DESCRIPTION
*Description of changes:*
* Override the max-timeout in the tagging tests as well to make them run faster (Saves 22s of sleep)
* Lowercase error messages in tests
* Removed test for failing to create publisher because of no context (Saves over 1 minute)

All unit tests now run in around 8 seconds, even if we have added a lot of them. 8 months ago they took around 10 minutes to run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
