### PR TITLE
Update node selectors

### DIFF
--- a/config/v1.6/aws-k8s-cni.yaml
+++ b/config/v1.6/aws-k8s-cni.yaml
@@ -69,7 +69,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
+                  - key: "kubernetes.io/os"
                     operator: In
                     values:
                       - linux
@@ -77,7 +77,7 @@ spec:
                     operator: In
                     values:
                       - amd64
-                  - key: eks.amazonaws.com/compute-type
+                  - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
                       - fargate


### PR DESCRIPTION
*Description of changes:*
* [`beta.kubernetes.io/os` is deprecated](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#beta-kubernetes-io-os-deprecated), switched to `kubernetes.io/os`
* Quoted compute-type key

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
