### PR TITLE
scripts/lib: bump up aws-k8s-tester to v1.2.2

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.1.7}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.2.2}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
ref. https://github.com/aws/aws-k8s-tester/commit/a0c7d18428538ef7f69eaf3d0e5af4c9887d8f98

Otherwise, https://github.com/kubernetes-sigs/aws-alb-ingress-controller/releases/tag/v1.1.7 will fail:

> kubebuilder/controller "msg"="Reconciler error" "error"="failed get WAFv2 webACL for load balancer arn:aws:elasticloadbalancing:us-west-2:607362164682:loadbalancer/app/7fbd7e3d-eks2020051714char-ad37/26de385bd4f0a46a: AccessDeniedException: User: arn:aws:sts::607362164682:assumed-role/eks-2020051714-charisma6fxe-role-ng/i-06acdfc5db3ccf8fd is not authorized to perform: wafv2:GetWebACLForResource on resource: arn:aws:wafv2:us-west-2:607362164682:regional/webacl/*\n\tstatus code: 400, request id: 40378ac6-9375-4575-a1e6-1dfb8d2842e4"  "controller"="alb-ingress-controller" "request"={"Namespace":"eks-2020051714-charisma6fxe-alb-2048","Name":"alb-2048-ingress"}

https://github.com/kubernetes-sigs/aws-alb-ingress-controller/releases/tag/v1.1.7 says:

> New IAM permission is required even no wafv2 annotation is used
