### PR TITLE
Update Calico images to v3.15.1 & set routeSource=WorkloadIPs

### DIFF
--- a/config/v1.7/calico.yaml
+++ b/config/v1.7/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.4
+          image: quay.io/calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -71,6 +71,8 @@ spec:
               value: "none"
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"
+            - name: FELIX_ROUTESOURCE
+              value: "WorkloadIPs"
             - name: NO_DEFAULT_POOLS
               value: "true"
             # Set based on the k8s node name.
@@ -547,7 +549,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.4
+        - image: quay.io/calico/typha:v3.15.1
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
Update Calico images to v3.15.1 & set `routeSource=WorkloadIPs` in Felix for v1.7 config.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->

**What type of PR is this?**
cleanup (updating images and fixing config)

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue(s) this PR fixes**:
- Updating Calico images
- Setting a Felix config

**What this PR does / why we need it**:

Proposed PR is the same as #1165, requesting to update Calico image version and Felix config to `v1.7` config in `release-v1.7` branch. 

**Testing**:
<!--output of manual testing/integration tests results-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
