### PR TITLE
Calico nodes require Configmap access in kube-system

### DIFF
--- a/config/v1.6/calico.yaml
+++ b/config/v1.6/calico.yaml
@@ -371,12 +371,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
-  # The CNI plugin needs to get pods, nodes, and namespaces.
+  # The CNI plugin needs to get pods, nodes, configmaps, and namespaces.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]


### PR DESCRIPTION
*Issue #, if available:*
aws-samples/eks-workshop#809

*Description of changes:*

The pods of `calico-node` went to `CrashLoopBackOff` status because the pods require ConfigMap access in `kube-system`.

```
failed to query kubeadm's config map error=configmaps "kubeadm-config" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```

I've confirmed that adding ConfigMap access to calico-node pods resolved the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
