### PR TITLE
Fix device number and update table name the device index

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -822,7 +822,7 @@ func TestEC2InstanceMetadataCache_waitForENIAndIPsAttached(t *testing.T) {
 	eni2Metadata := ENIMetadata{
 		ENIID:          eni2ID,
 		MAC:            eni2MAC,
-		DeviceNumber:   2,
+		DeviceNumber:   1,
 		SubnetIPv4CIDR: subnetCIDR,
 		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
 			{

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -483,7 +483,7 @@ func (ds *DataStore) DelIPv4AddressFromStore(eniID string, ipv4 string, force bo
 
 // AssignPodIPv4Address assigns an IPv4 address to pod
 // It returns the assigned IPv4 address, device number, error
-func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (string, int, error) {
+func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (ipv4address string, deviceNumber int, err error) {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -501,7 +501,7 @@ func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (string, int, error) 
 					ds.log.Warnf("Failed to update backing store: %v", err)
 					// Important! Unwind assignment
 					ds.unassignPodIPv4AddressUnsafe(eni, addr)
-					return "", 0, err
+					return "", -1, err
 				}
 
 				return addr.Address, eni.DeviceNumber, nil
@@ -510,7 +510,7 @@ func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (string, int, error) 
 		ds.log.Debugf("AssignPodIPv4Address: ENI %s does not have available addresses", eni.ID)
 	}
 	ds.log.Errorf("DataStore has no available IP addresses")
-	return "", 0, errors.New("assignPodIPv4AddressUnsafe: no available IP addresses")
+	return "", -1, errors.New("assignPodIPv4AddressUnsafe: no available IP addresses")
 }
 
 // It returns the assigned IPv4 address, device number

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -132,12 +132,12 @@ func TestSetupENINetworkMACFail(t *testing.T) {
 	assert.Errorf(t, err, "simulated failure")
 }
 
-func TestSetupENINetworkPrimary(t *testing.T) {
+func TestSetupENINetowrkErrorOnPrimaryENI(t *testing.T) {
 	ctrl, mockNetLink, _, _, _, _ := setup(t)
 	defer ctrl.Finish()
-
-	err := setupENINetwork(testeniIP, testMAC2, 0, testeniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
-	assert.NoError(t, err)
+	deviceNumber := 0
+	err := setupENINetwork(testeniIP, testMAC2, deviceNumber, testeniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
+	assert.Error(t, err)
 }
 
 func TestSetupHostNetworkNodePortDisabled(t *testing.T) {

--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -67,7 +67,7 @@ func main() {
 	for {
 		output, err := svc.DescribeInstanceTypes(describeInstanceTypesInput)
 		if err != nil {
-			log.Fatalf("Failed to call EC2 DescibeInstanceTypes: %v", err)
+			log.Fatalf("Failed to call EC2 DescribeInstanceTypes: %v", err)
 		}
 		// We just want the type name, ENI and IP limits
 		for _, info := range output.InstanceTypes {


### PR DESCRIPTION
*Description of changes:*
When we attach new ENIs, we store the `deviceNumber`. We used to add +1 to all except the primary (device number 0). This was done because of how we named the route tables. This PR does the following:
* Store the actual device number value in `deviceNumber` in the `ENI` struct (visible through introspect endpoint)
* Have a `tableNumber` that matches the existing number used by previous versions
* Set a hard upper limit of 100 for the device number to avoid clashes with vlan table names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
