### PR TITLE
Run conformance test as part of PR/Release certification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.19
+  k8s: circleci/kubernetes@0.11.0
 
 jobs:
   build:
@@ -26,11 +27,15 @@ jobs:
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       GO111MODULE: "on"
+      RUN_CONFORMANCE: "true"
     steps:
       - checkout
       - setup_remote_docker
       - aws-cli/setup:
           profile-name: awstester
+      - k8s/install-kubectl:
+          # requires 1.14.9 for k8s testing, since it uses log api.
+          kubectl-version: v1.14.9
       - run:
           name: Run the integration tests
           command: ./scripts/run-integration-tests.sh
@@ -50,3 +55,25 @@ workflows:
       - integration_test:
           requires:
             - hold
+
+  # runs integration test when new git tag is pushed.
+  run-test-on-tags:
+    jobs:
+      - integration_test:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+  # triggers daily test run on master
+  nightly-test-run:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - integration_test


### PR DESCRIPTION
*Description of changes:*

This changes updates CircleCI config.yaml to add following functionalities:

* Runs conformance tests as part of existing integration tests. This will now act as a gate keeper before merging the changes to master.
* Automatically trigger integration tests when new tags are pushed. Today AmazonEKS runs tests internally when new git tag is released. With this change when new git tag is released, it will run integration tests through circleCI.
* Adds nightly test run on master branch. With this we can catch regressions.

*Addresses Issue:* https://github.com/aws/amazon-vpc-cni-k8s/issues/686

Upcoming changes:
* Run only tests that are required for our CNI testing when merging PR. Conformance tests takes about 2 hours to complete and some of the test might not be necessary for our CNI plugin for eg testing kubectl etc.
* Run nightly run on branches that we have already cut. This will help us to catch regressions on already released versions.

Ran this on my personal repo - https://circleci.com/api/v1.1/project/github/SaranBalaji90/amazon-vpc-cni-k8s-1/78/output/108/0?file=true&allocation-id=5e552aea36810238d4b33f5d-0-build%2F50024F6D 

Adding some of my learning here to help others in future:
* If tags are used as filters in one of the job in any workflow, then all the jobs needs to have same tag filters. 
* CircleCI needs to be in individual branch to execute tests against those branches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
