### PR TITLE
enable manual override for VERSION in images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 		metrics-unit-test docker-metrics-test
 
 # VERSION is the source revision that executables and images are built from.
-VERSION = $(shell git describe --tags --always --dirty || echo "unknown")
+VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .


### PR DESCRIPTION
This change will allow you to pass a custom tag for CNI images as a `VERSION` command-line parameter. We will default to the old value if the param is not supplied.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
