### PR TITLE
Default to 1.16.10 for gingko tests

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -16,7 +16,7 @@ OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
 
 : "${AWS_DEFAULT_REGION:=us-west-2}"
-: "${K8S_VERSION:=1.17.9}"
+: "${K8S_VERSION:=1.16.10}"
 : "${PROVISION:=true}"
 : "${DEPROVISION:=true}"
 : "${BUILD:=true}"
@@ -241,7 +241,7 @@ if [[ $TEST_PASS -eq 0 && "$RUN_CONFORMANCE" == true ]]; then
   START=$SECONDS
 
   go install github.com/onsi/ginkgo/ginkgo
-  wget -qO- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test.tar.gz | tar -zxvf - --strip-components=4 -C /tmp  kubernetes/platforms/linux/amd64/e2e.test
+  wget -O- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test.tar.gz | tar -zxvf - --strip-components=4 -C /tmp  kubernetes/platforms/linux/amd64/e2e.test
   $GOPATH/bin/ginkgo -p --focus="Conformance"  --failFast --flakeAttempts 2 \
    --skip="(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]|\[Serial\]" /tmp/e2e.test -- --kubeconfig=$KUBECONFIG
 


### PR DESCRIPTION
*Description of changes:*
Saw issues fetching newer tests, defaulting to 1.16 for now.

Passing e2e test: https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/737/workflows/681bf79c-40ce-4cef-9b19-32648c027ba7/jobs/1479

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
