### PR TITLE
Fix logging texts for ENI cleanup

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1413,8 +1413,11 @@ func (cache *EC2InstanceMetadataCache) DeallocIPAddresses(eniID string, ips []st
 }
 
 func (cache *EC2InstanceMetadataCache) cleanUpLeakedENIs() {
+	cache.cleanUpLeakedENIsInternal(time.Duration(rand.Intn(eniCleanupStartupDelayMax)) * time.Second)
+}
+
+func (cache *EC2InstanceMetadataCache) cleanUpLeakedENIsInternal(startupDelay time.Duration) {
 	rand.Seed(time.Now().UnixNano())
-	startupDelay := time.Duration(rand.Intn(eniCleanupStartupDelayMax)) * time.Second
 	log.Infof("Will attempt to clean up AWS CNI leaked ENIs after waiting %s.", startupDelay)
 	time.Sleep(startupDelay)
 

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1430,6 +1430,8 @@ func (cache *EC2InstanceMetadataCache) cleanUpLeakedENIs() {
 			if err != nil {
 				awsUtilsErrInc("cleanUpLeakedENIDeleteErr", err)
 				log.Warnf("Failed to clean up leaked ENI %s: %v", eniID, err)
+			} else {
+				log.Debugf("Cleaned up leaked CNI ENI %s", eniID)
 			}
 		}
 	}
@@ -1528,7 +1530,7 @@ func (cache *EC2InstanceMetadataCache) getFilteredListOfNetworkInterfaces() ([]*
 		return nil, nil
 	}
 
-	log.Debugf("Found %d available instances with the AWS CNI tag.", len(networkInterfaces))
+	log.Debugf("Found %d leaked ENIs with the AWS CNI tag.", len(networkInterfaces))
 	return networkInterfaces, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
None

**What does this PR do / Why do we need it**:
The log lines when we are doing ENI cleanup don't look right.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Check logs when 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
