### PR TITLE
Added WithNoProxy dialopts to ignore proxies for grpc connection when dealing with unix socket.

### DIFF
--- a/cmd/grpc-health-probe/main.go
+++ b/cmd/grpc-health-probe/main.go
@@ -86,7 +86,8 @@ func main() {
 
 	opts := []grpc.DialOption{
 		grpc.WithUserAgent(userAgent),
-		grpc.WithBlock()}
+		grpc.WithBlock(),
+		grpc.WithNoProxy()}
 
 	opts = append(opts, grpc.WithInsecure())
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	google.golang.org/grpc v1.28.0
+	google.golang.org/grpc v1.29.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
+google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -53,7 +53,7 @@ func (c *Client) GetRunningPodSandboxes(log logger.Logger) (map[string]*SandboxI
 		socketPath = criSocketPath
 	}
 	log.Debugf("Getting running pod sandboxes from %q", socketPath)
-	conn, err := grpc.Dial(socketPath, grpc.WithInsecure())
+	conn, err := grpc.Dial(socketPath, grpc.WithInsecure(), grpc.WithNoProxy(), grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:* #931

*Description of changes:*

The non-grpc things are mostly HTTP requests that we do need to proxy. The grpc things, as noted, as via local sockets, which can't and shouldn't be proxied.

Providing our own dialer is an option, but this seems a little cleaner and like other folks might also find it useful.

== Tests ==
```
[ec2-user@ip-10-0-1-130 ~]$ kn describe ds/aws-node |grep -i env -A9
    Environment Variables from:
      proxy-environment-variables  ConfigMap  Optional: false
    Environment:
      AWS_VPC_K8S_CNI_LOGLEVEL:    DEBUG
      AWS_VPC_K8S_CNI_VETHPREFIX:  eni
      AWS_VPC_ENI_MTU:             9001
      MY_NODE_NAME:                 (v1:spec.nodeName)
    Mounts:
      /host/etc/cni/net.d from cni-net-dir (rw)
      /host/opt/cni/bin from cni-bin-dir (rw)
      /host/var/log from log-dir (rw)
      /var/run/docker.sock from dockersock (rw)

[ec2-user@ip-10-0-1-130 ~]$ kn exec -it aws-node-j8c5z env |grep -i proxy
HTTPS_PROXY=http://192.168.140.166:3128
HTTP_PROXY=http://192.168.140.166:3128
NO_PROXY=192.168.0.0/16,/var/run/dockershim.sock,localhost,10.100.0.0/16,127.0.0.1,169.254.169.254,.s3.us-east-2.amazonaws.com,api.ecr.us-east-2.amazonaws.com,dkr.ecr.us-east-2.amazonaws.com,ec2.us-east-2.amazonaws.com,.us-east-2.eks.amazonaws.com,.us-east-2.compute.internal

[ec2-user@ip-10-0-1-130 ~]$ kn describe cm/proxy-environment-variables
Name:         proxy-environment-variables
Namespace:    kube-system
Labels:       <none>
Annotations:
Data
====
HTTPS_PROXY:
----
http://192.168.140.166:3128
HTTP_PROXY:
----
http://192.168.140.166:3128
NO_PROXY:
----
192.168.0.0/16,/var/run/dockershim.sock,localhost,10.100.0.0/16,127.0.0.1,169.254.169.254,.s3.us-east-2.amazonaws.com,api.ecr.us-east-2.amazonaws.com,dkr.ecr.us-east-2.amazonaws.com,ec2.us-east-2.amazonaws.com,.us-east-2.eks.amazonaws.com,.us-east-2.compute.internal
Events:  <none>

[ec2-user@ip-10-0-1-130 ~]$ k get deploy
NAME         READY   UP-TO-DATE   AVAILABLE   AGE
pv-deploy    25/50   50           25          7m19s
pv-deploy6   0/100   0            0           26m

[ec2-user@ip-10-0-1-130 ~]$ kn get po -w
NAME                       READY   STATUS    RESTARTS   AGE
aws-node-j8c5z             1/1     Running   0          20m
aws-node-ss4vp             1/1     Running   0          22m
coredns-74dd858ddc-jw2bm   1/1     Running   0          16h
coredns-74dd858ddc-zcxdd   1/1     Running   0          16h
kube-proxy-pm46g           1/1     Running   0          13h
kube-proxy-xfhbw           1/1     Running   0          13h
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
