### PR TITLE
scripts/lib/aws: bump up aws-k8s-tester to v1.2.6

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.2.2}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.2.6}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
Includes various bug fixes.

ref. https://github.com/aws/aws-k8s-tester/blob/master/CHANGELOG/CHANGELOG-1.2.md#v126-2020-05-25