### PR TITLE
avoid 6 api rpm per pod by removing operator framework cache-reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 	k8s.io/cri-api v0.0.0-20191107035106-03d130a7dc28
 	k8s.io/kube-openapi v0.0.0-20190510232812-a01b7d5d6c22 // indirect
 )
+
+replace github.com/operator-framework/operator-sdk => github.com/grosser/operator-sdk v0.0.8-0.20200914235856-4b738c6ed745

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhp
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc h1:f8eY6cV/x1x+HLjOp4r72s/31/V2aTUtg5oKRRPf8/Q=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grosser/operator-sdk v0.0.8-0.20200914235856-4b738c6ed745 h1:o4WS0YZ7FFZvzLdlapX/O9AZuyG9SMNyA9w2r/U4RDA=
+github.com/grosser/operator-sdk v0.0.8-0.20200914235856-4b738c6ed745/go.mod h1:c6GS2WuX6LL3CsJODY42Jhhr89NOPoDJwTWVb9ekZ5Y=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -237,6 +239,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
+google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
 google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
we see requests to all api endpoints every minute coming from the k8sclient.GetKubeClient being hardcoded to reset every minute [here](https://github.com/operator-framework/operator-sdk/blob/v0.0.7/pkg/k8sclient/client.go#L66)

not calling operator sdk did not help (doing this)
```
	kubeConfig, err := rest.InClusterConfig()
	if err != nil {
		panic(err)
	}
	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
```
so I had to disable the cache-reset in operator-sdk

no more api spam now 🎉 

<img width="903" alt="Screen Shot 2020-09-14 at 5 29 26 PM" src="https://user-images.githubusercontent.com/11367/93151123-d9158f80-f6af-11ea-869c-3d0b9a5dbd82.png">

so I'd suggest either using that branch (kinda shady) or updating operator sdk (bunch of work I guess) or getting rid of operator-sdk (also lots of work) 😞 