### PR TITLE
Fix perf test bucket name

### DIFF
--- a/scripts/lib/performance_tests.sh
+++ b/scripts/lib/performance_tests.sh
@@ -11,23 +11,23 @@ function check_for_timeout() {
     fi
 }
 
-function save_results_to_file() {
+function uplaod_results_to_s3_bucket() {
     echo "$filename"
     echo "Date", "\"slot1\"", "\"slot2\"" >> "$filename"
     echo $(date +"%Y-%m-%d-%T"), $((SCALE_UP_DURATION_ARRAY[0])), $((SCALE_DOWN_DURATION_ARRAY[0])) >> "$filename"
     echo $(date +"%Y-%m-%d-%T"), $((SCALE_UP_DURATION_ARRAY[1])), $((SCALE_DOWN_DURATION_ARRAY[1])) >> "$filename"
     echo $(date +"%Y-%m-%d-%T"), $((SCALE_UP_DURATION_ARRAY[2])), $((SCALE_DOWN_DURATION_ARRAY[2])) >> "$filename"
 
-    cat $filename
+    cat "$filename"
     if [[ ${#PERFORMANCE_TEST_S3_BUCKET_NAME} -gt 0 ]]; then
-        aws s3 cp "$filename" "${PERFORMANCE_TEST_S3_BUCKET_NAME}${1}"
+        aws s3 cp "$filename" "s3://${PERFORMANCE_TEST_S3_BUCKET_NAME}/${1}/"
     else
         echo "No S3 bucket name given, skipping test result upload."
     fi
 }
 
 function check_for_slow_performance() {
-    BUCKET=s3://${PERFORMANCE_TEST_S3_BUCKET_NAME}${1}
+    BUCKET="s3://${PERFORMANCE_TEST_S3_BUCKET_NAME}/${1}/"
     FILE1=$(aws s3 ls "${BUCKET}" | sort | tail -n 2 | sed -n '1 p' | awk '{print $4}')
     FILE2=$(aws s3 ls "${BUCKET}" | sort | tail -n 3 | sed -n '1 p' | awk '{print $4}')
     FILE3=$(aws s3 ls "${BUCKET}" | sort | tail -n 4 | sed -n '1 p' | awk '{print $4}')
@@ -127,13 +127,13 @@ function run_performance_test_130_pods() {
     echo ""
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
-    filename="pod-130-Test#${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    save_results_to_file "/130-pods/"
+    filename="pod-130-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
+    uplaod_results_to_s3_bucket "130-pods"
     
     echo "TIMELINE: 130 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false
     if [[ ${#PERFORMANCE_TEST_S3_BUCKET_NAME} -gt 0 ]]; then
-        check_for_slow_performance "/130-pods/"
+        check_for_slow_performance "130-pods"
     fi
     $KUBECTL_PATH delete -f ./testdata/deploy-130-pods.yaml
 }
@@ -200,13 +200,13 @@ function run_performance_test_730_pods() {
     echo ""
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
-    filename="pod-730-Test#${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    save_results_to_file "/730-pods/"
+    filename="pod-730-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
+    uplaod_results_to_s3_bucket "730-pods"
     
     echo "TIMELINE: 730 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false
     if [[ ${#PERFORMANCE_TEST_S3_BUCKET_NAME} -gt 0 ]]; then
-        check_for_slow_performance "/730-pods/"
+        check_for_slow_performance "730-pods"
     fi
     $KUBECTL_PATH delete -f ./testdata/deploy-730-pods.yaml
 }
@@ -281,13 +281,13 @@ function run_performance_test_5000_pods() {
     echo ""
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
-    filename="pod-5000-Test#${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    save_results_to_file "/5000-pods/"
+    filename="pod-5000-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
+    uplaod_results_to_s3_bucket "5000-pods"
     
     echo "TIMELINE: 5000 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false
     if [[ ${#PERFORMANCE_TEST_S3_BUCKET_NAME} -gt 0 ]]; then
-        check_for_slow_performance "/5000-pods/"
+        check_for_slow_performance "5000-pods"
     fi
     $KUBECTL_PATH delete -f ./testdata/deploy-5000-pods.yaml
 }

--- a/scripts/lib/performance_tests.sh
+++ b/scripts/lib/performance_tests.sh
@@ -11,7 +11,7 @@ function check_for_timeout() {
     fi
 }
 
-function uplaod_results_to_s3_bucket() {
+function upload_results_to_s3_bucket() {
     echo "$filename"
     echo "Date", "\"slot1\"", "\"slot2\"" >> "$filename"
     echo $(date +"%Y-%m-%d-%T"), $((SCALE_UP_DURATION_ARRAY[0])), $((SCALE_DOWN_DURATION_ARRAY[0])) >> "$filename"
@@ -128,7 +128,7 @@ function run_performance_test_130_pods() {
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
     filename="pod-130-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    uplaod_results_to_s3_bucket "130-pods"
+    upload_results_to_s3_bucket "130-pods"
     
     echo "TIMELINE: 130 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false
@@ -201,7 +201,7 @@ function run_performance_test_730_pods() {
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
     filename="pod-730-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    uplaod_results_to_s3_bucket "730-pods"
+    upload_results_to_s3_bucket "730-pods"
     
     echo "TIMELINE: 730 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false
@@ -282,7 +282,7 @@ function run_performance_test_5000_pods() {
     DEPLOY_DURATION=$((SECONDS - DEPLOY_START))
 
     filename="pod-5000-Test-${TEST_ID}-$(date +"%m-%d-%Y-%T")-${TEST_IMAGE_VERSION}.csv"
-    uplaod_results_to_s3_bucket "5000-pods"
+    upload_results_to_s3_bucket "5000-pods"
     
     echo "TIMELINE: 5000 Pod performance test took $DEPLOY_DURATION seconds."
     RUNNING_PERFORMANCE=false

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -8,7 +8,7 @@
 
 # Performance
     * run from cni test account to upload test results
-        * set PERFORMANCE_TEST_S3_BUCKET_NAME to the name of the bucket (likely s3://cni-performance-tests)
+        * set PERFORMANCE_TEST_S3_BUCKET_NAME to the name of the bucket (likely `cni-performance-tests`)
     * set RUN_PERFORMANCE_TESTS=true
     * to view data graph:
         * Go to Isengard and open 719533996208 account (vpc-cni-ci-test) as admin


### PR DESCRIPTION
**Description of changes:**
* Fix bucket parameters for uploading performance test results.

**Tested locally**

Before change
```
pod-130-Test#15464-08-17-2020-17:24:37-v1.6.4-rc1-8-g723d18c5.csv
Date, "slot1", "slot2"
2020-08-17-17:24:37, 37, 74
2020-08-17-17:24:37, 59, 99
2020-08-17-17:24:37, 46, 86

usage: aws s3 cp <LocalPath> <S3Uri> or <S3Uri> <LocalPath> or <S3Uri> <S3Uri>
Error: Invalid argument type
```
After change (not real bucket)
```
./test-s3-call.sh 
pod-130-Test#15464-08-17-2020-17:24:37-v1.6.4-rc1-8-g723d18c5.csv
Date, "slot1", "slot2"
2020-08-17-23:35:30, 0, 0
2020-08-17-23:35:30, 0, 0
2020-08-17-23:35:30, 0, 0
upload failed: ./pod-130-Test#15464-08-17-2020-17:24:37-v1.6.4-rc1-8-g723d18c5.csv to s3://dummy-bucket/folder/pod-130-Test#15464-08-17-2020-17:24:37-v1.6.4-rc1-8-g723d18c5.csv An error occurred (AccessDenied) when calling the PutObject operation: Access Denied
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
