### PR TITLE
emit agent logs when timeout waiting for start

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -62,7 +62,8 @@ echo -n "checking for IPAM connectivity ... "
 
 if ! wait_for_ipam; then
     echo " failed."
-    echo "timed out waiting for IPAM daemon to start."
+    echo "timed out waiting for IPAM daemon to start:"
+    cat "$AGENT_LOG_PATH" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Simple change to entrypoint script to emit agent logs when timing out waiting for it to start.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
