### PR TITLE
Write to IPAM checkpoint file immediately after reading from CRI

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -359,6 +359,16 @@ func (ds *DataStore) ReadBackingStore() error {
 		ds.log.Debugf("Recovered %s => %s/%s", allocation.IPAMKey, eni.ID, addr.Address)
 	}
 
+	if ds.CheckpointMigrationPhase == 1 {
+		// For phase1: write whatever we just read above from
+		// CRI to backingstore immediately - just in case we
+		// _never_ see an add/del request before we upgrade to
+		// phase2.
+		if err := ds.writeBackingStoreUnsafe(); err != nil {
+			return err
+		}
+	}
+
 	ds.log.Debugf("Completed ipam state recovery")
 	return nil
 }


### PR DESCRIPTION
The current migration logic has a corner case: if we upgrade
1.6->1.7->1.8 and _never_ see a pod create/delete during the 1.7
phase, then we never write the IPAM checkpoint file.

This change just writes the file immediately after reading state from
CRI, if in migration phase1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
