### PR TITLE
[WIP] Use docker/CRI to discover pods at node init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ aws-k8s-agent
 aws-cni
 verify-aws
 verify-network
+coverage.txt
 *~
 *.swp
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,12 @@ docker-func-test: docker
 		"$(IMAGE_NAME)"
 
 # Run unit tests
+unit-test: export AWS_VPC_K8S_CNI_LOG_FILE=stdout
 unit-test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic $(ALLPKGS)
 
 # Run unit tests with race detection (can only be run natively)
+unit-test-race: export AWS_VPC_K8S_CNI_LOG_FILE=stdout
 unit-test-race: CGO_ENABLED=1
 unit-test-race: GOARCH=
 unit-test-race:

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -45,15 +45,12 @@ func _main() int {
 		return 1
 	}
 
-	discoverController := k8sapi.NewController(kubeClient)
-	go discoverController.DiscoverLocalK8SPods()
-
 	eniConfigController := eniconfig.NewENIConfigController()
 	if ipamd.UseCustomNetworkCfg() {
 		go eniConfigController.Start()
 	}
 
-	ipamContext, err := ipamd.New(discoverController, eniConfigController)
+	ipamContext, err := ipamd.New(kubeClient, eniConfigController)
 
 	if err != nil {
 		log.Errorf("Initialization failure: %v", err)

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -48,7 +48,7 @@ const (
 var logConfig = logger.Configuration{
 	BinaryName:  "aws-cni",
 	LogLevel:    "Debug",
-	LogLocation: "/var/log/test.log",
+	LogLocation: "stdout",
 }
 
 var log = logger.New(&logConfig)

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
+google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
 google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/k8sapi/mocks/k8sapi_mocks.go
+++ b/pkg/k8sapi/mocks/k8sapi_mocks.go
@@ -19,10 +19,9 @@
 package mock_k8sapi
 
 import (
-	reflect "reflect"
-
 	k8sapi "github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockK8SAPIs is a mock of K8SAPIs interface


### PR DESCRIPTION
*Issue* https://github.com/aws/amazon-vpc-cni-k8s/issues/711

*Description of changes:*
ipamd `nodeInit` relies on pod discovery watcher to get the list of running pods. The watcher and ipamd are launched in parallel. This can lead to a race condition where ipamd `getLocalPodsWithRetry` kicks in before the watcher is done with listing all the running pods on a node. If this happens, ipamd may end up allocating in-use IP addr to new pods

*Changes*
- Changed ipamd to query docker/CRI to discover the list of node local pods instead Kubernetes API
- Add support in the cri.go to get IP address of a pod and added `IP` field to `cri.SandboxInfo`
- Datastore inputs changed from `k8sapi.K8SPodInfo` to `cri.SandboxInfo`

*Alternative considered*
- Instead of using the watcher, make a blocking list pods call to the Kubernetes API server directly. This approach does not guarantee accurate state. On an overloaded system, API server might lag behind the node local state returning. While this approach would solve the original race condition, it can still return a different view of the running pods (eventually consistent)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
