### PR TITLE
Update Calico to v3.15.1 & set routeSource=WorkloadIPs

### DIFF
--- a/config/master/calico.yaml
+++ b/config/master/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.4
+          image: quay.io/calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -71,6 +71,8 @@ spec:
               value: "none"
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"
+            - name: FELIX_ROUTESOURCE
+              value: "WorkloadIPs"
             - name: NO_DEFAULT_POOLS
               value: "true"
             # Set based on the k8s node name.
@@ -547,7 +549,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.4
+        - image: quay.io/calico/typha:v3.15.1
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
*Description of changes:*

Greetings, proposing the following updates to calico.yaml:
* update Calico node and typha images to v3.15.1 -- [release-notes](https://docs.projectcalico.org/release-notes/) for Calico v3.15.1
* set Felix `routeSource` = `WorkloadIPs` when Calico is used for policy enforcement alone --  the default value for [routeSource](https://docs.projectcalico.org/reference/resources/felixconfig) is `CalicoIPAM` which is applicable when using Calico IPAM. For reference, we have made an [equivalent change ](https://github.com/tigera/operator/commit/b2e7fc5d5d41c5075b8fae8acad3cadbd112dc2d) in operator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
