### PR TITLE
Update probe settings

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -118,7 +118,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 60
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -128,7 +128,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 1
         "resources":
           "requests":
             "cpu": "10m"
@@ -161,6 +161,7 @@
           "name": "cni-bin-dir"
       "priorityClassName": "system-node-critical"
       "serviceAccountName": "aws-node"
+      "terminationGracePeriodSeconds": 10
       "tolerations":
       - "operator": "Exists"
       "volumes":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -118,7 +118,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 60
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -128,7 +128,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 1
         "resources":
           "requests":
             "cpu": "10m"
@@ -161,6 +161,7 @@
           "name": "cni-bin-dir"
       "priorityClassName": "system-node-critical"
       "serviceAccountName": "aws-node"
+      "terminationGracePeriodSeconds": 10
       "tolerations":
       - "operator": "Exists"
       "volumes":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -118,7 +118,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 60
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -128,7 +128,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 1
         "resources":
           "requests":
             "cpu": "10m"
@@ -161,6 +161,7 @@
           "name": "cni-bin-dir"
       "priorityClassName": "system-node-critical"
       "serviceAccountName": "aws-node"
+      "terminationGracePeriodSeconds": 10
       "tolerations":
       - "operator": "Exists"
       "volumes":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -118,7 +118,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 60
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -128,7 +128,7 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
-          "initialDelaySeconds": 35
+          "initialDelaySeconds": 1
         "resources":
           "requests":
             "cpu": "10m"
@@ -161,6 +161,7 @@
           "name": "cni-bin-dir"
       "priorityClassName": "system-node-critical"
       "serviceAccountName": "aws-node"
+      "terminationGracePeriodSeconds": 10
       "tolerations":
       - "operator": "Exists"
       "volumes":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -100,6 +100,7 @@ local awsnode = {
         },
         spec: {
           priorityClassName: "system-node-critical",
+          terminationGracePeriodSeconds: 10,
           affinity: {
             nodeAffinity: {
               requiredDuringSchedulingIgnoredDuringExecution: {
@@ -143,9 +144,11 @@ local awsnode = {
                 exec: {
                   command: ["/app/grpc-health-probe", "-addr=:50051"],
                 },
-                initialDelaySeconds: 35,
+                initialDelaySeconds: 1,
               },
-              livenessProbe: self.readinessProbe,
+              livenessProbe: self.readinessProbe + {
+                initialDelaySeconds: 60,
+              },
               env_:: {
                 AWS_VPC_ENI_MTU: "9001",
                 AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER: "false",


### PR DESCRIPTION
*Description of changes:*
* Reduce readiness probe startup delay to 1s
* Increase liveness probe startup delay to 60, since it will only fail if the CNI fails to start, or has crashed. 
* Reduce shutdown grace period to 10 seconds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
