### PR TITLE
Enable log config for the metrics agent

### DIFF
--- a/cmd/cni-metrics-helper/metrics/metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/metrics_test.go
@@ -17,14 +17,18 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/publisher"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 type testMetricsTarget struct {
 	metricFile         string
 	interestingMetrics map[string]metricsConvert
+}
+
+func (target *testMetricsTarget) getLogger() logger.Logger {
+	return logger.DefaultLogger()
 }
 
 func newTestMetricsTarget(metricFile string, interestingMetrics map[string]metricsConvert) *testMetricsTarget {

--- a/pkg/utils/logger/config.go
+++ b/pkg/utils/logger/config.go
@@ -35,7 +35,7 @@ type Configuration struct {
 func LoadLogConfig() *Configuration {
 	return &Configuration{
 		BinaryName:  binaryName,
-		LogLevel:    getLogLevel(),
+		LogLevel:    GetLogLevel(),
 		LogLocation: getLogFileLocation(),
 	}
 }
@@ -49,7 +49,7 @@ func getLogFileLocation() string {
 	return logFilePath
 }
 
-func getLogLevel() string {
+func GetLogLevel() string {
 	logLevel := os.Getenv(envLogLevel)
 	switch logLevel {
 	case "":

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -13,7 +13,7 @@
 
 package logger
 
-const pluginBinaryName = "aws-cni"
+const ipamdBinaryName = "aws-k8s-agent"
 
 //Log is global variable so that log functions can be directly accessed
 var log Logger
@@ -64,12 +64,11 @@ func (logf *structuredLogger) isEmpty() bool {
 
 //New logger initializes logger
 func New(inputLogConfig *Configuration) Logger {
-	if inputLogConfig.BinaryName != pluginBinaryName {
+	if inputLogConfig.BinaryName == ipamdBinaryName {
 		logConfig := LoadLogConfig()
 		log = logConfig.newZapLogger()
 		return log
 	}
-
 	log = inputLogConfig.newZapLogger()
 	return log
 }

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -39,13 +39,13 @@ func TestLogLevelReturnsOverriddenLevel(t *testing.T) {
 	defer os.Unsetenv(envLogLevel)
 
 	expectedLogLevel := zapcore.InfoLevel
-	inputLogLevel := getLogLevel()
+	inputLogLevel := GetLogLevel()
 	assert.Equal(t, expectedLogLevel, getZapLevel(inputLogLevel))
 }
 
 func TestLogLevelReturnsDefaultLevelWhenEnvNotSet(t *testing.T) {
 	expectedLogLevel := zapcore.DebugLevel
-	inputLogLevel := getLogLevel()
+	inputLogLevel := GetLogLevel()
 	assert.Equal(t, expectedLogLevel, getZapLevel(inputLogLevel))
 }
 
@@ -54,7 +54,7 @@ func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
 	defer os.Unsetenv(envLogLevel)
 
 	var expectedLogLevel zapcore.Level
-	inputLogLevel := getLogLevel()
+	inputLogLevel := GetLogLevel()
 	expectedLogLevel = zapcore.DebugLevel
 	assert.Equal(t, expectedLogLevel, getZapLevel(inputLogLevel))
 }

--- a/pkg/utils/logger/zaplogger.go
+++ b/pkg/utils/logger/zaplogger.go
@@ -111,7 +111,7 @@ func (logConfig *Configuration) newZapLogger() *structuredLogger {
 
 	logFilePath := logConfig.LogLocation
 
-	if strings.ToLower(logFilePath) != "stdout" {
+	if logFilePath != "" && strings.ToLower(logFilePath) != "stdout" {
 		writer = getLogWriter(logFilePath)
 	} else {
 		writer = zapcore.Lock(os.Stdout)


### PR DESCRIPTION
*Issue #, if available:*
#1089

*Description of changes:*
The cni-metrics-helper should check the same logging config env variable as ipamd does to get the log level. Will still log to stdout after this change.
* `cni-metrics-helper` will get the LogLevel from env variable `AWS_VPC_K8S_CNI_LOGLEVEL`
* Lowered the log level of full aggregated CloudWatch data to `Debug`
* Default empty `logFilePath` to `stdout` in Zap config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
