### PR TITLE
Add missing permissions in typha-cpha sa (Calico)

### DIFF
--- a/config/v1.6/calico.yaml
+++ b/config/v1.6/calico.yaml
@@ -634,7 +634,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["watch", "list"]
 
 ---
 
@@ -710,7 +710,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions", "apps"]
     resources: ["deployments/scale"]
     verbs: ["get", "update"]
 


### PR DESCRIPTION
*Description of changes:*

Add missing permission to Calico service account typha-cpha. Fixes permissions issues visible in `calico-typha-horizontal-autoscaler` pod logs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
