### PR TITLE
Update readme to explain DISABLE_TCP_EARLY_DEMUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,18 @@ Default: `false`
 To enable security groups for pods you need to have at least an EKS 1.17 eks.3 cluster. Setting `ENABLE_POD_ENI` to `true`
 will add the `vpc.amazonaws.com/has-trunk-attached` label to the node, signifying that the feature is enabled. 
 
+---
+
+`DISABLE_TCP_EARLY_DEMUX` (Since v1.7.3)
+
+Type: Boolean as a String
+
+Default: `false`
+
+If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to talk to pods using the per pod security group feature,
+`DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection latency slightly, that is why it is not
+ on by default. Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
+
 
 ### ENI tags related to Allocation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
Follow up to #1212

**What does this PR do / Why do we need it**:
All our environment variables should be explained.

**Testing done on this change**:
None

**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Just improved documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
