### PR TITLE
Configure rp_filter based on env variable

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -85,6 +85,10 @@ const (
 	// sent over the main ENI.
 	envConnmark = "AWS_VPC_K8S_CNI_CONNMARK"
 
+	// This environment variable indicates if ipamd should configure rp filter for primary interface. Default value is
+	// true. If set to false, then rp filter should be configured through init container.
+	envConfigureRpfilter = "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER"
+
 	// defaultConnmark is the default value for the connmark described above. Note: the mark space is a little crowded,
 	// - kube-proxy uses 0x0000c000
 	// - Calico uses 0xffff0000.
@@ -125,12 +129,13 @@ type NetworkAPIs interface {
 }
 
 type linuxNetwork struct {
-	useExternalSNAT        bool
-	excludeSNATCIDRs       []string
-	typeOfSNAT             snatType
-	nodePortSupportEnabled bool
-	connmark               uint32
-	mtu                    int
+	useExternalSNAT         bool
+	excludeSNATCIDRs        []string
+	typeOfSNAT              snatType
+	nodePortSupportEnabled  bool
+	shouldConfigureRpFilter bool
+	connmark                uint32
+	mtu                     int
 
 	netLink     netlinkwrapper.NetLink
 	ns          nswrapper.NS
@@ -163,12 +168,13 @@ const (
 // New creates a linuxNetwork object
 func New() NetworkAPIs {
 	return &linuxNetwork{
-		useExternalSNAT:        useExternalSNAT(),
-		excludeSNATCIDRs:       getExcludeSNATCIDRs(),
-		typeOfSNAT:             typeOfSNAT(),
-		nodePortSupportEnabled: nodePortSupportEnabled(),
-		mainENIMark:            getConnmark(),
-		mtu:                    GetEthernetMTU(""),
+		useExternalSNAT:         useExternalSNAT(),
+		excludeSNATCIDRs:        getExcludeSNATCIDRs(),
+		typeOfSNAT:              typeOfSNAT(),
+		nodePortSupportEnabled:  nodePortSupportEnabled(),
+		shouldConfigureRpFilter: shouldConfigureRpFilter(),
+		mainENIMark:             getConnmark(),
+		mtu:                     GetEthernetMTU(""),
 
 		netLink: netlinkwrapper.NewNetLink(),
 		ns:      nswrapper.NewNS(),
@@ -243,10 +249,14 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 		primaryIntfRPFilter := "net/ipv4/conf/" + primaryIntf + "/rp_filter"
 		const rpFilterLoose = "2"
 
-		log.Debugf("Setting RPF for primary interface: %s", primaryIntfRPFilter)
-		err = n.procSys.Set(primaryIntfRPFilter, rpFilterLoose)
-		if err != nil {
-			return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
+		if n.shouldConfigureRpFilter {
+			log.Debugf("Setting RPF for primary interface: %s", primaryIntfRPFilter)
+			err = n.procSys.Set(primaryIntfRPFilter, rpFilterLoose)
+			if err != nil {
+				return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
+		    }
+		} else {
+			log.Infof("Skip updating RPF for primary interface: %s", primaryIntfRPFilter)
 		}
 	}
 
@@ -594,6 +604,10 @@ func typeOfSNAT() snatType {
 
 func nodePortSupportEnabled() bool {
 	return getBoolEnvVar(envNodePortSupport, true)
+}
+
+func shouldConfigureRpFilter() bool {
+	return getBoolEnvVar(envConfigureRpfilter, true)
 }
 
 func getBoolEnvVar(name string, defaultValue bool) bool {

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -243,16 +243,10 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 		primaryIntfRPFilter := "net/ipv4/conf/" + primaryIntf + "/rp_filter"
 		const rpFilterLoose = "2"
 
-		if n.procSys.IsPathWriteAccessible(primaryIntfRPFilter) {
-			// Setting RPF will be removed from aws-node when we bump our minor version.
-			log.Debugf("Setting RPF for primary interface: %s", primaryIntfRPFilter)
-			err = n.procSys.Set(primaryIntfRPFilter, rpFilterLoose)
-			if err != nil {
-				return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
-		    }
-		} else {
-			// when aws-node run as an un-privileged pod, /proc will be mounted as read only
-			log.Infof("Skip updating RPF for primary interface: %s", primaryIntfRPFilter)
+		log.Debugf("Setting RPF for primary interface: %s", primaryIntfRPFilter)
+		err = n.procSys.Set(primaryIntfRPFilter, rpFilterLoose)
+		if err != nil {
+			return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
 		}
 	}
 

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -272,10 +272,11 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 	defer ctrl.Finish()
 
 	ln := &linuxNetwork{
-		useExternalSNAT:        true,
-		nodePortSupportEnabled: true,
-		mainENIMark:            defaultConnmark,
-		mtu:                    testMTU,
+		useExternalSNAT:         true,
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -285,16 +286,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 		procSys: mockProcSys,
 	}
 
-	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
-	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
-	var mainENIRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
-	mockNetLink.EXPECT().RuleDel(&mainENIRule)
-	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
+	setupNetLinkMocks(ctrl, mockNetLink)
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
@@ -349,11 +341,12 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 	defer ctrl.Finish()
 
 	ln := &linuxNetwork{
-		useExternalSNAT:        false,
-		excludeSNATCIDRs:       []string{"10.12.0.0/16", "10.13.0.0/16"},
-		nodePortSupportEnabled: true,
-		mainENIMark:            defaultConnmark,
-		mtu:                    testMTU,
+		useExternalSNAT:         false,
+		excludeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -363,16 +356,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		procSys: mockProcSys,
 	}
 
-	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
-
-	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
-	var mainENIRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
-	mockNetLink.EXPECT().RuleDel(&mainENIRule)
-	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
+	setupNetLinkMocks(ctrl, mockNetLink)
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
@@ -403,11 +387,12 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	defer ctrl.Finish()
 
 	ln := &linuxNetwork{
-		useExternalSNAT:        false,
-		excludeSNATCIDRs:       nil,
-		nodePortSupportEnabled: true,
-		mainENIMark:            defaultConnmark,
-		mtu:                    testMTU,
+		useExternalSNAT:         false,
+		excludeSNATCIDRs:        nil,
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -416,16 +401,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 		},
 		procSys: mockProcSys,
 	}
-	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
-
-	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
-	var mainENIRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
-	mockNetLink.EXPECT().RuleDel(&mainENIRule)
-	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
+	setupNetLinkMocks(ctrl, mockNetLink)
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
@@ -464,11 +440,12 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 	defer ctrl.Finish()
 
 	ln := &linuxNetwork{
-		useExternalSNAT:        false,
-		excludeSNATCIDRs:       []string{"10.12.0.0/16", "10.13.0.0/16"},
-		nodePortSupportEnabled: true,
-		mainENIMark:            defaultConnmark,
-		mtu:                    testMTU,
+		useExternalSNAT:         false,
+		excludeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -477,16 +454,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 		},
 		procSys: mockProcSys,
 	}
-	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
-
-	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
-	var mainENIRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
-	mockNetLink.EXPECT().RuleDel(&mainENIRule)
-	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
+	setupNetLinkMocks(ctrl, mockNetLink)
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
@@ -525,10 +493,11 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 	defer ctrl.Finish()
 
 	ln := &linuxNetwork{
-		useExternalSNAT:        true,
-		nodePortSupportEnabled: true,
-		mainENIMark:            defaultConnmark,
-		mtu:                    testMTU,
+		useExternalSNAT:         true,
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -537,16 +506,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 		},
 		procSys: mockProcSys,
 	}
-	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
-
-	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
-	var mainENIRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
-	mockNetLink.EXPECT().RuleDel(&mainENIRule)
-	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
+	setupNetLinkMocks(ctrl, mockNetLink)
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
@@ -580,6 +540,44 @@ func TestIncrementIPv4Addr(t *testing.T) {
 			assert.Equal(t, tc.expected, result, tc.name)
 		})
 	}
+}
+
+func TestSetupHostNetworkIgnoringRpFilterUpdate(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:         true,
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: false,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func() (iptablesIface, error) {
+			return mockIptables, nil
+		},
+		procSys: mockProcSys,
+	}
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	var vpcCIDRs []*string
+	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	assert.NoError(t, err)
+}
+
+func setupNetLinkMocks(ctrl *gomock.Controller, mockNetLink *mock_netlinkwrapper.MockNetLink) {
+	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
+	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
+
+	var hostRule netlink.Rule
+	mockNetLink.EXPECT().NewRule().Return(&hostRule)
+	mockNetLink.EXPECT().RuleDel(&hostRule)
+	var mainENIRule netlink.Rule
+	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
+	mockNetLink.EXPECT().RuleDel(&mainENIRule)
+	mockNetLink.EXPECT().RuleAdd(&mainENIRule)
 }
 
 type mockIptables struct {

--- a/pkg/procsyswrapper/mocks/procsys_mocks.go
+++ b/pkg/procsyswrapper/mocks/procsys_mocks.go
@@ -62,20 +62,6 @@ func (mr *MockProcSysMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockProcSys)(nil).Get), arg0)
 }
 
-// IsPathWriteAccessible mocks base method
-func (m *MockProcSys) IsPathWriteAccessible(arg0 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPathWriteAccessible", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPathWriteAccessible indicates an expected call of IsPathWriteAccessible
-func (mr *MockProcSysMockRecorder) IsPathWriteAccessible(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPathWriteAccessible", reflect.TypeOf((*MockProcSys)(nil).IsPathWriteAccessible), arg0)
-}
-
 // Set mocks base method
 func (m *MockProcSys) Set(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/procsyswrapper/procsys.go
+++ b/pkg/procsyswrapper/procsys.go
@@ -15,14 +15,11 @@ package procsyswrapper
 
 import (
 	"io/ioutil"
-
-	"golang.org/x/sys/unix"
 )
 
 type ProcSys interface {
 	Get(key string) (string, error)
 	Set(key, value string) error
-	IsPathWriteAccessible(key string) bool
 }
 
 type procSys struct {
@@ -44,9 +41,4 @@ func (p *procSys) Get(key string) (string, error) {
 
 func (p *procSys) Set(key, value string) error {
 	return ioutil.WriteFile(p.path(key), []byte(value), 0644)
-}
-
-// IsPathWriteAccessible verifies if aws-node pod can write to the specified path
-func (p *procSys) IsPathWriteAccessible(key string) bool {
-	return unix.Access(p.path(key), unix.W_OK) != nil
 }


### PR DESCRIPTION
*Description of changes:*

This PR reverts https://github.com/aws/amazon-vpc-cni-k8s/pull/901 and replaces the logic of configuring rp_filter through env variable instead of configuring based on file accessibility.

Thanks @anguslees for the suggestion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
