### PR TITLE
Changelog and config file changes for v1.6.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.4-rc1
+## v1.6.4
 * Bug - [Use docker/CRI to discover pods at node init](https://github.com/aws/amazon-vpc-cni-k8s/pull/1118) (#1118, @fawadkhaliq)
 
 ## v1.6.3

--- a/config/v1.6/aws-k8s-cni-cn.yaml
+++ b/config/v1.6/aws-k8s-cni-cn.yaml
@@ -77,6 +77,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64  
                   - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
@@ -86,7 +87,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.6.3
+        - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.6.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.6/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.6/aws-k8s-cni-us-gov-east-1.yaml
@@ -90,6 +90,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64  
                   - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
@@ -99,7 +100,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.6.3
+        - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.6.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.6/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.6/aws-k8s-cni-us-gov-west-1.yaml
@@ -90,6 +90,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64  
                   - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
@@ -99,7 +100,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.6.3
+        - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.6.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.6/aws-k8s-cni.yaml
+++ b/config/v1.6/aws-k8s-cni.yaml
@@ -77,6 +77,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64  
                   - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
@@ -90,6 +91,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64  
                   - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
@@ -99,7 +101,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.4-rc1
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.4
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/config/v1.6/cni-metrics-helper-cn.yaml
+++ b/config/v1.6/cni-metrics-helper-cn.yaml
@@ -75,7 +75,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.6.3
+      - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.6.4
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:

--- a/config/v1.6/cni-metrics-helper-us-east-1.yaml
+++ b/config/v1.6/cni-metrics-helper-us-east-1.yaml
@@ -75,7 +75,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.6.3
+      - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.6.4
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:

--- a/config/v1.6/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.6/cni-metrics-helper-us-gov-west-1.yaml
@@ -75,7 +75,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.6.3
+      - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.6.4
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:

--- a/config/v1.6/cni-metrics-helper.yaml
+++ b/config/v1.6/cni-metrics-helper.yaml
@@ -75,7 +75,7 @@ spec:
     spec:
       serviceAccountName: cni-metrics-helper
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.6.3
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.6.4
         imagePullPolicy: Always
         name: cni-metrics-helper
         env:


### PR DESCRIPTION
*Issue #, if available: Updating changelog and config file image for v1.6.4

*Description of changes: release v1.6.4

```
dev-dsk-varavaj-2b-72f02457 % grep "image:" *
aws-k8s-cni-cn.yaml:        - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.6.4
aws-k8s-cni-us-gov-east-1.yaml:        - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.6.4
aws-k8s-cni-us-gov-west-1.yaml:        - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.6.4
aws-k8s-cni.yaml:        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.4
calico.yaml:          image: quay.io/calico/node:v3.13.4
calico.yaml:        - image: quay.io/calico/typha:v3.13.4
calico.yaml:        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1
cni-metrics-helper-cn.yaml:      - image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.6.4
cni-metrics-helper-us-east-1.yaml:      - image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.6.4
cni-metrics-helper-us-gov-west-1.yaml:      - image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.6.4
cni-metrics-helper.yaml:      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.6.4

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
