### PR TITLE
Update run-integration-tests.sh to default to config/master

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -11,12 +11,12 @@ source $DIR/lib/cluster.sh
 
 OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
-AWS_REGION=${AWS_REGION:-us-west-2}
-K8S_VERSION=${K8S_VERSION:-1.14.6}
-PROVISION=${PROVISION:-true}
-DEPROVISION=${DEPROVISION:-true}
-BUILD=${BUILD:-true}
-RUN_CONFORMANCE=${RUN_CONFORMANCE:-false}
+: ${AWS_REGION:=us-west-2}
+: ${K8S_VERSION:=1.14.6}
+: ${PROVISION:=true}
+: ${DEPROVISION:=true}
+: ${BUILD:=true}
+: ${RUN_CONFORMANCE:=false}
 
 __cluster_created=0
 __cluster_deprovisioned=0
@@ -34,34 +34,33 @@ on_error() {
 }
 
 # test specific config, results location
-TEST_ID=${TEST_ID:-$RANDOM}
+: ${TEST_ID:=$RANDOM}
 TEST_DIR=/tmp/cni-test/$(date "+%Y%M%d%H%M%S")-$TEST_ID
 REPORT_DIR=${TEST_DIR}/report
 TEST_CONFIG_DIR="$TEST_DIR/config"
 
 # test cluster config location
 # Pass in CLUSTER_ID to reuse a test cluster
-CLUSTER_ID=${CLUSTER_ID:-$RANDOM}
+: ${CLUSTER_ID:=$RANDOM}
 CLUSTER_NAME=cni-test-$CLUSTER_ID
 TEST_CLUSTER_DIR=/tmp/cni-test/cluster-$CLUSTER_NAME
 CLUSTER_MANAGE_LOG_PATH=$TEST_CLUSTER_DIR/cluster-manage.log
-CLUSTER_CONFIG=${CLUSTER_CONFIG:-${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}
-KUBECONFIG_PATH=${KUBECONFIG_PATH:-${TEST_CLUSTER_DIR}/kubeconfig}
+: ${CLUSTER_CONFIG:=${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}
+: ${KUBECONFIG_PATH:=${TEST_CLUSTER_DIR}/kubeconfig}
 
 # shared binaries
-TESTER_DIR=${TESTER_DIR:-/tmp/aws-k8s-tester}
-TESTER_PATH=${TESTER_PATH:-$TESTER_DIR/aws-k8s-tester}
-KUBECTL_PATH=${KUBECTL_PATH:-$TESTER_DIR/kubectl}
+: ${TESTER_DIR:=/tmp/aws-k8s-tester}
+: ${TESTER_PATH:=$TESTER_DIR/aws-k8s-tester}
+: ${KUBECTL_PATH:=$TESTER_DIR/kubectl}
 
 LOCAL_GIT_VERSION=$(git describe --tags --always --dirty)
-# The stable image version is the image tag used in the latest stable
+# The manifest image version is the image tag we need to replace in the
 # aws-k8s-cni.yaml manifest
-STABLE_IMAGE_VERSION=${STABLE_IMAGE_VERSION:-v1.6.1}
+: ${MANIFEST_IMAGE_VERSION:=latest}
 TEST_IMAGE_VERSION=${IMAGE_VERSION:-$LOCAL_GIT_VERSION}
-# The CNI version we will start our k8s clusters with. We will then perform an
-# upgrade from this CNI to the CNI being tested (TEST_IMAGE_VERSION)
-BASE_CNI_VERSION=${BASE_CNI_VERSION:-v1.6}
-BASE_CONFIG_PATH="$DIR/../config/$BASE_CNI_VERSION/aws-k8s-cni.yaml"
+# We perform an upgrade to this manifest, with image replaced
+: ${MANIFEST_CNI_VERSION:=master}
+BASE_CONFIG_PATH="$DIR/../config/$MANIFEST_CNI_VERSION/aws-k8s-cni.yaml"
 TEST_CONFIG_PATH="$TEST_CONFIG_DIR/aws-k8s-cni.yaml"
 
 if [[ ! -f "$BASE_CONFIG_PATH" ]]; then
@@ -75,10 +74,10 @@ check_is_installed aws
 check_aws_credentials
 ensure_aws_k8s_tester
 
-AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}
-AWS_ECR_REGISTRY=${AWS_ECR_REGISTRY:-"$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"}
-AWS_ECR_REPO_NAME=${AWS_ECR_REPO_NAME:-"amazon-k8s-cni"}
-IMAGE_NAME=${IMAGE_NAME:-"$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME"}
+: ${AWS_ACCOUNT_ID:=$(aws sts get-caller-identity --query Account --output text)}
+: ${AWS_ECR_REGISTRY:="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"}
+: ${AWS_ECR_REPO_NAME:="amazon-k8s-cni"}
+: ${IMAGE_NAME:="$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME"}
 
 # `aws ec2 get-login` returns a docker login string, which we eval here to
 # login to the ECR registry
@@ -134,7 +133,7 @@ cp "$BASE_CONFIG_PATH" "$TEST_CONFIG_PATH"
 # TODO(jaypipes): Get rid of the hard-coded account ID and URL in the base
 # Daemonset template
 sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni,$IMAGE_NAME," "$TEST_CONFIG_PATH"
-sed -i'.bak' "s,$STABLE_IMAGE_VERSION,$TEST_IMAGE_VERSION," "$TEST_CONFIG_PATH"
+sed -i'.bak' "s,:$MANIFEST_IMAGE_VERSION,:$TEST_IMAGE_VERSION," "$TEST_CONFIG_PATH"
 
 export KUBECONFIG=$KUBECONFIG_PATH
 ADDONS_CNI_IMAGE=$($KUBECTL_PATH describe daemonset aws-node -n kube-system | grep Image | cut -d ":" -f 2-3 | tr -d '[:space:]')


### PR DESCRIPTION
Default to testing upgrades to `config/master` manifests in
`run-integration-tests.sh`.  Follow-on to #986.

Correct internal comment re starting version: we test upgrades from
whatever version is installed by `eks create cluster`.

Also: Switch to shell `${foo:=bar}` idiom to reduce duplication (and
chance for typos) in `foo=${foo:-bar}`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
