### PR TITLE
Remove docker.sock since it is not used

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -175,8 +175,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/docker.sock"
-          "name": "dockersock"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
       "hostNetwork": true
@@ -201,9 +199,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/docker.sock"
-        "name": "dockersock"
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -175,8 +175,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/docker.sock"
-          "name": "dockersock"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
       "hostNetwork": true
@@ -201,9 +199,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/docker.sock"
-        "name": "dockersock"
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -175,8 +175,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/docker.sock"
-          "name": "dockersock"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
       "hostNetwork": true
@@ -201,9 +199,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/docker.sock"
-        "name": "dockersock"
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -175,8 +175,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/docker.sock"
-          "name": "dockersock"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
       "hostNetwork": true
@@ -201,9 +199,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/docker.sock"
-        "name": "dockersock"
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -191,7 +191,6 @@ local awsnode = {
                 {mountPath: "/host/etc/cni/net.d", name: "cni-net-dir"},
                 {mountPath: "/host/var/log/aws-routed-eni", name: "log-dir"},
                 {mountPath: "/var/run/aws-node", name: "run-dir"},
-                {mountPath: "/var/run/docker.sock", name: "dockersock"},
                 {mountPath: "/var/run/dockershim.sock", name: "dockershim"},
               ],
             },
@@ -200,7 +199,6 @@ local awsnode = {
           volumes: [
             {name: "cni-bin-dir", hostPath: {path: "/opt/cni/bin"}},
             {name: "cni-net-dir", hostPath: {path: "/etc/cni/net.d"}},
-            {name: "dockersock", hostPath: {path: "/var/run/docker.sock"}},
             {name: "dockershim", hostPath: {path: "/var/run/dockershim.sock"}},
             {name: "log-dir",
               hostPath: {


### PR DESCRIPTION
*Issue #, if available:*
Resolves #1075

*Description of changes:*
* The `docker.sock` is only used in `v1.5.x` and earlier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
