### PR TITLE
Follow up to #934

### DIFF
--- a/config/v1.6/aws-k8s-cni-cn.yaml
+++ b/config/v1.6/aws-k8s-cni-cn.yaml
@@ -70,15 +70,15 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
+                  - key: "kubernetes.io/os"
                     operator: In
                     values:
                       - linux
-                  - key: "beta.kubernetes.io/arch"
+                  - key: "kubernetes.io/arch"
                     operator: In
                     values:
                       - amd64
-                  - key: eks.amazonaws.com/compute-type
+                  - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
                       - fargate

--- a/config/v1.6/aws-k8s-cni.yaml
+++ b/config/v1.6/aws-k8s-cni.yaml
@@ -73,7 +73,7 @@ spec:
                     operator: In
                     values:
                       - linux
-                  - key: "beta.kubernetes.io/arch"
+                  - key: "kubernetes.io/arch"
                     operator: In
                     values:
                       - amd64


### PR DESCRIPTION
*Issue #, if available:*
Follow up to #934

*Description of changes:*
1) As per documentation, `kubernetes-io-arch` node selector is also deprecated.  
https://v1-14.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#beta-kubernetes-io-arch-deprecated

2) Updating aws-k8s-cni-cn.yaml to have these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
