### PR TITLE
Mount /run/xtables.lock to prevent unwanted race conditions.

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -189,6 +189,8 @@
           "name": "run-dir"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
+        - "mountPath": "/run/xtables.lock"
+          "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
       - "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:latest"
@@ -214,6 +216,9 @@
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"
+      - "hostPath":
+          "path": "/run/xtables.lock"
+        "name": "xtables-lock"
       - "hostPath":
           "path": "/var/log/aws-routed-eni"
           "type": "DirectoryOrCreate"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -189,6 +189,8 @@
           "name": "run-dir"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
+        - "mountPath": "/run/xtables.lock"
+          "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
       - "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:latest"
@@ -214,6 +216,9 @@
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"
+      - "hostPath":
+          "path": "/run/xtables.lock"
+        "name": "xtables-lock"
       - "hostPath":
           "path": "/var/log/aws-routed-eni"
           "type": "DirectoryOrCreate"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -189,6 +189,8 @@
           "name": "run-dir"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
+        - "mountPath": "/run/xtables.lock"
+          "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
       - "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:latest"
@@ -214,6 +216,9 @@
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"
+      - "hostPath":
+          "path": "/run/xtables.lock"
+        "name": "xtables-lock"
       - "hostPath":
           "path": "/var/log/aws-routed-eni"
           "type": "DirectoryOrCreate"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -189,6 +189,8 @@
           "name": "run-dir"
         - "mountPath": "/var/run/dockershim.sock"
           "name": "dockershim"
+        - "mountPath": "/run/xtables.lock"
+          "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
       - "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:latest"
@@ -214,6 +216,9 @@
       - "hostPath":
           "path": "/var/run/dockershim.sock"
         "name": "dockershim"
+      - "hostPath":
+          "path": "/run/xtables.lock"
+        "name": "xtables-lock"
       - "hostPath":
           "path": "/var/log/aws-routed-eni"
           "type": "DirectoryOrCreate"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -198,6 +198,7 @@ local awsnode = {
                 {mountPath: "/host/var/log/aws-routed-eni", name: "log-dir"},
                 {mountPath: "/var/run/aws-node", name: "run-dir"},
                 {mountPath: "/var/run/dockershim.sock", name: "dockershim"},
+                {mountPath: "/run/xtables.lock", name: "xtables-lock"},
               ],
             },
           },
@@ -206,6 +207,7 @@ local awsnode = {
             {name: "cni-bin-dir", hostPath: {path: "/opt/cni/bin"}},
             {name: "cni-net-dir", hostPath: {path: "/etc/cni/net.d"}},
             {name: "dockershim", hostPath: {path: "/var/run/dockershim.sock"}},
+            {name: "xtables-lock", hostPath: {path: "/run/xtables.lock"}},
             {name: "log-dir",
               hostPath: {
                 path: "/var/log/aws-routed-eni",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue(s) this PR fixes**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/989#issuecomment-683392635

**What this PR does / why we need it**:
As initially mentioned in https://github.com/aws/amazon-vpc-cni-k8s/issues/989#issuecomment-683392635 we should mount `/run/xtables.lock` to prevent race conditions where multiple programs are manipulating iptables at the same time.

The `--wait` on iptables commands isn't actually respected unless we mount the iptables lock file in to the container.

The downside of this is that it introduces a blocking action where the cni will wait until the lock is released.

I'm not sure how the kubernetes manifests under `v1.x` are generated, can copy by hand if thats the case..

**If issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing**:
Running `flock -e /run/xtables.lock sleep 180` on the host before starting the container you will observe that the cni will wait 3 minutes until the lock is released. In theory this could be indefinitely according to the iptables manual.

Trying to replicate the exact bug I mentioned in the comment is extremely difficult because you have to be updating iptables at the exact same time as the cni is. We have only seen this bug observed in our production environments a handful of times so far.

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
n/a
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades and downgrades. Has it been tested?**:
Will not break upgrades/downgrades.

**Does this require config only upgrades?**:
yes?
<!--
If this change does not support kubectl patch please add the reason.
-->


**Does this PR introduce a user-facing change?**:
yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->


```release-note
Users are recommended to mount `/run/xtables.lock` to prevent unwanted race conditions.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
