### PR TITLE
Revert "scripts/lib: use tester v0.8.5"

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v0.8.5}
+    TESTER_RELEASE=${TESTER_RELEASE:-v0.7.1}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -15,8 +15,6 @@ function up-test-cluster() {
     echo -n "Configuring cluster $CLUSTER_NAME"
     AWS_K8S_TESTER_EKS_NAME=$CLUSTER_NAME \
         AWS_K8S_TESTER_EKS_KUBECONFIG_PATH=$KUBECONFIG_PATH \
-        AWS_K8S_TESTER_EKS_S3_BUCKET_NAME=amazon-vpc-cni-k8s-aws-k8s-tester \
-        AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=false \
         AWS_K8S_TESTER_EKS_PARAMETERS_VERSION=${K8S_VERSION%.*} \
         AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=false \
         AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=false \
@@ -24,8 +22,7 @@ function up-test-cluster() {
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_CREATE=false \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_ARN=arn:aws:iam::404174646922:role/K8sTester-ClusterManagementRole \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS={\"${CLUSTER_NAME}-mng-for-cni\":{\"name\":\"${CLUSTER_NAME}-mng-for-cni\",\"tags\":{\"group\":\"amazon-vpc-cni-k8s\"},\"remote-access-user-name\":\"ec2-user\",\"ami-type\":\"AL2_x86_64\",\"asg-min-size\":3,\"asg-max-size\":3,\"asg-desired-capacity\":3,\"instance-types\":[\"c5.xlarge\"]}} \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_FETCH_LOGS=true \
+        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS={\"${CLUSTER_NAME}-mng-for-cni\":{\"name\":\"${CLUSTER_NAME}-mng-for-cni\",\"tags\":{\"group\":\"amazon-vpc-cni-k8s\"},\"ami-type\":\"AL2_x86_64\",\"asg-min-size\":3,\"asg-max-size\":3,\"asg-desired-capacity\":3,\"instance-types\":[\"c5.xlarge\"]}} \
         AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=true \
         AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=true \
         AWS_K8S_TESTER_EKS_KUBECTL_PATH=$KUBECTL_PATH \


### PR DESCRIPTION
This reverts commit 28f27855306f8af123301df221e80a1ee24b305b until we can
figure out what about aws-k8s-tester 0.8.5 (or PR #875's configuration changes)
has broken testing.

Issue #880

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
