### PR TITLE
Disable codecov on patch

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -19,6 +19,11 @@ coverage:
         only_pulls: true
         flags:
           - "unittest"
+    # Disable patch since it is noisy and not correct
+    patch:
+      default:
+        enabled: no
+        if_not_found: success
 
 comment: false
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
Even a [PR with 84% patch test coverage](https://github.com/aws/amazon-vpc-cni-k8s/pull/1225/files) is so full of CodeCov warnings that it is hard to read. 

**Why do we need it**:
Just renaming an existing function or variable makes CodeCov treat it as a patch missing coverage and fail the check. We want to have all checks green for PRs to be merged. Some other projects having the same issue: argoproj/argo-cd#1926,  mozilla-mobile/firefox-tv#778, kata-containers/tests#508.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Open a PR, look at the file changes.

**Testing done on this change**:
None

**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
