### PR TITLE
Remove unnecessary/incorrect ClusterRole resource

### DIFF
--- a/config/v1.2/aws-k8s-cni.yaml
+++ b/config/v1.2/aws-k8s-cni.yaml
@@ -9,7 +9,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]
@@ -127,5 +126,3 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-
-

--- a/config/v1.3/aws-k8s-cni.yaml
+++ b/config/v1.3/aws-k8s-cni.yaml
@@ -9,7 +9,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]

--- a/config/v1.4/aws-k8s-cni-1.10.yaml
+++ b/config/v1.4/aws-k8s-cni-1.10.yaml
@@ -9,7 +9,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]

--- a/config/v1.4/aws-k8s-cni.yaml
+++ b/config/v1.4/aws-k8s-cni.yaml
@@ -9,7 +9,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]

--- a/config/v1.5/aws-k8s-cni-cn.yaml
+++ b/config/v1.5/aws-k8s-cni-cn.yaml
@@ -8,7 +8,6 @@ rules:
       - crd.k8s.amazonaws.com
     resources:
       - "*"
-      - namespaces
     verbs:
       - "*"
   - apiGroups: [""]

--- a/config/v1.5/aws-k8s-cni.yaml
+++ b/config/v1.5/aws-k8s-cni.yaml
@@ -8,7 +8,6 @@ rules:
       - crd.k8s.amazonaws.com
     resources:
       - "*"
-      - namespaces
     verbs:
       - "*"
   - apiGroups: [""]

--- a/config/v1.6/aws-k8s-cni.yaml
+++ b/config/v1.6/aws-k8s-cni.yaml
@@ -8,7 +8,6 @@ rules:
       - crd.k8s.amazonaws.com
     resources:
       - "*"
-      - namespaces
     verbs:
       - "*"
   - apiGroups: [""]


### PR DESCRIPTION
`crd.k8s.amazonaws.com/namespaces` does not exist, and even if it did
it would already be covered by `crd.k8s.amazonaws.com/*`.  Looks like
an incorrect merge at some point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
