### PR TITLE
Adding whitelist to filter accountId which is not included in given list.

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -154,6 +154,9 @@ type APIs interface {
 
 	// GetPrimaryENImac returns the mac address of the primary ENI
 	GetPrimaryENImac() string
+
+	// GetAccountId returns the account id/owner id
+	GetAccountId() string
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -1232,4 +1235,9 @@ func (cache *EC2InstanceMetadataCache) GetPrimaryENI() string {
 // GetPrimaryENImac returns the mac address of primary eni
 func (cache *EC2InstanceMetadataCache) GetPrimaryENImac() string {
 	return cache.primaryENImac
+}
+
+// GetAccountId returns the account id/owner id
+func (cache *EC2InstanceMetadataCache) GetAccountId() string {
+	return cache.accountID
 }

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -771,3 +771,12 @@ func TestEC2InstanceMetadataCache_getFilteredListOfNetworkInterfaces_Error(t *te
 	assert.Nil(t, got)
 	assert.Error(t, err)
 }
+
+func TestEC2InstanceMetadataCache_GetAccountId(t *testing.T) {
+	ctrl, _, mockEC2 := setup(t)
+	defer ctrl.Finish()
+
+	testId := "123"
+	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2, accountID: testId}
+	assert.Equal(t, testId, ins.GetAccountId())
+}

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -264,3 +264,17 @@ func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv4CIDRs", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv4CIDRs))
 }
+
+// GetAccountId mocks base method
+func (m *MockAPIs) GetAccountId() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountId")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAccountId returns the account id/owner id
+func (mr *MockAPIsMockRecorder) GetAccountId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountId", reflect.TypeOf((*MockAPIs)(nil).GetAccountId()))
+}

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -508,8 +508,8 @@ func (c *IPAMContext) getLocalPodsWithRetry() ([]*k8sapi.K8SPodInfo, error) {
 func (c *IPAMContext) StartNodeIPPoolManager() {
 	sleepDuration := ipPoolMonitorInterval / 2
 	for {
+		time.Sleep(sleepDuration)
 		if c.accountWhitelist == nil || contains(c.accountWhitelist, c.awsClient.GetAccountId()) {
-			time.Sleep(sleepDuration)
 			c.updateIPPoolIfRequired()
 		}
 		time.Sleep(sleepDuration)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -190,7 +190,7 @@ type IPAMContext struct {
 	// so that we don't reconcile and add it back too quickly if IMDS lags behind reality.
 	reconcileCooldownCache ReconcileCooldownCache
 	terminating            int32 // Flag to warn that the pod is about to shut down.
-	accountWhitelist     []string
+	accountWhitelist       []string
 }
 
 // UnmanagedENISet keeps a set of ENI IDs for ENIs tagged with "node.k8s.amazonaws.com/no_manage"

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -603,12 +603,16 @@ func TestContains(t *testing.T) {
 	targetAccount := "100"
 	assert.True(t, contains(accounts, targetAccount))
 	assert.False(t, contains(accounts, "102"))
+
+	var emptyAccounts []string
+	targetAccount = ""
+	assert.False(t, contains(emptyAccounts, targetAccount))
 }
 
 func TestGetENITrackingWhitelistedAccountIds(t *testing.T) {
-	_ = os.Setenv(envWhitelistedAccountIds, "100, 101, 102")
+	_ = os.Setenv(envWhitelistedAccountIds, "100, 101, 102, ")
 	accounts := getENITrackingWhitelistedAccountIds()
-	account := "100"
+	account := "101"
 	assert.Equal(t, 3, len(accounts))
 	assert.True(t, contains(accounts, account))
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -596,3 +596,20 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetENITrackingWhitelistedAccountIds(t *testing.T) {
+	ctrl, _, _, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
+	mockAWSUtils.EXPECT().GetAccountId().Return("101")
+	_ = os.Setenv("ALLOWED_ENI_TRACKING_IDS", "100, 101, 102")
+	accounts := getENITrackingWhitelistedAccountIds()
+	assert.Equal(t, len(accounts), 3)
+	assert.True(t, contains(accounts, mockAWSUtils.GetAccountId()))
+	assert.False(t, contains(accounts, "103"))
+
+	_ = os.Unsetenv("WARM_IP_TARGET")
+	accounts = getENITrackingWhitelistedAccountIds()
+	assert.Equal(t, accounts, nil)
+}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -14,6 +14,7 @@
 package ipamd
 
 import (
+	_ "fmt"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	mock_awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/mocks"
@@ -597,19 +598,17 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	}
 }
 
+func TestContains(t *testing.T) {
+	accounts := []string{"","100","101"}
+	targetAccount := "100"
+	assert.True(t, contains(accounts, targetAccount))
+	assert.False(t, contains(accounts, "102"))
+}
+
 func TestGetENITrackingWhitelistedAccountIds(t *testing.T) {
-	ctrl, _, _, _, _, _ := setup(t)
-	defer ctrl.Finish()
-
-	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
-	mockAWSUtils.EXPECT().GetAccountId().Return("101")
-	_ = os.Setenv("ALLOWED_ENI_TRACKING_IDS", "100, 101, 102")
+	_ = os.Setenv(envWhitelistedAccountIds, "100, 101, 102")
 	accounts := getENITrackingWhitelistedAccountIds()
-	assert.Equal(t, len(accounts), 3)
-	assert.True(t, contains(accounts, mockAWSUtils.GetAccountId()))
-	assert.False(t, contains(accounts, "103"))
-
-	_ = os.Unsetenv("WARM_IP_TARGET")
-	accounts = getENITrackingWhitelistedAccountIds()
-	assert.Equal(t, accounts, nil)
+	account := "100"
+	assert.Equal(t, 3, len(accounts))
+	assert.True(t, contains(accounts, account))
 }


### PR DESCRIPTION
*Issue #, if available:*
We want to limit tracking ENI calls to ec2.
*Description of changes:*
Added a whitelist that created base don given accounts. The current owner account id will be checked and only whitelisted id can keep tracking ENI and IPs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
