### PR TITLE
Remove unnecessary ClusterRole resource in aws-k8s-cni-cn.yaml 

### DIFF
--- a/config/v1.6/aws-k8s-cni-cn.yaml
+++ b/config/v1.6/aws-k8s-cni-cn.yaml
@@ -8,7 +8,6 @@ rules:
       - crd.k8s.amazonaws.com
     resources:
       - "*"
-      - namespaces
     verbs:
       - "*"
   - apiGroups: [""]


### PR DESCRIPTION
*Description of changes:*
To remove unecessary cluster role in aws-k8s-cni-cn.yaml file as this is already covered by `*` wildcard.

Moreover, to make it consistent with aws-k8s-cni.yaml, and avoid any confusion for consumer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
