### PR TITLE
Fix discovery RBAC issues in Kubernetes 1.17

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -25,6 +25,13 @@
   - "get"
   - "list"
   - "watch"
+- "apiGroups":
+  - "discovery.k8s.io"
+  "resources":
+  - "*"
+  "verbs":
+  - "list"
+  - "watch"
 ---
 "apiVersion": "apiextensions.k8s.io/v1beta1"
 "kind": "CustomResourceDefinition"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -25,6 +25,13 @@
   - "get"
   - "list"
   - "watch"
+- "apiGroups":
+  - "discovery.k8s.io"
+  "resources":
+  - "*"
+  "verbs":
+  - "list"
+  - "watch"
 ---
 "apiVersion": "apiextensions.k8s.io/v1beta1"
 "kind": "CustomResourceDefinition"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -25,6 +25,13 @@
   - "get"
   - "list"
   - "watch"
+- "apiGroups":
+  - "discovery.k8s.io"
+  "resources":
+  - "*"
+  "verbs":
+  - "list"
+  - "watch"
 ---
 "apiVersion": "apiextensions.k8s.io/v1beta1"
 "kind": "CustomResourceDefinition"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -25,6 +25,13 @@
   - "get"
   - "list"
   - "watch"
+- "apiGroups":
+  - "discovery.k8s.io"
+  "resources":
+  - "*"
+  "verbs":
+  - "list"
+  - "watch"
 ---
 "apiVersion": "apiextensions.k8s.io/v1beta1"
 "kind": "CustomResourceDefinition"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -38,6 +38,11 @@ local awsnode = {
         resources: ["eniconfigs"],
         verbs: ["get", "list", "watch"],
       },
+      {
+        apiGroups: ["discovery.k8s.io"],
+        resources: ["*"],
+        verbs: ["list", "watch"],
+      }
     ],
   },
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1036 

*Description of changes:*

Fixes RBAC issues that arise with Kubernetes 1.17 clusters, and the addition of the `discovery.k8s.io` API Service group.

Not sure what command I need to run to get all of the manifests in the `config/` directory to update correctly - maintainers, please advise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
