### PR TITLE
Handle stale IMDS metadata for secondary IPs

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -878,3 +878,15 @@ func TestEC2InstanceMetadataCache_waitForENIAndIPsAttached(t *testing.T) {
 		})
 	}
 }
+
+func TestEC2InstanceMetadataCache_SetUnmanagedENIs(t *testing.T) {
+	_, mockMetadata, _ := setup(t)
+	ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata}
+	ins.SetUnmanagedENIs(nil)
+	assert.False(t, ins.IsUnmanagedENI("eni-1"))
+	ins.SetUnmanagedENIs([]string{"eni-1", "eni-2"})
+	assert.True(t, ins.IsUnmanagedENI("eni-1"))
+	assert.False(t, ins.IsUnmanagedENI("eni-99"))
+	ins.SetUnmanagedENIs(nil)
+	assert.False(t, ins.IsUnmanagedENI("eni-1"))
+}

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -268,11 +268,9 @@ func (mr *MockAPIsMockRecorder) IsUnmanagedENI(arg0 interface{}) *gomock.Call {
 }
 
 // SetUnmanagedENIs mocks base method
-func (m *MockAPIs) SetUnmanagedENIs(arg0 []string) error {
+func (m *MockAPIs) SetUnmanagedENIs(arg0 []string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnmanagedENIs", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "SetUnmanagedENIs", arg0)
 }
 
 // SetUnmanagedENIs indicates an expected call of SetUnmanagedENIs

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -690,7 +690,7 @@ func (ds *DataStore) RemoveUnusedENIFromStore(warmIPTarget int, minimumIPTarget 
 	return removableENI
 }
 
-// RemoveENIFromDataStore removes an ENI from the datastore.  It return nil on success or an error.
+// RemoveENIFromDataStore removes an ENI from the datastore. It returns nil on success, or an error.
 func (ds *DataStore) RemoveENIFromDataStore(eniID string, force bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
@@ -704,9 +704,9 @@ func (ds *DataStore) RemoveENIFromDataStore(eniID string, force bool) error {
 		if !force {
 			return errors.New(ENIInUseError)
 		}
-		// This scenario can occur if the reconciliation process discovered this eni was detached
-		// from the EC2 instance outside of the control of ipamd.  If this happens, there's nothing
-		// we can do other than force all pods to be unassigned from the IPs on this eni.
+		// This scenario can occur if the reconciliation process discovered this ENI was detached
+		// from the EC2 instance outside of the control of ipamd. If this happens, there's nothing
+		// we can do other than force all pods to be unassigned from the IPs on this ENI.
 		ds.log.Warnf("Force removing eni %s with %d assigned pods", eniID, eni.AssignedIPv4Addresses())
 		forceRemovedENIs.Inc()
 		forceRemovedIPs.Add(float64(eni.AssignedIPv4Addresses()))


### PR DESCRIPTION
*Related issues:* #1070, #1094

*Description of changes:*
If the ENI metadata returned from IMDS does not match with what we have in the datastore, we need to verify with EC2 API.
* Always store the Primary IP of each ENI that gets added
* If `SetupENINetwork()`, always remove the ENI we just tried to add from the datastore
* Call EC2 if the number of secondary IPs is not what we expect
* If IMDS returns no ENIs at all, abort the reconcile since the primary ENI should never be gone
* When a Pod IP is out of cool down, only call EC2 once for that ENI
* When an ENI is completely missing from IMDS, still remove it from the datastore

Successful E2E tests: https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/812/workflows/673a9bc3-0122-4972-b276-dec44ec8f546/jobs/1639

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
