### PR TITLE
Wait for ENI and secondary IPs

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -77,8 +77,11 @@ const (
 var (
 	// ErrENINotFound is an error when ENI is not found.
 	ErrENINotFound = errors.New("ENI is not found")
-	// ErrNoNetworkInterfaces occurs when
-	// DesribeNetworkInterfaces(eniID) returns no network interfaces
+	// ErrAllSecondaryIPsNotFound is returned when not all secondary IPs on an ENI have been assigned
+	ErrAllSecondaryIPsNotFound = errors.New("All secondary IPs not found")
+	// ErrNoSecondaryIPsFound is returned when not all secondary IPs on an ENI have been assigned
+	ErrNoSecondaryIPsFound = errors.New("No secondary IPs have been assigned to this ENI")
+	// ErrNoNetworkInterfaces occurs when DescribeNetworkInterfaces(eniID) returns no network interfaces
 	ErrNoNetworkInterfaces = errors.New("No network interfaces found for ENI")
 	// Custom user agent
 	userAgent = request.WithAppendUserAgent("amazon-vpc-cni-k8s")
@@ -160,6 +163,9 @@ type APIs interface {
 
 	//isUnmanagedENI
 	IsUnmanagedENI(eniID string) bool
+
+	// WaitForENIAndIPsAttached waits until the ENI has been attached and the secondary IPs have been added
+	WaitForENIAndIPsAttached(eni string, wantedSecondaryIPs int) (ENIMetadata, error)
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -1282,18 +1288,71 @@ func (cache *EC2InstanceMetadataCache) AllocIPAddresses(eniID string, numIPs int
 	output, err := cache.ec2SVC.AssignPrivateIpAddressesWithContext(context.Background(), input, userAgent)
 	awsAPILatency.WithLabelValues("AssignPrivateIpAddresses", fmt.Sprint(err != nil)).Observe(msSince(start))
 	if err != nil {
-		log.Errorf("Failed to allocate a private IP addresses on ENI %v: %v", eniID, err)
-		awsAPIErrInc("AssignPrivateIpAddresses", err)
 		if containsPrivateIPAddressLimitExceededError(err) {
-			log.Debug("AssignPrivateIpAddresses returned PrivateIpAddressLimitExceeded")
+			log.Debug("AssignPrivateIpAddresses returned PrivateIpAddressLimitExceeded, probably because the data store was out of sync." +
+				"Returning nil since we will check this by calling EC2 to verify what addresses have already assigned to this ENI.")
 			return nil
 		}
+		log.Errorf("Failed to allocate a private IP addresses on ENI %v: %v", eniID, err)
+		awsAPIErrInc("AssignPrivateIpAddresses", err)
 		return errors.Wrap(err, "allocate IP address: failed to allocate a private IP address")
 	}
 	if output != nil {
 		log.Infof("Allocated %d private IP addresses", len(output.AssignedPrivateIpAddresses))
 	}
 	return nil
+}
+
+func (cache *EC2InstanceMetadataCache) WaitForENIAndIPsAttached(eni string, wantedSecondaryIPs int) (eniMetadata ENIMetadata, err error) {
+	return cache.waitForENIAndIPsAttached(eni, wantedSecondaryIPs, maxENIBackoffDelay)
+}
+
+func (cache *EC2InstanceMetadataCache) waitForENIAndIPsAttached(eni string, wantedSecondaryIPs int, maxBackoffDelay time.Duration) (eniMetadata ENIMetadata, err error) {
+	start := time.Now()
+	attempt := 0
+	// Wait until the ENI shows up in the instance metadata service and has at least some secondary IPs
+	err = retry.RetryNWithBackoff(retry.NewSimpleBackoff(time.Millisecond*100, maxBackoffDelay, 0.15, 2.0), maxENIEC2APIRetries, func() error {
+		attempt++
+		enis, err := cache.GetAttachedENIs()
+		if err != nil {
+			log.Warnf("Failed to increase pool, error trying to discover attached ENIs on attempt %d/%d: %v ", attempt, maxENIEC2APIRetries, err)
+			return ErrNoNetworkInterfaces
+		}
+		// Verify that the ENI we are waiting for is in the returned list
+		for _, returnedENI := range enis {
+			if eni == returnedENI.ENIID {
+				// Check how many Secondary IPs have been attached
+				eniIPCount := len(returnedENI.IPv4Addresses)
+				if eniIPCount <= 1 {
+					log.Debugf("No secondary IPv4 addresses available yet on ENI %s", returnedENI.ENIID)
+					return ErrNoSecondaryIPsFound
+				}
+				// At least some are attached
+				eniMetadata = returnedENI
+				// ipsToAllocate will be at most 1 less then the IP limit for the ENI because of the primary IP
+				if eniIPCount > wantedSecondaryIPs {
+					return nil
+				}
+				return ErrAllSecondaryIPsNotFound
+			}
+		}
+		log.Debugf("Not able to find the right ENI yet (attempt %d/%d)", attempt, maxENIEC2APIRetries)
+		return ErrENINotFound
+	})
+	awsAPILatency.WithLabelValues("waitForENIAndIPsAttached", fmt.Sprint(err != nil)).Observe(msSince(start))
+	if err != nil {
+		// If we have at least 1 Secondary IP, by now return what we have without an error
+		if err == ErrAllSecondaryIPsNotFound {
+			if len(eniMetadata.IPv4Addresses) > 1 {
+				// We have some Secondary IPs, return the ones we have
+				log.Warnf("This ENI only has %d IP addresses, we wanted %d", len(eniMetadata.IPv4Addresses), wantedSecondaryIPs)
+				return eniMetadata, nil
+			}
+		}
+		awsAPIErrInc("waitENIAttachedFailedToAssignIPs", err)
+		return ENIMetadata{}, errors.New("waitForENIAndIPsAttached: giving up trying to retrieve ENIs from metadata service")
+	}
+	return eniMetadata, nil
 }
 
 // DeallocIPAddresses allocates numIPs of IP address on an ENI

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -280,3 +280,18 @@ func (mr *MockAPIsMockRecorder) SetUnmanagedENIs(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetUnmanagedENIs), arg0)
 }
+
+// WaitForENIAndIPsAttached mocks base method
+func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENIMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForENIAndIPsAttached", arg0, arg1)
+	ret0, _ := ret[0].(awsutils.ENIMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForENIAndIPsAttached indicates an expected call of WaitForENIAndIPsAttached
+func (mr *MockAPIsMockRecorder) WaitForENIAndIPsAttached(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForENIAndIPsAttached", reflect.TypeOf((*MockAPIs)(nil).WaitForENIAndIPsAttached), arg0, arg1)
+}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -236,7 +236,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 		m.awsutils.EXPECT().AllocENI(false, nil, "").Return(eni2, nil)
 	}
 
-	m.awsutils.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,
 			MAC:            primaryMAC,
@@ -265,9 +265,10 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 				},
 			},
 		},
-	}, nil)
+	}
 
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
+	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 14).Return(eniMetadata[1], nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	m.awsutils.EXPECT().AllocIPAddresses(eni2, 14)
@@ -305,7 +306,7 @@ func TestTryAddIPToENI(t *testing.T) {
 
 	m.awsutils.EXPECT().AllocENI(false, nil, "").Return(secENIid, nil)
 	m.awsutils.EXPECT().AllocIPAddresses(secENIid, warmIpTarget)
-	m.awsutils.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,
 			MAC:            primaryMAC,
@@ -334,7 +335,8 @@ func TestTryAddIPToENI(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}
+	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 3).Return(eniMetadata[1], nil)
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)


### PR DESCRIPTION
*Issue #, if available:*
#989, #1148 

*Description of changes:*

The log statements helping us find #989 were added earlier this year in #909 and #939, but the issue has probably been there longer. The problem is detailed in #1148, we need to wait for the Secondary IPv4 addresses to show up in the EC2 response. This PR does the following:

* Move `waitENIAttached()` from `ipamd.go` to `awsutils.go`
* Added an additional argument for how many secondary IPs to wait for
* Use retry with backoff instead of for-loop with sleep.
* If we find at least 1 secondary IP, but less than we wanted, we don't return an error, but count it as a partial success
* Added unit tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
