### PR TITLE
Add a match expresison for 1.12 clusters

### DIFF
--- a/config/v1.6/aws-k8s-cni.yaml
+++ b/config/v1.6/aws-k8s-cni.yaml
@@ -69,6 +69,19 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
+                  - key: "beta.kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "beta.kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
+              - matchExpressions:
                   - key: "kubernetes.io/os"
                     operator: In
                     values:


### PR DESCRIPTION
*Description of changes:*

Applying the sample config to a 1.12 cluster requires the `beta.kubernetes.io` node labels. Adding a separate match expression to support older clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
