### PR TITLE
Revert "Added WithNoProxy dialopts to ignore proxies for grpc connection when dealing with unix socket."

### DIFF
--- a/cmd/grpc-health-probe/main.go
+++ b/cmd/grpc-health-probe/main.go
@@ -86,8 +86,7 @@ func main() {
 
 	opts := []grpc.DialOption{
 		grpc.WithUserAgent(userAgent),
-		grpc.WithBlock(),
-		grpc.WithNoProxy()}
+		grpc.WithBlock()}
 
 	opts = append(opts, grpc.WithInsecure())
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	google.golang.org/grpc v1.29.0
+	google.golang.org/grpc v1.28.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293

--- a/go.sum
+++ b/go.sum
@@ -237,7 +237,6 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -53,7 +53,7 @@ func (c *Client) GetRunningPodSandboxes(log logger.Logger) (map[string]*SandboxI
 		socketPath = criSocketPath
 	}
 	log.Debugf("Getting running pod sandboxes from %q", socketPath)
-	conn, err := grpc.Dial(socketPath, grpc.WithInsecure(), grpc.WithNoProxy(), grpc.WithBlock())
+	conn, err := grpc.Dial(socketPath, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-k8s#980

This should have gone into master first, since this fix is not in the v1.6.1 release. 