### PR TITLE
1.6 multi eni

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -99,7 +99,8 @@ func TestCmdAdd(t *testing.T) {
 	}
 
 	mocksNetwork.EXPECT().SetupNS(gomock.Any(), cmdArgs.IfName, cmdArgs.Netns,
-		addr, int(addNetworkReply.DeviceNumber), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		addr, int(addNetworkReply.DeviceNumber), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return(nil)
 
 	mocksTypes.EXPECT().PrintResult(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -162,7 +163,8 @@ func TestCmdAddErrSetupPodNetwork(t *testing.T) {
 	}
 
 	mocksNetwork.EXPECT().SetupNS(gomock.Any(), cmdArgs.IfName, cmdArgs.Netns,
-		addr, int(addNetworkReply.DeviceNumber), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error on SetupPodNetwork"))
+		addr, int(addNetworkReply.DeviceNumber), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return(errors.New("error on SetupPodNetwork"))
 
 	// when SetupPodNetwork fails, expect to return IP back to datastore
 	delNetworkReply := &rpc.DelNetworkReply{Success: true, IPv4Addr: ipAddr, DeviceNumber: devNum}

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -70,12 +70,13 @@ type createVethPairContext struct {
 	hostVethName string
 	addr         *net.IPNet
 	ipv4Subnet	 *net.IPNet
+	contHWAddress net.HardwareAddr
 	netLink      netlinkwrapper.NetLink
 	ip           ipwrapper.IP
 	mtu          int
 }
 
-func newCreateVethPairContext(contVethName string, hostVethName string, addr *net.IPNet, mtu int, ipv4Subnet *net.IPNet) *createVethPairContext {
+func newCreateVethPairContext(contVethName string, hostVethName string, addr *net.IPNet, mtu int, ipv4Subnet *net.IPNet, contHWAddress net.HardwareAddr) *createVethPairContext {
 	return &createVethPairContext{
 		contVethName: contVethName,
 		hostVethName: hostVethName,
@@ -84,6 +85,7 @@ func newCreateVethPairContext(contVethName string, hostVethName string, addr *ne
 		ip:           ipwrapper.NewIP(),
 		mtu:          mtu,
 		ipv4Subnet:   ipv4Subnet,
+		contHWAddress: contHWAddress,
 	}
 }
 
@@ -94,6 +96,7 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 			Name:  createVethContext.contVethName,
 			Flags: net.FlagUp,
 			MTU:   createVethContext.mtu,
+			HardwareAddr:  createVethContext.contHWAddress,
 		},
 		PeerName: createVethContext.hostVethName,
 	}
@@ -124,11 +127,12 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 		return errors.Wrapf(err, "setup NS network: failed to set link %q up", createVethContext.contVethName)
 	}
 
-	// Add a connected route to a dummy next hop (169.254.1.1)
+	// Add a connected route to a dummy next hop (169.254.1.1 + interface Index)
+	// Offsetting by the index to allow for routes to multiple interfaces in a container
 	// # ip route show
-	// default via 169.254.1.1 dev eth0
-	// 169.254.1.1 dev eth0
-	gw := net.IPv4(169, 254, 1, 1)
+	// default via 169.254.1.x dev eth0
+	// 169.254.1.x dev eth0
+	gw := net.IPv4(169, 254, 1, byte(1 + contVeth.Attrs().Index))
 	gwNet := &net.IPNet{IP: gw, Mask: net.CIDRMask(32, 32)}
 
 	if err = createVethContext.netLink.RouteReplace(&netlink.Route{
@@ -147,11 +151,13 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 		return errors.Wrap(err, "setup NS network: failed to add default route")
 	}
 
+	// Add a route for each interfaces local subnet that goes out that interface
 	if createVethContext.ipv4Subnet != nil {
 		routeSubnet := netlink.Route{
 			LinkIndex: contVeth.Attrs().Index,
-			Scope:     netlink.SCOPE_LINK,
-			Dst:       createVethContext.ipv4Subnet}
+			Dst:       createVethContext.ipv4Subnet,
+			Gw:        gw,
+		}
 
 		// Add or replace route
 		if err := createVethContext.netLink.RouteReplace(&routeSubnet); err != nil {
@@ -184,6 +190,11 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 	return nil
 }
 
+func generateMACAddress(addr *net.IPNet) net.HardwareAddr {
+	ipBytes := addr.IP.To4()
+	return net.HardwareAddr{0, 0, ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3]}
+}
+
 // SetupNS wires up linux networking for a pod's network
 func (os *linuxNetwork) SetupNS(hostVethName string, contVethName string, netnsPath string, addr *net.IPNet, table int, vpcCIDRs []string, useExternalSNAT bool, mtu int, log logger.Logger, ipv4Subnet *net.IPNet) error {
 	log.Debugf("SetupNS: hostVethName=%s, contVethName=%s, netnsPath=%s, table=%d, addr=%s, mtu=%d", hostVethName, contVethName, netnsPath, table, addr.String(), mtu)
@@ -200,7 +211,9 @@ func setupNS(hostVethName string, contVethName string, netnsPath string, addr *n
 		log.Debugf("Clean up old hostVeth: %v\n", hostVethName)
 	}
 
-	createVethContext := newCreateVethPairContext(contVethName, hostVethName, addr, mtu, ipv4Subnet)
+	contMac := generateMACAddress(addr)
+
+	createVethContext := newCreateVethPairContext(contVethName, hostVethName, addr, mtu, ipv4Subnet, contMac)
 	if err := ns.WithNetNSPath(netnsPath, createVethContext.run); err != nil {
 		log.Errorf("Failed to setup NS network %v", err)
 		return errors.Wrap(err, "setupNS network: failed to setup NS network")
@@ -298,6 +311,22 @@ func setupNS(hostVethName string, contVethName string, netnsPath string, addr *n
 			}
 		}
 	}
+
+	// add static ARP entry for container interface
+	// If the container is not in the same subnet as
+	// the aws-cni container need this static ARP entry to resolve
+	// the container IP as ARP won't work on async routed network.
+	neigh := &netlink.Neigh{
+		LinkIndex:    hostVeth.Attrs().Index,
+		State:        netlink.NUD_PERMANENT,
+		IP:           addr.IP,
+		HardwareAddr: contMac,
+	}
+
+	if err = netLink.NeighAdd(neigh); err != nil {
+		return errors.Wrap(err, "setup NS network: failed to add static ARP")
+	}
+
 	return nil
 }
 

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -66,25 +66,25 @@ func New() NetworkAPIs {
 // createVethPairContext wraps the parameters and the method to create the
 // veth pair to attach the container namespace
 type createVethPairContext struct {
-	contVethName string
-	hostVethName string
-	addr         *net.IPNet
-	ipv4Subnet	 *net.IPNet
+	contVethName  string
+	hostVethName  string
+	addr          *net.IPNet
+	ipv4Subnet    *net.IPNet
 	contHWAddress net.HardwareAddr
-	netLink      netlinkwrapper.NetLink
-	ip           ipwrapper.IP
-	mtu          int
+	netLink       netlinkwrapper.NetLink
+	ip            ipwrapper.IP
+	mtu           int
 }
 
 func newCreateVethPairContext(contVethName string, hostVethName string, addr *net.IPNet, mtu int, ipv4Subnet *net.IPNet, contHWAddress net.HardwareAddr) *createVethPairContext {
 	return &createVethPairContext{
-		contVethName: contVethName,
-		hostVethName: hostVethName,
-		addr:         addr,
-		netLink:      netlinkwrapper.NewNetLink(),
-		ip:           ipwrapper.NewIP(),
-		mtu:          mtu,
-		ipv4Subnet:   ipv4Subnet,
+		contVethName:  contVethName,
+		hostVethName:  hostVethName,
+		addr:          addr,
+		netLink:       netlinkwrapper.NewNetLink(),
+		ip:            ipwrapper.NewIP(),
+		mtu:           mtu,
+		ipv4Subnet:    ipv4Subnet,
 		contHWAddress: contHWAddress,
 	}
 }
@@ -93,10 +93,10 @@ func newCreateVethPairContext(contVethName string, hostVethName string, addr *ne
 func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:  createVethContext.contVethName,
-			Flags: net.FlagUp,
-			MTU:   createVethContext.mtu,
-			HardwareAddr:  createVethContext.contHWAddress,
+			Name:         createVethContext.contVethName,
+			Flags:        net.FlagUp,
+			MTU:          createVethContext.mtu,
+			HardwareAddr: createVethContext.contHWAddress,
 		},
 		PeerName: createVethContext.hostVethName,
 	}
@@ -132,7 +132,7 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 	// # ip route show
 	// default via 169.254.1.x dev eth0
 	// 169.254.1.x dev eth0
-	gw := net.IPv4(169, 254, 1, byte(1 + contVeth.Attrs().Index))
+	gw := net.IPv4(169, 254, 1, byte(1+contVeth.Attrs().Index))
 	gwNet := &net.IPNet{IP: gw, Mask: net.CIDRMask(32, 32)}
 
 	if err = createVethContext.netLink.RouteReplace(&netlink.Route{
@@ -142,12 +142,10 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 		return errors.Wrap(err, "setup NS network: failed to add default gateway")
 	}
 
-
-
 	// Add a default route via dummy next hop(169.254.1.1). Then all outgoing traffic will be routed by this
 	// default route via dummy next hop (169.254.1.1).
 	// If this is not the first interface, the route may already exist
-	if err = createVethContext.ip.AddDefaultRoute(gwNet.IP, contVeth); err != nil && err.Error() != "file exists"{
+	if err = createVethContext.ip.AddDefaultRoute(gwNet.IP, contVeth); err != nil && err.Error() != "file exists" {
 		return errors.Wrap(err, "setup NS network: failed to add default route")
 	}
 

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -102,7 +102,7 @@ func TestRun(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
 		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
@@ -276,7 +276,7 @@ func TestRunErrRouteAdd(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(errors.New("error on RouteReplace")),
 	)
@@ -321,7 +321,7 @@ func TestRunErrAddDefaultRoute(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
 		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(errors.New("error on AddDefaultRoute")),
@@ -368,7 +368,7 @@ func TestRunErrAddrAdd(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
 		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
@@ -417,7 +417,7 @@ func TestRunErrNeighAdd(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
 		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
@@ -471,7 +471,7 @@ func TestRunErrLinkSetNsFd(t *testing.T) {
 		// container setup
 		mockNetLink.EXPECT().LinkSetUp(mockContVeth).Return(nil),
 		// container
-		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs),
+		mockContVeth.EXPECT().Attrs().Return(mockLinkAttrs).Times(2),
 
 		mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil),
 		mockIP.EXPECT().AddDefaultRoute(gomock.Any(), mockContVeth).Return(nil),
@@ -537,6 +537,10 @@ func TestSetupPodNetwork(t *testing.T) {
 	mockNetLink.EXPECT().NewRule().Return(testRule)
 	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
 	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+
+	// Add static arp entry
+	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
+	mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(nil)
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
@@ -744,6 +748,10 @@ func TestSetupPodNetworkPrimaryIntf(t *testing.T) {
 	// test to-pod rule
 	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
 	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
+
+	// Add static arp entry
+	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
+	mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(nil)
 
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -597,6 +597,10 @@ func TestSetupPodNetworkErrNoIPv6(t *testing.T) {
 	mockNetLink.EXPECT().RuleDel(gomock.Any()).Return(nil)
 	mockNetLink.EXPECT().RuleAdd(gomock.Any()).Return(nil)
 
+	// Add static arp entry
+	mockHostVeth.EXPECT().Attrs().Return(mockLinkAttrs)
+	mockNetLink.EXPECT().NeighAdd(gomock.Any()).Return(nil)
+
 	addr := &net.IPNet{
 		IP:   net.ParseIP(testIP),
 		Mask: net.IPv4Mask(255, 255, 255, 255),

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -331,6 +331,7 @@ func TestRunErrAddDefaultRoute(t *testing.T) {
 	assert.Error(t, err)
 }
 
+
 func TestRunErrAddrAdd(t *testing.T) {
 	ctrl, mockNetLink, mockIP, _, _ := setup(t)
 	defer ctrl.Finish()
@@ -542,7 +543,7 @@ func TestSetupPodNetwork(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 	assert.NoError(t, err)
 }
 
@@ -597,7 +598,7 @@ func TestSetupPodNetworkErrNoIPv6(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, true, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 	assert.NoError(t, err)
 }
 
@@ -616,7 +617,7 @@ func TestSetupPodNetworkErrLinkByName(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 
 	assert.Error(t, err)
 }
@@ -641,7 +642,7 @@ func TestSetupPodNetworkErrLinkSetup(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 
 	assert.Error(t, err)
 }
@@ -663,7 +664,7 @@ func TestSetupPodNetworkErrProcSys(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err := setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 
 	assert.Error(t, err)
 }
@@ -699,7 +700,7 @@ func TestSetupPodNetworkErrRouteReplace(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 255),
 	}
 	var cidrs []string
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, testTable, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 
 	assert.Error(t, err)
 }
@@ -751,7 +752,7 @@ func TestSetupPodNetworkPrimaryIntf(t *testing.T) {
 
 	var cidrs []string
 
-	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys)
+	err = setupNS(testHostVethName, testContVethName, testnetnsPath, addr, 0, cidrs, false, mockNetLink, mockNS, mtu, log, mockProcSys, nil)
 	assert.NoError(t, err)
 }
 

--- a/cmd/routed-eni-cni-plugin/driver/mocks/driver_mocks.go
+++ b/cmd/routed-eni-cni-plugin/driver/mocks/driver_mocks.go
@@ -50,15 +50,16 @@ func (m *MockNetworkAPIs) EXPECT() *MockNetworkAPIsMockRecorder {
 }
 
 // SetupNS mocks base method
-func (m *MockNetworkAPIs) SetupNS(arg0, arg1, arg2 string, arg3 *net.IPNet, arg4 int, arg5 []string, arg6 bool, arg7 int, arg8 logger.Logger) error {
-	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+func (m *MockNetworkAPIs) SetupNS(arg0 string, arg1 string, arg2 string, arg3 *net.IPNet, arg4 int, arg5 []string, arg6 bool, arg7 int, arg8 logger.Logger,arg9 *net.IPNet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupNS indicates an expected call of SetupNS
-func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+func (mr *MockNetworkAPIsMockRecorder) SetupNS(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupNS), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 }
 
 // TeardownNS mocks base method

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -256,10 +256,14 @@ func TestGetAttachedENIs(t *testing.T) {
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(eniID, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetCIDR).Return(subnetCIDR, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataIPv4s).Return("", nil),
+		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil),
+		mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataDeviceNum).Return(eni2Device, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataInterface).Return(eni2ID, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataSubnetCIDR).Return(subnetCIDR, nil),
 		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataIPv4s).Return("", nil),
+		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataSubnetID).Return(subnetID, nil),
+		mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataSGs).Return(sgs, nil),
 	)
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
@@ -375,6 +379,8 @@ func TestDescribeAllENIs(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Times(2).Return(eni1Device, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Times(2).Return(eniID, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetCIDR).Times(2).Return(subnetCIDR, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Times(2).Return(subnetID, nil)
+	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Times(2).Return(sgs, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataIPv4s).Times(2).Return("", nil)
 
 	result := &ec2.DescribeNetworkInterfacesOutput{

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -48,7 +48,7 @@ const (
 
 type ENIConfig interface {
 	GetENIConfig(eniConfig string) (*v1alpha1.ENIConfigSpec, error)
-	GetAllENIConfigs() (map[string]*v1alpha1.ENIConfigSpec, error)
+	GetAllENIConfigs() map[string]*v1alpha1.ENIConfigSpec
 	Getter() *ENIConfigInfo
 }
 
@@ -208,17 +208,17 @@ func (eniCfg *ENIConfigController) GetENIConfig(eniConfigName string) (*v1alpha1
 }
 
 // Return the map of all eni configurations
-func (eniCfg *ENIConfigController) GetAllENIConfigs() (map[string]*v1alpha1.ENIConfigSpec, error) {
+func (eniCfg *ENIConfigController) GetAllENIConfigs() map[string]*v1alpha1.ENIConfigSpec {
 	eniCfg.eniLock.Lock()
 	defer eniCfg.eniLock.Unlock()
 
 	log.Debugf("Enis %s", eniCfg.eni)
 
 	if eniCfg.eni == nil || len(eniCfg.eni) == 0 {
-		return nil, ErrNoENIConfig
+		return nil
 	}
 
-	return eniCfg.eni, nil
+	return eniCfg.eni
 }
 
 // getEniConfigAnnotationDef returns eniConfigAnnotation

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -34,7 +34,7 @@ import (
 const (
 	defaultEniConfigAnnotationDef = "k8s.amazonaws.com/eniConfig"
 	defaultEniConfigLabelDef      = "k8s.amazonaws.com/eniConfig"
-	eniConfigDefault              = "default"
+	eniConfigDefault              = ""
 
 	// when "ENI_CONFIG_LABEL_DEF is defined, ENIConfigController will use that label key to
 	// search if is setting value for eniConfigLabelDef

--- a/pkg/eniconfig/eniconfig_test.go
+++ b/pkg/eniconfig/eniconfig_test.go
@@ -104,7 +104,7 @@ func TestENIConfig(t *testing.T) {
 	testHandler := NewHandler(testENIConfigController)
 
 	// If there is no default ENI config
-	_, err := testENIConfigController.MyENIConfig()
+	_, err := testENIConfigController.GetENIConfig("")
 	assert.Error(t, err)
 
 	// Start with default config
@@ -116,7 +116,7 @@ func TestENIConfig(t *testing.T) {
 
 	updateENIConfig(testHandler, eniConfigDefault, defaultCfg, false)
 
-	outputCfg, err := testENIConfigController.MyENIConfig()
+	outputCfg, err := testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCfg, *outputCfg)
 
@@ -127,7 +127,7 @@ func TestENIConfig(t *testing.T) {
 	group1Name := "group1ENIconfig"
 	updateENIConfig(testHandler, group1Name, group1Cfg, false)
 
-	outputCfg, err = testENIConfigController.MyENIConfig()
+	outputCfg, err = testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCfg, *outputCfg)
 
@@ -143,7 +143,7 @@ func TestNodeENIConfig(t *testing.T) {
 	updateNodeAnnotation(testHandler, myNodeName, myENIConfig, false)
 
 	// If there is no ENI config
-	_, err := testENIConfigController.MyENIConfig()
+	_, err := testENIConfigController.GetENIConfig("")
 	assert.Error(t, err)
 
 	// Add eniconfig for myENIConfig
@@ -151,7 +151,7 @@ func TestNodeENIConfig(t *testing.T) {
 		SecurityGroups: []string{"sg21-id", "sg22-id"},
 		Subnet:         "subnet21"}
 	updateENIConfig(testHandler, myENIConfig, group1Cfg, false)
-	outputCfg, err := testENIConfigController.MyENIConfig()
+	outputCfg, err := testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, group1Cfg, *outputCfg)
 
@@ -162,13 +162,13 @@ func TestNodeENIConfig(t *testing.T) {
 		SecurityGroups: defaultSGs,
 		Subnet:         defaultSubnet}
 	updateENIConfig(testHandler, eniConfigDefault, defaultCfg, false)
-	outputCfg, err = testENIConfigController.MyENIConfig()
+	outputCfg, err = testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, group1Cfg, *outputCfg)
 
 	// Delete node's myENIConfig annotation, then the value should fallback to default
 	updateNodeAnnotation(testHandler, myNodeName, myENIConfig, true)
-	outputCfg, err = testENIConfigController.MyENIConfig()
+	outputCfg, err = testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCfg, *outputCfg)
 
@@ -184,7 +184,7 @@ func TestNodeENIConfigLabel(t *testing.T) {
 	updateNodeLabel(testHandler, myNodeName, myENIConfig, false)
 
 	// If there is no ENI config
-	_, err := testENIConfigController.MyENIConfig()
+	_, err := testENIConfigController.GetENIConfig("")
 	assert.Error(t, err)
 
 	// Add eniconfig for myENIConfig
@@ -192,7 +192,7 @@ func TestNodeENIConfigLabel(t *testing.T) {
 		SecurityGroups: []string{"sg21-id", "sg22-id"},
 		Subnet:         "subnet21"}
 	updateENIConfig(testHandler, myENIConfig, group1Cfg, false)
-	outputCfg, err := testENIConfigController.MyENIConfig()
+	outputCfg, err := testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, group1Cfg, *outputCfg)
 
@@ -203,13 +203,13 @@ func TestNodeENIConfigLabel(t *testing.T) {
 		SecurityGroups: defaultSGs,
 		Subnet:         defaultSubnet}
 	updateENIConfig(testHandler, eniConfigDefault, defaultCfg, false)
-	outputCfg, err = testENIConfigController.MyENIConfig()
+	outputCfg, err = testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, group1Cfg, *outputCfg)
 
 	// Delete node's myENIConfig annotation, then the value should fallback to default
 	updateNodeLabel(testHandler, myNodeName, myENIConfig, true)
-	outputCfg, err = testENIConfigController.MyENIConfig()
+	outputCfg, err = testENIConfigController.GetENIConfig("")
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCfg, *outputCfg)
 

--- a/pkg/eniconfig/mocks/eniconfig_mocks.go
+++ b/pkg/eniconfig/mocks/eniconfig_mocks.go
@@ -63,17 +63,33 @@ func (mr *MockENIConfigMockRecorder) Getter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Getter", reflect.TypeOf((*MockENIConfig)(nil).Getter))
 }
 
-// MyENIConfig mocks base method
-func (m *MockENIConfig) MyENIConfig() (*v1alpha1.ENIConfigSpec, error) {
+
+// GetENIConfig mocks base method
+func (m *MockENIConfig) GetENIConfig(arg0 string) (*v1alpha1.ENIConfigSpec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MyENIConfig")
+	ret := m.ctrl.Call(m, "GetENIConfig", arg0)
 	ret0, _ := ret[0].(*v1alpha1.ENIConfigSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MyENIConfig indicates an expected call of MyENIConfig
-func (mr *MockENIConfigMockRecorder) MyENIConfig() *gomock.Call {
+// GetENIConfig indicates an expected call of GetENIConfig
+func (mr *MockENIConfigMockRecorder) GetENIConfig(arg0 string) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MyENIConfig", reflect.TypeOf((*MockENIConfig)(nil).MyENIConfig))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENIConfig", reflect.TypeOf((*MockENIConfig)(nil).GetENIConfig), arg0)
+}
+
+// GetAllENIConfigs mocks base method
+func (m *MockENIConfig) GetAllENIConfigs() (map[string]*v1alpha1.ENIConfigSpec, error) {
+	m.ctrl.T.Helper()
+    ret := m.ctrl.Call(m, "GetAllENIConfigs")
+	ret0, _ := ret[0].(map[string]*v1alpha1.ENIConfigSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllENIConfigs indicates an expected call of GetAllENIConfigs
+func (mr *MockENIConfigMockRecorder) GetAllENIConfigs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllENIConfigs", reflect.TypeOf((*MockENIConfig)(nil).GetAllENIConfigs))
 }

--- a/pkg/eniconfig/mocks/eniconfig_mocks.go
+++ b/pkg/eniconfig/mocks/eniconfig_mocks.go
@@ -80,12 +80,11 @@ func (mr *MockENIConfigMockRecorder) GetENIConfig(arg0 string) *gomock.Call {
 }
 
 // GetAllENIConfigs mocks base method
-func (m *MockENIConfig) GetAllENIConfigs() (map[string]*v1alpha1.ENIConfigSpec, error) {
+func (m *MockENIConfig) GetAllENIConfigs() map[string]*v1alpha1.ENIConfigSpec {
 	m.ctrl.T.Helper()
     ret := m.ctrl.Call(m, "GetAllENIConfigs")
 	ret0, _ := ret[0].(map[string]*v1alpha1.ENIConfigSpec)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetAllENIConfigs indicates an expected call of GetAllENIConfigs

--- a/pkg/eniconfig/mocks/eniconfig_mocks.go
+++ b/pkg/eniconfig/mocks/eniconfig_mocks.go
@@ -63,7 +63,6 @@ func (mr *MockENIConfigMockRecorder) Getter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Getter", reflect.TypeOf((*MockENIConfig)(nil).Getter))
 }
 
-
 // GetENIConfig mocks base method
 func (m *MockENIConfig) GetENIConfig(arg0 string) (*v1alpha1.ENIConfigSpec, error) {
 	m.ctrl.T.Helper()
@@ -82,7 +81,7 @@ func (mr *MockENIConfigMockRecorder) GetENIConfig(arg0 string) *gomock.Call {
 // GetAllENIConfigs mocks base method
 func (m *MockENIConfig) GetAllENIConfigs() map[string]*v1alpha1.ENIConfigSpec {
 	m.ctrl.T.Helper()
-    ret := m.ctrl.Call(m, "GetAllENIConfigs")
+	ret := m.ctrl.Call(m, "GetAllENIConfigs")
 	ret0, _ := ret[0].(map[string]*v1alpha1.ENIConfigSpec)
 	return ret0
 }

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -184,7 +184,7 @@ func NewDataStore(log logger.Logger) *DataStore {
 // AddENI add ENI to data store
 func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary bool, eniConfigName string) error {
 	addr := net.IPNet{
-		IP:	net.ParseIP("0.0.0.0"),
+		IP:   net.ParseIP("0.0.0.0"),
 		Mask: net.CIDRMask(32, 32),
 	}
 	return ds.AddENIWithSubnet(eniID, deviceNumber, isPrimary, eniConfigName, addr)
@@ -203,13 +203,13 @@ func (ds *DataStore) AddENIWithSubnet(eniID string, deviceNumber int,
 		return errors.New(DuplicatedENIError)
 	}
 	ds.eniIPPools[eniID] = &ENIIPPool{
-		createTime:    time.Now(),
-		IsPrimary:     isPrimary,
-		ID:            eniID,
-		DeviceNumber:  deviceNumber,
-		ENIConfigName: eniConfigName,
+		createTime:     time.Now(),
+		IsPrimary:      isPrimary,
+		ID:             eniID,
+		DeviceNumber:   deviceNumber,
+		ENIConfigName:  eniConfigName,
 		SubnetIPv4CIDR: subnetIPv4CIDR,
-		IPv4Addresses: make(map[string]*AddressInfo)}
+		IPv4Addresses:  make(map[string]*AddressInfo)}
 	enis.Set(float64(len(ds.eniIPPools)))
 	return nil
 }

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -181,15 +181,6 @@ func NewDataStore(log logger.Logger) *DataStore {
 	}
 }
 
-// AddENI add ENI to data store
-func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary bool, eniConfigName string) error {
-	addr := net.IPNet{
-		IP:   net.ParseIP("0.0.0.0"),
-		Mask: net.CIDRMask(32, 32),
-	}
-	return ds.AddENIWithSubnet(eniID, deviceNumber, isPrimary, eniConfigName, addr)
-}
-
 func (ds *DataStore) AddENIWithSubnet(eniID string, deviceNumber int,
 	isPrimary bool, eniConfigName string, subnetIPv4CIDR net.IPNet) error {
 

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -34,13 +34,13 @@ var log = logger.New(&logConfig)
 func TestAddENI(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, "")
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-1", 1, true)
+	err = ds.AddENI("eni-1", 1, true, "")
 	assert.Error(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, "")
 	assert.NoError(t, err)
 
 	assert.Equal(t, len(ds.eniIPPools), 2)
@@ -52,13 +52,13 @@ func TestAddENI(t *testing.T) {
 func TestDeleteENI(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, "")
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, "")
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-3", 3, false)
+	err = ds.AddENI("eni-3", 3, false, "")
 	assert.NoError(t, err)
 
 	eniInfos := ds.GetENIInfos()
@@ -84,7 +84,8 @@ func TestDeleteENI(t *testing.T) {
 		Namespace: "ns-1",
 		IP:        "1.1.1.1",
 	}
-	ip, device, err := ds.AssignPodIPv4Address(podInfo)
+	ipNet, device, err := ds.AssignPodIPv4Address(podInfo)
+	ip := ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -100,10 +101,10 @@ func TestDeleteENI(t *testing.T) {
 func TestAddENIIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, "")
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, "")
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -138,10 +139,10 @@ func TestAddENIIPv4Address(t *testing.T) {
 func TestGetENIIPPools(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, "")
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false)
+	err = ds.AddENI("eni-2", 2, false, "")
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -170,7 +171,7 @@ func TestGetENIIPPools(t *testing.T) {
 
 func TestDelENIIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
-	err := ds.AddENI("eni-1", 1, true)
+	err := ds.AddENI("eni-1", 1, true, "")
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -205,7 +206,8 @@ func TestDelENIIPv4Address(t *testing.T) {
 		Namespace: "ns-1",
 		IP:        "1.1.1.1",
 	}
-	ip, device, err := ds.AssignPodIPv4Address(podInfo)
+	ipNet, device, err := ds.AssignPodIPv4Address(podInfo)
+	ip := ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -226,9 +228,9 @@ func TestDelENIIPv4Address(t *testing.T) {
 func TestPodIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
 
-	ds.AddENI("eni-1", 1, true)
+	ds.AddENI("eni-1", 1, true, "")
 
-	ds.AddENI("eni-2", 2, false)
+	ds.AddENI("eni-2", 2, false, "")
 
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 
@@ -242,7 +244,8 @@ func TestPodIPv4Address(t *testing.T) {
 		IP:        "1.1.1.1",
 	}
 
-	ip, _, err := ds.AssignPodIPv4Address(&podInfo)
+	ipNet, _, err := ds.AssignPodIPv4Address(&podInfo)
+	ip := ipNet.IP.String()
 
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
@@ -250,7 +253,8 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, 2, len(ds.eniIPPools["eni-1"].IPv4Addresses))
 	assert.Equal(t, 1, ds.eniIPPools["eni-1"].AssignedIPv4Addresses)
 
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ipNet, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip = ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 
@@ -258,7 +262,8 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, len(*podsInfos), 1)
 
 	// duplicate add
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ipNet, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip = ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.1")
 	assert.Equal(t, ds.total, 3)
@@ -281,7 +286,8 @@ func TestPodIPv4Address(t *testing.T) {
 		IP:        "1.1.2.2",
 	}
 
-	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(&podInfo)
+	ipNet, pod1Ns2Device, err := ds.AssignPodIPv4Address(&podInfo)
+	ip = ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.2.2")
 	assert.Equal(t, ds.total, 3)
@@ -298,7 +304,8 @@ func TestPodIPv4Address(t *testing.T) {
 		Sandbox:   "container-1",
 	}
 
-	ip, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ipNet, _, err = ds.AssignPodIPv4Address(&podInfo)
+	ip = ipNet.IP.String()
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.2")
 	assert.Equal(t, ds.total, 3)
@@ -359,9 +366,9 @@ func TestPodIPv4Address(t *testing.T) {
 func TestWarmENIInteractions(t *testing.T) {
 	ds := NewDataStore(log)
 
-	ds.AddENI("eni-1", 1, true)
-	ds.AddENI("eni-2", 2, false)
-	ds.AddENI("eni-3", 3, false)
+	ds.AddENI("eni-1", 1, true, "")
+	ds.AddENI("eni-2", 2, false, "")
+	ds.AddENI("eni-3", 3, false, "")
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.2")
 	ds.AddIPv4AddressToStore("eni-2", "1.1.2.1")

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -14,6 +14,7 @@
 package datastore
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -34,13 +35,13 @@ var log = logger.New(&logConfig)
 func TestAddENI(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true, "")
+	err := ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-1", 1, true, "")
+	err = ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.Error(t, err)
 
-	err = ds.AddENI("eni-2", 2, false, "")
+	err = ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, len(ds.eniIPPools), 2)
@@ -52,13 +53,13 @@ func TestAddENI(t *testing.T) {
 func TestDeleteENI(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true, "")
+	err := ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false, "")
+	err = ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-3", 3, false, "")
+	err = ds.AddENIWithSubnet("eni-3", 3, false, "", net.IPNet{})
 	assert.NoError(t, err)
 
 	eniInfos := ds.GetENIInfos()
@@ -101,10 +102,10 @@ func TestDeleteENI(t *testing.T) {
 func TestAddENIIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true, "")
+	err := ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false, "")
+	err = ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -139,10 +140,10 @@ func TestAddENIIPv4Address(t *testing.T) {
 func TestGetENIIPPools(t *testing.T) {
 	ds := NewDataStore(log)
 
-	err := ds.AddENI("eni-1", 1, true, "")
+	err := ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.NoError(t, err)
 
-	err = ds.AddENI("eni-2", 2, false, "")
+	err = ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -171,7 +172,7 @@ func TestGetENIIPPools(t *testing.T) {
 
 func TestDelENIIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
-	err := ds.AddENI("eni-1", 1, true, "")
+	err := ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	assert.NoError(t, err)
 
 	err = ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
@@ -228,9 +229,9 @@ func TestDelENIIPv4Address(t *testing.T) {
 func TestPodIPv4Address(t *testing.T) {
 	ds := NewDataStore(log)
 
-	ds.AddENI("eni-1", 1, true, "")
+	ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 
-	ds.AddENI("eni-2", 2, false, "")
+	ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
 
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 
@@ -366,9 +367,9 @@ func TestPodIPv4Address(t *testing.T) {
 func TestWarmENIInteractions(t *testing.T) {
 	ds := NewDataStore(log)
 
-	ds.AddENI("eni-1", 1, true, "")
-	ds.AddENI("eni-2", 2, false, "")
-	ds.AddENI("eni-3", 3, false, "")
+	ds.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
+	ds.AddENIWithSubnet("eni-2", 2, false, "", net.IPNet{})
+	ds.AddENIWithSubnet("eni-3", 3, false, "", net.IPNet{})
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	ds.AddIPv4AddressToStore("eni-1", "1.1.1.2")
 	ds.AddIPv4AddressToStore("eni-2", "1.1.2.1")

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -706,13 +706,9 @@ func (c *IPAMContext) globalAllocateENI(enis []awsutils.ENIMetadata) error {
 		return fmt.Errorf("eniConfig does not exist")
 	}
 
-	allENIConfigs, err := c.eniConfig.GetAllENIConfigs()
+	allENIConfigs := c.eniConfig.GetAllENIConfigs()
 
 	log.Debugf("Try to pre-allocate an ENI from each ENIConfig")
-
-	if err != nil {
-		return err
-	}
 
 	var existingENIs []v1alpha1.ENIConfigSpec
 	for _, eni := range enis {
@@ -769,11 +765,7 @@ func (c *IPAMContext) matchENItoENIConfig(eniMetadata awsutils.ENIMetadata) (eni
 		return ""
 	}
 
-	allENIConfigs, err := c.eniConfig.GetAllENIConfigs()
-
-	if err != nil {
-		return ""
-	}
+	allENIConfigs := c.eniConfig.GetAllENIConfigs()
 
 	var securityGroups []string
 	for _, sg := range eniMetadata.SecurityGroups {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -697,7 +697,6 @@ func (c *IPAMContext) updateLastNodeIPPoolAction() {
 	logPoolStats(total, used, c.maxIPsPerENI)
 }
 
-
 // For each ENIConfig we want to make sure there is at least
 // one matching interface attached
 func (c *IPAMContext) globalAllocateENI(enis []awsutils.ENIMetadata) error {
@@ -720,7 +719,7 @@ func (c *IPAMContext) globalAllocateENI(enis []awsutils.ENIMetadata) error {
 		}
 
 		log.Debugf("Existing ENI %s, subnet %s, sgAll %s", eni.ENIID, eni.SubnetId, securityGroups)
-		existingENIs = append(existingENIs,v1alpha1.ENIConfigSpec{
+		existingENIs = append(existingENIs, v1alpha1.ENIConfigSpec{
 			SecurityGroups: securityGroups,
 			Subnet:         eni.SubnetId,
 		})

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -74,17 +74,17 @@ func TestNodeInit(t *testing.T) {
 
 
 	mockContext := &IPAMContext{
-		awsClient:     mockAWS,
-		k8sClient:     mockK8S,
-		maxIPsPerENI:  14,
-		maxENI:        4,
-		warmENITarget: 1,
-		warmIPTarget:  3,
-		primaryIP:     make(map[string]string),
-		terminating:   int32(0),
-		criClient:     mockCRI,
-		networkClient: mockNetwork,
-		eniConfig:     mockENIConfig,
+		awsClient:           mockAWS,
+		k8sClient:           mockK8S,
+		maxIPsPerENI:        14,
+		maxENI:              4,
+		warmENITarget:       1,
+		warmIPTarget:        3,
+		primaryIP:           make(map[string]string),
+		terminating:         int32(0),
+		criClient:           mockCRI,
+		networkClient:       mockNetwork,
+		eniConfig:           mockENIConfig,
 		useCustomNetworking: true,
 	}
 
@@ -169,7 +169,6 @@ func TestNodeInit(t *testing.T) {
 	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
 	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1, eni2, eni3}, nil)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), thirdMAC, thirdDevice, thirdSubnet)
-
 
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)
@@ -571,7 +570,6 @@ func TestIPAMContext_nodeIPPoolTooLow(t *testing.T) {
 	}
 }
 
-
 func TestMatchENItoENIConfig_NoConfig(t *testing.T) {
 	mockContext := &IPAMContext{}
 
@@ -604,7 +602,7 @@ func TestMatchENItoENIConfig_Match(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockContext := &IPAMContext{
-		eniConfig:     mockENIConfig,
+		eniConfig: mockENIConfig,
 	}
 
 	primary := true
@@ -627,7 +625,6 @@ func TestMatchENItoENIConfig_Match(t *testing.T) {
 		},
 		SubnetId:       "subnet1",
 		SecurityGroups: []*string{aws.String("sg1-id"), aws.String("sg2-id")},
-
 	}
 
 	podENIConfig := &v1alpha1.ENIConfigSpec{
@@ -653,7 +650,7 @@ func TestMatchENItoENIConfig_MisMatch(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockContext := &IPAMContext{
-		eniConfig:     mockENIConfig,
+		eniConfig:           mockENIConfig,
 		useCustomNetworking: true,
 	}
 
@@ -677,7 +674,6 @@ func TestMatchENItoENIConfig_MisMatch(t *testing.T) {
 		},
 		SubnetId:       "subnet1",
 		SecurityGroups: []*string{aws.String("sg1-id"), aws.String("sg2-id")},
-
 	}
 
 	podENIConfig := &v1alpha1.ENIConfigSpec{
@@ -703,10 +699,10 @@ func TestGlobalAllocateENI_NoENIConfigInContext(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockContext := &IPAMContext{
-		eniConfig:     nil,
+		eniConfig: nil,
 	}
 
-	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	err := mockContext.globalAllocateENI([]awsutils.ENIMetadata{})
 	assert.Error(t, err)
 
 }
@@ -716,10 +712,10 @@ func TestGlobalAllocateENI_NormalCase(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockContext := &IPAMContext{
-		awsClient:           mockAWS,
-		eniConfig:           mockENIConfig,
-		networkClient:       mockNetwork,
-		primaryIP:           make(map[string]string),
+		awsClient:     mockAWS,
+		eniConfig:     mockENIConfig,
+		networkClient: mockNetwork,
+		primaryIP:     make(map[string]string),
 	}
 
 	mockContext.dataStore = datastore.NewDataStore()
@@ -762,7 +758,7 @@ func TestGlobalAllocateENI_NormalCase(t *testing.T) {
 	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
 	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1}, nil)
 
-	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	err := mockContext.globalAllocateENI([]awsutils.ENIMetadata{})
 	assert.NoError(t, err)
 
 }
@@ -772,12 +768,12 @@ func TestGlobalAllocateENI_NoENIConfigsConfigured(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockContext := &IPAMContext{
-		eniConfig:     mockENIConfig,
+		eniConfig: mockENIConfig,
 	}
 
 	mockENIConfig.EXPECT().GetAllENIConfigs().Return(make(map[string]*v1alpha1.ENIConfigSpec))
 
-	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	err := mockContext.globalAllocateENI([]awsutils.ENIMetadata{})
 	assert.NoError(t, err)
 
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -68,7 +68,7 @@ func setup(t *testing.T) (*gomock.Controller,
 }
 
 func TestNodeInit(t *testing.T) {
-	ctrl, mockAWS, mockK8S, mockCRI, mockNetwork, _ := setup(t)
+	ctrl, mockAWS, mockK8S, mockCRI, mockNetwork, mockENIConfig := setup(t)
 	defer ctrl.Finish()
 
 
@@ -83,14 +83,41 @@ func TestNodeInit(t *testing.T) {
 		primaryIP:     make(map[string]string),
 		terminating:   int32(0),
 		criClient:     mockCRI,
-		networkClient: mockNetwork}
+		networkClient: mockNetwork,
+		eniConfig:     mockENIConfig,
+		useCustomNetworking: true,
+	}
 
 	eni1, eni2 := getDummyENIMetdata()
+
+	thirdENIid := "eni-00000002"
+	thirdMAC := "12:ef:2a:98:e5:5c"
+	thirdDevice := 3
+	thirdSubnet := "10.10.13.0/24"
+
+	notPrimary := false
+	testAddr11 := ipaddr11
+	testAddr12 := ipaddr12
+
+	eni3 := awsutils.ENIMetadata{
+		ENIID:          thirdENIid,
+		MAC:            thirdMAC,
+		DeviceNumber:   thirdDevice,
+		SubnetIPv4CIDR: thirdSubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr11, Primary: &notPrimary,
+			},
+			{
+				PrivateIpAddress: &testAddr12, Primary: &notPrimary,
+			},
+		},
+	}
 
 	var cidrs []*string
 	mockAWS.EXPECT().GetENILimit().Return(4, nil)
 	mockAWS.EXPECT().GetENIipLimit().Return(14, nil)
-	mockAWS.EXPECT().GetIPv4sFromEC2(eni1.ENIID).Return(eni1.IPv4Addresses, nil)
+	mockAWS.EXPECT().GetIPv4sFromEC2(eni2.ENIID).Return(eni2.IPv4Addresses, nil)
 	mockAWS.EXPECT().GetVPCIPv4CIDR().Return(vpcCIDR)
 
 	_, parsedVPCCIDR, _ := net.ParseCIDR(vpcCIDR)
@@ -122,6 +149,27 @@ func TestNodeInit(t *testing.T) {
 	mockNetwork.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any(), gomock.Any(), true)
 	// Add IPs
 	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
+
+	podENIConfig := &v1alpha1.ENIConfigSpec{
+		SecurityGroups: []string{"sg1-id", "sg2-id"},
+		Subnet:         "subnet1",
+	}
+
+	var sgPtrs []*string
+	for _, sg := range podENIConfig.SecurityGroups {
+		sgPtrs = append(sgPtrs, &sg)
+	}
+
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
+
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil).Times(4)
+	mockENIConfig.EXPECT().GetENIConfig("sample").Return(podENIConfig, nil)
+	mockAWS.EXPECT().AllocENI(true, gomock.Any(), podENIConfig.Subnet).Return(thirdENIid, nil)
+	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1, eni2, eni3}, nil)
+	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), thirdMAC, thirdDevice, thirdSubnet)
+
 
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)
@@ -212,9 +260,11 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 	for _, sgID := range podENIConfig.SecurityGroups {
 		sg = append(sg, aws.String(sgID))
 	}
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
 
 	if useENIConfig {
-		mockENIConfig.EXPECT().MyENIConfig().Return(podENIConfig, nil)
+		mockENIConfig.EXPECT().GetENIConfig("").Return(podENIConfig, nil)
 		mockAWS.EXPECT().AllocENI(true, sg, podENIConfig.Subnet).Return(eni2, nil)
 	} else {
 		mockAWS.EXPECT().AllocENI(false, nil, "").Return(eni2, nil)
@@ -252,6 +302,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 	}, nil)
 
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	mockAWS.EXPECT().AllocIPAddresses(eni2, 14)
@@ -296,6 +347,8 @@ func TestTryAddIPToENI(t *testing.T) {
 	for _, sgID := range podENIConfig.SecurityGroups {
 		sg = append(sg, aws.String(sgID))
 	}
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
 
 	mockAWS.EXPECT().AllocENI(false, nil, "").Return(secENIid, nil)
 	mockAWS.EXPECT().AllocIPAddresses(secENIid, warmIpTarget)
@@ -330,6 +383,7 @@ func TestTryAddIPToENI(t *testing.T) {
 		},
 	}, nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 
@@ -451,7 +505,7 @@ func TestGetWarmIPTargetState(t *testing.T) {
 	assert.Equal(t, 0, over)
 
 	// add 2 addresses to datastore
-	_ = mockContext.dataStore.AddENI("eni-1", 1, true)
+	_ = mockContext.dataStore.AddENI("eni-1", 1, true, "")
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.2")
 
@@ -517,9 +571,147 @@ func TestIPAMContext_nodeIPPoolTooLow(t *testing.T) {
 	}
 }
 
+
+func TestMatchENItoENIConfig_NoConfig(t *testing.T) {
+	/*	ctrl, mockAWS, mockK8S, _, mockNetwork, _ := setup(t)
+		defer ctrl.Finish()
+
+		mockContext := &IPAMContext{
+			awsClient:     mockAWS,
+			k8sClient:     mockK8S,
+			networkClient: mockNetwork,
+			primaryIP:     make(map[string]string),
+			terminating:   int32(0),
+		}
+	*/
+
+	mockContext := &IPAMContext{}
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	eni1 := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr1, Primary: &primary,
+			},
+			{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary,
+			},
+		},
+	}
+
+	result := mockContext.matchENItoENIConfig(eni1)
+	assert.Equal(t, "", result)
+}
+
+func TestMatchENItoENIConfig_Match(t *testing.T) {
+	ctrl, _, _, _, _, mockENIConfig := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		eniConfig:     mockENIConfig,
+	}
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	eni1 := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr1, Primary: &primary,
+			},
+			{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary,
+			},
+		},
+		SubnetId:       "subnet1",
+		SecurityGroups: []*string{aws.String("sg1-id"), aws.String("sg2-id")},
+
+	}
+
+	podENIConfig := &v1alpha1.ENIConfigSpec{
+		SecurityGroups: []string{"sg1-id", "sg2-id"},
+		Subnet:         "subnet1",
+	}
+	var sg []*string
+	for _, sgID := range podENIConfig.SecurityGroups {
+		sg = append(sg, aws.String(sgID))
+	}
+
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
+
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+
+	result := mockContext.matchENItoENIConfig(eni1)
+	assert.Equal(t, "sample", result)
+}
+
+func TestMatchENItoENIConfig_MisMatch(t *testing.T) {
+	ctrl, _, _, _, _, mockENIConfig := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		eniConfig:     mockENIConfig,
+	}
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	eni1 := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr1, Primary: &primary,
+			},
+			{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary,
+			},
+		},
+		SubnetId:       "subnet1",
+		SecurityGroups: []*string{aws.String("sg1-id"), aws.String("sg2-id")},
+
+	}
+
+	podENIConfig := &v1alpha1.ENIConfigSpec{
+		SecurityGroups: []string{"sg1-id", "sg2-id"},
+		Subnet:         "subnet2",
+	}
+	var sg []*string
+	for _, sgID := range podENIConfig.SecurityGroups {
+		sg = append(sg, aws.String(sgID))
+	}
+
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
+
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+
+	result := mockContext.matchENItoENIConfig(eni1)
+	assert.Equal(t, "", result)
+}
+
 func datastoreWith3FreeIPs() *datastore.DataStore {
 	datastoreWith3FreeIPs := datastore.NewDataStore(log)
-	_ = datastoreWith3FreeIPs.AddENI(primaryENIid, 1, true)
+	_ = datastoreWith3FreeIPs.AddENI(primaryENIid, 1, true, "")
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr01)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr02)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr03)

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -504,7 +504,7 @@ func TestGetWarmIPTargetState(t *testing.T) {
 	assert.Equal(t, 0, over)
 
 	// add 2 addresses to datastore
-	_ = mockContext.dataStore.AddENI("eni-1", 1, true, "")
+	_ = mockContext.dataStore.AddENIWithSubnet("eni-1", 1, true, "", net.IPNet{})
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.2")
 
@@ -718,7 +718,7 @@ func TestGlobalAllocateENI_NormalCase(t *testing.T) {
 		primaryIP:     make(map[string]string),
 	}
 
-	mockContext.dataStore = datastore.NewDataStore()
+	mockContext.dataStore = datastore.NewDataStore(log)
 
 	podENIConfig := &v1alpha1.ENIConfigSpec{
 		SecurityGroups: []string{"sg1-id", "sg2-id"},
@@ -780,7 +780,7 @@ func TestGlobalAllocateENI_NoENIConfigsConfigured(t *testing.T) {
 
 func datastoreWith3FreeIPs() *datastore.DataStore {
 	datastoreWith3FreeIPs := datastore.NewDataStore(log)
-	_ = datastoreWith3FreeIPs.AddENI(primaryENIid, 1, true, "")
+	_ = datastoreWith3FreeIPs.AddENIWithSubnet(primaryENIid, 1, true, "", net.IPNet{})
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr01)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr02)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr03)

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -163,7 +163,7 @@ func TestNodeInit(t *testing.T) {
 	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
 	podENIConfigs["sample"] = podENIConfig
 
-	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil).Times(4)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs).Times(4)
 	mockENIConfig.EXPECT().GetENIConfig("sample").Return(podENIConfig, nil)
 	mockAWS.EXPECT().AllocENI(true, gomock.Any(), podENIConfig.Subnet).Return(thirdENIid, nil)
 	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
@@ -302,7 +302,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 	}, nil)
 
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	mockAWS.EXPECT().AllocIPAddresses(eni2, 14)
@@ -383,7 +383,7 @@ func TestTryAddIPToENI(t *testing.T) {
 		},
 	}, nil)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs)
 	mockNetwork.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid)
 
@@ -573,18 +573,6 @@ func TestIPAMContext_nodeIPPoolTooLow(t *testing.T) {
 
 
 func TestMatchENItoENIConfig_NoConfig(t *testing.T) {
-	/*	ctrl, mockAWS, mockK8S, _, mockNetwork, _ := setup(t)
-		defer ctrl.Finish()
-
-		mockContext := &IPAMContext{
-			awsClient:     mockAWS,
-			k8sClient:     mockK8S,
-			networkClient: mockNetwork,
-			primaryIP:     make(map[string]string),
-			terminating:   int32(0),
-		}
-	*/
-
 	mockContext := &IPAMContext{}
 
 	primary := true
@@ -654,7 +642,7 @@ func TestMatchENItoENIConfig_Match(t *testing.T) {
 	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
 	podENIConfigs["sample"] = podENIConfig
 
-	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs)
 
 	result := mockContext.matchENItoENIConfig(eni1)
 	assert.Equal(t, "sample", result)
@@ -666,6 +654,7 @@ func TestMatchENItoENIConfig_MisMatch(t *testing.T) {
 
 	mockContext := &IPAMContext{
 		eniConfig:     mockENIConfig,
+		useCustomNetworking: true,
 	}
 
 	primary := true
@@ -703,10 +692,94 @@ func TestMatchENItoENIConfig_MisMatch(t *testing.T) {
 	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
 	podENIConfigs["sample"] = podENIConfig
 
-	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs, nil)
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs)
 
 	result := mockContext.matchENItoENIConfig(eni1)
 	assert.Equal(t, "", result)
+}
+
+func TestGlobalAllocateENI_NoENIConfigInContext(t *testing.T) {
+	ctrl, _, _, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		eniConfig:     nil,
+	}
+
+	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	assert.Error(t, err)
+
+}
+
+func TestGlobalAllocateENI_NormalCase(t *testing.T) {
+	ctrl, mockAWS, _, _, mockNetwork, mockENIConfig := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:           mockAWS,
+		eniConfig:           mockENIConfig,
+		networkClient:       mockNetwork,
+		primaryIP:           make(map[string]string),
+	}
+
+	mockContext.dataStore = datastore.NewDataStore()
+
+	podENIConfig := &v1alpha1.ENIConfigSpec{
+		SecurityGroups: []string{"sg1-id", "sg2-id"},
+		Subnet:         "subnet2",
+	}
+	var sg []*string
+	for _, sgID := range podENIConfig.SecurityGroups {
+		sg = append(sg, aws.String(sgID))
+	}
+
+	var podENIConfigs = make(map[string]*v1alpha1.ENIConfigSpec)
+	podENIConfigs["sample"] = podENIConfig
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+
+	eni1 := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr1, Primary: &primary,
+			},
+			{
+				PrivateIpAddress: &testAddr2, Primary: &notPrimary,
+			},
+		},
+	}
+
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(podENIConfigs).Times(2)
+	mockAWS.EXPECT().GetPrimaryENI().Return(primaryENIid).Times(2)
+	mockAWS.EXPECT().AllocENI(gomock.Any(), gomock.Any(), gomock.Any()).Return(primaryENIid, nil)
+	mockAWS.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
+	mockAWS.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{eni1}, nil)
+
+	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	assert.NoError(t, err)
+
+}
+
+func TestGlobalAllocateENI_NoENIConfigsConfigured(t *testing.T) {
+	ctrl, _, _, _, _, mockENIConfig := setup(t)
+	defer ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		eniConfig:     mockENIConfig,
+	}
+
+	mockENIConfig.EXPECT().GetAllENIConfigs().Return(make(map[string]*v1alpha1.ENIConfigSpec))
+
+	err := mockContext.globalAllocateENI( []awsutils.ENIMetadata{})
+	assert.NoError(t, err)
+
 }
 
 func datastoreWith3FreeIPs() *datastore.DataStore {

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -48,14 +48,14 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		in.Netns, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID, in.IfName, in.EniConfigName)
 
 	addr, deviceNumber, err := s.ipamContext.dataStore.AssignPodIPv4Address(&k8sapi.K8SPodInfo{
-		Name:      in.K8S_POD_NAME,
-		Namespace: in.K8S_POD_NAMESPACE,
-		Sandbox:   in.K8S_POD_INFRA_CONTAINER_ID,
-		IfName:    in.IfName,
+		Name:          in.K8S_POD_NAME,
+		Namespace:     in.K8S_POD_NAMESPACE,
+		Sandbox:       in.K8S_POD_INFRA_CONTAINER_ID,
+		IfName:        in.IfName,
 		ENIConfigName: in.EniConfigName})
 
 	ipv4Subnet := net.IPNet{
-		IP: addr.IP.Mask(addr.Mask),
+		IP:   addr.IP.Mask(addr.Mask),
 		Mask: addr.Mask,
 	}
 

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -44,13 +44,20 @@ type server struct {
 
 // AddNetwork processes CNI add network request and return an IP address for container
 func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rpc.AddNetworkReply, error) {
-	log.Infof("Received AddNetwork for NS %s, Pod %s, NameSpace %s, Sandbox %s, ifname %s",
-		in.Netns, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID, in.IfName)
+	log.Infof("Received AddNetwork for NS %s, Pod %s, NameSpace %s, Sandbox %s, ifname %s, ENIConfig %s",
+		in.Netns, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID, in.IfName, in.EniConfigName)
 
 	addr, deviceNumber, err := s.ipamContext.dataStore.AssignPodIPv4Address(&k8sapi.K8SPodInfo{
 		Name:      in.K8S_POD_NAME,
 		Namespace: in.K8S_POD_NAMESPACE,
-		Sandbox:   in.K8S_POD_INFRA_CONTAINER_ID})
+		Sandbox:   in.K8S_POD_INFRA_CONTAINER_ID,
+		IfName:    in.IfName,
+		ENIConfigName: in.EniConfigName})
+
+	ipv4Subnet := net.IPNet{
+		IP: addr.IP.Mask(addr.Mask),
+		Mask: addr.Mask,
+	}
 
 	var pbVPCcidrs []string
 	for _, cidr := range s.ipamContext.awsClient.GetVPCIPv4CIDRs() {
@@ -68,27 +75,28 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 
 	resp := rpc.AddNetworkReply{
 		Success:         err == nil,
-		IPv4Addr:        addr,
-		IPv4Subnet:      "",
+		IPv4Addr:        addr.IP.String(),
+		IPv4Subnet:      ipv4Subnet.String(),
 		DeviceNumber:    int32(deviceNumber),
 		UseExternalSNAT: useExternalSNAT,
 		VPCcidrs:        pbVPCcidrs,
 	}
 
-	log.Infof("Send AddNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", addr, deviceNumber, err)
+	log.Infof("Send AddNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", addr.String(), deviceNumber, err)
 	addIPCnt.Inc()
 	return &resp, nil
 }
 
 func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rpc.DelNetworkReply, error) {
-	log.Infof("Received DelNetwork for IP %s, Pod %s, Namespace %s, Sandbox %s",
-		in.IPv4Addr, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID)
+	log.Infof("Received DelNetwork for IP %s, Pod %s, Namespace %s, Sandbox %s, IfName %s",
+		in.IPv4Addr, in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.K8S_POD_INFRA_CONTAINER_ID, in.IfName)
 	delIPCnt.With(prometheus.Labels{"reason": in.Reason}).Inc()
 
 	ip, deviceNumber, err := s.ipamContext.dataStore.UnassignPodIPv4Address(&k8sapi.K8SPodInfo{
 		Name:      in.K8S_POD_NAME,
 		Namespace: in.K8S_POD_NAMESPACE,
-		Sandbox:   in.K8S_POD_INFRA_CONTAINER_ID})
+		Sandbox:   in.K8S_POD_INFRA_CONTAINER_ID,
+		IfName:    in.IfName})
 
 	if err != nil && err == datastore.ErrUnknownPod {
 		// If L-IPAMD restarts, the pod's IP address are assigned by only pod's name and namespace due to kubelet's introspection.

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -51,6 +51,10 @@ type K8SPodInfo struct {
 	Sandbox string
 	// IP is pod's ipv4 address
 	IP  string
+	// IfName is interface name
+	IfName string
+	// ENIConfigName
+	ENIConfigName string
 	UID string
 }
 

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -50,12 +50,12 @@ type K8SPodInfo struct {
 	// Sandbox is pod's sandbox id
 	Sandbox string
 	// IP is pod's ipv4 address
-	IP  string
+	IP string
 	// IfName is interface name
 	IfName string
 	// ENIConfigName
 	ENIConfigName string
-	UID string
+	UID           string
 }
 
 var log = logger.Get()

--- a/rpc/rpc.pb.go
+++ b/rpc/rpc.pb.go
@@ -29,6 +29,7 @@ type AddNetworkRequest struct {
 	K8S_POD_INFRA_CONTAINER_ID string   `protobuf:"bytes,3,opt,name=K8S_POD_INFRA_CONTAINER_ID,json=k8SPODINFRACONTAINERID,proto3" json:"K8S_POD_INFRA_CONTAINER_ID,omitempty"`
 	Netns                      string   `protobuf:"bytes,4,opt,name=Netns,json=netns,proto3" json:"Netns,omitempty"`
 	IfName                     string   `protobuf:"bytes,5,opt,name=IfName,json=ifName,proto3" json:"IfName,omitempty"`
+	EniConfigName              string `protobuf:"bytes,6,opt,name=EniConfigName" json:"EniConfigName,omitempty"`
 	XXX_NoUnkeyedLiteral       struct{} `json:"-"`
 	XXX_unrecognized           []byte   `json:"-"`
 	XXX_sizecache              int32    `json:"-"`
@@ -89,6 +90,13 @@ func (m *AddNetworkRequest) GetNetns() string {
 func (m *AddNetworkRequest) GetIfName() string {
 	if m != nil {
 		return m.IfName
+	}
+	return ""
+}
+
+func (m *AddNetworkRequest) GetEniConfigName() string {
+	if m != nil {
+		return m.EniConfigName
 	}
 	return ""
 }
@@ -177,6 +185,7 @@ type DelNetworkRequest struct {
 	K8S_POD_INFRA_CONTAINER_ID string   `protobuf:"bytes,3,opt,name=K8S_POD_INFRA_CONTAINER_ID,json=k8SPODINFRACONTAINERID,proto3" json:"K8S_POD_INFRA_CONTAINER_ID,omitempty"`
 	IPv4Addr                   string   `protobuf:"bytes,4,opt,name=IPv4Addr,json=iPv4Addr,proto3" json:"IPv4Addr,omitempty"`
 	Reason                     string   `protobuf:"bytes,5,opt,name=Reason,json=reason,proto3" json:"Reason,omitempty"`
+	IfName                     string `protobuf:"bytes,6,opt,name=IfName" json:"IfName,omitempty"`
 	XXX_NoUnkeyedLiteral       struct{} `json:"-"`
 	XXX_unrecognized           []byte   `json:"-"`
 	XXX_sizecache              int32    `json:"-"`
@@ -237,6 +246,13 @@ func (m *DelNetworkRequest) GetIPv4Addr() string {
 func (m *DelNetworkRequest) GetReason() string {
 	if m != nil {
 		return m.Reason
+	}
+	return ""
+}
+
+func (m *DelNetworkRequest) GetIfName() string {
+	if m != nil {
+		return m.IfName
 	}
 	return ""
 }

--- a/rpc/rpc.proto
+++ b/rpc/rpc.proto
@@ -14,6 +14,7 @@ message AddNetworkRequest {
   string K8S_POD_INFRA_CONTAINER_ID = 3;
   string Netns = 4;
   string IfName = 5;
+  string EniConfigName = 6;
 }
 
 message  AddNetworkReply{
@@ -31,6 +32,7 @@ message DelNetworkRequest {
   string K8S_POD_INFRA_CONTAINER_ID = 3;
   string IPv4Addr = 4;
   string Reason = 5;
+  string IfName = 6;
 }
 
 message DelNetworkReply {


### PR DESCRIPTION
*Description of changes:*

This does a few things:

    It allows for a worker node to interpret multiple ENIConfigs
    It then causes the worker node to attempt to bring up an ENI for each ENIConfig
    It allows multus to attach multiple interfaces to a single pod
    When installing a pod interface, allow for an ENIConfig to be specified to choose the IP to use.
    Add routes for local subnets in the container.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
