### PR TITLE
return only on error for tryAssignIPs method

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -447,7 +447,7 @@ func (c *IPAMContext) nodeInit() error {
 	increasedPool, err := c.tryAssignIPs()
 	if err == nil && increasedPool {
 		c.updateLastNodeIPPoolAction()
-	} else {
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -889,7 +889,7 @@ func (n *linuxNetwork) DeleteRuleListBySrc(src net.IPNet) error {
 
 // UpdateRuleListBySrc modify IP rules that have a matching source IP
 func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNet, toCIDRs []string, requiresSNAT bool) error {
-	log.Infof("Update Rule List[%v] for source[%v] with toCIDRs[%v], excludeSNATCIDRs[%v], requiresSNAT[%v]",
+	log.Debugf("Update Rule List[%v] for source[%v] with toCIDRs[%v], excludeSNATCIDRs[%v], requiresSNAT[%v]",
 		ruleList, src, toCIDRs, n.excludeSNATCIDRs, requiresSNAT)
 
 	srcRuleList, err := n.GetRuleListBySrc(ruleList, src)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When testing #903, for an edge case scenario where the EC2 instance cannot assign IP addresse when we call tryAssignIPs   during node init, which increasedPool == false and error == nil. Even though there was no error, we prematurely think this is returning error which was blocking spawning of go-routine which never updated ip rule table.   

With this change, we are explicitly checking if the error is not nil and then return error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
