### PR TITLE
enable manual override for VERSION in images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 		metrics-unit-test docker-metrics-test
 
 # VERSION is the source revision that executables and images are built from.
-VERSION = $(shell git describe --tags --always --dirty || echo "unknown")
+VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .


### PR DESCRIPTION
(cherry picked from commit 840a129186c192fd9cd78e7ddb5b57e990813109)

*Description of changes:*
* Cherry pick of Makefile update to make `VERSION` possible to override

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
