### PR TITLE
scripts/lib/aws: bump up tester to v1.3.9

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.3.6}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.3.9}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
Includes improvements to log fetcher + MNG deletion when metrics server
is installed.

https://github.com/aws/aws-k8s-tester/blob/master/CHANGELOG/CHANGELOG-1.3.md#v139-2020-06-15