### PR TITLE
Wait for ENI and secondary IPs

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -16,8 +16,11 @@ package awsutils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -794,6 +797,83 @@ func Test_badENIID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := badENIID(tt.errMsg); got != tt.want {
 				t.Errorf("badENIID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEC2InstanceMetadataCache_waitForENIAndIPsAttached(t *testing.T) {
+	type args struct {
+		eni                string
+		foundSecondaryIPs  int
+		wantedSecondaryIPs int
+		maxBackoffDelay    time.Duration
+		times              int
+	}
+	eni1Metadata := ENIMetadata{
+		ENIID:         eniID,
+		IPv4Addresses: nil,
+	}
+	isPrimary := true
+	notPrimary := false
+	primaryIP := eni2PrivateIP
+	secondaryIP1 := primaryIP + "0"
+	secondaryIP2 := primaryIP + "1"
+	eni2Metadata := ENIMetadata{
+		ENIID:          eni2ID,
+		MAC:            eni2MAC,
+		DeviceNumber:   2,
+		SubnetIPv4CIDR: subnetCIDR,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				Primary:          &isPrimary,
+				PrivateIpAddress: &primaryIP,
+			}, {
+				Primary:          &notPrimary,
+				PrivateIpAddress: &secondaryIP1,
+			}, {
+				Primary:          &notPrimary,
+				PrivateIpAddress: &secondaryIP2,
+			},
+		},
+	}
+	eniList := []ENIMetadata{eni1Metadata, eni2Metadata}
+	tests := []struct {
+		name            string
+		args            args
+		wantEniMetadata ENIMetadata
+		wantErr         bool
+	}{
+		{"Test wait success", args{eni: eni2ID, foundSecondaryIPs: 2, wantedSecondaryIPs: 2, maxBackoffDelay: 5 * time.Millisecond, times: 1}, eniList[1], false},
+		{"Test partial success", args{eni: eni2ID, foundSecondaryIPs: 2, wantedSecondaryIPs: 12, maxBackoffDelay: 5 * time.Millisecond, times: maxENIEC2APIRetries}, eniList[1], false},
+		{"Test wait fail", args{eni: eni2ID, foundSecondaryIPs: 0, wantedSecondaryIPs: 12, maxBackoffDelay: 5 * time.Millisecond, times: maxENIEC2APIRetries}, ENIMetadata{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, mockMetadata, mockEC2 := setup(t)
+			defer ctrl.Finish()
+			eniIPs := eni2PrivateIP
+			for i := 0; i < tt.args.foundSecondaryIPs; i++ {
+				eniIPs += " " + eni2PrivateIP + strconv.Itoa(i)
+			}
+			fmt.Println("eniips", eniIPs)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath).Return(primaryMAC+" "+eni2MAC, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataDeviceNum).Return(eni1Device, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataInterface).Return(primaryeniID, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataSubnetCIDR).Return(subnetCIDR, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+primaryMAC+metadataIPv4s).Return(eni1PrivateIP, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataDeviceNum).Return(eni2Device, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataInterface).Return(eni2ID, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataSubnetCIDR).Return(subnetCIDR, nil).Times(tt.args.times)
+			mockMetadata.EXPECT().GetMetadata(metadataMACPath+eni2MAC+metadataIPv4s).Return(eniIPs, nil).Times(tt.args.times)
+			cache := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
+			gotEniMetadata, err := cache.waitForENIAndIPsAttached(tt.args.eni, tt.args.wantedSecondaryIPs, tt.args.maxBackoffDelay)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("waitForENIAndIPsAttached() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotEniMetadata, tt.wantEniMetadata) {
+				t.Errorf("waitForENIAndIPsAttached() gotEniMetadata = %v, want %v", gotEniMetadata, tt.wantEniMetadata)
 			}
 		})
 	}

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -280,3 +280,18 @@ func (mr *MockAPIsMockRecorder) SetUnmanagedENIs(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetUnmanagedENIs), arg0)
 }
+
+// WaitForENIAndIPsAttached mocks base method
+func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENIMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForENIAndIPsAttached", arg0, arg1)
+	ret0, _ := ret[0].(awsutils.ENIMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForENIAndIPsAttached indicates an expected call of WaitForENIAndIPsAttached
+func (mr *MockAPIsMockRecorder) WaitForENIAndIPsAttached(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForENIAndIPsAttached", reflect.TypeOf((*MockAPIs)(nil).WaitForENIAndIPsAttached), arg0, arg1)
+}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -236,7 +236,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 		m.awsutils.EXPECT().AllocENI(false, nil, "").Return(eni2, nil)
 	}
 
-	m.awsutils.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,
 			MAC:            primaryMAC,
@@ -265,9 +265,10 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool) {
 				},
 			},
 		},
-	}, nil)
+	}
 
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
+	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 14).Return(eniMetadata[1], nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	m.awsutils.EXPECT().AllocIPAddresses(eni2, 14)
@@ -305,7 +306,7 @@ func TestTryAddIPToENI(t *testing.T) {
 
 	m.awsutils.EXPECT().AllocENI(false, nil, "").Return(secENIid, nil)
 	m.awsutils.EXPECT().AllocIPAddresses(secENIid, warmIpTarget)
-	m.awsutils.EXPECT().GetAttachedENIs().Return([]awsutils.ENIMetadata{
+	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,
 			MAC:            primaryMAC,
@@ -334,7 +335,8 @@ func TestTryAddIPToENI(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}
+	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 3).Return(eniMetadata[1], nil)
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)


### PR DESCRIPTION
Issue #, if available:
#989, #1148 

*Description of changes:*

The log statements helping us find #989 were added earlier this year in #909 and #939, but the issue has probably been there longer. The problem is detailed in #1148, we need to wait for the Secondary IPv4 addresses to show up in the EC2 response. This PR does the following:

* Move `waitENIAttached()` from `ipamd.go` to `awsutils.go`
* Added an additional argument for how many secondary IPs to wait for
* Use retry with backoff instead of for-loop with sleep.
* If we find at least 1 secondary IP, but less than we wanted, we don't return an error, but count it as a partial success
* Added unit tests 

(Replacing #1131 with a new PR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
