### PR TITLE
Cache go packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
           profile-name: awstester
       - restore_cache:
           keys:
+            - dependency-packages-store-{{ checksum "test/integration/go.mod" }}
             - dependency-packages-store
       - k8s/install-kubectl:
           # requires 1.14.9 for k8s testing, since it uses log api.
@@ -74,7 +75,7 @@ jobs:
           command: ./scripts/run-integration-tests.sh
           no_output_timeout: 15m
       - save_cache:
-          key: dependency-packages-store
+          key: dependency-packages-store-{{ checksum "test/integration/go.mod" }}
           paths:
             - /go/pkg
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - restore_cache:
           keys:
             - dependency-packages-store-{{ checksum "test/integration/go.mod" }}
-            - dependency-packages-store
+            - dependency-packages-store-
       - k8s/install-kubectl:
           # requires 1.14.9 for k8s testing, since it uses log api.
           kubectl-version: v1.14.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ jobs:
       - setup_remote_docker
       - aws-cli/setup:
           profile-name: awstester
+      - restore_cache:
+          keys:
+            - dependency-packages-store
       - k8s/install-kubectl:
           # requires 1.14.9 for k8s testing, since it uses log api.
           kubectl-version: v1.14.9
@@ -70,6 +73,11 @@ jobs:
           name: Run the integration tests
           command: ./scripts/run-integration-tests.sh
           no_output_timeout: 15m
+      - save_cache:
+          key: dependency-packages-store
+          paths:
+            - /go/pkg
+          when: always
       - store_artifacts:
           path: /tmp/cni-test
 


### PR DESCRIPTION
Cache go packages via CircleCI caching that are previously downloaded on every run.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
