### PR TITLE
Disable ENI sync flag

### DIFF
--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -596,3 +596,16 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 		})
 	}
 }
+
+func TestDisablingENIProvisioning(t *testing.T) {
+	ctrl, _, _, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	_ = os.Setenv(envDisableENIProvisioning, "true")
+	disabled := disablingENIProvisioning()
+	assert.True(t, disabled)
+
+	_ = os.Unsetenv(envDisableENIProvisioning)
+	disabled = disablingENIProvisioning()
+	assert.False(t, disabled)
+}


### PR DESCRIPTION
*Description of changes:*

If the all resources are provisioned upfront, based on the new flag, we can stop doing calls to EC2 to get ENI and IP.

* Add a new flag `DISABLE_NETWORK_RESOURCE_PROVISIONING` to control IP update check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
