### PR TITLE
Avoid caching dynamic VPC CIDR info

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -124,7 +124,6 @@ func TestInitWithEC2metadata(t *testing.T) {
 		assert.Equal(t, ins.primaryENI, primaryeniID)
 		assert.Equal(t, len(ins.securityGroups.SortedList()), 2)
 		assert.Equal(t, subnetID, ins.subnetID)
-		assert.Equal(t, len(ins.vpcIPv4CIDRs.SortedList()), 2)
 	}
 }
 

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -241,11 +241,12 @@ func (mr *MockAPIsMockRecorder) GetPrimaryENImac() *gomock.Call {
 }
 
 // GetVPCIPv4CIDRs mocks base method
-func (m *MockAPIs) GetVPCIPv4CIDRs() []string {
+func (m *MockAPIs) GetVPCIPv4CIDRs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPCIPv4CIDRs")
 	ret0, _ := ret[0].([]string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetVPCIPv4CIDRs indicates an expected call of GetVPCIPv4CIDRs

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -112,7 +112,7 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().IsUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
 
 	primaryIP := net.ParseIP(ipaddr01)
-	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs)
+	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs, nil)
 	m.awsutils.EXPECT().GetPrimaryENImac().Return("")
 	m.network.EXPECT().SetupHostNetwork(cidrs, "", &primaryIP, false).Return(nil)
 

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -140,7 +140,10 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		}
 		addr, deviceNumber, err = s.ipamContext.dataStore.AssignPodIPv4Address(ipamKey)
 	}
-	pbVPCcidrs := s.ipamContext.awsClient.GetVPCIPv4CIDRs()
+	pbVPCcidrs, err := s.ipamContext.awsClient.GetVPCIPv4CIDRs()
+	if err != nil {
+		return nil, err
+	}
 	for _, cidr := range pbVPCcidrs {
 		log.Debugf("VPC CIDR %s", cidr)
 	}


### PR DESCRIPTION
We expect the list of VPC CIDRs to change.  Rather than cache the VPC CIDRs and then asynchronously update that cache, just don't cache :) and fetch the latest VPC CIDRs on demand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
