### PR TITLE
create a temporary config file to be manipulated by sed in dockerfile

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -95,7 +95,7 @@ install aws-cni "$HOST_CNI_BIN_PATH"
 
 # create a temporary file to be manipulated by sed (ergh).
 # this enables you to mount your own config file from a configmap that is read only
-temp_config_file=$(mktmp)
+temp_config_file=$(mktemp)
 cp 10-aws.conflist "$temp_config_file"
 sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g "$temp_config_file"
 sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g "$temp_config_file"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -93,17 +93,13 @@ log_in_json info "Copying CNI plugin binary and config file ... "
 
 install aws-cni "$HOST_CNI_BIN_PATH"
 
-# create a temporary file to be manipulated by sed (ergh).
-# this enables you to mount your own config file from a configmap that is read only
-temp_config_file=$(mktemp)
-cp 10-aws.conflist "$temp_config_file"
-sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g "$temp_config_file"
-sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g "$temp_config_file"
-sed -i s~__PLUGINLOGFILE__~"${AWS_VPC_K8S_PLUGIN_LOG_FILE}"~g "$temp_config_file"
-sed -i s~__PLUGINLOGLEVEL__~"${AWS_VPC_K8S_PLUGIN_LOG_LEVEL}"~g "$temp_config_file"
-cp "$temp_config_file" "$HOST_CNI_CONFDIR_PATH"
-# clean up temp file
-rm "$temp_config_file"
+# modify the static config to populate it with the env vars
+sed \
+  -e s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g \
+  -e s~__MTU__~"${AWS_VPC_ENI_MTU}"~g \
+  -e s~__PLUGINLOGFILE__~"${AWS_VPC_K8S_PLUGIN_LOG_FILE}"~g \
+  -e s~__PLUGINLOGLEVEL__~"${AWS_VPC_K8S_PLUGIN_LOG_LEVEL}"~g \
+  10-aws.conflist > "$HOST_CNI_CONFDIR_PATH/10-aws.conflist"
 
 log_in_json info "Successfully copied CNI plugin binary and config file."
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -93,11 +93,15 @@ log_in_json info "Copying CNI plugin binary and config file ... "
 
 install aws-cni "$HOST_CNI_BIN_PATH"
 
-sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g 10-aws.conflist
-sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g 10-aws.conflist
-sed -i s~__PLUGINLOGFILE__~"${AWS_VPC_K8S_PLUGIN_LOG_FILE}"~g 10-aws.conflist
-sed -i s~__PLUGINLOGLEVEL__~"${AWS_VPC_K8S_PLUGIN_LOG_LEVEL}"~g 10-aws.conflist
-cp 10-aws.conflist "$HOST_CNI_CONFDIR_PATH"
+# create a temporary file to be manipulated by sed (ergh).
+# this enables you to mount your own config file from a configmap that is read only
+temp_config_file=$(mktmp)
+cp 10-aws.conflist "$temp_config_file"
+sed -i s~__VETHPREFIX__~"${AWS_VPC_K8S_CNI_VETHPREFIX}"~g "$temp_config_file"
+sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g "$temp_config_file"
+sed -i s~__PLUGINLOGFILE__~"${AWS_VPC_K8S_PLUGIN_LOG_FILE}"~g "$temp_config_file"
+sed -i s~__PLUGINLOGLEVEL__~"${AWS_VPC_K8S_PLUGIN_LOG_LEVEL}"~g "$temp_config_file"
+cp "$temp_config_file" "$HOST_CNI_CONFDIR_PATH"
 
 log_in_json info "Successfully copied CNI plugin binary and config file."
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -102,6 +102,8 @@ sed -i s~__MTU__~"${AWS_VPC_ENI_MTU}"~g "$temp_config_file"
 sed -i s~__PLUGINLOGFILE__~"${AWS_VPC_K8S_PLUGIN_LOG_FILE}"~g "$temp_config_file"
 sed -i s~__PLUGINLOGLEVEL__~"${AWS_VPC_K8S_PLUGIN_LOG_LEVEL}"~g "$temp_config_file"
 cp "$temp_config_file" "$HOST_CNI_CONFDIR_PATH"
+# clean up temp file
+rm "$temp_config_file"
 
 log_in_json info "Successfully copied CNI plugin binary and config file."
 


### PR DESCRIPTION
Currently, you can't easily provide your own config file for the cni. Mounting a file from a configmap is readonly, and the magical find replace that sed does is inline against the existing file fails. Instead, I am proposing that we copy the file to a tempfile and modify that before we copy it to its destination.

I thought about perhaps having an environment variable for a custom template file, flag, or similar, but I think that actually that could cause more complexity in the entrypoint script, and I didn't want to change the behavior that much.

Sorry for the 'ergh' next to the sed comment, I wanted to show that I wasn't a fan of how this works, the sedding of config files 🤣. I appreciate why this is done here though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
