### PR TITLE
Fix all golint issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ lint:
 	@command -v golint >/dev/null || { echo "ERROR: golint not installed"; exit 1; }
 	find . \
 	  -type f -name '*.go' \
-	  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" \
+	  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" -not -name "eniconfig.go" \
 	  -print0 | sort -z | xargs -0 -L1 -- golint $(LINT_FLAGS) 2>/dev/null
 
 # Run go vet on source code.

--- a/pkg/grpcwrapper/client.go
+++ b/pkg/grpcwrapper/client.go
@@ -17,12 +17,14 @@ import (
 	google_grpc "google.golang.org/grpc"
 )
 
+// GRPC is the ipamd client Dial interface
 type GRPC interface {
 	Dial(target string, opts ...google_grpc.DialOption) (*google_grpc.ClientConn, error)
 }
 
 type cniGRPC struct{}
 
+// New creates a new cniGRPC
 func New() GRPC {
 	return &cniGRPC{}
 }

--- a/pkg/ipamd/introspect.go
+++ b/pkg/ipamd/introspect.go
@@ -60,7 +60,7 @@ func (c *IPAMContext) ServeIntrospection() {
 
 	server := c.setupIntrospectionServer()
 	for {
-		_ = retry.RetryWithBackoff(retry.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
+		_ = retry.WithBackoff(retry.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
 			var ln net.Listener
 			var err error
 

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1260,7 +1260,7 @@ func (c *IPAMContext) getTrunkLinkIndex() (int, error) {
 
 		}
 	}
-	return -1, errors.New("no trunk!")
+	return -1, errors.New("no trunk found")
 }
 
 // SetNodeLabel sets or deletes a node label

--- a/pkg/ipamd/metrics.go
+++ b/pkg/ipamd/metrics.go
@@ -42,7 +42,7 @@ func (c *IPAMContext) ServeMetrics() {
 	server := c.setupMetricsServer()
 	for {
 		once := sync.Once{}
-		_ = retry.RetryWithBackoff(retry.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
+		_ = retry.WithBackoff(retry.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
 			err := server.ListenAndServe()
 			once.Do(func() {
 				log.Warnf("Error running http API: %v", err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -89,12 +89,11 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 				if trunkENI == "" {
 					log.Warn("Send AddNetworkReply: No trunk ENI found, cannot add a pod ENI")
 					return &failureResponse, nil
-				} else {
-					trunkENILinkIndex, err = s.ipamContext.getTrunkLinkIndex()
-					if err != nil {
-						log.Warn("Send AddNetworkReply: No trunk ENI Link Index found, cannot add a pod ENI")
-						return &failureResponse, nil
-					}
+				}
+				trunkENILinkIndex, err = s.ipamContext.getTrunkLinkIndex()
+				if err != nil {
+					log.Warn("Send AddNetworkReply: No trunk ENI Link Index found, cannot add a pod ENI")
+					return &failureResponse, nil
 				}
 				val, branch := pod.Annotations["vpc.amazonaws.com/pod-eni"]
 				if branch {
@@ -197,20 +196,19 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 			}
 			log.Warnf("Send DelNetworkReply: Failed to get pod spec: %v", err)
 			return &rpc.DelNetworkReply{Success: false}, err
-		} else {
-			val, branch := pod.Annotations["vpc.amazonaws.com/pod-eni"]
-			if branch {
-				// Parse JSON data
-				var podENIData []PodENIData
-				err := json.Unmarshal([]byte(val), &podENIData)
-				if err != nil || len(podENIData) < 1 {
-					log.Errorf("Failed to unmarshal PodENIData JSON: %v", err)
-				}
-				return &rpc.DelNetworkReply{
-					Success:   true,
-					PodVlanId: int32(podENIData[0].VlanID),
-					IPv4Addr:  podENIData[0].PrivateIP}, err
+		}
+		val, branch := pod.Annotations["vpc.amazonaws.com/pod-eni"]
+		if branch {
+			// Parse JSON data
+			var podENIData []PodENIData
+			err := json.Unmarshal([]byte(val), &podENIData)
+			if err != nil || len(podENIData) < 1 {
+				log.Errorf("Failed to unmarshal PodENIData JSON: %v", err)
 			}
+			return &rpc.DelNetworkReply{
+				Success:   true,
+				PodVlanId: int32(podENIData[0].VlanID),
+				IPv4Addr:  podENIData[0].PrivateIP}, err
 		}
 	}
 	ipamKey := datastore.IPAMKey{

--- a/pkg/ipwrapper/ip.go
+++ b/pkg/ipwrapper/ip.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// IP is the wrapper interface for containernetworking ip plugin
 type IP interface {
 	AddDefaultRoute(gw net.IP, dev netlink.Link) error
 }
@@ -27,6 +28,7 @@ type IP interface {
 type ipRoute struct {
 }
 
+// NewIP returns a new IP
 func NewIP() IP {
 	return &ipRoute{}
 }

--- a/pkg/k8sapi/discovery.go
+++ b/pkg/k8sapi/discovery.go
@@ -160,6 +160,7 @@ func (d *Controller) DiscoverK8SPods(podListWatcher *cache.ListWatch) {
 	select {}
 }
 
+// SetNodeLabel sets or deletes a label on the current node
 func (d *Controller) SetNodeLabel(key, value string) error {
 	// Find my node
 	node, err := d.kubeClient.CoreV1().Nodes().Get(d.myNodeName, metav1.GetOptions{})
@@ -193,6 +194,7 @@ func (d *Controller) SetNodeLabel(key, value string) error {
 	return nil
 }
 
+// GetPod returns a pod based on name and namespace
 func (d *Controller) GetPod(podName, namespace string) (*v1.Pod, error) {
 	return d.kubeClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 }

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -785,7 +785,7 @@ func setupENINetwork(eniIP string, eniMAC string, deviceNumber int, eniSubnetCID
 			return errors.Wrap(err, "setupENINetwork: failed to clean up old routes")
 		}
 
-		err = retry.RetryNWithBackoff(retry.NewSimpleBackoff(500*time.Millisecond, retryRouteAddInterval, 0.15, 2.0), maxRetryRouteAdd, func() error {
+		err = retry.NWithBackoff(retry.NewSimpleBackoff(500*time.Millisecond, retryRouteAddInterval, 0.15, 2.0), maxRetryRouteAdd, func() error {
 			if err := netLink.RouteReplace(&r); err != nil {
 				log.Debugf("Not able to set route %s/0 via %s table %d", r.Dst.IP.String(), gw.String(), tableNumber)
 				return errors.Wrapf(err, "setupENINetwork: unable to replace route entry %s", r.Dst.IP.String())

--- a/pkg/nswrapper/ns.go
+++ b/pkg/nswrapper/ns.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 )
 
+// NS is the wrapper interface for containernetworking ns plugin
 type NS interface {
 	WithNetNSPath(nspath string, toRun func(ns.NetNS) error) error
 }
@@ -24,6 +25,7 @@ type NS interface {
 type nsType struct {
 }
 
+// NewNS returns a new NS
 func NewNS() NS {
 	return &nsType{}
 }

--- a/pkg/procsyswrapper/procsys.go
+++ b/pkg/procsyswrapper/procsys.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 )
 
+// ProcSys is the /proc/sys interface wrapper
 type ProcSys interface {
 	Get(key string) (string, error)
 	Set(key, value string) error
@@ -26,6 +27,7 @@ type procSys struct {
 	prefix string
 }
 
+// NewProcSys returns a new ProcSys
 func NewProcSys() ProcSys {
 	return &procSys{prefix: "/proc/sys/"}
 }

--- a/pkg/rpcwrapper/client.go
+++ b/pkg/rpcwrapper/client.go
@@ -18,12 +18,14 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
+// RPC is the wrapper interface for the CNI gRPC backend client
 type RPC interface {
 	NewCNIBackendClient(cc *grpc.ClientConn) rpc.CNIBackendClient
 }
 
 type cniRPC struct{}
 
+// New returns a new RPC
 func New() RPC {
 	return &cniRPC{}
 }

--- a/pkg/typeswrapper/client.go
+++ b/pkg/typeswrapper/client.go
@@ -17,6 +17,7 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
+// CNITYPES is the wrapper interface for containernetworking types package
 type CNITYPES interface {
 	LoadArgs(args string, container interface{}) error
 	PrintResult(result cnitypes.Result, version string) error
@@ -24,6 +25,7 @@ type CNITYPES interface {
 
 type cniTYPES struct{}
 
+// New returns a new CNITYPES
 func New() CNITYPES {
 	return &cniTYPES{}
 }

--- a/pkg/utils/logger/config.go
+++ b/pkg/utils/logger/config.go
@@ -30,6 +30,7 @@ type Configuration struct {
 	LogLocation string
 }
 
+// LoadLogConfig returns the log configuration
 func LoadLogConfig() *Configuration {
 	return &Configuration{
 		LogLevel:    GetLogLevel(),
@@ -37,7 +38,7 @@ func LoadLogConfig() *Configuration {
 	}
 }
 
-// GetLogFileLocation returns the log file path
+// GetLogLocation returns the log file path
 func GetLogLocation() string {
 	logFilePath := os.Getenv(envLogFilePath)
 	if logFilePath == "" {
@@ -46,6 +47,7 @@ func GetLogLocation() string {
 	return logFilePath
 }
 
+// GetLogLevel returns the log level
 func GetLogLevel() string {
 	logLevel := os.Getenv(envLogLevel)
 	switch logLevel {

--- a/pkg/utils/retry/backoff.go
+++ b/pkg/utils/retry/backoff.go
@@ -20,11 +20,13 @@ import (
 	"time"
 )
 
+// Backoff is the backoff interface
 type Backoff interface {
 	Reset()
 	Duration() time.Duration
 }
 
+// SimpleBackoff is the default simple backoff
 type SimpleBackoff struct {
 	current        time.Duration
 	start          time.Duration
@@ -48,6 +50,7 @@ func NewSimpleBackoff(min, max time.Duration, jitterMultiple, multiple float64) 
 	}
 }
 
+// Duration gets the current duration including jitter
 func (sb *SimpleBackoff) Duration() time.Duration {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
@@ -56,6 +59,7 @@ func (sb *SimpleBackoff) Duration() time.Duration {
 	return AddJitter(ret, time.Duration(int64(float64(ret)*sb.jitterMultiple)))
 }
 
+// Reset resets the backoff
 func (sb *SimpleBackoff) Reset() {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()

--- a/pkg/utils/retry/errors.go
+++ b/pkg/utils/retry/errors.go
@@ -13,34 +13,41 @@
 
 package retry
 
+// Retriable is the retry interface
 type Retriable interface {
 	Retry() bool
 }
 
+// DefaultRetriable is the default retryable
 type DefaultRetriable struct {
 	retry bool
 }
 
+// Retry does the retry
 func (dr DefaultRetriable) Retry() bool {
 	return dr.retry
 }
 
+// NewRetriable creates a new Retriable
 func NewRetriable(retry bool) Retriable {
 	return DefaultRetriable{
 		retry: retry,
 	}
 }
 
+// RetriableError interface
 type RetriableError interface {
 	Retriable
 	error
 }
 
+// DefaultRetriableError is the default retriable error
 type DefaultRetriableError struct {
 	Retriable
 	error
 }
 
+// NewRetriableError returns a new retriable error
 func NewRetriableError(retriable Retriable, err error) RetriableError {
 	return &DefaultRetriableError{
 		retriable,

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -21,18 +21,18 @@ import (
 
 var _time ttime.Time = &ttime.DefaultTime{}
 
-// RetryWithBackoff takes a Backoff and a function to call that returns an error
+// WithBackoff takes a Backoff and a function to call that returns an error
 // If the error is nil then the function will no longer be called
 // If the error is Retriable then that will be used to determine if it should be retried
-func RetryWithBackoff(backoff Backoff, fn func() error) error {
-	return RetryWithBackoffCtx(context.Background(), backoff, fn)
+func WithBackoff(backoff Backoff, fn func() error) error {
+	return WithBackoffCtx(context.Background(), backoff, fn)
 }
 
-// RetryWithBackoffCtx takes a context, a Backoff, and a function to call that returns an error
+// WithBackoffCtx takes a context, a Backoff, and a function to call that returns an error
 // If the context is done, nil will be returned
 // If the error is nil then the function will no longer be called
 // If the error is Retriable then that will be used to determine if it should be retried
-func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) error {
+func WithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) error {
 	var err error
 	for {
 		select {
@@ -49,23 +49,23 @@ func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) 
 	}
 }
 
-// RetryNWithBackoff takes a Backoff, a maximum number of tries 'n', and a
+// NWithBackoff takes a Backoff, a maximum number of tries 'n', and a
 // function that returns an error. The function is called until either it does
 // not return an error or the maximum tries have been reached.
 // If the error returned is Retriable, the Retriability of it will be respected.
 // If the number of tries is exhausted, the last error will be returned.
-func RetryNWithBackoff(backoff Backoff, n int, fn func() error) error {
-	return RetryNWithBackoffCtx(context.Background(), backoff, n, fn)
+func NWithBackoff(backoff Backoff, n int, fn func() error) error {
+	return NWithBackoffCtx(context.Background(), backoff, n, fn)
 }
 
-// RetryNWithBackoffCtx takes a context, a Backoff, a maximum number of tries 'n', and a function that returns an error.
+// NWithBackoffCtx takes a context, a Backoff, a maximum number of tries 'n', and a function that returns an error.
 // The function is called until it does not return an error, the context is done, or the maximum tries have been
 // reached.
 // If the error returned is Retriable, the Retriability of it will be respected.
 // If the number of tries is exhausted, the last error will be returned.
-func RetryNWithBackoffCtx(ctx context.Context, backoff Backoff, n int, fn func() error) error {
+func NWithBackoffCtx(ctx context.Context, backoff Backoff, n int, fn func() error) error {
 	var err error
-	_ = RetryWithBackoffCtx(ctx, backoff, func() error {
+	_ = WithBackoffCtx(ctx, backoff, func() error {
 		err = fn()
 		n--
 		if n == 0 {

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -35,7 +35,7 @@ func TestRetryWithBackoff(t *testing.T) {
 	t.Run("retries", func(t *testing.T) {
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
 		counter := 3
-		_ = RetryWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+		_ = WithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
 			if counter == 0 {
 				return nil
 			}
@@ -47,7 +47,7 @@ func TestRetryWithBackoff(t *testing.T) {
 
 	t.Run("no retries", func(t *testing.T) {
 		// no sleeps
-		_ = RetryWithBackoff(NewSimpleBackoff(10*time.Millisecond, 20*time.Millisecond, 0, 2), func() error {
+		_ = WithBackoff(NewSimpleBackoff(10*time.Millisecond, 20*time.Millisecond, 0, 2), func() error {
 			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
 		})
 	})
@@ -63,7 +63,7 @@ func TestRetryWithBackoffCtx(t *testing.T) {
 	t.Run("retries", func(t *testing.T) {
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
 		counter := 3
-		_ = RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+		_ = WithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
 			if counter == 0 {
 				return nil
 			}
@@ -75,7 +75,7 @@ func TestRetryWithBackoffCtx(t *testing.T) {
 
 	t.Run("no retries", func(t *testing.T) {
 		// no sleeps
-		_ = RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(10*time.Millisecond, 20*time.Millisecond, 0, 2), func() error {
+		_ = WithBackoffCtx(context.TODO(), NewSimpleBackoff(10*time.Millisecond, 20*time.Millisecond, 0, 2), func() error {
 			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
 		})
 	})
@@ -84,7 +84,7 @@ func TestRetryWithBackoffCtx(t *testing.T) {
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
 		counter := 2
 		ctx, cancel := context.WithCancel(context.TODO())
-		_ = RetryWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+		_ = WithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
 			counter--
 			if counter == 0 {
 				cancel()
@@ -107,7 +107,7 @@ func TestRetryNWithBackoff(t *testing.T) {
 		// 2 tries, 1 sleep
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
 		counter := 3
-		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+		err := NWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
 			counter--
 			return errors.New("err")
 		})
@@ -119,7 +119,7 @@ func TestRetryNWithBackoff(t *testing.T) {
 		// 3 tries, 2 sleeps
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
 		counter := 3
-		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+		err := NWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
 			counter--
 			if counter == 0 {
 				return nil
@@ -142,7 +142,7 @@ func TestRetryNWithBackoffCtx(t *testing.T) {
 		// 2 tries, 1 sleep
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
 		counter := 3
-		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+		err := NWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
 			counter--
 			return errors.New("err")
 		})
@@ -154,7 +154,7 @@ func TestRetryNWithBackoffCtx(t *testing.T) {
 		// 3 tries, 2 sleeps
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
 		counter := 3
-		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+		err := NWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
 			counter--
 			if counter == 0 {
 				return nil
@@ -170,7 +170,7 @@ func TestRetryNWithBackoffCtx(t *testing.T) {
 		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
 		counter := 3
 		ctx, cancel := context.WithCancel(context.TODO())
-		err := RetryNWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+		err := NWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
 			counter--
 			if counter == 1 {
 				cancel()


### PR DESCRIPTION

**What type of PR is this?**

cleanup

**What does this PR do**:
This PR fixes all `golint` warnings. After this is merged, we can enforce [golint](https://github.com/golang/lint) in our unit test runs. Warnings fixed:
* Missing or misspelled comments fixed
* Unused argument removed
* Removed unnecessary else-statements after returns
* Fixed stuttering function names (`retry.Retry...`)


**Testing**:
Output of `make lint` before this PR:
```
> make lint 
find . \
  -type f -name '*.go' \
  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" \
  -print0 | sort -z | xargs -0 -L1 -- golint -set_exit_status 2>/dev/null
./pkg/awsutils/awsutils.go:1338:1: exported method EC2InstanceMetadataCache.WaitForENIAndIPsAttached should have comment or be unexported
./pkg/eniconfig/eniconfig.go:61:6: type name will be used as eniconfig.ENIConfigController by other packages, and that stutters; consider calling this Controller
./pkg/eniconfig/eniconfig.go:71:6: type name will be used as eniconfig.ENIConfigInfo by other packages, and that stutters; consider calling this Info
./pkg/eniconfig/eniconfig.go:170:1: exported method ENIConfigController.Getter should have comment or be unexported
./pkg/grpcwrapper/client.go:20:6: exported type GRPC should have comment or be unexported
./pkg/grpcwrapper/client.go:26:1: exported function New should have comment or be unexported
./pkg/ipamd/datastore/data_store.go:55:1: comment on exported const CheckpointMigrationPhase should be of the form "CheckpointMigrationPhase ..."
./pkg/ipamd/datastore/data_store.go:76:1: comment on exported const BackfillNetworkName should be of the form "BackfillNetworkName ..."
./pkg/ipamd/datastore/data_store.go:78:7: exported const BackfillNetworkIface should have comment or be unexported
./pkg/ipamd/datastore/data_store.go:551:1: exported method DataStore.GetTrunkENI should have comment or be unexported
./pkg/ipamd/ipamd.go:1263:24: error strings should not be capitalized or end with punctuation or a newline
./pkg/ipamd/rpc_handler.go:92:12: if block ends with a return statement, so drop this else and outdent its block
./pkg/ipamd/rpc_handler.go:200:10: if block ends with a return statement, so drop this else and outdent its block
./pkg/ipwrapper/ip.go:23:6: exported type IP should have comment or be unexported
./pkg/ipwrapper/ip.go:30:1: exported function NewIP should have comment or be unexported
./pkg/k8sapi/discovery.go:163:1: exported method Controller.SetNodeLabel should have comment or be unexported
./pkg/k8sapi/discovery.go:196:1: exported method Controller.GetPod should have comment or be unexported
./pkg/nswrapper/ns.go:20:6: exported type NS should have comment or be unexported
./pkg/nswrapper/ns.go:27:1: exported function NewNS should have comment or be unexported
./pkg/procsyswrapper/procsys.go:20:6: exported type ProcSys should have comment or be unexported
./pkg/procsyswrapper/procsys.go:29:1: exported function NewProcSys should have comment or be unexported
./pkg/rpcwrapper/client.go:21:6: exported type RPC should have comment or be unexported
./pkg/rpcwrapper/client.go:27:1: exported function New should have comment or be unexported
./pkg/typeswrapper/client.go:20:6: exported type CNITYPES should have comment or be unexported
./pkg/typeswrapper/client.go:27:1: exported function New should have comment or be unexported
./pkg/utils/logger/config.go:33:1: exported function LoadLogConfig should have comment or be unexported
./pkg/utils/logger/config.go:40:1: comment on exported function GetLogLocation should be of the form "GetLogLocation ..."
./pkg/utils/logger/config.go:49:1: exported function GetLogLevel should have comment or be unexported
./pkg/utils/retry/backoff.go:23:6: exported type Backoff should have comment or be unexported
./pkg/utils/retry/backoff.go:28:6: exported type SimpleBackoff should have comment or be unexported
./pkg/utils/retry/backoff.go:51:1: exported method SimpleBackoff.Duration should have comment or be unexported
./pkg/utils/retry/backoff.go:59:1: exported method SimpleBackoff.Reset should have comment or be unexported
./pkg/utils/retry/errors.go:16:6: exported type Retriable should have comment or be unexported
./pkg/utils/retry/errors.go:20:6: exported type DefaultRetriable should have comment or be unexported
./pkg/utils/retry/errors.go:24:1: exported method DefaultRetriable.Retry should have comment or be unexported
./pkg/utils/retry/errors.go:28:1: exported function NewRetriable should have comment or be unexported
./pkg/utils/retry/errors.go:34:6: exported type RetriableError should have comment or be unexported
./pkg/utils/retry/errors.go:39:6: exported type DefaultRetriableError should have comment or be unexported
./pkg/utils/retry/errors.go:44:1: exported function NewRetriableError should have comment or be unexported
./pkg/utils/retry/retry.go:27:6: func name will be used as retry.RetryWithBackoff by other packages, and that stutters; consider calling this WithBackoff
./pkg/utils/retry/retry.go:35:6: func name will be used as retry.RetryWithBackoffCtx by other packages, and that stutters; consider calling this WithBackoffCtx
./pkg/utils/retry/retry.go:57:6: func name will be used as retry.RetryNWithBackoff by other packages, and that stutters; consider calling this NWithBackoff
./pkg/utils/retry/retry.go:66:6: func name will be used as retry.RetryNWithBackoffCtx by other packages, and that stutters; consider calling this NWithBackoffCtx
make: *** [Makefile:236: lint] Error 123
>
```

After this PR:
```
> make lint
find . \
  -type f -name '*.go' \
  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" -not -name "eniconfig.go" \
  -print0 | sort -z | xargs -0 -L1 -- golint -set_exit_status 2>/dev/null
> 
```

**Automation added to e2e**:
No logic changes in the code, only comments and renames

**Will this break upgrades and downgrades. Has it been tested?**:
No

**Does this require CNI config changes?**:
No

**Does this PR introduce a user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
