### PR TITLE
Minor Dockerfile cleanup

### DIFF
--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -3,7 +3,7 @@ ARG golang_image=golang:1.13-stretch
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
-ARG GOARCH=
+ARG GOARCH
 # Configure build with Go modules
 ENV GO111MODULE=on
 ENV GOPROXY=direct

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -3,7 +3,7 @@ ARG golang_image=golang:1.13-stretch
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
-ARG GOARCH=
+ARG GOARCH
 # Configure build with Go modules
 ENV GO111MODULE=on
 ENV GOPROXY=direct

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -3,6 +3,7 @@ ARG golang_image=golang:1.13-stretch
 FROM $golang_image
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 
+ARG GOARCH
 ARG arch
 ENV ARCH=$arch
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Removed unnecessary [`=`](https://github.com/moby/moby/blob/master/Dockerfile.buildx#L13)
* Added `ARG GOARCH` to avoid test warning

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
