### PR TITLE
This commit will make the aws-cni-support.sh executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,8 @@ debug-script:
 	@echo "$(VISIT_URL)"
 	@echo
 	curl -L $(FETCH_URL) -o ./aws-cni-support.sh
-
+	chmod +x ./aws-cni-support.sh
+	
 # Run all source code checks.
 check: check-format lint vet
 


### PR DESCRIPTION
*Issue #1006 , if available: Make aws-cni-support.sh executable (#1006) 

*Description of changes: Added chmod following get of the script in Makefile.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
