### PR TITLE
Reduce number of calls to EC2 API

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -114,8 +114,11 @@ type APIs interface {
 	// GetAttachedENIs retrieves eni information from instance metadata service
 	GetAttachedENIs() (eniList []ENIMetadata, err error)
 
-	// DescribeENI returns the IPv4 addresses of ENI interface, tags, and the ENI attachment ID
-	DescribeENI(eniID string) (addrList []*ec2.NetworkInterfacePrivateIpAddress, tags map[string]string, attachemdID *string, err error)
+	// GetIPv4sFromEC2 returns the IPv4 addresses for a given ENI
+	GetIPv4sFromEC2(eniID string) (addrList []*ec2.NetworkInterfacePrivateIpAddress, err error)
+
+	// DescribeAllENIs calls EC2 and returns the ENIMetadata and a tag map for each ENI
+	DescribeAllENIs() ([]ENIMetadata, map[string]TagMap, error)
 
 	// AllocIPAddress allocates an IP address for an ENI
 	AllocIPAddress(eniID string) error
@@ -165,9 +168,6 @@ type EC2InstanceMetadataCache struct {
 	region           string
 	accountID        string
 
-	// dynamic
-	currentENIs int
-
 	ec2Metadata ec2metadata.EC2Metadata
 	ec2SVC      ec2wrapper.EC2
 }
@@ -188,9 +188,6 @@ type ENIMetadata struct {
 
 	// The ip addresses allocated for the network interface
 	IPv4Addresses []*ec2.NetworkInterfacePrivateIpAddress
-
-	// Tags are the tags associated with this ENI in AWS
-	Tags map[string]string
 }
 
 func (eni ENIMetadata) PrimaryIPv4Address() string {
@@ -201,6 +198,8 @@ func (eni ENIMetadata) PrimaryIPv4Address() string {
 	}
 	return ""
 }
+
+type TagMap map[string]string
 
 // msSince returns milliseconds since start.
 func msSince(start time.Time) float64 {
@@ -370,7 +369,6 @@ func (cache *EC2InstanceMetadataCache) setPrimaryENI() error {
 	}
 	eniMACs := strings.Fields(metadataENImacs)
 	log.Debugf("Discovered %d interfaces.", len(eniMACs))
-	cache.currentENIs = len(eniMACs)
 
 	// retrieve the attached ENIs
 	for _, eniMAC := range eniMACs {
@@ -411,7 +409,7 @@ func (cache *EC2InstanceMetadataCache) setPrimaryENI() error {
 		if cache.primaryENImac == result[0] {
 			//primary interface
 			cache.primaryENI = eni
-			log.Debugf("Found ENI %s is a primary ENI", eni)
+			log.Debugf("%s is the primary ENI of this instance", eni)
 			return nil
 		}
 	}
@@ -429,7 +427,6 @@ func (cache *EC2InstanceMetadataCache) GetAttachedENIs() (eniList []ENIMetadata,
 	}
 	macsStrs := strings.Fields(macs)
 	log.Debugf("Total number of interfaces found: %d ", len(macsStrs))
-	cache.currentENIs = len(macsStrs)
 
 	var enis []ENIMetadata
 	// retrieve the attached ENIs
@@ -446,7 +443,7 @@ func (cache *EC2InstanceMetadataCache) GetAttachedENIs() (eniList []ENIMetadata,
 func (cache *EC2InstanceMetadataCache) getENIMetadata(macStr string) (ENIMetadata, error) {
 	eniMACList := strings.Split(macStr, "/")
 	eniMAC := eniMACList[0]
-	log.Debugf("Found ENI mac address : %s", eniMAC)
+	log.Debugf("Found ENI MAC address: %s", eniMAC)
 
 	eni, deviceNum, err := cache.getENIDeviceNumber(eniMAC)
 	if err != nil {
@@ -458,42 +455,17 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(macStr string) (ENIMetadat
 	if err != nil {
 		return ENIMetadata{}, errors.Wrapf(err, "get ENI metadata: failed to retrieve IPs and CIDR for ENI: %s", eniMAC)
 	}
-	privateIPv4s, tags, _, err := cache.DescribeENI(eni)
-	if err != nil {
-		return ENIMetadata{}, errors.Wrapf(err, "get ENI metadata: failed to describe ENI: %s, %v", eniMAC, err)
-	}
-	// getIPsAndCIDR() queries IMDS for IPv4 addresses attached to the ENI.
-	// DescribeENI() calls the DescribeNetworkInterfaces AWS API call, which
-	// technically should be the source of truth and contain the freshest
-	// information. Let's just do a quick scan here and output some diagnostic
-	// messages if we find stale info in the IMDS result.
-	imdsIPv4Set := sets.NewString(imdsIPv4s...)
-	privateIPv4Set := sets.String{}
-	for _, privateIPv4 := range privateIPv4s {
-		privateIPv4Set.Insert(aws.StringValue(privateIPv4.PrivateIpAddress))
-	}
-	missingIMDS := privateIPv4Set.Difference(imdsIPv4Set).List()
-	missingDNI := imdsIPv4Set.Difference(privateIPv4Set).List()
-	if len(missingIMDS) > 0 {
-		strMissing := strings.Join(missingIMDS, ",")
-		log.Debugf("getENIMetadata: DescribeNetworkInterfaces(%s) yielded private IPv4 addresses %s that were not yet found in IMDS.", eni, strMissing)
-	}
-	if len(missingDNI) > 0 {
-		strMissing := strings.Join(missingDNI, ",")
-		log.Debugf("getENIMetadata: IMDS query yielded stale IPv4 addresses %s that were not found in DescribeNetworkInterfaces(%s).", strMissing, eni)
-	}
 	return ENIMetadata{
 		ENIID:          eni,
 		MAC:            eniMAC,
 		DeviceNumber:   deviceNum,
 		SubnetIPv4CIDR: cidr,
-		IPv4Addresses:  privateIPv4s,
-		Tags:           tags,
+		IPv4Addresses:  imdsIPv4s,
 	}, nil
 }
 
 // getIPsAndCIDR return list of IPs, CIDR, error
-func (cache *EC2InstanceMetadataCache) getIPsAndCIDR(eniMAC string) ([]string, string, error) {
+func (cache *EC2InstanceMetadataCache) getIPsAndCIDR(eniMAC string) ([]*ec2.NetworkInterfacePrivateIpAddress, string, error) {
 	start := time.Now()
 	cidr, err := cache.ec2Metadata.GetMetadata(metadataMACPath + eniMAC + metadataSubnetCIDR)
 	awsAPILatency.WithLabelValues("GetMetadata", fmt.Sprint(err != nil)).Observe(msSince(start))
@@ -506,7 +478,7 @@ func (cache *EC2InstanceMetadataCache) getIPsAndCIDR(eniMAC string) ([]string, s
 	log.Debugf("Found CIDR %s for ENI %s", cidr, eniMAC)
 
 	start = time.Now()
-	ipv4s, err := cache.ec2Metadata.GetMetadata(metadataMACPath + eniMAC + metadataIPv4s)
+	ipv4sAsString, err := cache.ec2Metadata.GetMetadata(metadataMACPath + eniMAC + metadataIPv4s)
 	awsAPILatency.WithLabelValues("GetMetadata", fmt.Sprint(err != nil)).Observe(msSince(start))
 	if err != nil {
 		awsAPIErrInc("GetMetadata", err)
@@ -514,9 +486,20 @@ func (cache *EC2InstanceMetadataCache) getIPsAndCIDR(eniMAC string) ([]string, s
 		return nil, "", errors.Wrapf(err, "failed to retrieve ENI %s local-ipv4s", eniMAC)
 	}
 
-	ipv4Strs := strings.Fields(ipv4s)
+	ipv4Strs := strings.Fields(ipv4sAsString)
 	log.Debugf("Found IP addresses %v on ENI %s", ipv4Strs, eniMAC)
-	return ipv4Strs, cidr, nil
+	ipv4s := make([]*ec2.NetworkInterfacePrivateIpAddress, 0, len(ipv4Strs))
+	// network/interfaces/macs/mac/public-ipv4s	The public IP address or Elastic IP addresses associated with the interface.
+	// There may be multiple IPv4 addresses on an instance. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+	isFirst := true
+	for _, ipv4 := range ipv4Strs {
+		// TODO: Verify that the first IP is always the primary
+		primary := isFirst
+		ip := ipv4
+		ipv4s = append(ipv4s, &ec2.NetworkInterfacePrivateIpAddress{PrivateIpAddress: &ip, Primary: &primary})
+		isFirst = false
+	}
+	return ipv4s, cidr, nil
 }
 
 // getENIDeviceNumber returns ENI ID, device number, error
@@ -554,6 +537,7 @@ func (cache *EC2InstanceMetadataCache) getENIDeviceNumber(eniMAC string) (string
 	return eni, int(deviceNum + 1), nil
 }
 
+// awsGetFreeDeviceNumber calls EC2 API DescribeInstances to get the next free device index
 func (cache *EC2InstanceMetadataCache) awsGetFreeDeviceNumber() (int, error) {
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{aws.String(cache.instanceID)},
@@ -637,7 +621,7 @@ func (cache *EC2InstanceMetadataCache) AllocENI(useCustomCfg bool, sg []*string,
 	return eniID, nil
 }
 
-// return attachment id, error
+//  attachENI calls EC2 API to attach the ENI and returns the attachment id
 func (cache *EC2InstanceMetadataCache) attachENI(eniID string) (string, error) {
 	// attach to instance
 	freeDevice, err := cache.awsGetFreeDeviceNumber()
@@ -807,14 +791,13 @@ func (cache *EC2InstanceMetadataCache) freeENI(eniName string, sleepDelayAfterDe
 	log.Infof("Trying to free ENI: %s", eniName)
 
 	// Find out attachment
-	_, _, attachID, err := cache.DescribeENI(eniName)
+	attachID, err := cache.getENIAttachmentID(eniName)
 	if err != nil {
 		if err == ErrENINotFound {
 			log.Infof("ENI %s not found. It seems to be already freed", eniName)
 			return nil
 		}
-
-		awsUtilsErrInc("FreeENIDescribeENIFailed", err)
+		awsUtilsErrInc("getENIAttachmentIDFailed", err)
 		log.Errorf("Failed to retrieve ENI %s attachment id: %v", eniName, err)
 		return errors.Wrap(err, "FreeENI: failed to retrieve ENI's attachment id")
 	}
@@ -855,6 +838,28 @@ func (cache *EC2InstanceMetadataCache) freeENI(eniName string, sleepDelayAfterDe
 	return nil
 }
 
+// getENIAttachmentID calls EC2 to fetch the attachmentID of a given ENI
+func (cache *EC2InstanceMetadataCache) getENIAttachmentID(eniID string) (*string, error) {
+	eniIds := make([]*string, 0)
+	eniIds = append(eniIds, aws.String(eniID))
+	input := &ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: eniIds}
+
+	start := time.Now()
+	result, err := cache.ec2SVC.DescribeNetworkInterfaces(input)
+	awsAPILatency.WithLabelValues("DescribeNetworkInterfaces", fmt.Sprint(err != nil)).Observe(msSince(start))
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				return nil, ErrENINotFound
+			}
+		}
+		awsAPIErrInc("DescribeNetworkInterfaces", err)
+		log.Errorf("Failed to get ENI %s information from EC2 control plane %v", eniID, err)
+		return nil, errors.Wrap(err, "failed to describe network interface")
+	}
+	return result.NetworkInterfaces[0].Attachment.AttachmentId, nil
+}
+
 func (cache *EC2InstanceMetadataCache) deleteENI(eniName string, maxBackoffDelay time.Duration) error {
 	log.Debugf("Trying to delete ENI: %s", eniName)
 	deleteInput := &ec2.DeleteNetworkInterfaceInput{
@@ -882,9 +887,8 @@ func (cache *EC2InstanceMetadataCache) deleteENI(eniName string, maxBackoffDelay
 	return err
 }
 
-// DescribeENI returns the IPv4 addresses, tags, and attachment id of the given ENI
-// return: private IP address, tags, attachment id, error
-func (cache *EC2InstanceMetadataCache) DescribeENI(eniID string) ([]*ec2.NetworkInterfacePrivateIpAddress, map[string]string, *string, error) {
+// GetIPv4sFromEC2 calls EC2 and returns a list of all addresses on the ENI
+func (cache *EC2InstanceMetadataCache) GetIPv4sFromEC2(eniID string) (addrList []*ec2.NetworkInterfacePrivateIpAddress, err error) {
 	eniIds := make([]*string, 0)
 	eniIds = append(eniIds, aws.String(eniID))
 	input := &ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: eniIds}
@@ -895,23 +899,101 @@ func (cache *EC2InstanceMetadataCache) DescribeENI(eniID string) ([]*ec2.Network
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				return nil, nil, nil, ErrENINotFound
+				return nil, ErrENINotFound
 			}
 		}
 		awsAPIErrInc("DescribeNetworkInterfaces", err)
 		log.Errorf("Failed to get ENI %s information from EC2 control plane %v", eniID, err)
-		return nil, nil, nil, errors.Wrap(err, "failed to describe network interface")
+		return nil, errors.Wrap(err, "failed to describe network interface")
 	}
-	tags := make(map[string]string, len(result.NetworkInterfaces[0].TagSet))
-	for _, tag := range result.NetworkInterfaces[0].TagSet {
-		if tag.Key == nil || tag.Value == nil {
-			log.Errorf("nil tag on ENI: %v", eniID)
-			continue
-		}
-		tags[*tag.Key] = *tag.Value
+	return result.NetworkInterfaces[0].PrivateIpAddresses, nil
+}
+
+// DescribeAllENIs calls EC2 to refrech the ENIMetadata and tags for all attached ENIs
+func (cache *EC2InstanceMetadataCache) DescribeAllENIs() ([]ENIMetadata, map[string]TagMap, error) {
+	// Fetch all local ENI info from metadata
+	allENIs, err := cache.GetAttachedENIs()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "DescribeAllENIs: failed to get local ENI metadata")
 	}
 
-	return result.NetworkInterfaces[0].PrivateIpAddresses, tags, result.NetworkInterfaces[0].Attachment.AttachmentId, nil
+	eniMap := make(map[string]ENIMetadata, len(allENIs))
+	var eniIDs []string
+	for _, eni := range allENIs {
+		eniIDs = append(eniIDs, eni.ENIID)
+		eniMap[eni.ENIID] = eni
+	}
+	input := &ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: aws.StringSlice(eniIDs)}
+
+	start := time.Now()
+	ec2Response, err := cache.ec2SVC.DescribeNetworkInterfaces(input)
+	awsAPILatency.WithLabelValues("DescribeNetworkInterfaces", fmt.Sprint(err != nil)).Observe(msSince(start))
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				return nil, nil, ErrENINotFound
+			}
+		}
+		awsAPIErrInc("DescribeNetworkInterfaces", err)
+		log.Errorf("Failed to call ec2:DescribeNetworkInterfaces for %v: %v", eniIDs, err)
+		return nil, nil, errors.Wrap(err, "failed to describe network interfaces")
+	}
+	// Collect ENI response into ENI metadata and tags.
+	tagMap := make(map[string]TagMap, len(ec2Response.NetworkInterfaces))
+	for _, ec2res := range ec2Response.NetworkInterfaces {
+		eniID := aws.StringValue(ec2res.NetworkInterfaceId)
+		eniMetadata := eniMap[eniID]
+		// Check IPv4 addresses
+		logOutOfSyncState(eniID, eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
+		tags := make(map[string]string, len(ec2res.TagSet))
+		for _, tag := range ec2res.TagSet {
+			if tag.Key == nil || tag.Value == nil {
+				log.Errorf("nil tag on ENI: %v", eniMetadata.ENIID)
+				continue
+			}
+			tags[*tag.Key] = *tag.Value
+		}
+		if len(tags) > 0 {
+			tagMap[eniMetadata.ENIID] = tags
+		}
+	}
+	return allENIs, tagMap, nil
+}
+
+// logOutOfSyncState compares the IP and metadata returned by IMDS and the EC2 API DescribeNetworkInterfaces calls
+func logOutOfSyncState(eniID string, imdsIPv4s, ec2IPv4s []*ec2.NetworkInterfacePrivateIpAddress) {
+	// Comparing the IMDS IPv4 addresses attached to the ENI with the DescribeNetworkInterfaces AWS API call, which
+	// technically should be the source of truth and contain the freshest information. Let's just do a quick scan here
+	// and output some diagnostic messages if we find stale info in the IMDS result.
+	imdsIPv4Set := sets.String{}
+	imdsPrimaryIP := ""
+	for _, imdsIPv4 := range imdsIPv4s {
+		imdsIPv4Set.Insert(aws.StringValue(imdsIPv4.PrivateIpAddress))
+		if aws.BoolValue(imdsIPv4.Primary) {
+			imdsPrimaryIP = aws.StringValue(imdsIPv4.PrivateIpAddress)
+		}
+	}
+	ec2IPv4Set := sets.String{}
+	ec2IPv4PrimaryIP := ""
+	for _, privateIPv4 := range ec2IPv4s {
+		ec2IPv4Set.Insert(aws.StringValue(privateIPv4.PrivateIpAddress))
+		if aws.BoolValue(privateIPv4.Primary) {
+			ec2IPv4PrimaryIP = aws.StringValue(privateIPv4.PrivateIpAddress)
+		}
+	}
+	missingIMDS := ec2IPv4Set.Difference(imdsIPv4Set).List()
+	missingDNI := imdsIPv4Set.Difference(ec2IPv4Set).List()
+	if len(missingIMDS) > 0 {
+		strMissing := strings.Join(missingIMDS, ",")
+		log.Infof("logOutOfSyncState: DescribeNetworkInterfaces(%s) yielded private IPv4 addresses %s that were not yet found in IMDS.", eniID, strMissing)
+	}
+	if len(missingDNI) > 0 {
+		strMissing := strings.Join(missingDNI, ",")
+		log.Infof("logOutOfSyncState: IMDS query yielded stale IPv4 addresses %s that were not found in DescribeNetworkInterfaces(%s).", strMissing, eniID)
+	}
+	if imdsPrimaryIP != ec2IPv4PrimaryIP {
+		log.Infof("logOutOfSyncState: Primary IPs do not mach for %s. IMDS: %s, EC2: %s", eniID, imdsPrimaryIP, ec2IPv4PrimaryIP)
+	}
 }
 
 // AllocIPAddress allocates an IP address for an ENI
@@ -1001,11 +1083,11 @@ func (cache *EC2InstanceMetadataCache) AllocIPAddresses(eniID string, numIPs int
 	_, err = cache.ec2SVC.AssignPrivateIpAddresses(input)
 	awsAPILatency.WithLabelValues("AssignPrivateIpAddresses", fmt.Sprint(err != nil)).Observe(msSince(start))
 	if err != nil {
+		log.Errorf("Failed to allocate a private IP addresses on ENI %v: %v",eniID, err)
 		awsAPIErrInc("AssignPrivateIpAddresses", err)
 		if containsPrivateIPAddressLimitExceededError(err) {
 			return nil
 		}
-		log.Errorf("Failed to allocate a private IP address %v", err)
 		return errors.Wrap(err, "allocate IP address: failed to allocate a private IP address")
 	}
 	return nil

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -50,7 +50,7 @@ const (
 	eniAttachID   = "eni-attach-beb21856"
 	eni1Device    = "0"
 	eni1PrivateIP = "10.0.0.1"
-	eni2Device    = "2"
+	eni2Device    = "1"
 	eni2PrivateIP = "10.0.0.2"
 	eni2AttachID  = "eni-attach-fafdfafd"
 	eni2ID        = "eni-12341234"
@@ -76,7 +76,7 @@ func TestInitWithEC2metadata(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
@@ -106,7 +106,7 @@ func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
@@ -128,7 +128,7 @@ func TestInitWithEC2metadataSubnetErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)
@@ -149,7 +149,7 @@ func TestInitWithEC2metadataSGErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, errors.New("Error on SG"))
@@ -168,7 +168,7 @@ func TestInitWithEC2metadataENIErrs(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return("", errors.New("Err on ENIs"))
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return("", errors.New("err on ENIs"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	err := ins.initWithEC2Metadata()
@@ -183,7 +183,7 @@ func TestInitWithEC2metadataMACErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, errors.New("Error on MAC"))
+	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, errors.New("error on MAC"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	err := ins.initWithEC2Metadata()
@@ -195,7 +195,7 @@ func TestInitWithEC2metadataLocalIPErr(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, errors.New("Error on localIP"))
+	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, errors.New("error on localIP"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	err := ins.initWithEC2Metadata()
@@ -208,7 +208,7 @@ func TestInitWithEC2metadataInstanceErr(t *testing.T) {
 
 	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, errors.New("Error on instanceID"))
+	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, errors.New("error on instanceID"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	err := ins.initWithEC2Metadata()
@@ -219,7 +219,7 @@ func TestInitWithEC2metadataAZErr(t *testing.T) {
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
-	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, errors.New("Error on metadata AZ"))
+	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, errors.New("error on metadata AZ"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	err := ins.initWithEC2Metadata()
@@ -246,47 +246,10 @@ func TestSetPrimaryENs(t *testing.T) {
 }
 
 func TestGetAttachedENIs(t *testing.T) {
-	ctrl, mockMetadata, mockEC2 := setup(t)
+	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
 
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC+" "+eni2MAC, nil)
-
-	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any()).
-		DoAndReturn(func(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
-			output := []*ec2.NetworkInterface{}
-			for _, in := range input.NetworkInterfaceIds {
-				ip := ""
-				attachID := ""
-				switch *in {
-				case eniID:
-					ip, attachID = eni1PrivateIP, eniAttachID
-				case eni2ID:
-					ip, attachID = eni2PrivateIP, eni2AttachID
-				default:
-					panic("no such id " + *in)
-				}
-
-				output = append(output, &ec2.NetworkInterface{
-					PrivateIpAddresses: []*ec2.NetworkInterfacePrivateIpAddress{
-						{
-							PrivateIpAddress: &ip,
-						},
-					},
-					Attachment: &ec2.NetworkInterfaceAttachment{
-						AttachmentId: &attachID,
-					},
-					TagSet: []*ec2.Tag{
-						{
-							Key:   aws.String("foo"),
-							Value: aws.String("foo-value"),
-						},
-					},
-				})
-			}
-			return &ec2.DescribeNetworkInterfacesOutput{
-				NetworkInterfaces: output,
-			}, nil
-		}).Times(2)
 
 	gomock.InOrder(
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil),
@@ -299,7 +262,7 @@ func TestGetAttachedENIs(t *testing.T) {
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataIPv4s).Return("", nil),
 	)
 
-	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
+	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
 	ens, err := ins.GetAttachedENIs()
 	assert.NoError(t, err)
 	assert.Equal(t, len(ens), 2)
@@ -342,15 +305,18 @@ func TestAWSGetFreeDeviceNumberNoDevice(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDescribeENI(t *testing.T) {
-	ctrl, _, mockEC2 := setup(t)
+func TestDescribeAllENIs(t *testing.T) {
+	ctrl, mockMetadata, mockEC2 := setup(t)
 	defer ctrl.Finish()
 
-	attachmentID := eniAttachID
-	attachment := &ec2.NetworkInterfaceAttachment{AttachmentId: &attachmentID}
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Times(2).Return(primaryMAC, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Times(2).Return(eni1Device, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Times(2).Return(eniID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetCIDR).Times(2).Return(subnetCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataIPv4s).Times(2).Return("", nil)
+
 	result := &ec2.DescribeNetworkInterfacesOutput{
 		NetworkInterfaces: []*ec2.NetworkInterface{{
-			Attachment: attachment,
 			TagSet: []*ec2.Tag{
 				{Key: aws.String("foo"), Value: aws.String("foo-value")},
 			},
@@ -359,22 +325,19 @@ func TestDescribeENI(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		expID   *string
-		exptags map[string]string
+		exptags map[string]TagMap
 		awsErr  error
 		expErr  error
 	}{
-		{"success DescribeENI", &attachmentID, map[string]string{"foo": "foo-value"}, nil, nil},
-		{"not found error", nil, nil, awserr.New("InvalidNetworkInterfaceID.NotFound", "", nil), ErrENINotFound},
+		{"success DescribeENI", map[string]TagMap{"": {"foo": "foo-value"}}, nil, nil},
+		{"not found error", nil, awserr.New("InvalidNetworkInterfaceID.NotFound", "", nil), ErrENINotFound},
 	}
 
 	for _, tc := range testCases {
 		mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any()).Return(result, tc.awsErr)
-
-		ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-		_, tags, id, err := ins.DescribeENI("test-eni")
+		ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
+		_, tags, err := ins.DescribeAllENIs()
 		assert.Equal(t, tc.expErr, err, tc.name)
-		assert.Equal(t, tc.expID, id, tc.name)
 		assert.Equal(t, tc.exptags, tags, tc.name)
 	}
 }
@@ -388,7 +351,7 @@ func TestTagEni(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return("1", nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil)

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -19,11 +19,10 @@
 package mock_awsutils
 
 import (
-	reflect "reflect"
-
 	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockAPIs is a mock of APIs interface
@@ -106,21 +105,20 @@ func (mr *MockAPIsMockRecorder) DeallocIPAddresses(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeallocIPAddresses", reflect.TypeOf((*MockAPIs)(nil).DeallocIPAddresses), arg0, arg1)
 }
 
-// DescribeENI mocks base method
-func (m *MockAPIs) DescribeENI(arg0 string) ([]*ec2.NetworkInterfacePrivateIpAddress, map[string]string, *string, error) {
+// DescribeAllENIs mocks base method
+func (m *MockAPIs) DescribeAllENIs() ([]awsutils.ENIMetadata, map[string]awsutils.TagMap, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeENI", arg0)
-	ret0, _ := ret[0].([]*ec2.NetworkInterfacePrivateIpAddress)
-	ret1, _ := ret[1].(map[string]string)
-	ret2, _ := ret[2].(*string)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret := m.ctrl.Call(m, "DescribeAllENIs")
+	ret0, _ := ret[0].([]awsutils.ENIMetadata)
+	ret1, _ := ret[1].(map[string]awsutils.TagMap)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// DescribeENI indicates an expected call of DescribeENI
-func (mr *MockAPIsMockRecorder) DescribeENI(arg0 interface{}) *gomock.Call {
+// DescribeAllENIs indicates an expected call of DescribeAllENIs
+func (mr *MockAPIsMockRecorder) DescribeAllENIs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeENI", reflect.TypeOf((*MockAPIs)(nil).DescribeENI), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAllENIs", reflect.TypeOf((*MockAPIs)(nil).DescribeAllENIs))
 }
 
 // FreeENI mocks base method
@@ -180,6 +178,21 @@ func (m *MockAPIs) GetENIipLimit() (int, error) {
 func (mr *MockAPIsMockRecorder) GetENIipLimit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENIipLimit", reflect.TypeOf((*MockAPIs)(nil).GetENIipLimit))
+}
+
+// GetIPv4sFromEC2 mocks base method
+func (m *MockAPIs) GetIPv4sFromEC2(arg0 string) ([]*ec2.NetworkInterfacePrivateIpAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPv4sFromEC2", arg0)
+	ret0, _ := ret[0].([]*ec2.NetworkInterfacePrivateIpAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPv4sFromEC2 indicates an expected call of GetIPv4sFromEC2
+func (mr *MockAPIsMockRecorder) GetIPv4sFromEC2(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv4sFromEC2", reflect.TypeOf((*MockAPIs)(nil).GetIPv4sFromEC2), arg0)
 }
 
 // GetLocalIPv4 mocks base method


### PR DESCRIPTION
*Issue #, if available:* #887

*Description of changes:*
* Remove Tags from the metadata struct, since tags are only available by calling EC2
* Remove `currentENIs` value since it's not used anywhere
* Made a separate function to get IPv4 addresses for one ENI from EC2
* Made another function to only get the ENI `AttachmentID` from EC2
* Batch the call to check all attached ENIs into one API request
* Added tests for `no_manage`
* Verified that `no_manage` tags on both restarts and adding new ENIs to a node

Test showing number of `DescribeNetworkInterfaces` calls running 5000 pods on 100 nodes:
![ipamd-ec2-api-calls](https://user-images.githubusercontent.com/50456/79260240-d2ee5f00-7e42-11ea-949e-3cf3871b4598.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
