### PR TITLE
added warning if delete on termination is set to false for the primar…

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1019,6 +1019,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() ([]ENIMetadata, map[str
 		if len(tags) > 0 {
 			tagMap[eniMetadata.ENIID] = tags
 		}
+		if aws.Int64Value(ec2res.Attachment.DeviceIndex) == 0 && !aws.BoolValue(ec2res.Attachment.DeleteOnTermination) {
+			log.Warn("Primary ENI will not get deleted when node terminates because 'delete_on_termination' is set to false")
+		}
 	}
 	return verifiedENIs, tagMap, nil
 }


### PR DESCRIPTION
…y eni

*Issue #, if available:* #1023 

*Description of changes:*

Added a warning message if primary eni has delete on termination set to false.

****
For UT, I set the delete on termination to false and below ipamd log shows the warning - 

{"level":"debug","ts":"2020-06-12T19:50:46.104Z","caller":"awsutils/awsutils.go:442","msg":"Found ENI: eni-07f2cc3f10e738161, MAC 0a:fb:8c:29:a9:58, device 2"}
{"level":"debug","ts":"2020-06-12T19:50:46.104Z","caller":"awsutils/awsutils.go:462","msg":"Found CIDR 192.168.64.0/19 for ENI 0a:fb:8c:29:a9:58"}
{"level":"debug","ts":"2020-06-12T19:50:46.105Z","caller":"awsutils/awsutils.go:462","msg":"Found IP addresses [192.168.71.210 192.168.82.25 192.168.86.90 192.168.94.77 192.168.91.157 192.168.75.142 192.168.64.191 192.168.71.80 192.168.95.18 192.168.72.36] on ENI 0a:fb:8c:29:a9:58"}
**{"level":"warn","ts":"2020-06-12T19:50:46.202Z","caller":"ipamd/ipamd.go:328","msg":"Primary ENI will not get deleted when node terminates because 'delete_on_termination' is set to false"}**

******

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
