### PR TITLE
Remove old pre-1.3 migration code

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -52,7 +52,6 @@ const (
 	metadataSGs          = "/security-group-ids/"
 	metadataSubnetID     = "/subnet-id/"
 	metadataVPCcidrs     = "/vpc-ipv4-cidr-blocks/"
-	metadataVPCcidr      = "/vpc-ipv4-cidr-block/"
 	metadataDeviceNum    = "/device-number/"
 	metadataInterface    = "/interface-id/"
 	metadataSubnetCIDR   = "/subnet-ipv4-cidr-block"
@@ -138,9 +137,6 @@ type APIs interface {
 
 	// DeallocIPAddresses deallocates the list of IP addresses from a ENI
 	DeallocIPAddresses(eniID string, ips []string) error
-
-	// GetVPCIPv4CIDR returns VPC's 1st CIDR
-	GetVPCIPv4CIDR() string
 
 	// GetVPCIPv4CIDRs returns VPC's CIDRs from instance metadata
 	GetVPCIPv4CIDRs() []string
@@ -352,15 +348,6 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 		return errors.Wrap(err, "get instance metadata: failed to retrieve subnet-ids")
 	}
 	log.Debugf("Found subnet-id: %s ", cache.subnetID)
-
-	// retrieve vpc-ipv4-cidr-block
-	cache.vpcIPv4CIDR, err = cache.ec2Metadata.GetMetadata(metadataMACPath + mac + metadataVPCcidr)
-	if err != nil {
-		awsAPIErrInc("GetMetadata", err)
-		log.Errorf("Failed to retrieve vpc-ipv4-cidr-block from instance metadata service")
-		return errors.Wrap(err, "get instance metadata: failed to retrieve vpc-ipv4-cidr-block data")
-	}
-	log.Debugf("Found vpc-ipv4-cidr-block: %s ", cache.vpcIPv4CIDR)
 
 	// retrieve security groups
 	err = cache.refreshSGIDs(mac)
@@ -1337,11 +1324,6 @@ func (cache *EC2InstanceMetadataCache) getFilteredListOfNetworkInterfaces() ([]*
 
 	log.Debugf("Found %d available instances with the AWS CNI tag.", len(networkInterfaces))
 	return networkInterfaces, nil
-}
-
-// GetVPCIPv4CIDR returns VPC CIDR
-func (cache *EC2InstanceMetadataCache) GetVPCIPv4CIDR() string {
-	return cache.vpcIPv4CIDR
 }
 
 // GetVPCIPv4CIDRs returns VPC CIDRs

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -86,7 +86,6 @@ func TestInitWithEC2metadata(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil).AnyTimes()
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil).AnyTimes()
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(metadataVPCIPv4CIDRs, nil).AnyTimes()
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
@@ -98,31 +97,7 @@ func TestInitWithEC2metadata(t *testing.T) {
 	assert.Equal(t, ins.primaryENImac, primaryMAC)
 	assert.Equal(t, len(ins.securityGroups.SortedList()), 2)
 	assert.Equal(t, subnetID, ins.subnetID)
-	assert.Equal(t, vpcCIDR, ins.vpcIPv4CIDR)
 	assert.Equal(t, len(ins.vpcIPv4CIDRs.SortedList()), 2)
-}
-
-func TestInitWithEC2metadataVPCcidrErr(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-	ctrl, mockMetadata, _ := setup(t)
-	defer ctrl.Finish()
-
-	mockMetadata.EXPECT().GetMetadata(metadataAZ).Return(az, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataLocalIP).Return(localIP, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataInstanceID).Return(instanceID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataInstanceType).Return(instanceType, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMAC).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, errors.New("Error on VPCcidr"))
-
-	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
-	err := ins.initWithEC2Metadata(ctx)
-	assert.Error(t, err)
 }
 
 func TestInitWithEC2metadataSubnetErr(t *testing.T) {
@@ -163,7 +138,6 @@ func TestInitWithEC2metadataSGErr(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataOwnerID).Return("1234", nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, errors.New("Error on SG"))
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
@@ -449,7 +423,6 @@ func TestTagEni(t *testing.T) {
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryMAC, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSGs).Return(sgs, nil).AnyTimes()
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetID).Return(subnetID, nil)
-	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidr).Return(vpcCIDR, nil)
 	mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataVPCcidrs).Return(vpcCIDR, nil).AnyTimes()
 
 	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -238,20 +238,6 @@ func (mr *MockAPIsMockRecorder) GetPrimaryENImac() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryENImac", reflect.TypeOf((*MockAPIs)(nil).GetPrimaryENImac))
 }
 
-// GetVPCIPv4CIDR mocks base method
-func (m *MockAPIs) GetVPCIPv4CIDR() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVPCIPv4CIDR")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetVPCIPv4CIDR indicates an expected call of GetVPCIPv4CIDR
-func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDR() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv4CIDR", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv4CIDR))
-}
-
 // GetVPCIPv4CIDRs mocks base method
 func (m *MockAPIs) GetVPCIPv4CIDRs() []string {
 	m.ctrl.T.Helper()

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -338,14 +338,9 @@ func (c *IPAMContext) nodeInit() error {
 		return err
 	}
 
-	_, vpcCIDR, err := net.ParseCIDR(c.awsClient.GetVPCIPv4CIDR())
-	if err != nil {
-		return errors.Wrap(err, "ipamd init: failed to retrieve VPC CIDR")
-	}
-
 	vpcCIDRs := c.awsClient.GetVPCIPv4CIDRs()
 	primaryIP := net.ParseIP(c.awsClient.GetLocalIPv4())
-	err = c.networkClient.SetupHostNetwork(vpcCIDR, vpcCIDRs, c.awsClient.GetPrimaryENImac(), &primaryIP)
+	err = c.networkClient.SetupHostNetwork(vpcCIDRs, c.awsClient.GetPrimaryENImac(), &primaryIP)
 	if err != nil {
 		return errors.Wrap(err, "ipamd init: failed to set up host network")
 	}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -100,13 +100,11 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().GetENIipLimit().Return(14, nil)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Addresses, nil)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Addresses, nil)
-	m.awsutils.EXPECT().GetVPCIPv4CIDR().Return(vpcCIDR)
 
-	_, parsedVPCCIDR, _ := net.ParseCIDR(vpcCIDR)
 	primaryIP := net.ParseIP(ipaddr01)
 	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs)
 	m.awsutils.EXPECT().GetPrimaryENImac().Return("")
-	m.network.EXPECT().SetupHostNetwork(parsedVPCCIDR, cidrs, "", &primaryIP).Return(nil)
+	m.network.EXPECT().SetupHostNetwork(cidrs, "", &primaryIP).Return(nil)
 
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
 

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -122,17 +122,17 @@ func (mr *MockNetworkAPIsMockRecorder) SetupENINetwork(arg0, arg1, arg2, arg3 in
 }
 
 // SetupHostNetwork mocks base method
-func (m *MockNetworkAPIs) SetupHostNetwork(arg0 *net.IPNet, arg1 []string, arg2 string, arg3 *net.IP) error {
+func (m *MockNetworkAPIs) SetupHostNetwork(arg0 []string, arg1 string, arg2 *net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetupHostNetwork", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupHostNetwork indicates an expected call of SetupHostNetwork
-func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2)
 }
 
 // UpdateRuleListBySrc mocks base method

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -156,15 +156,12 @@ func TestSetupHostNetworkNodePortDisabled(t *testing.T) {
 	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 
 	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
 	var mainENIRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)
 
 	var vpcCIDRs []string
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
 
@@ -290,7 +287,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 
 	var vpcCIDRs []string
 
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]map[string][][]string{
@@ -359,7 +356,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
 	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 	assert.Equal(t,
 		map[string]map[string][][]string{
@@ -411,7 +408,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
 
 	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -464,7 +461,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 
 	// remove exclusions
 	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -508,7 +505,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
 	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
 
@@ -559,7 +556,7 @@ func TestSetupHostNetworkIgnoringRpFilterUpdate(t *testing.T) {
 	setupNetLinkMocks(ctrl, mockNetLink)
 
 	var vpcCIDRs []string
-	err := ln.SetupHostNetwork(testENINetIPNet, vpcCIDRs, loopback, &testENINetIP)
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP)
 	assert.NoError(t, err)
 }
 
@@ -567,9 +564,6 @@ func setupNetLinkMocks(ctrl *gomock.Controller, mockNetLink *mock_netlinkwrapper
 	mockPrimaryInterfaceLookup(ctrl, mockNetLink)
 	mockNetLink.EXPECT().LinkSetMTU(gomock.Any(), testMTU).Return(nil)
 
-	var hostRule netlink.Rule
-	mockNetLink.EXPECT().NewRule().Return(&hostRule)
-	mockNetLink.EXPECT().RuleDel(&hostRule)
 	var mainENIRule netlink.Rule
 	mockNetLink.EXPECT().NewRule().Return(&mainENIRule)
 	mockNetLink.EXPECT().RuleDel(&mainENIRule)


### PR DESCRIPTION
Also removes only use of IMDS vpc-ipv4-cidr-block

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
