### PR TITLE
fix permissions for eniconfig CRD

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -26,7 +26,17 @@
   - "list"
   - "watch"
 - "apiGroups":
-  - "discovery.k8s.io"
+  - ""
+  "resources":
+  - "pods"
+  - "nodes"
+  - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - "extensions"
   "resources":
   - "*"
   "verbs":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -26,7 +26,17 @@
   - "list"
   - "watch"
 - "apiGroups":
-  - "discovery.k8s.io"
+  - ""
+  "resources":
+  - "pods"
+  - "nodes"
+  - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - "extensions"
   "resources":
   - "*"
   "verbs":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -26,7 +26,17 @@
   - "list"
   - "watch"
 - "apiGroups":
-  - "discovery.k8s.io"
+  - ""
+  "resources":
+  - "pods"
+  - "nodes"
+  - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - "extensions"
   "resources":
   - "*"
   "verbs":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -26,7 +26,17 @@
   - "list"
   - "watch"
 - "apiGroups":
-  - "discovery.k8s.io"
+  - ""
+  "resources":
+  - "pods"
+  - "nodes"
+  - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - "extensions"
   "resources":
   - "*"
   "verbs":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -39,7 +39,12 @@ local awsnode = {
         verbs: ["get", "list", "watch"],
       },
       {
-        apiGroups: ["discovery.k8s.io"],
+        apiGroups: [""],
+        resources: ["pods", "nodes", "namespaces"],
+        verbs: ["list", "watch", "get"],
+      },
+      {
+        apiGroups: ["extensions"],
         resources: ["*"],
         verbs: ["list", "watch"],
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
RBAC permissions where modified in #972 and because of that ipamd wasn't able to read the eniconfig.

```
{"level":"debug","ts":"2020-07-09T03:33:45.049Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: group1-pod-netconfig, [sg-06890cfdb4f320d41 sg-0df0bdc36b193bf2e], subnet-06b7d51ed625c2904"}
{"level":"debug","ts":"2020-07-09T03:33:45.050Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: group2-pod-netconfig, [sg-06890cfdb4f320d41 sg-0df0bdc36b193bf2e], subnet-0fb799a0537fc487f"}
{"level":"debug","ts":"2020-07-09T03:33:45.050Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: group3-pod-netconfig, [sg-06890cfdb4f320d41 sg-0df0bdc36b193bf2e], subnet-01368c6fe629a0b3f"}
......
{"level":"debug","ts":"2020-07-09T03:33:47.706Z","caller":"ipamd/ipamd.go:681","msg":"Skip the primary ENI for need IP check"}
{"level":"error","ts":"2020-07-09T03:33:47.706Z","caller":"ipamd/ipamd.go:600","msg":"Failed to get pod ENI config"}
```

After updating the permissions -

```
{"level":"debug","ts":"2020-07-10T18:36:32.810Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: us-west-2c, [], subnet-04ae54ecbe9033dcc"}
{"level":"debug","ts":"2020-07-10T18:36:32.810Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: us-west-2d, [], subnet-0a30623c6fe641f62"}
{"level":"debug","ts":"2020-07-10T18:36:32.810Z","caller":"sdk/informer-sync.go:88","msg":"Handle ENIConfig Add/Update: us-west-2b, [], subnet-03049978f259b4632"}
{"level":"debug","ts":"2020-07-10T18:36:36.045Z","caller":"sdk/informer-sync.go:88","msg":"Handle corev1.Node: ip-192-168-8-26.us-west-2.compute.internal, map[node.alpha.kubernetes.io/ttl:0 volumes.kubernetes.io/controller-managed-attach-detach:true], map[alpha.eksctl.io/cluster-name:cni-varavaj alpha.eksctl.io/nodegroup-name:cni-varavaj-nodegroup beta.kubernetes.io/arch:amd64 beta.kubernetes.io/instance-type:m5.large beta.kubernetes.io/os:linux eks.amazonaws.com/nodegroup:cni-varavaj-nodegroup eks.amazonaws.com/nodegroup-image:ami-006a66549e71b3ff4 failure-domain.beta.kubernetes.io/region:us-west-2 failure-domain.beta.kubernetes.io/zone:us-west-2c kubernetes.io/arch:amd64 kubernetes.io/hostname:ip-192-168-8-26.us-west-2.compute.internal kubernetes.io/os:linux]"}
{"level":"debug","ts":"2020-07-10T18:36:36.045Z","caller":"sdk/informer-sync.go:88","msg":"Handle corev1.Node: ip-192-168-45-57.us-west-2.compute.internal, map[node.alpha.kubernetes.io/ttl:0 volumes.kubernetes.io/controller-managed-attach-detach:true], map[alpha.eksctl.io/cluster-name:cni-varavaj alpha.eksctl.io/nodegroup-name:cni-varavaj-nodegroup beta.kubernetes.io/arch:amd64 beta.kubernetes.io/instance-type:m5.large beta.kubernetes.io/os:linux eks.amazonaws.com/nodegroup:cni-varavaj-nodegroup eks.amazonaws.com/nodegroup-image:ami-006a66549e71b3ff4 failure-domain.beta.kubernetes.io/region:us-west-2 failure-domain.beta.kubernetes.io/zone:us-west-2d kubernetes.io/arch:amd64 kubernetes.io/hostname:ip-192-168-45-57.us-west-2.compute.internal kubernetes.io/os:linux]"}
{"level":"debug","ts":"2020-07-10T18:36:36.045Z","caller":"sdk/informer-sync.go:88","msg":"Handle corev1.Node: ip-192-168-76-65.us-west-2.compute.internal, map[node.alpha.kubernetes.io/ttl:0 volumes.kubernetes.io/controller-managed-attach-detach:true], map[alpha.eksctl.io/cluster-name:cni-varavaj alpha.eksctl.io/nodegroup-name:cni-varavaj-nodegroup beta.kubernetes.io/arch:amd64 beta.kubernetes.io/instance-type:m5.large beta.kubernetes.io/os:linux eks.amazonaws.com/nodegroup:cni-varavaj-nodegroup eks.amazonaws.com/nodegroup-image:ami-006a66549e71b3ff4 failure-domain.beta.kubernetes.io/region:us-west-2 failure-domain.beta.kubernetes.io/zone:us-west-2b kubernetes.io/arch:amd64 kubernetes.io/hostname:ip-192-168-76-65.us-west-2.compute.internal kubernetes.io/os:linux]"}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
