### PR TITLE
Bump Calico to 1.13.4

### DIFF
--- a/config/master/calico.yaml
+++ b/config/master/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.0
+          image: quay.io/calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -546,7 +546,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.0
+        - image: quay.io/calico/typha:v3.13.4
           name: calico-typha
           ports:
             - containerPort: 5473

--- a/config/v1.6/calico.yaml
+++ b/config/v1.6/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.0
+          image: quay.io/calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -546,7 +546,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.0
+        - image: quay.io/calico/typha:v3.13.4
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
*Issue #, if available:*
More information on the https://www.projectcalico.org/security-bulletins/
https://github.com/kubernetes/kubernetes/issues/91507

*Description of changes:*
bump both calico/node and calico/typha to v3.13.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
