### PR TITLE
Fix statcheck issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-jsonnet v0.16.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/google/gopacket v1.1.17
+	github.com/google/gopacket v1.1.18
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/aws/aws-sdk-go v1.31.4 h1:YZ0uEYIWeanGuAomElHmRWMAbXVqrQixxgf2vtIjO6M=
-github.com/aws/aws-sdk-go v1.31.4/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.14 h1:ucjyVEvtIdtn4acf+RKsgk6ybAYeMLXpGZeqoVvi7Kk=
 github.com/aws/aws-sdk-go v1.33.14/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -74,8 +72,8 @@ github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
-github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
-github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
+github.com/google/gopacket v1.1.18 h1:lum7VRA9kdlvBi7/v2p7/zcbkduHaCH/SVVyurs7OpY=
+github.com/google/gopacket v1.1.18/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=

--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -114,6 +114,9 @@ func main() {
 		Timestamp: time.Now().Format(time.RFC3339),
 		ENILimits: eniLimits,
 	})
+	if err != nil {
+		log.Fatalf("Failed to generate template: %v\n", err)
+	}
 	log.Infof("Generated %s", ipLimitFileName)
 
 	// Generate --max-pods file for awslabs/amazon-eks-ami
@@ -132,10 +135,10 @@ func main() {
 		Timestamp: time.Now().Format(time.RFC3339),
 		ENIPods:   eniPods,
 	})
-	log.Infof("Generated %s", eniMaxPodsFileName)
 	if err != nil {
 		log.Fatalf("Failed to generate template: %v\n", err)
 	}
+	log.Infof("Generated %s", eniMaxPodsFileName)
 }
 
 // addManualLimits has the list of faulty or missing instance types

--- a/test/cmd/packet-verifier/packet-verifier.go
+++ b/test/cmd/packet-verifier/packet-verifier.go
@@ -150,15 +150,14 @@ func main() {
 						os.Exit(1)
 					}
 
-					for _, route := range routes {
-						parentLink, err := netlink.LinkByIndex(route.LinkIndex)
+					if len(routes) > 0 {
+						parentLink, err := netlink.LinkByIndex(routes[0].LinkIndex)
 						if err != nil {
 							fmt.Printf("unable to get parent ENI for the link %+v", err)
 							os.Exit(1)
 						}
 						eniToMonitor := eniConfig{name: parentLink.Attrs().Name}
 						enis = append(enis, eniToMonitor)
-						break
 					}
 				}
 			}


### PR DESCRIPTION

**What type of PR is this?**

cleanup

**What does this PR do**:
Fixes two issues found by staticcheck:
* An error value was ignored in `gen_vpc_ip_limits.go`
* `packet-verifier.go` had a break in the wrong for-loop
* Bump `google/gopacket` to [v1.1.18](https://github.com/google/gopacket/compare/v1.1.17...v1.1.18)

**If issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing**:
Before this change:
```
[master]> staticcheck github.com/aws/amazon-vpc-cni-k8s/...
scripts/gen_vpc_ip_limits.go:110:2: this value of err is never used (SA4006)
test/cmd/packet-verifier/packet-verifier.go:161:7: the surrounding loop is unconditionally terminated (SA4004)
[master]>   
```
After:
```
[fix-staticheck-issues]> staticcheck github.com/aws/amazon-vpc-cni-k8s/...
[fix-staticheck-issues]> 
```

**Automation added to e2e**:
None

**Will this break upgrades and downgrades. Has it been tested?**:
No

**Does this require any CNI config changes?**:
No

**Does this PR introduce a user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
