### PR TITLE
Add bash command instead of orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@0.1.19
   k8s: circleci/kubernetes@0.11.0
-  #  codecov: codecov/codecov@1.0.5
 
 references:
   build_job: &build
@@ -24,8 +23,17 @@ references:
       - run: make vet
       # TODO: Enable architecture specific unit-test when Circle CI supports it!
       - run: make unit-test ARCH=amd64
-      #- codecov/upload:
-      #  file: coverage.txt
+      - run:
+          name: Upload Coverage Results
+          command: |
+            curl -s https://codecov.io/bash | bash -s -- \
+              -f "coverage.txt" \
+              -t "${CODECOV_TOKEN}" \
+              -n "${CIRCLE_BUILD_NUM}" \
+              -y ".codecov.yml" \
+              -F "" \
+              -Z || echo 'Codecov upload failed'
+          when: always
 
 jobs:
   build_x86_64:


### PR DESCRIPTION
*Description of changes:*

Adding the bash command recommended by https://codecov.io instead of using the CircleCI orb, since it's "unmanaged". Will add the badge in a follow up PR since we want to generate the reports first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
