### PR TITLE
Fixing node Selector on Calico.yml for 1.15 and 1.16 version of CNI

### DIFF
--- a/config/v1.5/calico.yaml
+++ b/config/v1.5/calico.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force

--- a/config/v1.6/calico.yaml
+++ b/config/v1.6/calico.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force


### PR DESCRIPTION
*Issue #, if available:* 867

*Description of changes:* Just removing "beta" from node Selector. This use was deprecated according to: https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
