### PR TITLE
Add GitHub workflows for testing

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -1,0 +1,41 @@
+name: Nightly e2e tests
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # every night
+
+jobs:
+  # Run nightly e2e tests on self-hosted runner
+  integration-cron:
+    runs-on: self-hosted
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Clean up stale docker images
+        run: docker image prune -f
+
+      - name: Get dependencies
+        run: |
+          go get -u golang.org/x/lint/golint
+          go get -u golang.org/x/tools/cmd/goimports
+
+      - name: Run e2e tests
+        env:
+          DISABLE_PROMPT: true
+          ROLE_CREATE: false
+          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
+          RUN_CONFORMANCE: true
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          RUN_TESTER_LB_ADDONS: true
+          S3_BUCKET_CREATE: false
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+        run: |
+          ./scripts/run-integration-tests.sh

--- a/.github/workflows/forked-pr-tests.yml
+++ b/.github/workflows/forked-pr-tests.yml
@@ -1,0 +1,78 @@
+name: Manual test runner workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'PR number we want to run tests on'
+        default: ''
+        required: true
+
+jobs:
+  # Repo owner has triggered this run
+  integration-fork:
+    runs-on: self-hosted
+    if:
+      github.event.inputs.pull_request_number != ''
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+
+      # Check out a merge commit
+      - name: Check out latest commit in the PR as a merge commit
+        uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.inputs.pull_request_number }}/merge'
+
+      - name: Get dependencies
+        run: |
+          go get -u golang.org/x/lint/golint
+          go get -u golang.org/x/tools/cmd/goimports
+
+      - name: Clean up stale docker images
+        run: docker image prune -f
+
+      - name: Run e2e tests
+        env:
+          DISABLE_PROMPT: true
+          ROLE_CREATE: false
+          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
+          RUN_CONFORMANCE: true
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          S3_BUCKET_CREATE: false
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+        run: |
+          ./scripts/run-integration-tests.sh
+
+      # Update check run called "integration-fork" to be completed
+      - uses: actions/github-script@v1
+        id: update-check-run-completed
+        env:
+          number: ${{ github.event.inputs.pull_request_number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: checks } = await github.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const { data: result } = await github.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+            return result;

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,40 @@
+name: Integration tests
+
+on:
+  pull_request_target:
+
+jobs:
+  # Branch-based pull request from this repo
+  integration-trusted:
+    runs-on: self-hosted
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -u golang.org/x/lint/golint
+          go get -u golang.org/x/tools/cmd/goimports
+
+      - name: Clean up stale docker images
+        run: docker image prune -f
+
+      - name: Run e2e tests
+        env:
+          DISABLE_PROMPT: true
+          ROLE_CREATE: false
+          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
+          RUN_CONFORMANCE: true
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          S3_BUCKET_CREATE: false
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+        run: |
+          ./scripts/run-integration-tests.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,41 @@
+name: Run unit tests
+
+on:
+  pull_request_target:
+    branches: [ master ]
+
+jobs:
+
+  build_x86_64:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -u golang.org/x/lint/golint
+        go get -u golang.org/x/tools/cmd/goimports
+
+    - name: Run code checks
+      run: |
+        make check-format
+        # make lint LINT_FLAGS=
+        make vet
+
+    - name: Build
+      run: make build-linux
+
+    - name: Unit Tests
+      run: make unit-test
+
+    - name: Upload code coverage
+      run: bash <(curl -s https://codecov.io/bash)

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -6,6 +6,7 @@ check_aws_credentials() {
 }
 
 ensure_ecr_repo() {
+    echo "Ensuring that $2 exists for account $1"
     local __registry_account_id="$1"
     local __repo_name="$2"
     if ! `aws ecr describe-repositories --registry-id "$__registry_account_id" --repository-names "$__repo_name" >/dev/null 2>&1`; then
@@ -28,6 +29,9 @@ ensure_aws_k8s_tester() {
 }
 
 ensure_eksctl() {
-    curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-    sudo mv -v /tmp/eksctl /usr/local/bin
+    EKS_BIN=/usr/local/bin/eksctl
+    if [[ ! -e $EKS_BIN ]]; then
+        curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+        sudo mv -v /tmp/eksctl $EKS_BIN
+    fi
 }

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function down-test-cluster() {
-    if [[ -n "${CIRCLE_JOB:-}" ]]; then
+    if [[ -n "${CIRCLE_JOB:-}" || -n "${DISABLE_PROMPT:-}" ]]; then
         $TESTER_PATH eks delete cluster --enable-prompt=false --path $CLUSTER_CONFIG || (echo "failed!" && exit 1)
     else
         echo -n "Deleting cluster $CLUSTER_NAME (this may take ~10 mins) ... "
@@ -34,14 +34,14 @@ function up-test-cluster() {
         AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_ARN=$ROLE_ARN \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_CREATE=$ROLE_CREATE \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_ARN=$ROLE_ARN \
+        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_ARN=$MNG_ROLE_ARN \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS=$MNGS \
         AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_FETCH_LOGS=true \
-        AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=true \
-        AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=true \
+        AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=$RUN_TESTER_LB_ADDONS \
+        AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=$RUN_TESTER_LB_ADDONS \
         $TESTER_PATH eks create config --path $CLUSTER_CONFIG 1>&2
 
-    if [[ -n "${CIRCLE_JOB:-}" ]]; then
+    if [[ -n "${CIRCLE_JOB:-}" || -n "${DISABLE_PROMPT:-}" ]]; then
         $TESTER_PATH eks create cluster --enable-prompt=false --path $CLUSTER_CONFIG || (echo "failed!" && exit 1)
     else
         echo -n "Creating cluster $CLUSTER_NAME (this may take ~20 mins. details: tail -f $CLUSTER_MANAGE_LOG_PATH)... "

--- a/scripts/lib/integration.sh
+++ b/scripts/lib/integration.sh
@@ -11,6 +11,7 @@ function run_kops_conformance() {
     done
     echo "Updated!"
 
+    GOPATH=$(go env GOPATH)
     go install github.com/onsi/ginkgo/ginkgo
     wget -qO- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test.tar.gz | tar -zxvf - --strip-components=4 -C /tmp  kubernetes/platforms/linux/amd64/e2e.test
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -21,6 +21,7 @@ ARCH=$(go env GOARCH)
 : "${DEPROVISION:=true}"
 : "${BUILD:=true}"
 : "${RUN_CONFORMANCE:=false}"
+: "${RUN_TESTER_LB_ADDONS:=false}"
 : "${RUN_KOPS_TEST:=false}"
 : "${RUN_BOTTLEROCKET_TEST:=false}"
 : "${RUN_PERFORMANCE_TESTS:=false}"
@@ -51,7 +52,8 @@ on_error() {
 
 # test specific config, results location
 : "${TEST_ID:=$RANDOM}"
-TEST_DIR=/tmp/cni-test/$(date "+%Y%M%d%H%M%S")-$TEST_ID
+: "${TEST_BASE_DIR:=${DIR}/cni-test}"
+TEST_DIR=${TEST_BASE_DIR}/$(date "+%Y%M%d%H%M%S")-$TEST_ID
 REPORT_DIR=${TEST_DIR}/report
 TEST_CONFIG_DIR="$TEST_DIR/config"
 
@@ -59,16 +61,17 @@ TEST_CONFIG_DIR="$TEST_DIR/config"
 # Pass in CLUSTER_ID to reuse a test cluster
 : "${CLUSTER_ID:=$RANDOM}"
 CLUSTER_NAME=cni-test-$CLUSTER_ID
-TEST_CLUSTER_DIR=/tmp/cni-test/cluster-$CLUSTER_NAME
+TEST_CLUSTER_DIR=${TEST_BASE_DIR}/cluster-$CLUSTER_NAME
 CLUSTER_MANAGE_LOG_PATH=$TEST_CLUSTER_DIR/cluster-manage.log
 : "${CLUSTER_CONFIG:=${TEST_CLUSTER_DIR}/${CLUSTER_NAME}.yaml}"
 : "${KUBECONFIG_PATH:=${TEST_CLUSTER_DIR}/kubeconfig}"
 : "${ADDONS_CNI_IMAGE:=""}"
 
 # shared binaries
-: "${TESTER_DIR:=/tmp/aws-k8s-tester}"
+: "${TESTER_DIR:=${DIR}/aws-k8s-tester}"
 : "${TESTER_PATH:=$TESTER_DIR/aws-k8s-tester}"
 : "${KUBECTL_PATH:=$TESTER_DIR/kubectl}"
+export PATH=${PATH}:$TESTER_DIR
 
 LOCAL_GIT_VERSION=$(git describe --tags --always --dirty)
 # The manifest image version is the image tag we need to replace in the
@@ -99,14 +102,14 @@ ensure_aws_k8s_tester
 : "${INIT_IMAGE_NAME:="$AWS_ECR_REGISTRY/$AWS_INIT_ECR_REPO_NAME"}"
 : "${ROLE_CREATE:=true}"
 : "${ROLE_ARN:=""}"
+: "${MNG_ROLE_ARN:=""}"
 
 # S3 bucket initialization
 : "${S3_BUCKET_CREATE:=true}"
 : "${S3_BUCKET_NAME:=""}"
 
-# `aws ec2 get-login` returns a docker login string, which we eval here to login to the ECR registry
-# shellcheck disable=SC2046
-eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email) >/dev/null 2>&1
+echo "Logging in to docker repo"
+aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY}
 ensure_ecr_repo "$AWS_ACCOUNT_ID" "$AWS_ECR_REPO_NAME"
 ensure_ecr_repo "$AWS_ACCOUNT_ID" "$AWS_INIT_ECR_REPO_NAME"
 
@@ -119,7 +122,7 @@ if [[ $(docker images -q "$IMAGE_NAME:$TEST_IMAGE_VERSION" 2> /dev/null) ]]; the
 else
     echo "CNI image $IMAGE_NAME:$TEST_IMAGE_VERSION does not exist in repository."
     if [[ $TEST_IMAGE_VERSION != "$LOCAL_GIT_VERSION" ]]; then
-        __cni_source_tmpdir="/tmp/cni-src-$IMAGE_VERSION"
+        __cni_source_tmpdir="${TEST_BASE_DIR}/cni-src-$IMAGE_VERSION"
         echo "Checking out CNI source code for $IMAGE_VERSION ..."
 
         git clone --depth=1 --branch "$TEST_IMAGE_VERSION" \
@@ -240,12 +243,15 @@ if [[ $TEST_PASS -eq 0 && "$RUN_CONFORMANCE" == true ]]; then
   echo "Running conformance tests against cluster."
   START=$SECONDS
 
-  go install github.com/onsi/ginkgo/ginkgo
-  wget -O- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test.tar.gz | tar -zxvf - --strip-components=4 -C /tmp  kubernetes/platforms/linux/amd64/e2e.test
-  $GOPATH/bin/ginkgo -p --focus="Conformance"  --failFast --flakeAttempts 2 \
-   --skip="(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]|\[Serial\]" /tmp/e2e.test -- --kubeconfig=$KUBECONFIG
+  GOPATH=$(go env GOPATH)
+  echo "PATH: $PATH"
 
-  /tmp/e2e.test --ginkgo.focus="\[Serial\].*Conformance" --kubeconfig=$KUBECONFIG --ginkgo.failFast --ginkgo.flakeAttempts 2 \
+  go install github.com/onsi/ginkgo/ginkgo
+  wget -qO- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test.tar.gz | tar -zxvf - --strip-components=4 -C ${TEST_BASE_DIR}  kubernetes/platforms/linux/amd64/e2e.test
+  $GOPATH/bin/ginkgo -p --focus="Conformance" --failFast --flakeAttempts 2 \
+   --skip="(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]|\[Serial\]" ${TEST_BASE_DIR}/e2e.test -- --kubeconfig=$KUBECONFIG
+
+  ${TEST_BASE_DIR}/e2e.test --ginkgo.focus="\[Serial\].*Conformance" --kubeconfig=$KUBECONFIG --ginkgo.failFast --ginkgo.flakeAttempts 2 \
     --ginkgo.skip="(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]"
 
   CONFORMANCE_DURATION=$((SECONDS - START))


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue(s) this PR fixes**:

We want to enable e2e tests on PRs before they are merged. (This PR replaces #1194 with a simpler solution)

**What this PR does**:

- Add a standard unit test run for all PRs
- Add integration tests for PRs that run on on a manual workflow trigger
- Add a nightly test run. 

To do this we use the recently added [`pull_request_target `](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) that always runs in the context of the base repository for the PR.

The manual workflow is triggered by a [`workflow_dispatch`](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch) event that is only available to users with write permissions to the repo.

This PR also does the first step of #786, disabling the NLB and ALB tests on PR e2e tests, but run them in the nightly tests by setting `RUN_TESTER_LB_ADDONS=true`.

**Testing**:

Manual e2 run triggered:
https://github.com/mogren/amazon-vpc-cni-k8s/runs/1074412555?check_suite_focus=true

Tests on in-repo branch PRs works:
https://github.com/mogren/amazon-vpc-cni-k8s/runs/1069555238?check_suite_focus=true

Nightly test run:
https://github.com/mogren/amazon-vpc-cni-k8s/runs/1072813881?check_suite_focus=true

The changes to the `run-integration-tests.sh` script still works with CircleCI:
https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/883/workflows/33505350-bd9a-437b-99e0-526e678ae4e8/jobs/1787

**Automation added to e2e**:
This PR runs the e2e tests as GitHub workflows

**Will this break upgrades and downgrades. Has it been tested?**:
It will not

**Does this require config changes**:
No CNI config changes, but it does require adding [self hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository) to the `aws/amazon-vpc-cni-k8s` repo.

**Does this PR introduce a user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
