### PR TITLE
Ignore some additional folders in Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ references:
               -f "coverage.txt" \
               -t "${CODECOV_TOKEN}" \
               -n "${CIRCLE_BUILD_NUM}" \
-              -y ".codecov.yml" \
               -F "" \
               -Z || echo 'Codecov upload failed'
           when: always

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -33,5 +33,9 @@ coverage:
 comment: false
 
 ignore:
+  - "docs/**/*"
+  - "config/**/*"
+  - "rpc/**/*"
+  - "scripts/**/*"
   - "test/**/*"
   - "testdata/**/*"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Moved `.codecov.yml` to `.github/`
* Ignore docs and config folders
* Remove deprecated argument:

> DeprecationWarning: The -y flag is no longer supported by Codecov.
>  codecov.yml must be located underneath the root, dev/, or .github/ directories


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
