### PR TITLE
scripts: use auto-generated SSH key, "aws eks update-kubeconfig"

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v0.6.8}
+    TESTER_RELEASE=${TESTER_RELEASE:-v0.7.1}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -13,8 +13,6 @@ function down-test-cluster() {
 
 function up-test-cluster() {
     echo -n "Configuring cluster $CLUSTER_NAME"
-    ssh-keygen -q -P cni-test -f $SSH_KEY_PATH
-
     AWS_K8S_TESTER_EKS_NAME=$CLUSTER_NAME \
         AWS_K8S_TESTER_EKS_KUBECONFIG_PATH=$KUBECONFIG_PATH \
         AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=${K8S_VERSION%.*} \
@@ -25,8 +23,6 @@ function up-test-cluster() {
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_CREATE=false \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_ARN=arn:aws:iam::404174646922:role/K8sTester-ClusterManagementRole \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS={\"${CLUSTER_NAME}-mng-for-cni\":{\"name\":\"${CLUSTER_NAME}-mng-for-cni\",\"tags\":{\"group\":\"amazon-vpc-cni-k8s\"},\"ami-type\":\"AL2_x86_64\",\"asg-min-size\":3,\"asg-max-size\":3,\"asg-desired-capacity\":3,\"instance-types\":[\"c5.xlarge\"]}} \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_REMOTE_ACCESS_PRIVATE_KEY_PATH=$SSH_KEY_PATH \
-        AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_PATH=$AUTHENTICATOR_PATH \
         AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=true \
         AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=true \
         AWS_K8S_TESTER_EKS_KUBECTL_PATH=$KUBECTL_PATH \

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -46,13 +46,11 @@ CLUSTER_NAME=cni-test-$CLUSTER_ID
 TEST_CLUSTER_DIR=/tmp/cni-test/cluster-$CLUSTER_NAME
 CLUSTER_MANAGE_LOG_PATH=$TEST_CLUSTER_DIR/cluster-manage.log
 CLUSTER_CONFIG=${CLUSTER_CONFIG:-${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}
-SSH_KEY_PATH=${SSH_KEY_PATH:-${TEST_CLUSTER_DIR}/id_rsa}
 KUBECONFIG_PATH=${KUBECONFIG_PATH:-${TEST_CLUSTER_DIR}/kubeconfig}
 
 # shared binaries
 TESTER_DIR=${TESTER_DIR:-/tmp/aws-k8s-tester}
 TESTER_PATH=${TESTER_PATH:-$TESTER_DIR/aws-k8s-tester}
-AUTHENTICATOR_PATH=${AUTHENTICATOR_PATH:-$TESTER_DIR/aws-iam-authenticator}
 KUBECTL_PATH=${KUBECTL_PATH:-$TESTER_DIR/kubectl}
 
 LOCAL_GIT_VERSION=$(git describe --tags --always --dirty)
@@ -115,7 +113,6 @@ echo "+ Cluster config dir: $TEST_CLUSTER_DIR"
 echo "+ Result dir:         $TEST_DIR"
 echo "+ Tester:             $TESTER_PATH"
 echo "+ Kubeconfig:         $KUBECONFIG_PATH"
-echo "+ Node SSH key:       $SSH_KEY_PATH"
 echo "+ Cluster config:     $CLUSTER_CONFIG"
 echo "+ AWS Account ID:     $AWS_ACCOUNT_ID"
 echo "+ CNI image to test:  $IMAGE_NAME:$TEST_IMAGE_VERSION"


### PR DESCRIPTION
- Use https://github.com/aws/aws-k8s-tester/blob/master/CHANGELOG-0.6.md#v069-2020-03-05 with improved VPC clean up.
- Remove `AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_REMOTE_ACCESS_PRIVATE_KEY_PATH` which was not being used in tester; it instead auto-generates using `aws ec2 create-key-pair` API https://github.com/aws/aws-k8s-tester/blob/018cb4234b1b7b7ed09ad1af65745a0da00f215e/eks/mng/key-pair.go#L21-L37.
- Remove `AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_PATH` and use `aws eks update-kubeconfig` https://github.com/aws/aws-k8s-tester/blob/018cb4234b1b7b7ed09ad1af65745a0da00f215e/eks/kubeconfig.go#L53-L79.