### PR TITLE
Log tests to stdout by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ docker-func-test: docker
 		"$(IMAGE_NAME)"
 
 # Run unit tests
+unit-test: export AWS_VPC_K8S_CNI_LOG_FILE=stdout
 unit-test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic $(ALLPKGS)
 

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -48,7 +48,7 @@ const (
 var logConfig = logger.Configuration{
 	BinaryName:  "aws-cni",
 	LogLevel:    "Debug",
-	LogLocation: "/var/log/test.log",
+	LogLocation: "stdout",
 }
 
 var log = logger.New(&logConfig)

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -26,7 +26,7 @@ import (
 var logConfig = logger.Configuration{
 	BinaryName:  "aws-cni",
 	LogLevel:    "Debug",
-	LogLocation: "/var/log/test.log",
+	LogLocation: "stdout",
 }
 
 var log = logger.New(&logConfig)


### PR DESCRIPTION
*Description of changes:*
* Tests currently try to log to `/host` which fails with a write error. Just logging to `stdout` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
