### PR TITLE
Add support to toggle TCP early demux

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -193,7 +193,10 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:latest"
+      - "env":
+        - "name": "DISABLE_TCP_EARLY_DEMUX"
+          "value": "false"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:latest"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -193,7 +193,10 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:latest"
+      - "env":
+        - "name": "DISABLE_TCP_EARLY_DEMUX"
+          "value": "false"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:latest"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -193,7 +193,10 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:latest"
+      - "env":
+        - "name": "DISABLE_TCP_EARLY_DEMUX"
+          "value": "false"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:latest"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -193,7 +193,10 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:latest"
+      - "env":
+        - "name": "DISABLE_TCP_EARLY_DEMUX"
+          "value": "false"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:latest"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -227,6 +227,11 @@ local awsnode = {
               image: "%s/amazon-k8s-cni-init:%s" % [$.ecrRepo, $.version],
               imagePullPolicy: "Always",
               securityContext: {privileged: true},
+              env: [
+                {
+                  name: "DISABLE_TCP_EARLY_DEMUX", value: "false",
+                },
+              ],
               volumeMounts: [
                 {mountPath: "/host/opt/cni/bin", name: "cni-bin-dir"},
               ],

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -27,7 +27,14 @@ TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-meta
 HOST_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
 PRIMARY_IF=$(ip -4 -o a | grep "$HOST_IP" | awk '{print $2}')
 sysctl -w "net.ipv4.conf.$PRIMARY_IF.rp_filter=2"
-
 cat "/proc/sys/net/ipv4/conf/$PRIMARY_IF/rp_filter"
+
+# Set DISABLE_TCP_EARLY_DEMUX to true to enable kubelet to pod-eni TCP communication
+# https://lwn.net/Articles/503420/ and https://github.com/aws/amazon-vpc-cni-k8s/pull/1212 for background
+if [ "${DISABLE_TCP_EARLY_DEMUX:-false}" == "true" ]; then
+    sysctl -w "net.ipv4.tcp_early_demux=0"
+else
+    sysctl -w "net.ipv4.tcp_early_demux=1"
+fi
 
 echo "CNI init container done"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
This PR adds support to toggle tcp_early_demux. This change is required to support liveliness/readiness check on pods using its own security groups. Reason being, unlike regular pods, for pods using security groups kubelet traffic doesn't directly reach the host veth of the pod. For pods using security groups, traffic goes out of the eth0 and then comes back in through Trunk ENI. At this point response packets from the pod (SYN-ACK or ACK) are dropped because of tcp_early_demux setting.

Two scenario where the packets were dropped are
1. From Kubelet to pod-eni: Kubelet send SYN packet and pod responded with SYN-ACK but kernel dropped the packet after receiving it in host veth dev.
2. From pod-eni to kubelet: Pod-eni sent ACK in response to SYN-ACK from kubelet but ACK pkt is dropped by kernel again post host veth dev.

tcp_early_demux is enabled by default. Disabling tcp_early_demux adds 10-15 ms to overall packet throughput.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Performing curl from host ns to branch eni pod will fail without the change.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
After updating cni init container, instance has tcp early demux disabled on the instance and curl started working.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
NA

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Yes

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
