### PR TITLE
Clean up go lint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ lint:
 	@command -v golint >/dev/null || { echo "ERROR: golint not installed"; exit 1; }
 	find . \
 	  -type f -name '*.go' \
-	  -not -name 'mock_*' -not -name 'mocks_*' \
+	  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" \
 	  -print0 | sort -z | xargs -0 -L1 -- golint $(LINT_FLAGS) 2>/dev/null
 
 # Run go vet on source code.

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -285,7 +285,7 @@ func (m *testMocks) setupMockForVethCreation(failAt string) *mock_netlink.MockLi
 	m.netlink.EXPECT().LinkByName(testHostVethName).Return(mockHostVeth, nil)
 
 	if failAt == "veth-procsys" {
-		m.procsys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(errors.New("Error writing to /proc/sys/..."))
+		m.procsys.EXPECT().Set("net/ipv6/conf/"+testHostVethName+"/accept_ra", "0").Return(errors.New("error writing to /proc/sys/"))
 		return nil
 	}
 	var procsysRet error

--- a/config/master/doc.go
+++ b/config/master/doc.go
@@ -5,7 +5,7 @@ package manifests
 
 //go:generate go run github.com/google/go-jsonnet/cmd/jsonnet -S -m . manifests.jsonnet
 
-// Make a 'direct' dependency, so 'go mod tidy' doesn't remove it.
 import (
+	// Make a 'direct' dependency, so 'go mod tidy' doesn't remove it.
 	_ "github.com/google/go-jsonnet"
 )

--- a/pkg/apis/crd/v1alpha1/register.go
+++ b/pkg/apis/crd/v1alpha1/register.go
@@ -14,8 +14,10 @@ const (
 )
 
 var (
+	// SchemeBuilder knows the ENIConfig and ENIConfigList types
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme add the SchemeBuilder
+	AddToScheme = SchemeBuilder.AddToScheme
 	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: version}
 )

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -6,6 +6,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ENIConfigList is the ENI config list
 type ENIConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
@@ -14,6 +15,7 @@ type ENIConfigList struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ENIConfig is the per ENI config
 type ENIConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -21,10 +23,13 @@ type ENIConfig struct {
 	Status            ENIConfigStatus `json:"status,omitempty"`
 }
 
+// ENIConfigSpec is the spec for this ENI
 type ENIConfigSpec struct {
 	SecurityGroups []string `json:"securityGroups"`
 	Subnet         string   `json:"subnet"`
 }
+
+// ENIConfigStatus is empty
 type ENIConfigStatus struct {
 	// Fill me
 }

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -214,6 +214,7 @@ type InstanceTypeLimits struct {
 	IPv4Limit int
 }
 
+// PrimaryIPv4Address returns the primary IP of this node
 func (eni ENIMetadata) PrimaryIPv4Address() string {
 	for _, addr := range eni.IPv4Addresses {
 		if aws.BoolValue(addr.Primary) {
@@ -223,6 +224,7 @@ func (eni ENIMetadata) PrimaryIPv4Address() string {
 	return ""
 }
 
+// TagMap keeps track of the EC2 tags on each ENI
 type TagMap map[string]string
 
 // msSince returns milliseconds since start.
@@ -245,6 +247,7 @@ type StringSet struct {
 	data sets.String
 }
 
+// SortedList returnsa sorted string slice from this set
 func (ss *StringSet) SortedList() []string {
 	ss.RLock()
 	defer ss.RUnlock()
@@ -252,12 +255,14 @@ func (ss *StringSet) SortedList() []string {
 	return ss.data.List()
 }
 
+// Set sets the string set
 func (ss *StringSet) Set(items []string) {
 	ss.Lock()
 	defer ss.Unlock()
 	ss.data = sets.NewString(items...)
 }
 
+// Difference compares this StringSet with another
 func (ss *StringSet) Difference(other *StringSet) *StringSet {
 	ss.RLock()
 	other.RLock()
@@ -267,6 +272,7 @@ func (ss *StringSet) Difference(other *StringSet) *StringSet {
 	return &StringSet{data: ss.data.Difference(other.data)}
 }
 
+// Has returns true if the StringSet contains the string
 func (ss *StringSet) Has(item string) bool {
 	ss.RLock()
 	defer ss.RUnlock()

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -33,12 +33,15 @@ type SandboxInfo struct {
 	IP string
 }
 
+// APIs is the CRI interface
 type APIs interface {
 	GetRunningPodSandboxes(log logger.Logger) ([]*SandboxInfo, error)
 }
 
+// Client is an empty struct
 type Client struct{}
 
+// New creates a new CRI client
 func New() *Client {
 	return &Client{}
 }

--- a/pkg/ec2metadatawrapper/ec2metadatawrapper.go
+++ b/pkg/ec2metadatawrapper/ec2metadatawrapper.go
@@ -13,8 +13,8 @@ const (
 
 // TODO: Move away from using mock
 
-// HttpClient is used to help with testing
-type HttpClient interface {
+// HTTPClient is used to help with testing
+type HTTPClient interface {
 	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
 	Region() (string, error)
 }
@@ -26,11 +26,11 @@ type EC2MetadataClient interface {
 }
 
 type ec2MetadataClientImpl struct {
-	client HttpClient
+	client HTTPClient
 }
 
 // New creates an ec2metadata client to retrieve metadata
-func New(client HttpClient) EC2MetadataClient {
+func New(client HTTPClient) EC2MetadataClient {
 	if client == nil {
 		awsSession := session.Must(session.NewSession(aws.NewConfig().
 			WithMaxRetries(metadataRetries),

--- a/pkg/ec2metadatawrapper/ec2metadatawrapper_test.go
+++ b/pkg/ec2metadatawrapper/ec2metadatawrapper_test.go
@@ -36,7 +36,7 @@ func TestGetInstanceIdentityDocHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockGetter := mockec2metadatawrapper.NewMockHttpClient(ctrl)
+	mockGetter := mockec2metadatawrapper.NewMockHTTPClient(ctrl)
 	testClient := New(mockGetter)
 
 	mockGetter.EXPECT().GetInstanceIdentityDocument().Return(testInstanceIdentityDoc, nil)
@@ -50,7 +50,7 @@ func TestGetInstanceIdentityDocError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockGetter := mockec2metadatawrapper.NewMockHttpClient(ctrl)
+	mockGetter := mockec2metadatawrapper.NewMockHTTPClient(ctrl)
 	testClient := New(mockGetter)
 
 	mockGetter.EXPECT().GetInstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("test error"))
@@ -64,7 +64,7 @@ func TestGetRegionHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockGetter := mockec2metadatawrapper.NewMockHttpClient(ctrl)
+	mockGetter := mockec2metadatawrapper.NewMockHTTPClient(ctrl)
 	testClient := New(mockGetter)
 
 	mockGetter.EXPECT().Region().Return(iidRegion, nil)
@@ -78,7 +78,7 @@ func TestGetRegionErr(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockGetter := mockec2metadatawrapper.NewMockHttpClient(ctrl)
+	mockGetter := mockec2metadatawrapper.NewMockHTTPClient(ctrl)
 	testClient := New(mockGetter)
 
 	mockGetter.EXPECT().Region().Return("", errors.New("test error"))

--- a/pkg/ec2metadatawrapper/mocks/ec2metadatawrapper_mocks.go
+++ b/pkg/ec2metadatawrapper/mocks/ec2metadatawrapper_mocks.go
@@ -8,46 +8,46 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mock of HttpClient interface
-type MockHttpClient struct {
+// Mock of HTTPClient interface
+type MockHTTPClient struct {
 	ctrl     *gomock.Controller
-	recorder *_MockHttpClientRecorder
+	recorder *_MockHTTPClientRecorder
 }
 
-// Recorder for MockHttpClient (not exported)
-type _MockHttpClientRecorder struct {
-	mock *MockHttpClient
+// Recorder for MockHTTPClient (not exported)
+type _MockHTTPClientRecorder struct {
+	mock *MockHTTPClient
 }
 
-func NewMockHttpClient(ctrl *gomock.Controller) *MockHttpClient {
-	mock := &MockHttpClient{ctrl: ctrl}
-	mock.recorder = &_MockHttpClientRecorder{mock}
+func NewMockHTTPClient(ctrl *gomock.Controller) *MockHTTPClient {
+	mock := &MockHTTPClient{ctrl: ctrl}
+	mock.recorder = &_MockHTTPClientRecorder{mock}
 	return mock
 }
 
-func (_m *MockHttpClient) EXPECT() *_MockHttpClientRecorder {
+func (_m *MockHTTPClient) EXPECT() *_MockHTTPClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockHttpClient) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+func (_m *MockHTTPClient) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
 	ret := _m.ctrl.Call(_m, "GetInstanceIdentityDocument")
 	ret0, _ := ret[0].(ec2metadata.EC2InstanceIdentityDocument)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockHttpClientRecorder) GetInstanceIdentityDocument() *gomock.Call {
+func (_mr *_MockHTTPClientRecorder) GetInstanceIdentityDocument() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceIdentityDocument")
 }
 
-func (_m *MockHttpClient) Region() (string, error) {
+func (_m *MockHTTPClient) Region() (string, error) {
 	ret := _m.ctrl.Call(_m, "Region")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockHttpClientRecorder) Region() *gomock.Call {
+func (_mr *_MockHTTPClientRecorder) Region() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Region")
 }
 

--- a/pkg/ec2wrapper/client.go
+++ b/pkg/ec2wrapper/client.go
@@ -20,6 +20,7 @@ import (
 	ec2svc "github.com/aws/aws-sdk-go/service/ec2"
 )
 
+// EC2 is the EC2 wrapper interface
 type EC2 interface {
 	CreateNetworkInterfaceWithContext(ctx aws.Context, input *ec2svc.CreateNetworkInterfaceInput, opts ...request.Option) (*ec2svc.CreateNetworkInterfaceOutput, error)
 	DescribeInstancesWithContext(ctx aws.Context, input *ec2svc.DescribeInstancesInput, opts ...request.Option) (*ec2svc.DescribeInstancesOutput, error)
@@ -34,6 +35,7 @@ type EC2 interface {
 	CreateTagsWithContext(ctx aws.Context, input *ec2svc.CreateTagsInput, opts ...request.Option) (*ec2svc.CreateTagsOutput, error)
 }
 
+// New creates a new EC2 wrapper
 func New(sess *session.Session) EC2 {
 	return ec2svc.New(sess)
 }

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -46,11 +46,13 @@ const (
 	envEniConfigLabelDef      = "ENI_CONFIG_LABEL_DEF"
 )
 
+// ENIConfig interface
 type ENIConfig interface {
 	MyENIConfig() (*v1alpha1.ENIConfigSpec, error)
 	Getter() *ENIConfigInfo
 }
 
+// ErrNoENIConfig is the missing ENIConfig error
 var ErrNoENIConfig = errors.New("eniconfig: eniconfig is not available")
 
 var log = logger.Get()

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1218,9 +1218,10 @@ func (c *IPAMContext) getTrunkLinkIndex() (int, error) {
 
 		}
 	}
-	return -1, errors.New("No trunk!")
+	return -1, errors.New("no trunk!")
 }
 
+// SetNodeLabel sets or deletes a node label
 func (c *IPAMContext) SetNodeLabel(key, value string) error {
 	// Find my node
 	node, err := c.k8sClient.CoreV1().Nodes().Get(c.myNodeName, metav1.GetOptions{})
@@ -1254,6 +1255,7 @@ func (c *IPAMContext) SetNodeLabel(key, value string) error {
 	return nil
 }
 
+// GetPod returns the pod matching the name and namespace
 func (c *IPAMContext) GetPod(podName, namespace string) (*v1.Pod, error) {
 	return c.k8sClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -289,13 +289,13 @@ func TestTryAddIPToENI(t *testing.T) {
 	testAddr11 := ipaddr11
 	testAddr12 := ipaddr12
 
-	warmIpTarget := 3
+	warmIPTarget := 3
 	mockContext := &IPAMContext{
 		awsClient:     m.awsutils,
 		maxIPsPerENI:  14,
 		maxENI:        4,
 		warmENITarget: 1,
-		warmIPTarget:  warmIpTarget,
+		warmIPTarget:  warmIPTarget,
 		networkClient: m.network,
 		eniConfig:     m.eniconfig,
 		primaryIP:     make(map[string]string),
@@ -305,7 +305,7 @@ func TestTryAddIPToENI(t *testing.T) {
 	mockContext.dataStore = testDatastore()
 
 	m.awsutils.EXPECT().AllocENI(false, nil, "").Return(secENIid, nil)
-	m.awsutils.EXPECT().AllocIPAddresses(secENIid, warmIpTarget)
+	m.awsutils.EXPECT().AllocIPAddresses(secENIid, warmIPTarget)
 	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -53,7 +53,7 @@ type PodENIData struct {
 	ENIID      string `json:"eniId"`
 	IfAddress  string `json:"ifAddress"`
 	PrivateIP  string `json:"privateIp"`
-	VlanID     int    `json:"vlanId"`
+	VlanID     int    `json:"vlanID"`
 	SubnetCIDR string `json:"subnetCidr"`
 }
 
@@ -71,7 +71,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 
 	failureResponse := rpc.AddNetworkReply{Success: false}
-	var deviceNumber, vlanId, trunkENILinkIndex int
+	var deviceNumber, vlanID, trunkENILinkIndex int
 	var addr, branchENIMAC, podENISubnetGW string
 	var err error
 	if s.ipamContext.enablePodENI {
@@ -108,8 +108,8 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 					firstENI := podENIData[0]
 					addr = firstENI.PrivateIP
 					branchENIMAC = firstENI.IfAddress
-					vlanId = firstENI.VlanID
-					if addr == "" || branchENIMAC == "" || vlanId == 0 {
+					vlanID = firstENI.VlanID
+					if addr == "" || branchENIMAC == "" || vlanID == 0 {
 						log.Errorf("Failed to parse pod-ENI annotation: %s", val)
 						return &failureResponse, nil
 					}
@@ -160,7 +160,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		DeviceNumber:    int32(deviceNumber),
 		UseExternalSNAT: useExternalSNAT,
 		VPCcidrs:        pbVPCcidrs,
-		PodVlanId:       int32(vlanId),
+		PodVlanId:       int32(vlanID),
 		PodENIMAC:       branchENIMAC,
 		PodENISubnetGW:  podENISubnetGW,
 		ParentIfIndex:   int32(trunkENILinkIndex),

--- a/pkg/utils/ttime/ttime.go
+++ b/pkg/utils/ttime/ttime.go
@@ -11,6 +11,7 @@ type Time interface {
 	AfterFunc(d time.Duration, f func()) Timer
 }
 
+// Timer is the timer interface
 type Timer interface {
 	Reset(d time.Duration) bool
 	Stop() bool

--- a/test/cmd/packet-verifier/packet-verifier.go
+++ b/test/cmd/packet-verifier/packet-verifier.go
@@ -32,9 +32,9 @@ var (
 	vlanIDToMonitor int
 
 	// pcap parameters (requires libpcap-devel to be installed on the host)
-	snapshot_len int32 = 1024
-	promiscuous        = false
-	timeout            = 30 * time.Second
+	snapshotLen int32 = 1024
+	promiscuous       = false
+	timeout           = 30 * time.Second
 )
 
 // eniConfig details regarding ENIs
@@ -197,7 +197,7 @@ func monitorPacketOnInterfaces(ipToMonitor net.IP, vlanIDToMonitor int, enis []e
 
 // monitorPackets monitors the packets on the interfaces
 func monitorPackets(ipToMonitor net.IP, vlanIDToMonitor int, iface eniConfig) error {
-	handle, err := pcap.OpenLive(iface.name, snapshot_len, promiscuous, timeout)
+	handle, err := pcap.OpenLive(iface.name, snapshotLen, promiscuous, timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*
No code changes, only cleaning up `go lint` warnings. There are more warnings to clean up, just don't want to put all of them in the same PR.
* Renamed variables
* Added comments
* Filtering out `cni.go` since it has some `ALL_CAPS` names by necessity.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
