### PR TITLE
adding node affinity for Fargate

### DIFF
--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -76,6 +76,10 @@ spec:
                     operator: In
                     values:
                       - amd64
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
*Issue #, if available:* N/A 

*Description of changes:*

Upon creating new EKS version ( 1.14 k8s version), it comes with default 1.5.3 CNI version which comes with nodeAffinity for Fargate. However, the same parameters are missing on Github.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
