### PR TITLE
bugfix: make metrics-helper docker logging statement multi-arch compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ docker-metrics:
 		-f scripts/dockerfiles/Dockerfile.metrics \
 		-t "$(METRICS_IMAGE_NAME)" \
 		.
-	@echo "Built Docker image \"amazon/cni-metrics-helper:$(VERSION)\""
+	@echo "Built Docker image \"$(METRICS_IMAGE_NAME)\""
 
 # Run metrics helper unit test suite (must be run natively).
 metrics-unit-test: CGO_ENABLED=1


### PR DESCRIPTION
bugfix: make metrics-helper docker logging statement multi-arch compatible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
