### PR TITLE
Bump delay, test is still flaky

### DIFF
--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -114,9 +114,9 @@ func TestCloudWatchPublisherWithGreaterThanMaxDatapointsAndStop(t *testing.T) {
 	go cloudwatchPublisher.monitor(testMonitorDuration)
 
 	// Delays added to prevent test flakiness
-	<-time.After(2 * testMonitorDuration)
+	<-time.After(5 * testMonitorDuration)
 	cloudwatchPublisher.Stop()
-	<-time.After(2 * testMonitorDuration)
+	<-time.After(5 * testMonitorDuration)
 
 	assert.Empty(t, cloudwatchPublisher.localMetricData)
 }


### PR DESCRIPTION
*Description of changes:*
Test is still flaky in CircleCI. Bumping the delay a bit. This should be refactored, but unblocking for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
