### PR TITLE
scripts/lib/aws.sh: bump up tester version to v1.4.4

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.4.0}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.4.4}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
Includes various fixes + Fluentd add-on

https://github.com/aws/aws-k8s-tester/blob/master/CHANGELOG/CHANGELOG-1.4.md
