### PR TITLE
Add some minimal tests to metrics

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -28,6 +28,7 @@ coverage:
 comment: false
 
 ignore:
+  - "cmd/**/main.go"
   - "config/**/*"
   - "docs/**/*"
   - "misc/**/*"

--- a/cmd/cni-metrics-helper/metrics/cni_metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/cni_metrics_test.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/publisher/mock_publisher"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var logConfig = logger.Configuration{
+	LogLevel:    "Debug",
+	LogLocation: "stdout",
+}
+
+var log = logger.New(&logConfig)
+
+type testMocks struct {
+	ctrl               *gomock.Controller
+	clientset          *k8sfake.Clientset
+	discoverController *k8sapi.Controller
+	mockPublisher      *mock_publisher.MockPublisher
+}
+
+func setup(t *testing.T) *testMocks {
+	ctrl := gomock.NewController(t)
+	fakeClientset := k8sfake.NewSimpleClientset()
+	return &testMocks{
+		ctrl:               ctrl,
+		clientset:          fakeClientset,
+		discoverController: k8sapi.NewController(fakeClientset),
+		mockPublisher:      mock_publisher.NewMockPublisher(ctrl),
+	}
+}
+
+func TestCNIMetricsNew(t *testing.T) {
+	m := setup(t)
+	_, _ = m.clientset.CoreV1().Pods("kube-system").Create(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "aws-node-1"}})
+	cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, m.discoverController, false, log)
+	assert.NotNil(t, cniMetric)
+	assert.NotNil(t, cniMetric.getCWMetricsPublisher())
+	assert.NotEmpty(t, cniMetric.getInterestingMetrics())
+	assert.Equal(t, log, cniMetric.getLogger())
+	assert.False(t, cniMetric.submitCloudWatch())
+}

--- a/pkg/k8sapi/generate_mocks.go
+++ b/pkg/k8sapi/generate_mocks.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package k8sapi
+
+//go:generate go run github.com/golang/mock/mockgen -destination mocks/k8sapi_mocks.go -copyright_file ../../scripts/copyright.txt . K8SAPIs

--- a/pkg/k8sapi/mocks/k8sapi_mocks.go
+++ b/pkg/k8sapi/mocks/k8sapi_mocks.go
@@ -21,7 +21,6 @@ package mock_k8sapi
 import (
 	reflect "reflect"
 
-	k8sapi "github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 )
@@ -62,21 +61,6 @@ func (m *MockK8SAPIs) GetPod(arg0, arg1 string) (*v1.Pod, error) {
 func (mr *MockK8SAPIsMockRecorder) GetPod(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPod", reflect.TypeOf((*MockK8SAPIs)(nil).GetPod), arg0, arg1)
-}
-
-// K8SGetLocalPodIPs mocks base method
-func (m *MockK8SAPIs) K8SGetLocalPodIPs() ([]*k8sapi.K8SPodInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "K8SGetLocalPodIPs")
-	ret0, _ := ret[0].([]*k8sapi.K8SPodInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// K8SGetLocalPodIPs indicates an expected call of K8SGetLocalPodIPs
-func (mr *MockK8SAPIsMockRecorder) K8SGetLocalPodIPs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "K8SGetLocalPodIPs", reflect.TypeOf((*MockK8SAPIs)(nil).K8SGetLocalPodIPs))
 }
 
 // SetNodeLabel mocks base method


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
* Fix broken mocks
* Add generate_mock.go for discovery.go
* Initial scaffolding to add more unit tests (discovery.go needs a cleanup..)
* Ignore main.go for test coverage, it is just for wiring together the other components.

**Why do we need it**:
Small steps to clean up the code base

**Testing done on this change**:
Just added a unit test, and `make unit-test` is passing

**Automation added to e2e**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
