### PR TITLE
Seems the rule got merged twice

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -447,17 +447,6 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDRs []string, primaryMAC string, pr
 		},
 	})
 
-	iptableRules = append(iptableRules, iptablesRule{
-		name:        "connmark restore for primary ENI from vlan",
-		shouldExist: n.nodePortSupportEnabled,
-		table:       "mangle",
-		chain:       "PREROUTING",
-		rule: []string{
-			"-m", "comment", "--comment", "AWS, primary ENI",
-			"-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", fmt.Sprintf("%#x", n.mainENIMark),
-		},
-	})
-
 	for _, rule := range iptableRules {
 		log.Debugf("execute iptable rule : %s", rule.name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
None

**What does this PR do / Why do we need it**:
When the vlan changes were merged, this rule got duplicated. Not causing any issues, but 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Just duplicate code

**Testing done on this change**:
Unit tests only

**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
