### PR TITLE
Add note about WARM_IP_TARGET to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ elastic network interfaces on the node are unable to provide these free addresse
 until `WARM_IP_TARGET` free IP addresses are available.
 
 **NOTE!** Avoid this setting for large clusters, or if the cluster has high pod churn. Setting it will cause additional calls to the
-EC2 API and that might cause throttling of the requests. It is strongly suggested to set `MINIMUM_IP_TARGET` when using `MINIMUM_IP_TARGET`.
+EC2 API and that might cause throttling of the requests. It is strongly suggested to set `MINIMUM_IP_TARGET` when using `WARM_IP_TARGET`.
 
 If both `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Used to configure the MTU size for attached ENIs. The valid range is from `576` 
 
 ---
 
-`AWS_VPC_K8S_CNI_EXTERNALSNAT` (Since v1.6.0)
+`AWS_VPC_K8S_CNI_EXTERNALSNAT`
 
 Type: Boolean
 
@@ -196,7 +196,7 @@ Disable (`none`) this functionality if you rely on sequential port allocation fo
 
 ---
 
-`AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS`
+`AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` (Since v1.6.0)
 
 Type: String
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To select an `ENIConfig` based upon availability zone set this to `failure-domai
 
 ---
 
-`AWS_VPC_ENI_MTU`
+`AWS_VPC_ENI_MTU` (Since v1.6.0)
 
 Type: Integer
 
@@ -164,7 +164,7 @@ Used to configure the MTU size for attached ENIs. The valid range is from `576` 
 
 ---
 
-`AWS_VPC_K8S_CNI_EXTERNALSNAT`
+`AWS_VPC_K8S_CNI_EXTERNALSNAT` (Since v1.6.0)
 
 Type: Boolean
 
@@ -233,15 +233,19 @@ Type: Integer
 Default: None
 
 Specifies the number of free IP addresses that the `ipamD` daemon should attempt to keep available for pod assignment on the node.
-For example, if `WARM_IP_TARGET` is set to 10, then `ipamD` attempts to keep 10 free IP addresses available at all times. If the
+For example, if `WARM_IP_TARGET` is set to 5, then `ipamD` attempts to keep 5 free IP addresses available at all times. If the
 elastic network interfaces on the node are unable to provide these free addresses, `ipamD` attempts to allocate more interfaces
 until `WARM_IP_TARGET` free IP addresses are available.
+
+**NOTE!** Avoid this setting for large clusters, or if the cluster has high pod churn. Setting it will cause additional calls to the
+EC2 API and that might cause throttling of the requests. It is strongly suggested to set `MINIMUM_IP_TARGET` when using `MINIMUM_IP_TARGET`.
+
 If both `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are set, `ipamD` will attempt to meet both constraints.
 This environment variable overrides `WARM_ENI_TARGET` behavior.
 
 ---
 
-`MINIMUM_IP_TARGET`
+`MINIMUM_IP_TARGET` (Since v1.6.0)
 
 Type: Integer
 


### PR DESCRIPTION
*Description of changes:*
* Added warning to the README that setting a `WARM_IP_TARGET` will cause more calls to EC2 API.
* 5 is a more reasonable warm IP target example.
* Added (Since v1.6.0) to the new environment variables 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
