### PR TITLE
update cluster-proportional-autoscaler to 1.7.1

### DIFF
--- a/config/v1.6/calico.yaml
+++ b/config/v1.6/calico.yaml
@@ -683,7 +683,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler


### PR DESCRIPTION
*Description of changes:*

There are open CVEs in cluster-proportional-autoscaler v1.1.2, update to 1.7.1

```
trivy --ignore-unfixed k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
2020-03-25T13:08:15.877-0700	INFO	Detecting Alpine vulnerabilities...
2020-03-25T13:08:15.878-0700	WARN	This OS version is no longer supported by the distribution: alpine 3.4.4
2020-03-25T13:08:15.878-0700	WARN	The vulnerability detection may be insufficient because security updates are not provided

k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2 (alpine 3.4.4)
=====================================================================
Total: 22 (UNKNOWN: 0, LOW: 2, MEDIUM: 16, HIGH: 4, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+--------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+---------+------------------+----------+-------------------+---------------+--------------------------------+
| busybox | CVE-2016-6301    | HIGH     | 1.24.2-r11        | 1.24.2-r13    | busybox: NTP server denial of  |
|         |                  |          |                   |               | service flaw                   |
+         +------------------+----------+                   +---------------+--------------------------------+
|         | CVE-2017-15873   | MEDIUM   |                   | 1.24.2-r14    | busybox: Integer overflow in   |
|         |                  |          |                   |               | the get_next_block function    |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2017-16544   |          |                   |               | busybox: Insufficient          |
|         |                  |          |                   |               | sanitization of filenames when |
|         |                  |          |                   |               | autocompleting                 |
+---------+------------------+----------+-------------------+---------------+--------------------------------+
| musl    | CVE-2016-8859    | HIGH     | 1.1.14-r12        | 1.1.14-r13    | Multiple integer overflows in  |
|         |                  |          |                   |               | the TRE library and musl libc  |
|         |                  |          |                   |               | allow attackers...             |
+         +------------------+----------+                   +---------------+--------------------------------+
|         | CVE-2017-15650   | MEDIUM   |                   | 1.1.14-r16    | musl libc before 1.1.17 has    |
|         |                  |          |                   |               | a buffer overflow via crafted  |
|         |                  |          |                   |               | DNS replies...                 |
+---------+------------------+          +-------------------+---------------+--------------------------------+
| openssl | CVE-2017-3731    |          | 1.0.2j-r0         | 1.0.2k-r0     | openssl: Truncated packet      |
|         |                  |          |                   |               | could crash via OOB read       |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2017-3732    |          |                   |               | openssl: BN_mod_exp may        |
|         |                  |          |                   |               | produce incorrect results on   |
|         |                  |          |                   |               | x86_64                         |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2017-3735    |          |                   | 1.0.2m-r0     | openssl: Malformed X.509       |
|         |                  |          |                   |               | IPAdressFamily could cause OOB |
|         |                  |          |                   |               | read                           |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2017-3736    |          |                   |               | openssl: bn_sqrx8x_internal    |
|         |                  |          |                   |               | carry bug on x86_64            |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2017-3737    |          |                   | 1.0.2n-r0     | openssl: Read/write after SSL  |
|         |                  |          |                   |               | object in error state          |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2017-3738    |          |                   |               | openssl: rsaz_1024_mul_avx2    |
|         |                  |          |                   |               | overflow bug on x86_64         |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-0732    |          |                   | 1.0.2o-r1     | openssl: Malicious server can  |
|         |                  |          |                   |               | send large prime to client     |
|         |                  |          |                   |               | during DH(E) TLS...            |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-0733    |          |                   | 1.0.2o-r0     | openssl: Implementation bug in |
|         |                  |          |                   |               | PA-RISC CRYPTO_memcmp function |
|         |                  |          |                   |               | allows attackers to forge      |
|         |                  |          |                   |               | authenticated...               |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-0734    |          |                   | 1.0.2q-r0     | openssl: timing side channel   |
|         |                  |          |                   |               | attack in the DSA signature    |
|         |                  |          |                   |               | algorithm                      |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-0737    |          |                   | 1.0.2o-r2     | openssl: RSA key generation    |
|         |                  |          |                   |               | cache timing vulnerability in  |
|         |                  |          |                   |               | crypto/rsa/rsa_gen.c allows    |
|         |                  |          |                   |               | attackers to...                |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-0739    |          |                   | 1.0.2o-r0     | openssl: Handling of crafted   |
|         |                  |          |                   |               | recursive ASN.1 structures can |
|         |                  |          |                   |               | cause a stack overflow...      |
+         +------------------+----------+                   +---------------+--------------------------------+
|         | CVE-2016-7055    | LOW      |                   | 1.0.2k-r0     | openssl: Carry propagating bug |
|         |                  |          |                   |               | in Montgomery multiplication   |
+         +------------------+          +                   +---------------+--------------------------------+
|         | CVE-2018-5407    |          |                   | 1.0.2q-r0     | openssl: Side-channel          |
|         |                  |          |                   |               | vulnerability on               |
|         |                  |          |                   |               | SMT/Hyper-Threading            |
|         |                  |          |                   |               | architectures (PortSmash)      |
+---------+------------------+----------+-------------------+---------------+--------------------------------+
| zlib    | CVE-2016-9841    | HIGH     | 1.2.8-r2          | 1.2.11-r0     | zlib: Out-of-bounds pointer    |
|         |                  |          |                   |               | arithmetic in inffast.c        |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2016-9843    |          |                   |               | zlib: Big-endian out-of-bounds |
|         |                  |          |                   |               | pointer                        |
+         +------------------+----------+                   +               +--------------------------------+
|         | CVE-2016-9840    | MEDIUM   |                   |               | zlib: Out-of-bounds pointer    |
|         |                  |          |                   |               | arithmetic in inftrees.c       |
+         +------------------+          +                   +               +--------------------------------+
|         | CVE-2016-9842    |          |                   |               | zlib: Undefined left shift of  |
|         |                  |          |                   |               | negative number                |
+---------+------------------+----------+-------------------+---------------+--------------------------------+
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.