### PR TITLE
Make a deep copy for introspection

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -819,7 +819,7 @@ func (ds *DataStore) FreeableIPs(eniID string) []string {
 	return freeable
 }
 
-// GetENIInfos provides ENI IP information to introspection endpoint
+// GetENIInfos provides ENI and IP information about the datastore
 func (ds *DataStore) GetENIInfos() *ENIInfos {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
@@ -831,7 +831,14 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 	}
 
 	for eni, eniInfo := range ds.eniPool {
-		eniInfos.ENIs[eni] = *eniInfo
+		tmpENIInfo := *eniInfo
+		tmpENIInfo.IPv4Addresses = make(map[string]*AddressInfo, len(eniInfo.IPv4Addresses))
+		// Since IP Addresses might get removed, we need to make a deep copy here.
+		for eni, ipAddrInfoRef := range eniInfo.IPv4Addresses {
+			ipAddrInfo := *ipAddrInfoRef
+			tmpENIInfo.IPv4Addresses[eni] = &ipAddrInfo
+		}
+		eniInfos.ENIs[eni] = tmpENIInfo
 	}
 	return &eniInfos
 }

--- a/pkg/ipamd/introspect.go
+++ b/pkg/ipamd/introspect.go
@@ -130,9 +130,7 @@ func (c *IPAMContext) setupIntrospectionServer() *http.Server {
 
 func eniV1RequestHandler(ipam *IPAMContext) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		eniInfos := ipam.dataStore.GetENIInfos()
-		log.Debugf("eniInfos: %+v", eniInfos)
-		responseJSON, err := json.Marshal(eniInfos)
+		responseJSON, err := json.Marshal(ipam.dataStore.GetENIInfos())
 		if err != nil {
 			log.Errorf("Failed to marshal ENI data: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -908,13 +908,13 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 		return
 	}
 	attachedENIs := c.filterUnmanagedENIs(allENIs)
-	currentENIIPPools := c.dataStore.GetENIInfos().ENIs
+	currentENIs := c.dataStore.GetENIInfos().ENIs
 	trunkENI := c.dataStore.GetTrunkENI()
 
 	// Check if a new ENI was added, if so we need to update the tags.
 	needToUpdateTags := false
 	for _, attachedENI := range attachedENIs {
-		if _, ok := currentENIIPPools[attachedENI.ENIID]; !ok {
+		if _, ok := currentENIs[attachedENI.ENIID]; !ok {
 			needToUpdateTags = true
 			break
 		}
@@ -950,8 +950,8 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 			log.Debugf("Reconcile existing ENI %s IP pool", attachedENI.ENIID)
 			// Reconcile IP pool
 			c.eniIPPoolReconcile(eniIPPool, attachedENI, attachedENI.ENIID)
-			// Mark action, remove this ENI from currentENIIPPools map
-			delete(currentENIIPPools, attachedENI.ENIID)
+			// Mark action, remove this ENI from currentENIs map
+			delete(currentENIs, attachedENI.ENIID)
 			continue
 		}
 
@@ -968,7 +968,7 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 	}
 
 	// Sweep phase: since the marked ENI have been removed, the remaining ones needs to be sweeped
-	for eni := range currentENIIPPools {
+	for eni := range currentENIs {
 		log.Infof("Reconcile and delete detached ENI %s", eni)
 		// Force the delete, since aws local metadata has told us that this ENI is no longer
 		// attached, so any IPs assigned from this ENI will no longer work.


### PR DESCRIPTION
*Issue #, if available:* #1101

*Description of changes:*
Follow up to #1178. The logs make it clear that `map[string]*AddressInfo` inside the `ENI` struct is causing the issue: 
```
{"level":"info","ts":"2020-08-30T16:48:05.305Z","caller":"http/server.go:2416","msg":"Handling http request: GET, from: 127.0.0.1:56308, URI: /v1/enis"}
{"level":"debug","ts":"2020-08-30T16:48:05.305Z","caller":"http/server.go:2041","msg":"eniInfos: &{TotalIPs:42 AssignedIPs:3 ENIs:map[eni-04e635dd5bb78338c:{ID:eni-04e635dd5bb78338c createTime:{wall:13820161790756677995 ext:1420777325 loc:0x559806b2f3c0} IsPrimary:true IsTrunk:false DeviceNumber:0 IPv4Addresses:map[192.168.67.189:0xc000489620 192.168.69.119:0xc0004897a0 192.168.73.173:0xc000489320 192.168.74.37:0xc0004893e0 192.168.76.135:0xc000489440 192.168.79.14:0xc000489380 192.168.84.205:0xc0004892c0 192.168.86.63:0xc0004896e0 192.168.87.28:0xc000489560 192.168.88.155:0xc0004894a0 192.168.88.244:0xc000489740 192.168.90.222:0xc000489680 192.168.92.61:0xc0004895c0 192.168.94.188:0xc000489500]} eni-087c7067a58f9d3b0:{ID:eni-087c7067a58f9d3b0 createTime:{wall:13820161790756768172 ext:1420867502 loc:0x559806b2f3c0} IsPrimary:false IsTrunk:false DeviceNumber:2 IPv4Addresses:map[192.168.65.23:0xc0005de060 192.168.66.255:0xc000489f20 192.168.71.122:0xc000489da0 192.168.74.63:0xc000489ec0 192.168.75.147:0xc0005de000 192.168.77.190:0xc000489e60 192.168.80.132:0xc000489bc0 192.168.81.170:0xc000489b60 192.168.82.81:0xc000489f80 192.168.83.248:0xc000489d40 192.168.83.254:0xc000489e00 192.168.83.7:0xc000489c20 192.168.87.152:0xc000489c80 192.168.87.24:0xc000489ce0]} eni-099ea6395cdb509e6:{ID:eni-099ea6395cdb509e6 createTime:{wall:13820161790758681173 ext:1422780502 loc:0x559806b2f3c0} IsPrimary:false IsTrunk:true DeviceNumber:4 IPv4Addresses:map[192.168.69.116:0xc000489080 192.168.70.178:0xc000488fc0 192.168.70.45:0xc000488cc0 192.168.72.114:0xc000488f60 192.168.77.192:0xc000488d80 192.168.79.195:0xc000488e40 192.168.80.157:0xc000488f00 192.168.84.107:0xc000488c00 192.168.87.154:0xc000488ea0 192.168.87.206:0xc000488d20 192.168.87.234:0xc000488ba0 192.168.88.225:0xc000488de0 192.168.91.242:0xc000489020 192.168.92.75:0xc000488c60]}]}"}
```
* Making a deep copy of the `IPv4Addresses` map.
* Remove verbose logging
* Rename `currentENIIPPools` to `currentENIs` since the struct was renamed [in #972](https://github.com/aws/amazon-vpc-cni-k8s/pull/972/files#diff-9377ea0fd9a5d87e7a1c75a48c5c78a8R504)

e2e tests passing https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/784/workflows/d2d2bd30-118e-408b-894d-490879722a7e/jobs/1587

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
