### PR TITLE
Fix order of file copies in entrypoint.sh

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -60,7 +60,15 @@ wait_for_ipam() {
 
 echo -n "Copying portmap binary... "
 
-cp portmap "$HOST_CNI_BIN_PATH"
+if [[ -f "$HOST_CNI_BIN_PATH" ]]
+then
+    mv "$HOST_CNI_BIN_PATH" "$HOST_CNI_BIN_PATH.old"
+    cp portmap "$HOST_CNI_BIN_PATH"
+    rm "$HOST_CNI_BIN_PATH.old"
+else
+    cp portmap "$HOST_CNI_BIN_PATH"
+fi
+
 
 echo -n "Starting IPAM daemon in the background ... "
 ./aws-k8s-agent | tee -i "$AGENT_LOG_PATH" 2>&1 &

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,11 +58,9 @@ wait_for_ipam() {
     return 1
 }
 
-echo -n "Copying CNI plugin binaries and config files ... "
+echo -n "Copying portmap binary... "
 
 cp portmap "$HOST_CNI_BIN_PATH"
-cp aws-cni "$HOST_CNI_BIN_PATH"
-cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"
 
 echo -n "Starting IPAM daemon in the background ... "
 ./aws-k8s-agent | tee -i "$AGENT_LOG_PATH" 2>&1 &
@@ -78,6 +76,11 @@ if ! wait_for_ipam; then
 fi
 
 echo "ok."
+
+echo "Copying additional CNI plugin binaries and config files"
+
+cp aws-cni "$HOST_CNI_BIN_PATH"
+cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"
 
 sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g 10-aws.conflist
 sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g 10-aws.conflist

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,6 +58,12 @@ wait_for_ipam() {
     return 1
 }
 
+echo -n "Copying CNI plugin binaries and config files ... "
+
+cp portmap "$HOST_CNI_BIN_PATH"
+cp aws-cni "$HOST_CNI_BIN_PATH"
+cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"
+
 echo -n "Starting IPAM daemon in the background ... "
 ./aws-k8s-agent | tee -i "$AGENT_LOG_PATH" 2>&1 &
 echo "ok."
@@ -72,12 +78,6 @@ if ! wait_for_ipam; then
 fi
 
 echo "ok."
-
-echo -n "Copying CNI plugin binaries and config files ... "
-
-cp portmap "$HOST_CNI_BIN_PATH"
-cp aws-cni "$HOST_CNI_BIN_PATH"
-cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"
 
 sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g 10-aws.conflist
 sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g 10-aws.conflist

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -61,15 +61,10 @@ wait_for_ipam() {
 echo -n "Copying portmap binary ... "
 
 HOST_PORTMAP="$HOST_CNI_BIN_PATH/portmap"
-if [[ -f "$HOST_PORTMAP" ]]
-then
-    mv "$HOST_PORTMAP" "$HOST_PORTMAP.old"
-    cp portmap "$HOST_CNI_BIN_PATH"
-    rm "$HOST_PORTMAP.old"
-else
-    cp portmap "$HOST_CNI_BIN_PATH"
+if [[ -f "$HOST_PORTMAP" ]]; then
+    rm "$HOST_PORTMAP"
 fi
-
+cp portmap "$HOST_CNI_BIN_PATH"
 
 echo -n "Starting IPAM daemon in the background ... "
 ./aws-k8s-agent | tee -i "$AGENT_LOG_PATH" 2>&1 &

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,7 +58,7 @@ wait_for_ipam() {
     return 1
 }
 
-echo -n "Copying portmap binary... "
+echo -n "Copying portmap binary ... "
 
 HOST_PORTMAP="$HOST_CNI_BIN_PATH/portmap"
 if [[ -f "$HOST_PORTMAP" ]]
@@ -86,7 +86,7 @@ fi
 
 echo "ok."
 
-echo "Copying additional CNI plugin binaries and config files"
+echo -n "Copying additional CNI plugin binaries and config files ... "
 
 cp aws-cni "$HOST_CNI_BIN_PATH"
 cp aws-cni-support.sh "$HOST_CNI_BIN_PATH"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -60,11 +60,12 @@ wait_for_ipam() {
 
 echo -n "Copying portmap binary... "
 
-if [[ -f "$HOST_CNI_BIN_PATH" ]]
+HOST_PORTMAP="$HOST_CNI_BIN_PATH/portmap"
+if [[ -f "$HOST_PORTMAP" ]]
 then
-    mv "$HOST_CNI_BIN_PATH" "$HOST_CNI_BIN_PATH.old"
+    mv "$HOST_PORTMAP" "$HOST_PORTMAP.old"
     cp portmap "$HOST_CNI_BIN_PATH"
-    rm "$HOST_CNI_BIN_PATH.old"
+    rm "$HOST_PORTMAP.old"
 else
     cp portmap "$HOST_CNI_BIN_PATH"
 fi


### PR DESCRIPTION
Fixes this error when you upgrade the CNI because the CNI starts prior to portmap
is copied and portmap is then sometimes in use by the time the cp commands execute

*Issue #, if available:*

*Description of changes:*
This fixes the following error from causing the CNI pod to enter crashloopbackoff:
`cp: cannot create regular file '/host/opt/cni/bin/portmap': Text file busy`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
