### PR TITLE
Use -buildmode=pie for binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       <<: *env
       # Target the GOARCH for x86_64
       ARCH: amd64
+      BUILD_MODE: "-buildmode=pie"
 
   build_aarch64:
     <<: *build
@@ -41,6 +42,7 @@ jobs:
       <<: *env
       # Target the GOARCH for aarch64
       ARCH: arm64
+      BUILD_MODE: ""
 
   integration_test:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v
 IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(ARCH),arm64))
 # GOLANG_IMAGE is the building golang container image used.
 GOLANG_IMAGE = golang:1.13-stretch
-# For the requseted build, these are the set of Go specific build environment
-# variables.
+# For the requested build, these are the set of Go specific build environment variables.
 export GOARCH ?= $(ARCH)
 export GOOS = linux
 export CGO_ENABLED = 0
@@ -94,7 +93,8 @@ dist: all
 	docker save $(METRICS_IMAGE_NAME) | gzip > $(METRICS_IMAGE_DIST)
 
 # Build the VPC CNI plugin agent using the host's Go toolchain.
-build-linux: BUILD_FLAGS = -ldflags '-s -w $(LDFLAGS)'
+BUILD_MODE ?= -buildmode=pie
+build-linux: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS)'
 build-linux:
 	go build $(BUILD_FLAGS) -o aws-k8s-agent     ./cmd/aws-k8s-agent
 	go build $(BUILD_FLAGS) -o aws-cni           ./cmd/routed-eni-cni-plugin


### PR DESCRIPTION
*Description of changes:*
* Enable `-buildmode=pie`
* Override for cross-compiles since we have native dependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
