### PR TITLE
Handle EKS created ENI sg update

### DIFF
--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -252,3 +252,31 @@ func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv4CIDRs", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv4CIDRs))
 }
+
+// IsUnmanagedENI mocks base method
+func (m *MockAPIs) IsUnmanagedENI(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUnmanagedENI", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsUnmanagedENI indicates an expected call of IsUnmanagedENI
+func (mr *MockAPIsMockRecorder) IsUnmanagedENI(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnmanagedENI", reflect.TypeOf((*MockAPIs)(nil).IsUnmanagedENI), arg0)
+}
+
+// SetUnmanagedENIs mocks base method
+func (m *MockAPIs) SetUnmanagedENIs(arg0 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUnmanagedENIs", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetUnmanagedENIs indicates an expected call of SetUnmanagedENIs
+func (mr *MockAPIsMockRecorder) SetUnmanagedENIs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetUnmanagedENIs), arg0)
+}


### PR DESCRIPTION
Issue #964

*Description of changes:*
Currently when security group is updated to a worker node only the primary ENI was getting updated but not the EKS created ENIs. With this fix - when the security group is refreshed, check is made if new security groups are added or if some are deleted. Based on that security group update is called for all the attached ENIs.

```
 [
        [
            "ip-192-168-37-145.us-west-2.compute.internal",
            "cni-cri-nodegroup",
            "us-west-2d",
            "192.168.37.145",
            "44.234.21.183",
            [
                [
                    "eni-0a283fed36c186635",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891"
                    ]
                ],
                [
                    "eni-0744e81da61b30f02",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891"
                    ]
                ],
                [
                    "eni-03dc607a4b6e01118",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891"
                    ]
                ]
            ]
        ]
```

On adding a new SG, all 3 ENIs are getting updated -

```
[
            "ip-192-168-37-145.us-west-2.compute.internal",
            "cni-cri-nodegroup",
            "us-west-2d",
            "192.168.37.145",
            "44.234.21.183",
            [
                [
                    "eni-0a283fed36c186635",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891",
                        "JayTesting"
                    ]
                ],
                [
                    "eni-0744e81da61b30f02",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891",
                        "JayTesting"
                    ]
                ],
                [
                    "eni-03dc607a4b6e01118",
                    [
                        "eks-remoteAccess-24b9aa7f-4032-a130-dd9c-fbf5d790c788",
                        "eks-cluster-sg-cni-cri-916166891",
                        "JayTesting"
                    ]
                ]
            ]
        ]
```

```
{"level":"info","ts":"2020-08-19T02:18:43.750Z","caller":"ipamd/ipamd.go:293","msg":"Custom networking false"}
kubectl set env daemonset aws-node -n kube-system AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=false
{"level":"info","ts":"2020-08-19T02:21:51.418Z","caller":"ipamd/ipamd.go:293","msg":"Custom networking true"}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
