### PR TITLE
Spelling correction: "weather" -> "whether"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Default: `hashrandom`
 
 Valid Values: `hashrandom`, `prng`, `none`
 
-Specifies weather the SNAT `iptables` rule should randomize the outgoing ports for connections\. This should be used when
+Specifies whether the SNAT `iptables` rule should randomize the outgoing ports for connections\. This should be used when
 `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`. When enabled (`hashrandom`) the `--random` flag will be added to the SNAT `iptables`
 rule\. To use pseudo random number generation rather than hash based (i.e. `--random-fully`) use `prng` for the environment
 variable. For old versions of `iptables` that do not support `--random-fully` this option will fall back to `--random`.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Corrects the use of "weather" to "whether" in the documentation for `AWS_VPC_K8S_CNI_RANDOMIZESNAT`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
