### PR TITLE
return only on error for tryAssignIPs method

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -447,7 +447,7 @@ func (c *IPAMContext) nodeInit() error {
 	increasedPool, err := c.tryAssignIPs()
 	if err == nil && increasedPool {
 		c.updateLastNodeIPPoolAction()
-	} else {
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -889,7 +889,7 @@ func (n *linuxNetwork) DeleteRuleListBySrc(src net.IPNet) error {
 
 // UpdateRuleListBySrc modify IP rules that have a matching source IP
 func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNet, toCIDRs []string, requiresSNAT bool) error {
-	log.Infof("Update Rule List[%v] for source[%v] with toCIDRs[%v], excludeSNATCIDRs[%v], requiresSNAT[%v]",
+	log.Debugf("Update Rule List[%v] for source[%v] with toCIDRs[%v], excludeSNATCIDRs[%v], requiresSNAT[%v]",
 		ruleList, src, toCIDRs, n.excludeSNATCIDRs, requiresSNAT)
 
 	srcRuleList, err := n.GetRuleListBySrc(ruleList, src)


### PR DESCRIPTION
*Issue #, if available:*
Cherry pick of #1152 to release-1.7

*Description of changes:*
* Fix too verbose logging
* Fix returning too early
(cherry picked from commit 0492ba981f3f24b0f85ac9ccdaa5316af5f7f780)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
