### PR TITLE
Fix a log message

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -713,7 +713,7 @@ func (ds *DataStore) RemoveENIFromDataStore(eniID string, force bool) error {
 
 	ds.total -= len(eni.IPv4Addresses)
 	ds.log.Infof("RemoveENIFromDataStore %s: IP address pool stats: free %d addresses, total: %d, assigned: %d",
-		eni, len(eni.IPv4Addresses), ds.total, ds.assigned)
+		eniID, len(eni.IPv4Addresses), ds.total, ds.assigned)
 	delete(ds.eniPool, eniID)
 
 	// Prometheus gauge


### PR DESCRIPTION
A logging message was dumping the full golang struct by mistake rather
than just the relevant ID string (and is not a debug-level message).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
