### PR TITLE
scripts/lib/aws: tester v1.3.6, enable color outputs

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.3.1}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.3.6}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -14,6 +14,7 @@ function down-test-cluster() {
 function up-test-cluster() {
     echo -n "Configuring cluster $CLUSTER_NAME"
     AWS_K8S_TESTER_EKS_NAME=$CLUSTER_NAME \
+        AWS_K8S_TESTER_EKS_LOG_COLOR=true \
         AWS_K8S_TESTER_EKS_KUBECONFIG_PATH=$KUBECONFIG_PATH \
         AWS_K8S_TESTER_EKS_KUBECTL_PATH=$KUBECTL_PATH \
         AWS_K8S_TESTER_EKS_S3_BUCKET_NAME=$S3_BUCKET_NAME \


### PR DESCRIPTION
Includes various bug fixes + color output if $TERM is supported.
Fallback to plain text output automatic.

ref.
https://github.com/aws/aws-k8s-tester/blob/master/CHANGELOG/CHANGELOG-1.3.md#v136-2020-06-12
