### PR TITLE
Make sure we have space for a trunk ENI

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,6 @@ Default: `""`
 
 Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag" section below.
 
-
 ---
 
 `ENABLE_POD_ENI` (Since v1.7.0)
@@ -422,8 +421,7 @@ Type: Boolean as a String
 Default: `false`
 
 To enable security groups for pods you need to have at least an EKS 1.17 eks.3 cluster. Setting `ENABLE_POD_ENI` to `true`
-will add the `vpc.amazonaws.com/has-trunk-attached` label to the node, signifying that the feature is enabled. 
-
+will add the `vpc.amazonaws.com/has-trunk-attached` label to the node if it is possible to attach an additional ENI.
 
 ### ENI tags related to Allocation
 

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -827,13 +827,17 @@ func logPoolStats(total, used, maxAddrsPerENI int) {
 
 func (c *IPAMContext) askForTrunkENIIfNeeded() {
 	if c.enablePodENI && c.dataStore.GetTrunkENI() == "" {
+		// Check that there is room for a trunk ENI to be attached:
+		if c.dataStore.GetENIs() >= (c.maxENI - c.unmanagedENI) {
+			log.Debug("No slot available for a trunk ENI to be attached. Not labeling the node")
+			return
+		}
 		// We need to signal that VPC Resource Controller needs to attach a trunk ENI
 		err := c.SetNodeLabel("vpc.amazonaws.com/has-trunk-attached", "false")
 		if err != nil {
 			podENIErrInc("askForTrunkENIIfNeeded")
 			log.Errorf("Failed to set node label", err)
 		}
-		return
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug fix

**Which issue does this PR fix**:
#1202

**What does this PR do / Why do we need it**:
We should only set the `vpc.amazonaws.com/has-trunk-attached` label on the node if there is space to attach one more ENI.

**Testing done on this change**:
Manual test in a cluster with `MAX_ENI=1`:
```
{"level":"debug","ts":"2020-09-13T00:13:38.120Z","caller":"ipamd/ipamd.go:481","msg":"No slot available for a trunk ENI to be attached. Not labeling the node"}
{"level":"debug","ts":"2020-09-13T00:13:40.620Z","caller":"ipamd/ipamd.go:476","msg":"Reconciling ENI/IP pool info because time since last 2562047h47m16.854775807s <= 1m0s"}
{"level":"debug","ts":"2020-09-13T00:13:40.621Z","caller":"ipamd/ipamd.go:912","msg":"Total number of interfaces found: 1 "}
```
After removing the `MAX_ENI` setting, the label gets applied, and a trunk ENI attached:
```
{"level":"info","ts":"2020-09-13T00:15:29.736Z","caller":"ipamd/ipamd.go:836","msg":"Updated node ip-192-168-198-30.us-west-2.compute.internal with label \"vpc.amazonaws.com/has-trunk-attached\": \"false\""}
{"level":"debug","ts":"2020-09-13T00:15:32.240Z","caller":"ipamd/ipamd.go:836","msg":"Node label \"vpc.amazonaws.com/has-trunk-attached\" is already \"false\""}
{"level":"info","ts":"2020-09-13T00:15:34.862Z","caller":"ipamd/ipamd.go:946","msg":"Updated node ip-192-168-198-30.us-west-2.compute.internal with label \"vpc.amazonaws.com/has-trunk-attached\": \"true\""}
```

**Automation added to e2e**:
None. Standard e2e tests pass: https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/963/workflows/34c4ef50-c137-4ea8-a1b1-039964bf7cd0/jobs/1950

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
