### PR TITLE
Add .mailmap to get correct emails per user

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Andrew Rudoi <andrewrudoi@gmail.com> <arudoi@newrelic.com>
+Claes Mogren <claes.mogren@gmail.com> <mogren@amazon.com>
+Kit Ewbank <Christopher.Ewbank@capitalone.com> <Kit_Ewbank@hotmail.com>
+Liwen Wu <liwenwu@amazon.com> liwen wu <liwenwu@amazon.com> <ubuntu@ip-10-0-1-11.ec2.internal>
+Nick Turner <nic@amazon.com> Nicholas Turner <1205393+nckturner@users.noreply.github.com>
+Shaun Crampton <shaun@cantab.net> <shaun@tigera.io>
+Taylor Bertie <45247171+taylorb-syd@users.noreply.github.com> <bertiet@amazon.com>

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -115,6 +115,7 @@ func TestCloudWatchPublisherWithGreaterThanMaxDatapointsAndStop(t *testing.T) {
 
 	<-time.After(2 * testMonitorDuration)
 	cloudwatchPublisher.Stop()
+	<-time.After(testMonitorDuration)
 
 	assert.Empty(t, cloudwatchPublisher.localMetricData)
 }


### PR DESCRIPTION
*Description of changes:*
Noticed that some users, including me, had commits with different emails. Adding a `.mailmap` to correct that issue. (Doc ref: [mailmap.txt](https://github.com/git/git/blob/master/Documentation/mailmap.txt))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
