### PR TITLE
go 1.15 was just released. We should at least bump to 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 references:
   build_job: &build
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment: &env
       GO111MODULE: "on"
@@ -54,7 +54,7 @@ jobs:
 
   integration_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env
@@ -85,7 +85,7 @@ jobs:
 
   performance_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env
@@ -118,7 +118,7 @@ jobs:
 
   kops_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env
@@ -150,7 +150,7 @@ jobs:
 
   warm_ip_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env
@@ -181,7 +181,7 @@ jobs:
 
   warm_eni_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env
@@ -212,7 +212,7 @@ jobs:
 
   bottlerocket_test:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     environment:
       <<: *env

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 # Only the last two Go releases are supported by the Go team with security updates.
 # Any older versions are considered deprecated.
 go:
-  - "1.13.x"
+  - "1.14.x"
 
 # Only clone the most recent commit.
 git:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v
 # provide an alternate suffix or to omit.
 IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(ARCH),arm64))
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE = golang:1.13-stretch
+GOLANG_IMAGE = golang:1.14-stretch
 # For the requested build, these are the set of Go specific build environment variables.
 export GOARCH ?= $(ARCH)
 export GOOS = linux

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Alternatively there is also a [Helm](https://helm.sh/) chart: [eks/aws-vpc-cni](
 * `make` defaults to `make build-linux` that builds the Linux binaries.
 * `unit-test`, `format`,`lint` and `vet` provide ways to run the respective tests/tools and should be run before submitting a PR.
 * `make docker` will create a docker container using the docker-build with the finished binaries, with a tag of `amazon/amazon-k8s-cni:latest`
-* `make docker-build` uses a docker container (golang:1.13) to build the binaries.
-* `make docker-unit-tests` uses a docker container (golang:1.13) to run all unit tests.
+* `make docker-build` uses a docker container (golang:1.14) to build the binaries.
+* `make docker-unit-tests` uses a docker container (golang:1.14) to run all unit tests.
 
 ## Components
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-cni-k8s
 
-go 1.13
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.31.4

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=

--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -1,5 +1,5 @@
 ARG docker_arch
-ARG golang_image=golang:1.13-stretch
+ARG golang_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -1,5 +1,5 @@
 ARG docker_arch
-ARG golang_image=golang:1.13-stretch
+ARG golang_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,5 +1,5 @@
 ARG docker_arch
-ARG golang_image=golang:1.13-stretch
+ARG golang_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -1,5 +1,5 @@
 ARG docker_arch
-ARG golang_image=golang:1.13-stretch
+ARG golang_image
 FROM $golang_image
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-cni-k8s/test/integration
 
-go 1.13
+go 1.14
 
 replace k8s.io/api => k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 


### PR DESCRIPTION
*Description of changes:*
[go 1.15 was just released](https://golang.org/doc/go1.15). Only the [last two releases get security fixes](https://golang.org/doc/devel/release.html#policy), so we need to bump the version to at least 1.14.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
