### PR TITLE
Update the k8s-tester and kubernetes version for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,8 @@ jobs:
             - dependency-packages-store-{{ checksum "test/integration/go.mod" }}
             - dependency-packages-store-
       - k8s/install-kubectl:
-          # requires 1.14.9 for k8s testing, since it uses log api.
-          kubectl-version: v1.14.9
+          # Requires at least 1.14.9 for k8s testing, since it uses log api.
+          kubectl-version: v1.17.9
       - run:
           name: Run the integration tests
           command: ./scripts/run-integration-tests.sh

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -15,7 +15,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.4.0}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.4.8}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -16,7 +16,7 @@ OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
 
 : "${AWS_DEFAULT_REGION:=us-west-2}"
-: "${K8S_VERSION:=1.14.6}"
+: "${K8S_VERSION:=1.17.9}"
 : "${PROVISION:=true}"
 : "${DEPROVISION:=true}"
 : "${BUILD:=true}"


### PR DESCRIPTION
*Description of changes:*
* Bump k8s-tester to `v1.4.8`
* Bump kubernetes client to `v1.17.9`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
