### PR TITLE
refresh subnet/CIDR information periodically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	google.golang.org/grpc v1.29.0
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -14,9 +14,11 @@
 package awsutils
 
 import (
+	"context"
 	"errors"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,8 +69,18 @@ func setup(t *testing.T) (*gomock.Controller,
 }
 
 func TestInitWithEC2metadata(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
+
+	metadataVPCIPv4CIDRs := "192.168.0.0/16	100.66.0.0/1"
+	vpcIPv4CIDRs := strings.Fields(metadataVPCIPv4CIDRs)
+	var cidr []*string
+	for _, vpcCIDR := range vpcIPv4CIDRs {
+		log.Debugf("Found VPC CIDR: %s", vpcCIDR)
+		cidr = append(cidr, aws.String(vpcCIDR))
+	}
 
 	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, nil)
@@ -79,24 +91,27 @@ func TestInitWithEC2metadata(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil).AnyTimes()
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil).AnyTimes()
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(vpcCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(metadataVPCIPv4CIDRs, nil).AnyTimes()
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, az, ins.availabilityZone)
 	assert.Equal(t, localIP, ins.localIPv4)
 	assert.Equal(t, ins.instanceID, instanceID)
 	assert.Equal(t, ins.primaryENImac, primaryMAC)
-	assert.Equal(t, len(ins.securityGroups), 2)
+	assert.Equal(t, len(ins.securityGroups.data), 2)
 	assert.Equal(t, subnetID, ins.subnetID)
 	assert.Equal(t, vpcCIDR, ins.vpcIPv4CIDR)
+	assert.Equal(t, len(ins.vpcIPv4CIDRs.data), 2)
 }
 
 func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -109,16 +124,17 @@ func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, errors.New("Error on VPCcidr"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataSubnetErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -131,15 +147,16 @@ func TestInitWithEC2metadataSubnetErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, errors.New("Error on Subnet"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataSGErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -152,14 +169,18 @@ func TestInitWithEC2metadataSGErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, errors.New("Error on SG"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataENIErrs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -171,11 +192,13 @@ func TestInitWithEC2metadataENIErrs(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return("", errors.New("err on ENIs"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataMACErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -186,11 +209,13 @@ func TestInitWithEC2metadataMACErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, errors.New("error on MAC"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataLocalIPErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -198,11 +223,13 @@ func TestInitWithEC2metadataLocalIPErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, errors.New("error on localIP"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataInstanceErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
@@ -211,18 +238,20 @@ func TestInitWithEC2metadataInstanceErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, errors.New("error on instanceID"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataAZErr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
 	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, errors.New("error on metadata AZ"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.Error(t, err)
 }
 
@@ -412,6 +441,8 @@ func TestDescribeAllENIs(t *testing.T) {
 }
 
 func TestTagEni(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	defer cancel()
 	ctrl, mockMetadata, mockEC2 := setup(t)
 	defer ctrl.Finish()
 	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
@@ -423,13 +454,13 @@ func TestTagEni(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil).AnyTimes()
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(vpcCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(vpcCIDR, nil).AnyTimes()
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
-	err := ins.initWithEC2Metadata()
+	err := ins.initWithEC2Metadata(ctx)
 	assert.NoError(t, err)
 	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))
 	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -104,7 +104,7 @@ func TestNodeInit(t *testing.T) {
 
 	_, parsedVPCCIDR, _ := net.ParseCIDR(vpcCIDR)
 	primaryIP := net.ParseIP(ipaddr01)
-	m.awsutils.EXPECT().GetVPCIPv4CIDRs().Return(cidrs)
+	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs)
 	m.awsutils.EXPECT().GetPrimaryENImac().Return("")
 	m.network.EXPECT().SetupHostNetwork(parsedVPCCIDR, cidrs, "", &primaryIP).Return(nil)
 


### PR DESCRIPTION
*Issue #, if available:* #737 

*Description of changes:* 
1) Added forever go-routine to update VPC CIDR blocks by checking EC2 instance metadata every 30 seconds
2) Added forever go-routine to update `ip rules` only if there is a new VPC CIDR added for existing pods to enable connectivity between pods running on VPC CIDR1(old) on eth1 to pods running on VPC CIDR2 (new) on eth1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
