### PR TITLE
Less verbose logging

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -26,7 +26,6 @@ const binaryName = "ipamd"
 
 var version string
 
-
 func main() {
 	os.Exit(_main())
 }
@@ -34,7 +33,7 @@ func main() {
 func _main() int {
 	//Do not add anything before initializing logger
 	logConfig := logger.Configuration{
-		BinaryName:   binaryName,
+		BinaryName: binaryName,
 	}
 	log := logger.New(&logConfig)
 

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -101,9 +101,9 @@ func LoadNetConf(bytes []byte) (*NetConf, logger.Logger, error) {
 
 	//logConfig
 	logConfig := logger.Configuration{
-		BinaryName:   conf.Name,
-		LogLevel:     conf.PluginLogLevel,
-		LogLocation:  conf.PluginLogFile,
+		BinaryName:  conf.Name,
+		LogLevel:    conf.PluginLogLevel,
+		LogLocation: conf.PluginLogFile,
 	}
 	log := logger.New(&logConfig)
 

--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -33,16 +33,16 @@ import (
 )
 
 const (
-	containerID = "test-container"
-	netNS       = "/proc/ns/1234"
-	ifName      = "eth0"
-	cniVersion  = "1.0"
-	cniName     = "aws-cni"
+	containerID    = "test-container"
+	netNS          = "/proc/ns/1234"
+	ifName         = "eth0"
+	cniVersion     = "1.0"
+	cniName        = "aws-cni"
 	pluginLogLevel = "Debug"
-	pluginLogFile = "/var/log/aws-routed-eni/plugin.log"
-	cniType     = "aws-cni"
-	ipAddr      = "10.0.1.15"
-	devNum      = 4
+	pluginLogFile  = "/var/log/aws-routed-eni/plugin.log"
+	cniType        = "aws-cni"
+	ipAddr         = "10.0.1.15"
+	devNum         = 4
 )
 
 var netConf = &NetConf{CNIVersion: cniVersion,

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -15,10 +15,11 @@ package driver
 
 import (
 	"errors"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"net"
 	"os"
 	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -45,9 +46,9 @@ const (
 )
 
 var logConfig = logger.Configuration{
-	BinaryName:   "aws-cni",
-	LogLevel:     "Debug",
-	LogLocation:  "/var/log/test.log",
+	BinaryName:  "aws-cni",
+	LogLevel:    "Debug",
+	LogLocation: "/var/log/test.log",
 }
 
 var log = logger.New(&logConfig)

--- a/cmd/routed-eni-cni-plugin/driver/mocks/driver_mocks.go
+++ b/cmd/routed-eni-cni-plugin/driver/mocks/driver_mocks.go
@@ -18,9 +18,10 @@
 package mock_driver
 
 import (
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	net "net"
 	reflect "reflect"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 
 	gomock "github.com/golang/mock/gomock"
 )

--- a/pkg/awsutils/gen_vpc_ip_limits.go
+++ b/pkg/awsutils/gen_vpc_ip_limits.go
@@ -18,11 +18,12 @@
 package main
 
 import (
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"os"
 	"sort"
 	"text/template"
 	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 
 	"github.com/aws/aws-sdk-go/aws"
 

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -100,7 +100,7 @@ type ENIIPPool struct {
 	// IsPrimary indicates whether ENI is a primary ENI
 	IsPrimary bool
 	ID        string
-	// DeviceNumber is the device number of ENI
+	// DeviceNumber is the device number of ENI (0 means the primary ENI)
 	DeviceNumber int
 	// AssignedIPv4Addresses is the number of IP addresses already been assigned
 	AssignedIPv4Addresses int
@@ -127,7 +127,7 @@ type PodKey struct {
 type PodIPInfo struct {
 	// IP is the IP address of pod
 	IP string
-	// DeviceNumber is the device number of  pod
+	// DeviceNumber is the device number of the ENI
 	DeviceNumber int
 }
 
@@ -138,7 +138,7 @@ type DataStore struct {
 	eniIPPools map[string]*ENIIPPool
 	podsIP     map[PodKey]PodIPInfo
 	lock       sync.RWMutex
-	log 	   logger.Logger
+	log        logger.Logger
 }
 
 // PodInfos contains pods IP information which uses key name_namespace_sandbox
@@ -171,7 +171,7 @@ func NewDataStore(log logger.Logger) *DataStore {
 	return &DataStore{
 		eniIPPools: make(map[string]*ENIIPPool),
 		podsIP:     make(map[PodKey]PodIPInfo),
-		log: 		log,
+		log:        log,
 	}
 }
 

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -14,18 +14,19 @@
 package datastore
 
 import (
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"testing"
 	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 	"github.com/stretchr/testify/assert"
 )
 
 var logConfig = logger.Configuration{
-	BinaryName:   "aws-cni",
-	LogLevel:     "Debug",
-	LogLocation:  "/var/log/test.log",
+	BinaryName:  "aws-cni",
+	LogLevel:    "Debug",
+	LogLocation: "/var/log/test.log",
 }
 
 var log = logger.New(&logConfig)

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -254,7 +254,7 @@ func (d *Controller) handlePodUpdate(key string) error {
 		d.workerPodsLock.Lock()
 		defer d.workerPodsLock.Unlock()
 
-		log.Debugf("Update for pod %s: %+v, %+v", podName, pod.Status, pod.Spec)
+		log.Debugf("Update for pod %s: %v", podName, pod.Status.Phase)
 
 		// Save pod info
 		d.workerPods[key] = &K8SPodInfo{

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -114,7 +114,7 @@ const (
 
 var log = logger.Get()
 
-// NetworkAPIs defines the host level and the eni level network related operations
+// NetworkAPIs defines the host level and the ENI level network related operations
 type NetworkAPIs interface {
 	// SetupNodeNetwork performs node level network configuration
 	SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, primaryMAC string, primaryAddr *net.IP) error
@@ -254,7 +254,7 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 			err = n.procSys.Set(primaryIntfRPFilter, rpFilterLoose)
 			if err != nil {
 				return errors.Wrapf(err, "failed to configure %s RPF check", primaryIntf)
-		    }
+			}
 		} else {
 			log.Infof("Skip updating RPF for primary interface: %s", primaryIntfRPFilter)
 		}

--- a/pkg/utils/logger/config.go
+++ b/pkg/utils/logger/config.go
@@ -21,21 +21,21 @@ const (
 	defaultLogFilePath = "/host/var/log/aws-routed-eni/ipamd.log"
 	defaultLogLevel    = "Debug"
 	binaryName         = "L-IPamD"
-	envLogLevel         = "AWS_VPC_K8S_CNI_LOGLEVEL"
-	envLogFilePath      = "AWS_VPC_K8S_CNI_LOG_FILE"
+	envLogLevel        = "AWS_VPC_K8S_CNI_LOGLEVEL"
+	envLogFilePath     = "AWS_VPC_K8S_CNI_LOG_FILE"
 )
 
 // Configuration stores the config for the logger
 type Configuration struct {
-	BinaryName   string
-	LogLevel     string
-	LogLocation  string
+	BinaryName  string
+	LogLevel    string
+	LogLocation string
 }
 
 func LoadLogConfig() *Configuration {
-    return &Configuration{
-		BinaryName: binaryName,
-		LogLevel: getLogLevel(),
+	return &Configuration{
+		BinaryName:  binaryName,
+		LogLevel:    getLogLevel(),
 		LogLocation: getLogFileLocation(),
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
Having a watch print the whole pod spec is too verbose

*Description of changes:*
* Print just the pod status, not the whole spec
* `make format`
* Fixed two comments

One log line before:
```
{"level":"debug","ts":"2020-04-10T17:43:11.091Z","caller":"k8sapi/discovery.go:216","msg":"Update for pod hello3-6d565cc9b6-ltrhb: 
{Phase:Running Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2020-04-10 17:43:09 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2020-04-10 17:43:11 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2020-04-10 17:43:11 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2020-04-10 17:43:09 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:10.10.23.150 PodIP:10.10.2.224 StartTime:2020-04-10 17:43:09 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:hello3 State:{Waiting:nil Running:&ContainerStateRunning{StartedAt:2020-04-10 17:43:10 +0000 UTC,} Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:true RestartCount:0 Image:gcr.io/google-samples/hello-go-gke:1.0 ImageID:docker-pullable://gcr.io/google-samples/hello-go-gke@sha256:4ea9cd3d35f81fc91bdebca3fae50c180a1048be0613ad0f811595365040396e ContainerID:docker://6fb38d4ba26a9fbb9286e43660d0007ae5163a7a0998e9f4c1faffa4d52d2ed7}] QOSClass:BestEffort}, 
{Volumes:[{Name:default-token-sxdn6 VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:&SecretVolumeSource{SecretName:default-token-sxdn6,Items:[],DefaultMode:*420,Optional:nil,} NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil}}] InitContainers:[] Containers:[{Name:hello3 Image:gcr.io/google-samples/hello-go-gke:1.0 Command:[] Args:[] WorkingDir: Ports:[{Name:http HostPort:0 ContainerPort:80 Protocol:TCP HostIP:}] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:default-token-sxdn6 ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath: MountPropagation:<nil>}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] RestartPolicy:Always TerminationGracePeriodSeconds:0xc00051aed8 ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:map[] ServiceAccountName:default DeprecatedServiceAccount:default AutomountServiceAccountToken:<nil> NodeName:ip-10-10-23-150.us-west-2.compute.internal HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],} ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName:default-scheduler Tolerations:[{Key:node.kubernetes.io/not-ready Operator:Exists Value: Effect:NoExecute TolerationSeconds:0xc00051af90} {Key:node.kubernetes.io/unreachable Operator:Exists Value: Effect:NoExecute TolerationSeconds:0xc00051afb0}] HostAliases:[] PriorityClassName: Priority:0xc00051afc0 DNSConfig:nil ReadinessGates:[]}"}

```

Logs after:
```
{"level":"debug","ts":"2020-04-10T19:56:12.604Z","caller":"k8sapi/discovery.go:216","msg":"Update for pod hello-6c9c9df6cd-rdvrn: Pending"}
{"level":"debug","ts":"2020-04-10T19:56:13.004Z","caller":"k8sapi/discovery.go:216","msg":"Update for pod hello-6c9c9df6cd-jvj8f: Pending"}
{"level":"debug","ts":"2020-04-10T19:56:13.404Z","caller":"k8sapi/discovery.go:216","msg":"Update for pod hello-6c9c9df6cd-klqvn: Running"}
{"level":"debug","ts":"2020-04-10T19:56:13.804Z","caller":"k8sapi/discovery.go:216","msg":"Update for pod hello-6c9c9df6cd-fqjnn: Running"}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
