### PR TITLE
Make entrypoint script fail if any step fails, remove unnecessary command substitution

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -47,7 +47,7 @@ wait_for_ipam() {
 
     until [ $__sleep_time -eq 8 ]; do
         sleep $(( __sleep_time++ ))
-        if $(./grpc-health-probe -addr 127.0.0.1:50051 >/dev/null 2>&1); then
+        if ./grpc-health-probe -addr 127.0.0.1:50051 >/dev/null 2>&1; then
             return 0
         fi
     done
@@ -86,7 +86,7 @@ fi
 
 # bring the aws-k8s-agent process back into the foreground
 echo "foregrounding IPAM daemon ... "
-fg %1 >/dev/null 2>&1 || $(echo "failed (process terminated)" && cat "$AGENT_LOG_PATH" && exit 1)
+fg %1 >/dev/null 2>&1 || { echo "failed (process terminated)" && cat "$AGENT_LOG_PATH" && exit 1; }
 
 # Best practice states we should send the container's CMD output to stdout, so
 # let's tee back up the log file into stdout

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,6 +21,8 @@
 # CNI plugin binary and its configuration file to the well-known directory that
 # Kubelet looks in.
 
+# turn on exit on subprocess error and exit on undefined variables
+set -eu
 # turn on bash's job control
 set -m
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

The entrypoint script added in #735 is not run with `set -e`, so if any of the commands in it fails (such as installing the CNI), the script will silently succeed. This is a regression, since the previous code would catch this and error out.

I ran into this when I noticed some nodes on our cluster running 1.6rc6 were failing to start pods with CNI errors, despite having an apparently-healthy CNI pod running. Upon looking at the pod's logs, I saw the following:

```
2020-02-11T17:51:20.908196958+00:00 stdout P starting IPAM daemon in background ... 
2020-02-11T17:51:20.908344789+00:00 stdout F ok.
2020-02-11T17:51:20.908357137+00:00 stdout P checking for IPAM connectivity ... 
2020-02-11T17:51:40.933888193+00:00 stdout F ok.
2020-02-11T17:51:40.933888193+00:00 stdout P copying CNI plugin binaries and config files ... 
2020-02-11T17:51:41.056950001+00:00 stderr F cp: error writing '/host/opt/cni/bin/aws-cni': Cannot allocate memory
2020-02-11T17:51:41.056950001+00:00 stderr F cp: failed to extend '/host/opt/cni/bin/aws-cni': Cannot allocate memory
2020-02-11T17:51:41.064360344+00:00 stdout F  ok.
2020-02-11T17:51:41.064424913+00:00 stdout F foregrounding IPAM daemon ... 
``` 

The issue turned out to be on our end: an overly-aggressive memory limit (which worked fine on rc4, but the shell script approach increases the peak memory required by quite a bit). But nevertheless, `cp` failed, and the script blindly charged on, when it should probably have crashed (which would have drawn my attention to it much more quickly).

The main change I made to the script was to add `set -e`, which will make the script fail if any command it invokes fails (if not in the context of an `if` or `||` or similar). While I was at it, I made two additional changes that aren't causing issues but are probably good ideas:

- `set -u`, which will make the script abort on undefined variable access (helps with typos)
- Two places in the code used `$(...)` (command substitution) when they don't intend to execute the output of the command inside. One instance was completely unnecessary, the other I replaced with `{ }` to group the commands.

I'm happy to revert either or both of these extra changes, but they jumped out at me while I was making the first one so I figured I'd submit them.

I've tested this change on our development cluster and it doesn't seem to have any issues. Additionally, I simulated an issue where it couldn't write to the `aws-cni` binary (by creating a bogus symlink), and confirmed that the pod failed to start with the following log:

```
starting IPAM daemon in background ... ok.
checking for IPAM connectivity ... ok.
copying CNI plugin binaries and config files ... cp: not writing through dangling symlink '/host/opt/cni/bin/aws-cni'
``` 

which is the expected outcome with this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.