### PR TITLE
Refactor driver_test to be O(n) rather than O(n^2)

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -53,28 +53,33 @@ var logConfig = logger.Configuration{
 
 var log = logger.New(&logConfig)
 
-func setup(t *testing.T) (*gomock.Controller,
-	*mock_netlinkwrapper.MockNetLink,
-	*mocks_ip.MockIP,
-	*mock_nswrapper.MockNS,
-	*mock_procsyswrapper.MockProcSys) {
-	ctrl := gomock.NewController(t)
-	return ctrl,
-		mock_netlinkwrapper.NewMockNetLink(ctrl),
-		mocks_ip.NewMockIP(ctrl),
-		mock_nswrapper.NewMockNS(ctrl),
-		mock_procsyswrapper.NewMockProcSys(ctrl)
+type testMocks struct {
+	ctrl    *gomock.Controller
+	netlink *mock_netlinkwrapper.MockNetLink
+	ip      *mocks_ip.MockIP
+	ns      *mock_nswrapper.MockNS
+	netns   *mock_ns.MockNetNS
+	procsys *mock_procsyswrapper.MockProcSys
 }
 
-func TestRun(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+func setup(t *testing.T) *testMocks {
+	ctrl := gomock.NewController(t)
+	return &testMocks{
+		ctrl:    ctrl,
+		netlink: mock_netlinkwrapper.NewMockNetLink(ctrl),
+		ip:      mocks_ip.NewMockIP(ctrl),
+		ns:      mock_nswrapper.NewMockNS(ctrl),
+		netns:   mock_ns.NewMockNetNS(ctrl),
+		procsys: mock_procsyswrapper.NewMockProcSys(ctrl),
+	}
+}
 
+func (m *testMocks) mockWithFailureAt(t *testing.T, failAt string) *createVethPairContext {
 	mockContext := &createVethPairContext{
 		contVethName: testContVethName,
 		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
+		netLink:      m.netlink,
+		ip:           m.ip,
 		addr: &net.IPNet{
 			IP:   net.ParseIP(testIP),
 			Mask: net.IPv4Mask(255, 255, 255, 255),
@@ -87,425 +92,213 @@ func TestRun(t *testing.T) {
 	mockLinkAttrs := &netlink.LinkAttrs{
 		HardwareAddr: hwAddr,
 	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+	mockHostVeth := mock_netlink.NewMockLink(m.ctrl)
+	mockContVeth := mock_netlink.NewMockLink(m.ctrl)
 
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
-		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
+	var call *gomock.Call
 
-		// container addr
-		mockNetLink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(nil),
+	// veth pair
+	if failAt == "link-add" {
+		call = m.netlink.EXPECT().LinkAdd(gomock.Any()).Return(errors.New("error on LinkAdd"))
+		return mockContext
+	}
+	call = m.netlink.EXPECT().LinkAdd(gomock.Any()).Return(nil)
 
-		// neighbor
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		// hostVethMAC
-		mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(nil),
+	//hostVeth
+	if failAt == "link-by-name" {
+		call = m.netlink.EXPECT().LinkByName(gomock.Any()).Return(nil, errors.New("error on LinkByName host")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil).After(call)
 
-		mockNS.EXPECT().Fd().Return(uintptr(testFD)),
-		// move it host namespace
-		mockNetLink.EXPECT().LinkSetNsFd(mockHostVeth, testFD).Return(nil),
-	)
+	//host side setup
+	if failAt == "link-setup" {
+		call = m.netlink.EXPECT().LinkSetUp(mockHostVeth).Return(errors.New("error on LinkSetup")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().LinkSetUp(mockHostVeth).Return(nil).After(call)
 
-	err = mockContext.run(mockNS)
+	//container side
+	if failAt == "link-byname" {
+		call = m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, errors.New("error on LinkByName container")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil).After(call)
+
+	// container setup
+	call = m.netlink.EXPECT().LinkSetUp(mockContVeth).Return(nil).After(call)
+	// container
+	call = mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).After(call)
+
+	if failAt == "route-replace" {
+		call = m.netlink.EXPECT().RouteReplace(gomock.Any()).Return(errors.New("error on RouteReplace")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().RouteReplace(gomock.Any()).Return(nil).After(call)
+
+	if failAt == "add-defaultroute" {
+		call = m.ip.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(errors.New("error on AddDefaultRoute")).After(call)
+		return mockContext
+	}
+	call = m.ip.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil).After(call)
+
+	// container addr
+	if failAt == "addr-add" {
+		call = m.netlink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(errors.New("error on AddrAdd")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(nil).After(call)
+
+	// neighbor
+	call = mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).After(call)
+	// hostVethMAC
+	call = mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs).After(call)
+	if failAt == "neigh-add" {
+		call = m.netlink.EXPECT().NeighAdd(gomock.Any()).Return(errors.New("error on NeighAdd")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().NeighAdd(gomock.Any()).Return(nil).After(call)
+
+	call = m.netns.EXPECT().Fd().Return(uintptr(testFD)).After(call)
+	// move it host namespace
+	if failAt == "link-setns" {
+		call = m.netlink.EXPECT().LinkSetNsFd(mockHostVeth, testFD).Return(errors.New("error on LinkSetNsFd")).After(call)
+		return mockContext
+	}
+	call = m.netlink.EXPECT().LinkSetNsFd(mockHostVeth, testFD).Return(nil).After(call)
+
+	return mockContext
+}
+
+func TestRun(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := m.mockWithFailureAt(t, "")
+
+	err := mockContext.run(m.netns)
 	assert.NoError(t, err)
 }
 
 func TestRunLinkAddErr(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "link-add")
 
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(errors.New("error on LinkAdd")),
-	)
-
-	err := mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrLinkByNameHost(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "link-by-name")
 
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(nil, errors.New("error on LinkByName host")),
-	)
-
-	err := mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrSetup(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "link-setup")
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(errors.New("error on LinkSetup")),
-	)
-
-	err := mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrLinkByNameCont(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "link-byname")
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, errors.New("error on LinkByName container")),
-	)
-
-	err := mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrRouteAdd(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "route-replace")
 
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(errors.New("error on RouteReplace")),
-	)
-
-	err = mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrAddDefaultRoute(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "add-defaultroute")
 
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
-		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(errors.New("error on AddDefaultRoute")),
-	)
-
-	err = mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrAddrAdd(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "addr-add")
 
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
-		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
-
-		// container addr
-		mockNetLink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(errors.New("error on AddrAdd")),
-	)
-
-	err = mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrNeighAdd(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "neigh-add")
 
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
-		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
-
-		// container addr
-		mockNetLink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(nil),
-		// neighbor
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		// hostVethMAC
-		mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(errors.New("error on NeighAdd")),
-	)
-
-	err = mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
 func TestRunErrLinkSetNsFd(t *testing.T) {
-	ctrl, mockNetLink, mockIP, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockContext := &createVethPairContext{
-		contVethName: testContVethName,
-		hostVethName: testHostVethName,
-		netLink:      mockNetLink,
-		ip:           mockIP,
-		addr: &net.IPNet{
-			IP:   net.ParseIP(testIP),
-			Mask: net.IPv4Mask(255, 255, 255, 255),
-		},
-	}
+	mockContext := m.mockWithFailureAt(t, "link-setns")
 
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-	mockContVeth := mock_netlink.NewMockLink(ctrl)
-	mockNS := mock_ns.NewMockNetNS(ctrl)
-	gomock.InOrder(
-		// veth pair
-		mockNetLink.EXPECT().LinkAdd(gomock.Any()).Return(nil),
-		//hostVeth
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockHostVeth, nil),
-		//host side setup
-		mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil),
-		//container side
-		mockNetLink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil),
-		// container setup
-		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
-		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-
-		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
-		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
-
-		// container addr
-		mockNetLink.EXPECT().AddrAdd(mockContVeth, gomock.Any()).Return(nil),
-		// neighbor
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		// hostVethMAC
-		mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs),
-		mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(nil),
-
-		mockNS.EXPECT().Fd().Return(uintptr(testFD)),
-		// move it host namespace
-		mockNetLink.EXPECT().LinkSetNsFd(mockHostVeth, testFD).Return(errors.New("error on LinkSetNsFd")),
-	)
-
-	err = mockContext.run(mockNS)
+	err := mockContext.run(m.netns)
 	assert.Error(t, err)
 }
 
-func TestSetupPodNetwork(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+func (m *testMocks) mockSetupPodNetworkWithFailureAt(t *testing.T, failAt string) {
+	mockHostVeth := mock_netlink.NewMockLink(m.ctrl)
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
+	m.netlink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
+	m.ns.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
 
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
+	if failAt == "link-byname" {
+		m.netlink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("error on hostVethName"))
+		return
+	}
+	m.netlink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
 
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(nil)
+	if failAt == "procsys" {
+		m.procsys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(errors.New("Error writing to /proc/sys/..."))
+		return
+	}
+	var procsysRet error
+	if failAt == "no-ipv6" {
+		// Note os.ErrNotExist return - should be ignored
+		procsysRet = os.ErrNotExist
+	}
+	m.procsys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(procsysRet)
+	m.procsys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(procsysRet)
 
-	mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil)
+	if failAt == "link-setup" {
+		m.netlink.EXPECT().LinkSetUp(mockHostVeth).Return(errors.New("error on LinkSetup"))
+		return
+	}
+	m.netlink.EXPECT().LinkSetUp(mockHostVeth).Return(nil)
 
 	hwAddr, err := net.ParseMAC(testMAC)
 	assert.NoError(t, err)
@@ -516,7 +309,11 @@ func TestSetupPodNetwork(t *testing.T) {
 	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
 	//add host route
 	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
+	if failAt == "route-replace" {
+		m.netlink.EXPECT().RouteReplace(gomock.Any()).Return(errors.New("error on RouteReplace"))
+		return
+	}
+	m.netlink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
 
 	testRule := &netlink.Rule{
 		SuppressIfgroup:   -1,
@@ -527,237 +324,115 @@ func TestSetupPodNetwork(t *testing.T) {
 		Goto:              -1,
 		Flow:              -1,
 	}
-	mockNetLink.EXPECT().NewRule().Return(testRule)
+	m.netlink.EXPECT().NewRule().Return(testRule)
 	// test to-pod rule
-	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+	m.netlink.EXPECT().RuleDel(gomock.Any()).Return(nil)
+	m.netlink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
 
 	// test from-pod rule
-	mockNetLink.EXPECT().NewRule().Return(testRule)
-	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+	// FIXME(gus): this is the same as to-pod rule :/
+	m.netlink.EXPECT().NewRule().Return(testRule)
+	m.netlink.EXPECT().RuleDel(gomock.Any()).Return(nil)
+	m.netlink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+}
+
+func TestSetupPodNetwork(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	m.mockSetupPodNetworkWithFailureAt(t, "")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, m.netlink, m.ns, mtu, log, m.procsys)
 	assert.NoError(t, err)
 }
 
 func TestSetupPodNetworkErrNoIPv6(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
-
-	// Note os.ErrNotExist return - should be ignored
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(os.ErrNotExist)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(os.ErrNotExist)
-
-	mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil)
-
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	//log.Printf
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	//add host route
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
-
-	testRule := &netlink.Rule{
-		SuppressIfgroup:   -1,
-		SuppressPrefixlen: -1,
-		Priority:          -1,
-		Mark:              -1,
-		Mask:              -1,
-		Goto:              -1,
-		Flow:              -1,
-	}
-	mockNetLink.EXPECT().NewRule().Return(testRule)
-	// test to-pod rule
-	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
-
-	// test from-pod rule
-	mockNetLink.EXPECT().NewRule().Return(testRule)
-	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+	m.mockSetupPodNetworkWithFailureAt(t, "no-ipv6")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, m.netlink, m.ns, mtu, log, m.procsys)
 	assert.NoError(t, err)
 }
 
 func TestSetupPodNetworkErrLinkByName(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("error on hostVethName"))
+	m.mockSetupPodNetworkWithFailureAt(t, "link-byname")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, m.netlink, m.ns, mtu, log, m.procsys)
 
 	assert.Error(t, err)
 }
 
 func TestSetupPodNetworkErrLinkSetup(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
-
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(nil)
-
-	mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(errors.New("error on LinkSetup"))
+	m.mockSetupPodNetworkWithFailureAt(t, "link-setup")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, m.netlink, m.ns, mtu, log, m.procsys)
 
 	assert.Error(t, err)
 }
 
 func TestSetupPodNetworkErrProcSys(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
-
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(errors.New("Error writing to /proc/sys/..."))
+	m.mockSetupPodNetworkWithFailureAt(t, "procsys")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, m.netlink, m.ns, mtu, log, m.procsys)
 
 	assert.Error(t, err)
 }
 
 func TestSetupPodNetworkErrRouteReplace(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
-
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(nil)
-
-	mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil)
-
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	//log.Printf
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	//add host route
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(errors.New("error on RouteReplace"))
+	m.mockSetupPodNetworkWithFailureAt(t, "route-replace")
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, m.netlink, m.ns, mtu, log, m.procsys)
 
 	assert.Error(t, err)
 }
 
-func TestSetupPodNetworkPrimaryIntf(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockProcSys := setup(t)
-	defer ctrl.Finish()
-
-	mockHostVeth := mock_netlink.NewMockLink(ctrl)
-
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, errors.New("hostVeth already exists"))
-	mockNS.EXPECT().WithNetNSPath(testnetnsPath, gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
-
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_redirects", "0").Return(nil)
-
-	mockNetLink.EXPECT().LinkSetUp(mockHostVeth).Return(nil)
-
-	hwAddr, err := net.ParseMAC(testMAC)
-	assert.NoError(t, err)
-	mockLinkAttrs := &netlink.LinkAttrs{
-		HardwareAddr: hwAddr,
-	}
-	//log.Printf
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	//add host route
-	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
-	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
-
-	testRule := &netlink.Rule{
-		SuppressIfgroup:   -1,
-		SuppressPrefixlen: -1,
-		Priority:          -1,
-		Mark:              -1,
-		Mask:              -1,
-		Goto:              -1,
-		Flow:              -1,
-	}
-	mockNetLink.EXPECT().NewRule().Return(testRule)
-	// test to-pod rule
-	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
-	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
-
-	addr := &net.IPNet{
-		IP:   net.ParseIP(testIP),
-		Mask: net.IPv4Mask(255, 255, 255, 255),
-	}
-
-	var cidrs []string
-
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
-	assert.NoError(t, err)
-}
-
 func TestTearDownPodNetwork(t *testing.T) {
-	ctrl, mockNetLink, _, _, _ := setup(t)
-	defer ctrl.Finish()
+	m := setup(t)
+	defer m.ctrl.Finish()
 
 	testRule := &netlink.Rule{
 		SuppressIfgroup:   -1,
@@ -769,47 +444,18 @@ func TestTearDownPodNetwork(t *testing.T) {
 		Flow:              -1,
 	}
 	gomock.InOrder(
-		mockNetLink.EXPECT().NewRule().Return(testRule),
+		m.netlink.EXPECT().NewRule().Return(testRule),
 		// test to-pod rule
-		mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil),
+		m.netlink.EXPECT().RuleDel(gomock.Any()).Return(nil),
 
 		// test from-pod rule
-		mockNetLink.EXPECT().RouteDel(gomock.Any()).Return(nil),
+		m.netlink.EXPECT().RouteDel(gomock.Any()).Return(nil),
 	)
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
-	err := tearDownNS(addr, 0, mockNetLink, log)
-	assert.NoError(t, err)
-}
-
-func TestTearDownPodNetworkMain(t *testing.T) {
-	ctrl, mockNetLink, _, _, _ := setup(t)
-	defer ctrl.Finish()
-
-	testRule := &netlink.Rule{
-		SuppressIfgroup:   -1,
-		SuppressPrefixlen: -1,
-		Priority:          -1,
-		Mark:              -1,
-		Mask:              -1,
-		Goto:              -1,
-		Flow:              -1,
-	}
-	gomock.InOrder(
-		mockNetLink.EXPECT().NewRule().Return(testRule),
-		// test to-pod rule
-		mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil),
-
-		mockNetLink.EXPECT().RouteDel(gomock.Any()).Return(nil),
-	)
-
-	addr := &net.IPNet{
-		IP:   net.ParseIP(testIP),
-		Mask: net.IPv4Mask(255, 255, 255, 255),
-	}
-	err := tearDownNS(addr, 0, mockNetLink, log)
+	err := tearDownNS(addr, 0, m.netlink, log)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Refactor driver_test to stop the number of lines of code becoming
greater than the amount of storage in S3.

Also: remove 2 tests that were duplicates of other tests (?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
