### PR TITLE
Add missing run-dir and log-dir mounts for init container

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -179,6 +179,10 @@
         "volumeMounts":
         - "mountPath": "/host/opt/cni/bin"
           "name": "cni-bin-dir"
+        - "mountPath": "/var/run/aws-node"
+          "name": "run-dir"
+        - "mountPath": "/var/log/aws-routed-eni"
+          "name": "log-dir"
       "priorityClassName": "system-node-critical"
       "serviceAccountName": "aws-node"
       "terminationGracePeriodSeconds": 10


### PR DESCRIPTION
Hi, I wonder if I'm somewhat alone with running into this only because I deploy Kubernetes on EC2 nodes manually. My VM should have the proper IAM privileges. I followed these instructions: https://docs.aws.amazon.com/eks/latest/userguide/worker_node_IAM_role.html

It searches for `ipam.json` in `/var/run/aws-node` in the Init container for aws-node. I noticed this container does not mount both that directory and also no log directory.

I'm having some issues still, it's still not creating the file. Also if I try to create an empty file, it does find it, but doesn't accept it. Does it make sense that I had to make these changes?

This is the last bit of the log messages the init container tries to write:

```
...
28    1593174903.782256 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.782Z\",\"caller\":\"awsutils/awsutils.go:948\",\"msg\":\"Total number of interfaces found: 1 \"}\n", 131) = 131
28    1593174903.782367 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.782Z\",\"caller\":\"awsutils/awsutils.go:443\",\"msg\":\"Found ENI MAC address: 0a:8e:d0:81:33:a6\"}\n", 135) = 135
28    1593174903.800527 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.800Z\",\"caller\":\"awsutils/awsutils.go:457\",\"msg\":\"Using device number 0 for primary eni: eni-00b7096277a484055\"}\n", 155) = 155
28    1593174903.800649 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.800Z\",\"caller\":\"awsutils/awsutils.go:443\",\"msg\":\"Found ENI: eni-00b7096277a484055, MAC 0a:8e:d0:81:33:a6, device 0\"}\n", 160) = 160
28    1593174903.828628 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.828Z\",\"caller\":\"awsutils/awsutils.go:463\",\"msg\":\"Found CIDR 10.0.0.0/17 for ENI 0a:8e:d0:81:33:a6\"}\n", 143) = 143
28    1593174903.832689 write(8, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:03.832Z\",\"caller\":\"awsutils/awsutils.go:463\",\"msg\":\"Found IP addresses [10.0.15.174] on ENI 0a:8e:d0:81:33:a6\"}\n", 152) = 152
28    1593174904.044962 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.044Z\",\"caller\":\"ipamd/ipamd.go:317\",\"msg\":\"DescribeAllENIs success: ENIs: 1, tagged: 0\"}\n", 132 <unfinished ...>
28    1593174904.045192 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.045Z\",\"caller\":\"ipamd/ipamd.go:317\",\"msg\":\"Discovered ENI eni-00b7096277a484055, trying to set it up\"}\n", 146) = 146
28    1593174904.045409 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.045Z\",\"caller\":\"ipamd/ipamd.go:697\",\"msg\":\"DataStore Add an ENI eni-00b7096277a484055\"}\n", 131) = 131
28    1593174904.045791 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.045Z\",\"caller\":\"ipamd/ipamd.go:711\",\"msg\":\"IP Address Pool stats: total: 0, assigned: 0\"}\n", 133) = 133
28    1593174904.046007 write(7, "{\"level\":\"info\",\"ts\":\"2020-06-26T12:35:04.045Z\",\"caller\":\"ipamd/ipamd.go:317\",\"msg\":\"ENI eni-00b7096277a484055 set up.\"}\n", 121) = 121
28    1593174904.046242 write(7, "{\"level\":\"info\",\"ts\":\"2020-06-26T12:35:04.046Z\",\"caller\":\"ipamd/ipamd.go:396\",\"msg\":\"Reading ipam state from backing store\"}\n", 125 <unfinished ...>
28    1593174904.046295 openat(AT_FDCWD, "/var/run/aws-node/ipam.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
28    1593174904.046534 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.046Z\",\"caller\":\"ipamd/ipamd.go:396\",\"msg\":\"backing store restore returned err open /var/run/aws-node/ipam.json: no such file or directory\"}\n", 183 <unfinished ...>
28    1593174904.046732 write(7, "{\"level\":\"info\",\"ts\":\"2020-06-26T12:35:04.046Z\",\"caller\":\"ipamd/ipamd.go:396\",\"msg\":\"Backing store not found. Querying CRI.\"}\n", 126 <unfinished ...>
28    1593174904.047166 write(7, "{\"level\":\"debug\",\"ts\":\"2020-06-26T12:35:04.047Z\",\"caller\":\"datastore/data_store.go:277\",\"msg\":\"Getting running pod sandboxes from \\\"unix:///var/run/dockershim.sock\\\"\"}\n", 168) = 168
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
