### PR TITLE
Update RollingUpdate strategy to allow 10% unavailable

### DIFF
--- a/config/v1.0/aws-k8s-cni.yaml
+++ b/config/v1.0/aws-k8s-cni.yaml
@@ -45,6 +45,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node

--- a/config/v1.1/aws-k8s-cni.yaml
+++ b/config/v1.1/aws-k8s-cni.yaml
@@ -45,6 +45,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node

--- a/config/v1.2/aws-k8s-cni.yaml
+++ b/config/v1.2/aws-k8s-cni.yaml
@@ -53,6 +53,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node

--- a/config/v1.3/aws-k8s-cni.yaml
+++ b/config/v1.3/aws-k8s-cni.yaml
@@ -54,6 +54,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node

--- a/config/v1.4/aws-k8s-cni.yaml
+++ b/config/v1.4/aws-k8s-cni.yaml
@@ -54,6 +54,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -54,6 +54,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   selector:
     matchLabels:
       k8s-app: aws-node


### PR DESCRIPTION
*Description of changes:*

This updates the `RollingUpdate` strategy to allow more pods to update simultaneously. When updating a reasonably sized cluster (~400 nodes), having a single pod update at a time takes an _extremely_ long time. 

The PR changes the update strategy to allow 10% unavailable. This aligns with the update strategy from kube-proxy ([here](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/kube-proxy/kube-proxy-ds.yaml#L19))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
