### PR TITLE
Minor code cleanup

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -84,32 +84,25 @@ func init() {
 
 // LoadNetConf converts inputs (i.e. stdin) to NetConf
 func LoadNetConf(bytes []byte) (*NetConf, logger.Logger, error) {
-	var conf NetConf
+	// Default config
+	conf := NetConf{
+		MTU:        "9001",
+		VethPrefix: "eni",
+	}
+
 	if err := json.Unmarshal(bytes, &conf); err != nil {
 		return nil, nil, errors.Wrap(err, "add cmd: error loading config from args")
 	}
 
-	//logConfig
 	logConfig := logger.Configuration{
 		LogLevel:    conf.PluginLogLevel,
 		LogLocation: conf.PluginLogFile,
 	}
 	log := logger.New(&logConfig)
 
-	// MTU
-	if conf.MTU == "" {
-		log.Debug("MTU not set, defaulting to 9001")
-		conf.MTU = "9001"
-	}
-
-	// Default the host-side veth prefix to 'eni'.
-	if conf.VethPrefix == "" {
-		conf.VethPrefix = "eni"
-	}
 	if len(conf.VethPrefix) > 4 {
 		return nil, nil, errors.New("conf.VethPrefix can be at most 4 characters long")
 	}
-
 	return &conf, log, nil
 }
 


### PR DESCRIPTION

**What type of PR is this?**

cleanup

**Why do we need it**:
More idiomatic go

**If issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
No issue

**Testing**:
Overriding the default values works, `AWS_VPC_ENI_MTU=1500`:
```
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.196.XX  netmask 255.255.224.0  broadcast 192.168.223.255
        inet6 fe80::8e8:51ff:fea1:cccc  prefixlen 64  scopeid 0x20<link>

eniab6a8de41e1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::64da:d0ff:fe28:1932  prefixlen 64  scopeid 0x20<link>
        ether 66:da:d0:28:19:32  txqueuelen 0  (Ethernet)
```
Deleting the config completely, we fall back to the default:
```
enic440f455693: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
        inet6 fe80::147d:7eff:fef0:f2ed  prefixlen 64  scopeid 0x20<link>
        ether 16:7d:7e:f0:f2:ed  txqueuelen 0  (Ethernet)
```

**Automation added to e2e**:
No

**Will this break upgrades and downgrades. Has it been tested?**:
No

**Does this change require any CNI config changes?**:
No

**Does this PR introduce a user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
