### PR TITLE
Cover Warm IP and Warm ENI targets release tests.

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -28,3 +28,16 @@ function display_timelines() {
     echo "TIMELINE: Conformance tests took $CONFORMANCE_DURATION seconds."
     echo "TIMELINE: Down processes took $DOWN_DURATION seconds."
 }
+
+function run_warm_ip_test() {
+    $KUBECTL_PATH set env ds aws-node -n kube-system WARM_IP_TARGET=2
+    $KUBECTL_PATH set env ds aws-node -n kube-system MINIMUM_IP_TARGET=10
+    #Sleep a couple seconds to ensure propogation
+    sleep 2
+    KUBECTL_WARM_IP_TARGET=$(kubectl describe ds -n kube-system | grep WARM_IP_TARGET)
+    KUBECTL_MINIMUM_IP_TARGET=$(kubectl describe ds -n kube-system | grep MINIMUM_IP_TARGET)
+    if [[ $KUBECTL_WARM_IP_TARGET != *"2"* || $KUBECTL_MINIMUM_IP_TARGET != *"10"* ]]; then
+        echo "WARM_IP_TARGET not propogated!"
+        on_error
+    fi
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -41,3 +41,14 @@ function run_warm_ip_test() {
         on_error
     fi
 }
+
+function run_warm_eni_test() {
+    $KUBECTL_PATH set env ds aws-node -n kube-system WARM_ENI_TARGET=0
+    #Sleep a couple seconds to ensure propogation
+    sleep 2
+    KUBECTL_WARM_ENI_TARGET=$(kubectl describe ds -n kube-system | grep WARM_ENI_TARGET)
+    if [[ $KUBECTL_WARM_ENI_TARGET != *"0" ]]; then
+        echo "WARM_ENI_TARGET not propogated!"
+        on_error
+    fi
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -19,6 +19,7 @@ ARCH=$(go env GOARCH)
 : "${DEPROVISION:=true}"
 : "${BUILD:=true}"
 : "${RUN_CONFORMANCE:=false}"
+: "${RUN_WARM_IP_TEST:=false}"
 
 __cluster_created=0
 __cluster_deprovisioned=0
@@ -185,7 +186,9 @@ sleep 110
 CNI_IMAGE_UPDATE_DURATION=$((SECONDS - START))
 echo "TIMELINE: Updating CNI image took $CNI_IMAGE_UPDATE_DURATION seconds."
 
-$KUBECTL_PATH set env ds aws-node -n kube-system WARM_IP_TARGET=2
+if [[ RUN_WARM_IP_TEST == true ]]; then
+    run_warm_ip_test
+fi
 
 echo "*******************************************************************************"
 echo "Running integration tests on current image:"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -20,6 +20,7 @@ ARCH=$(go env GOARCH)
 : "${BUILD:=true}"
 : "${RUN_CONFORMANCE:=false}"
 : "${RUN_WARM_IP_TEST:=false}"
+: "${RUN_WARM_ENI_TEST:=false}"
 
 __cluster_created=0
 __cluster_deprovisioned=0
@@ -188,6 +189,9 @@ echo "TIMELINE: Updating CNI image took $CNI_IMAGE_UPDATE_DURATION seconds."
 
 if [[ RUN_WARM_IP_TEST == true ]]; then
     run_warm_ip_test
+fi
+if [[ RUN_WARM_ENI_TEST == true ]]; then
+    run_warm_eni_test
 fi
 
 echo "*******************************************************************************"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -185,6 +185,8 @@ sleep 110
 CNI_IMAGE_UPDATE_DURATION=$((SECONDS - START))
 echo "TIMELINE: Updating CNI image took $CNI_IMAGE_UPDATE_DURATION seconds."
 
+$KUBECTL_PATH set env ds aws-node -n kube-system WARM_IP_TARGET=2
+
 echo "*******************************************************************************"
 echo "Running integration tests on current image:"
 echo ""


### PR DESCRIPTION
Create automated tests for warm IP and warm ENI release tests by setting environment variables RUN_WARM_IP_TEST=true and RUN_WARM_ENI_TEST=true respectively.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
