### PR TITLE
Some refresh cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ verify-network
 portmap
 grpc-health-probe
 cni-metrics-helper
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ unit-test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic $(ALLPKGS)
 
 # Run unit tests with race detection (can only be run natively)
+unit-test-race: export AWS_VPC_K8S_CNI_LOG_FILE=stdout
 unit-test-race: CGO_ENABLED=1
 unit-test-race: GOARCH=
 unit-test-race:

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -120,7 +120,7 @@ func (m *testMocks) mockWithFailureAt(t *testing.T, failAt string) *createVethPa
 
 	//container side
 	if failAt == "link-byname" {
-		 m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, errors.New("error on LinkByName container")).After(call)
+		m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, errors.New("error on LinkByName container")).After(call)
 		return mockContext
 	}
 	call = m.netlink.EXPECT().LinkByName(gomock.Any()).Return(mockContVeth, nil).After(call)

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -68,7 +68,7 @@ func setup(t *testing.T) (*gomock.Controller,
 }
 
 func TestInitWithEC2metadata(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -96,14 +96,14 @@ func TestInitWithEC2metadata(t *testing.T) {
 	assert.Equal(t, localIP, ins.localIPv4)
 	assert.Equal(t, ins.instanceID, instanceID)
 	assert.Equal(t, ins.primaryENImac, primaryMAC)
-	assert.Equal(t, len(ins.securityGroups.data), 2)
+	assert.Equal(t, len(ins.securityGroups.SortedList()), 2)
 	assert.Equal(t, subnetID, ins.subnetID)
 	assert.Equal(t, vpcCIDR, ins.vpcIPv4CIDR)
-	assert.Equal(t, len(ins.vpcIPv4CIDRs.data), 2)
+	assert.Equal(t, len(ins.vpcIPv4CIDRs.SortedList()), 2)
 }
 
 func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -126,7 +126,7 @@ func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataSubnetErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -148,7 +148,7 @@ func TestInitWithEC2metadataSubnetErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataSGErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -172,7 +172,7 @@ func TestInitWithEC2metadataSGErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataENIErrs(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -190,7 +190,7 @@ func TestInitWithEC2metadataENIErrs(t *testing.T) {
 }
 
 func TestInitWithEC2metadataMACErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -207,7 +207,7 @@ func TestInitWithEC2metadataMACErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataLocalIPErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -221,7 +221,7 @@ func TestInitWithEC2metadataLocalIPErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataInstanceErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -236,7 +236,7 @@ func TestInitWithEC2metadataInstanceErr(t *testing.T) {
 }
 
 func TestInitWithEC2metadataAZErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, _ := setup(t)
 	defer ctrl.Finish()
@@ -434,7 +434,7 @@ func TestDescribeAllENIs(t *testing.T) {
 }
 
 func TestTagEni(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	ctrl, mockMetadata, mockEC2 := setup(t)
 	defer ctrl.Finish()

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -253,10 +253,10 @@ func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDR() *gomock.Call {
 }
 
 // GetVPCIPv4CIDRs mocks base method
-func (m *MockAPIs) GetVPCIPv4CIDRs() []*string {
+func (m *MockAPIs) GetVPCIPv4CIDRs() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPCIPv4CIDRs")
-	ret0, _ := ret[0].([]*string)
+	ret0, _ := ret[0].([]string)
 	return ret0
 }
 

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -95,7 +95,7 @@ func TestNodeInit(t *testing.T) {
 
 	eni1, eni2 := getDummyENIMetadata()
 
-	var cidrs []*string
+	var cidrs []string
 	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
 	m.awsutils.EXPECT().GetENIipLimit().Return(14, nil)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Addresses, nil)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -53,10 +53,9 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 	addr, deviceNumber, err := s.ipamContext.dataStore.AssignPodIPv4Address(ipamKey)
 
-	var pbVPCcidrs []string
-	for _, cidr := range s.ipamContext.awsClient.GetVPCIPv4CIDRs() {
-		log.Debugf("VPC CIDR %s", *cidr)
-		pbVPCcidrs = append(pbVPCcidrs, *cidr)
+	pbVPCcidrs := s.ipamContext.awsClient.GetVPCIPv4CIDRs()
+	for _, cidr := range pbVPCcidrs {
+		log.Debugf("VPC CIDR %s", cidr)
 	}
 
 	useExternalSNAT := s.ipamContext.networkClient.UseExternalSNAT()

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
-	"github.com/aws/aws-sdk-go/aws"
 
 	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
 
@@ -48,11 +47,11 @@ func TestServer_AddNetwork(t *testing.T) {
 		IfName:      "eni",
 	}
 
-	vpcCIDRs := []*string{aws.String(vpcCIDR)}
+	vpcCIDRs := []string{vpcCIDR}
 	testCases := []struct {
 		name               string
 		useExternalSNAT    bool
-		vpcCIDRs           []*string
+		vpcCIDRs           []string
 		snatExclusionCIDRs []string
 	}{
 		{
@@ -80,11 +79,7 @@ func TestServer_AddNetwork(t *testing.T) {
 
 		assert.Equal(t, tc.useExternalSNAT, addNetworkReply.UseExternalSNAT, tc.name)
 
-		var expectedCIDRs []string
-		for _, cidr := range tc.vpcCIDRs {
-			expectedCIDRs = append(expectedCIDRs, *cidr)
-		}
-		expectedCIDRs = append([]string{vpcCIDR}, tc.snatExclusionCIDRs...)
+		expectedCIDRs := append([]string{vpcCIDR}, tc.snatExclusionCIDRs...)
 		assert.Equal(t, expectedCIDRs, addNetworkReply.VPCcidrs, tc.name)
 	}
 }

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -122,7 +122,7 @@ func (mr *MockNetworkAPIsMockRecorder) SetupENINetwork(arg0, arg1, arg2, arg3 in
 }
 
 // SetupHostNetwork mocks base method
-func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 []*string, arg2 string, arg3 *net.IP) error {
+func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 []string, arg2 string, arg3 *net.IP) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -113,7 +113,7 @@ var log = logger.Get()
 // NetworkAPIs defines the host level and the ENI level network related operations
 type NetworkAPIs interface {
 	// SetupNodeNetwork performs node level network configuration
-	SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, primaryMAC string, primaryAddr *net.IP) error
+	SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []string, primaryMAC string, primaryAddr *net.IP) error
 	// SetupENINetwork performs eni level network configuration
 	SetupENINetwork(eniIP string, mac string, table int, subnetCIDR string) error
 	UseExternalSNAT() bool
@@ -205,7 +205,7 @@ func findPrimaryInterfaceName(primaryMAC string) (string, error) {
 }
 
 // SetupHostNetwork performs node level network configuration
-func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, primaryMAC string, primaryAddr *net.IP) error {
+func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []string, primaryMAC string, primaryAddr *net.IP) error {
 	log.Info("Setting up host network... ")
 
 	hostRule := n.netLink.NewRule()
@@ -294,7 +294,7 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDR *net.IPNet, vpcCIDRs []*string, 
 	}
 	var allCIDRs []snatCIDR
 	for _, cidr := range vpcCIDRs {
-		allCIDRs = append(allCIDRs, snatCIDR{cidr: *cidr, isExclusion: false})
+		allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: false})
 	}
 	for _, cidr := range n.excludeSNATCIDRs {
 		allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: true})

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -165,7 +163,7 @@ func TestSetupHostNetworkNodePortDisabled(t *testing.T) {
 	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)
 
-	var vpcCIDRs []*string
+	var vpcCIDRs []string
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
@@ -290,7 +288,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	var vpcCIDRs []*string
+	var vpcCIDRs []string
 
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
@@ -360,8 +358,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	var vpcCIDRs []*string
-	vpcCIDRs = []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -405,7 +402,6 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	vpcCIDRs := []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3")
@@ -414,6 +410,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
 
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
@@ -466,7 +463,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
 
 	// remove exclusions
-	vpcCIDRs := []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
@@ -510,8 +507,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	var vpcCIDRs []*string
-	vpcCIDRs = []*string{aws.String("10.10.0.0/16"), aws.String("10.11.0.0/16")}
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
@@ -562,7 +558,7 @@ func TestSetupHostNetworkIgnoringRpFilterUpdate(t *testing.T) {
 	}
 	setupNetLinkMocks(ctrl, mockNetLink)
 
-	var vpcCIDRs []*string
+	var vpcCIDRs []string
 	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
*Issue #, if available:*

Related to #903 and #1056 

*Description of changes:*

* Made sure the unit race tests pass
* Fix logging error for `make unit-test-race`
* Removed two unused constants
* Use `[]string` instead of `[]*string` for getting the strings from the set
* Ran `make format`, so please review diff with "Ignore white space"

Ping  @nithu0115 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
