### PR TITLE
Handle version mismatch between CNI and IPAMD

### DIFF
--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -120,6 +120,10 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		}
 	}
 	if addr == "" {
+		if in.ContainerID == "" || in.IfName == "" || in.NetworkName == "" {
+			log.Errorf("Unable to generate IPAMKey from %+v", in)
+			return &failureResponse, nil
+		}
 		ipamKey := datastore.IPAMKey{
 			ContainerID: in.ContainerID,
 			IfName:      in.IfName,

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -78,6 +78,9 @@ if [[ "$AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER" != "false" ]]; then
     done
 fi
 
+log_in_json info "Install CNI binary.."
+install aws-cni "$HOST_CNI_BIN_PATH"
+
 log_in_json info "Starting IPAM daemon in the background ... "
 ./aws-k8s-agent | tee -i "$AGENT_LOG_PATH" 2>&1 &
 
@@ -89,9 +92,7 @@ if ! wait_for_ipam; then
     exit 1
 fi
 
-log_in_json info "Copying CNI plugin binary and config file ... "
-
-install aws-cni "$HOST_CNI_BIN_PATH"
+log_in_json info "Copying config file ... "
 
 # modify the static config to populate it with the env vars
 sed \


### PR DESCRIPTION
*Issue #, if available:

*Description of changes: During upgrades/downgrades we can have a situation where ipamd is upgraded but the CNI binary is still old. So to handle such race conditions, we will copy the CNI binary first and then wait for IPAMD to come up.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
