### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.7.2-rc1
+## v1.7.2
 
 * Bug - [Avoid deleting ENIs being created by older CNI versions](https://github.com/aws/amazon-vpc-cni-k8s/pull/1109) (#1109, @jayanthvn)
 * Bug - [Add iptables fix and update to v1.7.x](https://github.com/aws/amazon-vpc-cni-k8s/pull/1187) (#1187, @mogren)

--- a/README.md
+++ b/README.md
@@ -412,6 +412,19 @@ Default: `""`
 
 Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag" section below.
 
+
+---
+
+`ENABLE_POD_ENI` (Since v1.7.0)
+
+Type: Boolean as a String
+
+Default: `false`
+
+To enable security groups for pods you need to have at least an EKS 1.17 eks.3 cluster. Setting `ENABLE_POD_ENI` to `true`
+will add the `vpc.amazonaws.com/has-trunk-attached` label to the node, signifying that the feature is enabled. 
+
+
 ### ENI tags related to Allocation
 
 This plugin interacts with the following tags on ENIs:

--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.1"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.2"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -193,7 +193,7 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.1"
+      - "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.1"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.2"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -193,7 +193,7 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.1"
+      - "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.1"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.2"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -193,7 +193,7 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.1"
+      - "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.1"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.2"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -193,7 +193,7 @@
           "name": "xtables-lock"
       "hostNetwork": true
       "initContainers":
-      - "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.1"
+      - "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/cni-metrics-helper-cn.yaml
+++ b/config/v1.7/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.1"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.1"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.1"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper.yaml
+++ b/config/v1.7/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.1"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.2"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
The PR is releasing v1.7.2
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
This PR is not for fixing issues.

**What does this PR do / Why do we need it**:
We need this PR to release latest CNI v1.7.2.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Apply the aws-k8s-cni.yaml
% kubectl describe daemonset aws-node -n kube-system | grep 1.7
    Image:        602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.2
    Image:      602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.2
    Port:       61678/TCP
    Host Port:  61678/TCP

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Using existing e2e tests. No new test cases were added.
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. It was tested in a running cluster.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Recommend to apply updating from the config instead of patch into running daemonset.
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
