### PR TITLE
Quote some variables to satify shellcheck

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -5,18 +5,20 @@ set -Euo pipefail
 trap 'on_error $LINENO' ERR
 
 DIR=$(cd "$(dirname "$0")"; pwd)
-source $DIR/lib/common.sh
-source $DIR/lib/aws.sh
-source $DIR/lib/cluster.sh
+source "$DIR"/lib/common.sh
+source "$DIR"/lib/aws.sh
+source "$DIR"/lib/cluster.sh
 
+# Variables used in /lib/aws.sh
 OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
-: ${AWS_DEFAULT_REGION:=us-west-2}
-: ${K8S_VERSION:=1.14.6}
-: ${PROVISION:=true}
-: ${DEPROVISION:=true}
-: ${BUILD:=true}
-: ${RUN_CONFORMANCE:=false}
+
+: "${AWS_DEFAULT_REGION:=us-west-2}"
+: "${K8S_VERSION:=1.14.6}"
+: "${PROVISION:=true}"
+: "${DEPROVISION:=true}"
+: "${BUILD:=true}"
+: "${RUN_CONFORMANCE:=false}"
 
 __cluster_created=0
 __cluster_deprovisioned=0
@@ -34,37 +36,36 @@ on_error() {
 }
 
 # test specific config, results location
-: ${TEST_ID:=$RANDOM}
+: "${TEST_ID:=$RANDOM}"
 TEST_DIR=/tmp/cni-test/$(date "+%Y%M%d%H%M%S")-$TEST_ID
 REPORT_DIR=${TEST_DIR}/report
 TEST_CONFIG_DIR="$TEST_DIR/config"
 
 # test cluster config location
 # Pass in CLUSTER_ID to reuse a test cluster
-: ${CLUSTER_ID:=$RANDOM}
+: "${CLUSTER_ID:=$RANDOM}"
 CLUSTER_NAME=cni-test-$CLUSTER_ID
 TEST_CLUSTER_DIR=/tmp/cni-test/cluster-$CLUSTER_NAME
-CLUSTER_MANAGE_LOG_PATH=$TEST_CLUSTER_DIR/cluster-manage.log
-: ${CLUSTER_CONFIG:=${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}
-: ${KUBECONFIG_PATH:=${TEST_CLUSTER_DIR}/kubeconfig}
+: "${CLUSTER_CONFIG:=${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}"
+: "${KUBECONFIG_PATH:=${TEST_CLUSTER_DIR}/kubeconfig}"
 
 # shared binaries
-: ${TESTER_DIR:=/tmp/aws-k8s-tester}
-: ${TESTER_PATH:=$TESTER_DIR/aws-k8s-tester}
-: ${KUBECTL_PATH:=$TESTER_DIR/kubectl}
+: "${TESTER_DIR:=/tmp/aws-k8s-tester}"
+: "${TESTER_PATH:=$TESTER_DIR/aws-k8s-tester}"
+: "${KUBECTL_PATH:=$TESTER_DIR/kubectl}"
 
 LOCAL_GIT_VERSION=$(git describe --tags --always --dirty)
 # The manifest image version is the image tag we need to replace in the
 # aws-k8s-cni.yaml manifest
-: ${MANIFEST_IMAGE_VERSION:=latest}
+: "${MANIFEST_IMAGE_VERSION:=latest}"
 TEST_IMAGE_VERSION=${IMAGE_VERSION:-$LOCAL_GIT_VERSION}
 # We perform an upgrade to this manifest, with image replaced
-: ${MANIFEST_CNI_VERSION:=master}
+: "${MANIFEST_CNI_VERSION:=master}"
 BASE_CONFIG_PATH="$DIR/../config/$MANIFEST_CNI_VERSION/aws-k8s-cni.yaml"
 TEST_CONFIG_PATH="$TEST_CONFIG_DIR/aws-k8s-cni.yaml"
 
 if [[ ! -f "$BASE_CONFIG_PATH" ]]; then
-    echo "$BASE_CONFIG_PATH DOES NOT exist. Set \$CNI_TEMPLATE_VERSION to an existing directory in ./config/"
+    echo "$BASE_CONFIG_PATH DOES NOT exist. Set \$MANIFEST_CNI_VERSION to an existing directory in ./config/"
     exit
 fi
 
@@ -74,26 +75,26 @@ check_is_installed aws
 check_aws_credentials
 ensure_aws_k8s_tester
 
-: ${AWS_ACCOUNT_ID:=$(aws sts get-caller-identity --query Account --output text)}
-: ${AWS_ECR_REGISTRY:="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"}
-: ${AWS_ECR_REPO_NAME:="amazon-k8s-cni"}
-: ${IMAGE_NAME:="$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME"}
-: ${ROLE_CREATE:=true}
-: ${ROLE_ARN:=""}
+: "${AWS_ACCOUNT_ID:=$(aws sts get-caller-identity --query Account --output text)}"
+: "${AWS_ECR_REGISTRY:="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"}"
+: "${AWS_ECR_REPO_NAME:="amazon-k8s-cni"}"
+: "${IMAGE_NAME:="$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME"}"
+: "${ROLE_CREATE:=true}"
+: "${ROLE_ARN:=""}"
 
 # S3 bucket initialization
-: ${S3_BUCKET_CREATE:=true}
-: ${S3_BUCKET_NAME:=""}
+: "${S3_BUCKET_CREATE:=true}"
+: "${S3_BUCKET_NAME:=""}"
 
-# `aws ec2 get-login` returns a docker login string, which we eval here to
-# login to the ECR registry
+# `aws ec2 get-login` returns a docker login string, which we eval here to login to the ECR registry
+# shellcheck disable=SC2046
 eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email) >/dev/null 2>&1
 ensure_ecr_repo "$AWS_ACCOUNT_ID" "$AWS_ECR_REPO_NAME"
 
 # Check to see if the image already exists in the Docker repository, and if
 # not, check out the CNI source code for that image tag, build the CNI
 # image and push it to the Docker repository
-if [[ $(docker images -q $IMAGE_NAME:$TEST_IMAGE_VERSION 2> /dev/null) ]]; then
+if [[ $(docker images -q "$IMAGE_NAME:$TEST_IMAGE_VERSION" 2> /dev/null) ]]; then
     echo "CNI image $IMAGE_NAME:$TEST_IMAGE_VERSION already exists in repository. Skipping image build..."
 else
     echo "CNI image $IMAGE_NAME:$TEST_IMAGE_VERSION does not exist in repository."
@@ -101,12 +102,12 @@ else
         __cni_source_tmpdir="/tmp/cni-src-$IMAGE_VERSION"
         echo "Checking out CNI source code for $IMAGE_VERSION ..."
 
-        git clone --depth=1 --branch $TEST_IMAGE_VERSION \
-            https://github.com/aws/amazon-vpc-cni-k8s $__cni_source_tmpdir || exit 1
-        pushd $__cni_source_tmpdir
+        git clone --depth=1 --branch "$TEST_IMAGE_VERSION" \
+            https://github.com/aws/amazon-vpc-cni-k8s "$__cni_source_tmpdir" || exit 1
+        pushd "$__cni_source_tmpdir"
     fi
-    make docker IMAGE=$IMAGE_NAME VERSION=$TEST_IMAGE_VERSION
-    docker push $IMAGE_NAME:$TEST_IMAGE_VERSION
+    make docker IMAGE="$IMAGE_NAME" VERSION="$TEST_IMAGE_VERSION"
+    docker push "$IMAGE_NAME:$TEST_IMAGE_VERSION"
     if [[ $TEST_IMAGE_VERSION != "$LOCAL_GIT_VERSION" ]]; then
         popd
     fi
@@ -122,10 +123,10 @@ echo "+ Cluster config:     $CLUSTER_CONFIG"
 echo "+ AWS Account ID:     $AWS_ACCOUNT_ID"
 echo "+ CNI image to test:  $IMAGE_NAME:$TEST_IMAGE_VERSION"
 
-mkdir -p $TEST_DIR
-mkdir -p $REPORT_DIR
-mkdir -p $TEST_CLUSTER_DIR
-mkdir -p $TEST_CONFIG_DIR
+mkdir -p "$TEST_DIR"
+mkdir -p "$REPORT_DIR"
+mkdir -p "$TEST_CLUSTER_DIR"
+mkdir -p "$TEST_CONFIG_DIR"
 
 if [[ "$PROVISION" == true ]]; then
     up-test-cluster
@@ -133,10 +134,8 @@ if [[ "$PROVISION" == true ]]; then
 fi
 
 echo "Using $BASE_CONFIG_PATH as a template"
-
 cp "$BASE_CONFIG_PATH" "$TEST_CONFIG_PATH"
 
-# TODO(jaypipes): Get rid of the hard-coded account ID and URL in the base
 # Daemonset template
 sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni,$IMAGE_NAME," "$TEST_CONFIG_PATH"
 sed -i'.bak' "s,:$MANIFEST_IMAGE_VERSION,:$TEST_IMAGE_VERSION," "$TEST_CONFIG_PATH"


### PR DESCRIPTION
*Description of changes:*
* Ran the integration test script through shellcheck. 
* Added quotes around the default assignments to avoid [SC2223](https://github.com/koalaman/shellcheck/wiki/SC2223)
* Removed one unused un-exported variable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
