### PR TITLE
[ipamd] de-dup calls to DescribeNetworkInterfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ aws-cni
 verify-aws
 verify-network
 *~
+*.swp
 .idea/
 *.iml
 .DS_Store

--- a/ipamd/ipamd_test.go
+++ b/ipamd/ipamd_test.go
@@ -156,7 +156,6 @@ func TestNodeInit(t *testing.T) {
 	var rules []netlink.Rule
 	mockNetwork.EXPECT().GetRuleList().Return(rules, nil)
 
-	mockAWS.EXPECT().GetVPCIPv4CIDRs().Return(cidrs)
 	mockNetwork.EXPECT().UseExternalSNAT().Return(false)
 	mockNetwork.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any(), gomock.Any(), true)
 	// Add IPs


### PR DESCRIPTION
In `IPAMContext.nodeInit()` and `IPAMContext.nodeIPPoolReconcile()`, the
`IPAMContext.setupENI()` method was being called, passing in an
`ENIMetadata` struct that contained the "local" IPv4 addresses that had
been queried from IMDS. `IPAMContext.setupENI()` called the
`IPAMContext.getENIAddresses()` method, however, which in turn calls the
AWS EC2 DescribeNetworkInterfaces API. The DescribeNetworkInterfaces API
call is expensive and throttled, and so we need to be careful how often
we call it.

In the case of `IPAMContext.nodeInit()` and
`IPAMContext.nodeIPPoolReconcile()`, they were both calling
`IPAMContext.setupENI()` and passing along an `ENIMetadata` struct that both
methods had previously constructed using the
`EC2InstanceMetadataCache.GetAttachedENIs()` method, which in turn called
`EC2InstanceMetadataCache.getENIMetadata()`.
`EC2InstanceMetadataCache.getENIMetadata()` itself ended up calling the
DescribeNetworkInterfaces EC2 API for each ENI on the host machine. So,
the slice of `ENIMetadata` structs returned from
`EC2InstanceMetadataCache.GetAttachedENIs()` -- which was being called by
`IPAMContext.nodeInit()` and `IPAMContext.nodeIPPoolReconcile()` *already
had the most up-to-date information from the DescribeNetworkInterfaces
EC2 API call*.

Therefore, what this patch does is simply modify the `ENIMetadata` struct
to store the slice of pointer to `ec2.NetworkInterfacePrivateIpAddress`
structs that is returned from the DescribeNetworkInterfaces EC2 API
call. That way, for methods like `IPAMContext.setupENI()`, which passes in
an `ENIMetadata` struct, we can remove the call to
`IPAMContext.getENIAddresses()` which cuts down on the number of duplicate
calls to DescribeNetworkInterfaces EC2 API.

Issue #808

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
