### PR TITLE
Feat/include snat cidrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Type: String
 Default: empty
 
 Specify a comma separated list of IPv4 CIDRs to exclude from SNAT. For every item in the list an `iptables` rule and off\-VPC
-IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`.
+IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false` and `AWS_VPC_K8S_CNI_INCLUDE_SNAT_CIDRS=""`.
 
 ---
 
@@ -218,7 +218,7 @@ Type: String
 Default: empty
 
 Specify a comma separated list of IPv4 CIDRs to include in SNAT. For every item in the list an `iptables` rule and off\-VPC
-IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`.
+IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false` and `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS=""`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ IP rule will be applied. If an item is not a valid ipv4 range it will be skipped
 
 ---
 
+`AWS_VPC_K8S_CNI_INCLUDE_SNAT_CIDRS`
+
+Type: String
+
+Default: empty
+
+Specify a comma separated list of IPv4 CIDRs to include in SNAT. For every item in the list an `iptables` rule and off\-VPC
+IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`.
+
+---
+
 `WARM_ENI_TARGET`
 
 Type: Integer as a String

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -333,9 +333,6 @@ func (c *IPAMContext) nodeInit() error {
 	}
 
 	vpcCIDRs := c.awsClient.GetVPCIPv4CIDRs()
-	for _, cidr := range c.networkClient.GetIncludeSNATCIDRs() {
-		vpcCIDRs = append(vpcCIDRs, cidr)
-	}
 	primaryIP := net.ParseIP(c.awsClient.GetLocalIPv4())
 	err = c.networkClient.SetupHostNetwork(vpcCIDRs, c.awsClient.GetPrimaryENImac(), &primaryIP, c.enablePodENI)
 	if err != nil {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1305,4 +1305,3 @@ func (c *IPAMContext) SetNodeLabel(key, value string) error {
 func (c *IPAMContext) GetPod(podName, namespace string) (*v1.Pod, error) {
 	return c.k8sClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 }
-

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -333,6 +333,9 @@ func (c *IPAMContext) nodeInit() error {
 	}
 
 	vpcCIDRs := c.awsClient.GetVPCIPv4CIDRs()
+	for _, cidr := range c.networkClient.GetIncludeSNATCIDRs() {
+		vpcCIDRs = append(vpcCIDRs, cidr)
+	}
 	primaryIP := net.ParseIP(c.awsClient.GetLocalIPv4())
 	err = c.networkClient.SetupHostNetwork(vpcCIDRs, c.awsClient.GetPrimaryENImac(), &primaryIP, c.enablePodENI)
 	if err != nil {
@@ -1305,3 +1308,4 @@ func (c *IPAMContext) SetNodeLabel(key, value string) error {
 func (c *IPAMContext) GetPod(podName, namespace string) (*v1.Pod, error) {
 	return c.k8sClient.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 }
+

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -78,6 +78,20 @@ func (mr *MockNetworkAPIsMockRecorder) GetExcludeSNATCIDRs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExcludeSNATCIDRs", reflect.TypeOf((*MockNetworkAPIs)(nil).GetExcludeSNATCIDRs))
 }
 
+// GetIncludeSNATCIDRs mocks base method
+func (m *MockNetworkAPIs) GetIncludeSNATCIDRs() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIncludeSNATCIDRs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetIncludeSNATCIDRs indicates an expected call of GetIncludeSNATCIDRs
+func (mr *MockNetworkAPIsMockRecorder) GetIncludeSNATCIDRs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIncludeSNATCIDRs", reflect.TypeOf((*MockNetworkAPIs)(nil).GetIncludeSNATCIDRs))
+}
+
 // GetLinkByMac mocks base method
 func (m *MockNetworkAPIs) GetLinkByMac(arg0 string, arg1 time.Duration) (netlink.Link, error) {
 	m.ctrl.T.Helper()

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -130,6 +130,7 @@ type NetworkAPIs interface {
 	SetupENINetwork(eniIP string, mac string, deviceNumber int, subnetCIDR string) error
 	UseExternalSNAT() bool
 	GetExcludeSNATCIDRs() []string
+	GetIncludeSNATCIDRs() []string
 	GetRuleList() ([]netlink.Rule, error)
 	GetRuleListBySrc(ruleList []netlink.Rule, src net.IPNet) ([]netlink.Rule, error)
 	UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNet, toCIDRs []string, toFlag bool) error

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -338,7 +338,15 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDRs []string, primaryMAC string, pr
 
 	// build IPTABLES chain for SNAT of non-VPC outbound traffic and excluded CIDRs
 	var chains []string
-	for i := 0; i <= len(allCIDRs); i++ {
+
+	// if include snat mode, all cidr iptables have to be in one chain
+	var chainsLen int
+	if n.includeSNATCIDRs != nil {
+		chainsLen = 1
+	}else{
+		chainsLen = len(allCIDRs)
+	}
+	for i := 0; i <= chainsLen; i++ {
 		chain := fmt.Sprintf("AWS-SNAT-CHAIN-%d", i)
 		log.Debugf("Setup Host Network: iptables -N %s -t nat", chain)
 		if err := ipt.NewChain("nat", chain); err != nil && !containChainExistErr(err) {
@@ -361,14 +369,11 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDRs []string, primaryMAC string, pr
 		}})
 
 	for i, cidr := range allCIDRs {
-		curChain := chains[i]
-		curName := fmt.Sprintf("[%d] AWS-SNAT-CHAIN", i)
-		nextChain := chains[i+1]
 		comment := "AWS SNAT CHAIN"
-		if cidr.isExclusion {
-			comment += " EXCLUSION"
-		}
 		if cidr.isInclusion {
+			curChain := chains[0]
+			curName := fmt.Sprintf("[%d] AWS-SNAT-CHAIN", 0)
+			nextChain := chains[1]
 			comment += " INCLUSION"
 			log.Debugf("Setup Host Network: iptables -A %s -d %s -t nat -j %s", curChain, cidr, nextChain)
 
@@ -381,6 +386,12 @@ func (n *linuxNetwork) SetupHostNetwork(vpcCIDRs []string, primaryMAC string, pr
 					"-d", cidr.cidr, "-m", "comment", "--comment", comment, "-j", nextChain,
 				}})	
 		}else{
+			curChain := chains[i]
+			curName := fmt.Sprintf("[%d] AWS-SNAT-CHAIN", i)
+			nextChain := chains[i+1]
+			if cidr.isExclusion {
+				comment += " EXCLUSION"
+			}
 			log.Debugf("Setup Host Network: iptables -A %s ! -d %s -t nat -j %s", curChain, cidr, nextChain)
 
 			iptableRules = append(iptableRules, iptablesRule{

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -950,7 +950,9 @@ func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNe
 	log.Infof("Remove current list [%v]", srcRuleList)
 	var srcRuleTable int
 	for _, rule := range srcRuleList {
-		srcRuleTable = rule.Table
+		if rule.Table != mainRoutingTable {
+			srcRuleTable = rule.Table
+		}
 		if err := n.netLink.RuleDel(&rule); err != nil && !containsNoSuchRule(err) {
 			log.Errorf("Failed to cleanup old IP rule: %v", err)
 			return errors.Wrapf(err, "UpdateRuleListBySrc: failed to delete old rule")
@@ -993,7 +995,7 @@ func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNe
 			podRule := n.netLink.NewRule()
 			_, podRule.Dst, _ = net.ParseCIDR(cidr)
 			podRule.Src = &src
-			podRule.Table = 254 // main
+			podRule.Table = mainRoutingTable
 			podRule.Priority = fromPodRulePriority - 1
 
 			err = n.netLink.RuleAdd(podRule)

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -1032,7 +1032,7 @@ func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNe
 			log.Errorf("Failed to add pod IP rule: %v", err)
 			return errors.Wrapf(err, "UpdateRuleListBySrc: failed to add pod rule")
 		}
-		log.Infof("UpdateRuleListBySrc: Successfully added pod rule[%v]", podRule)		
+		log.Infof("UpdateRuleListBySrc: Successfully added pod rule[%v]", podRule)
 	}
 	return nil
 }

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -612,13 +612,13 @@ func getIncludeSNATCIDRs() []string {
 		return nil
 	}
 
-	excludeCIDRs := os.Getenv(envIncludeSNATCIDRs)
+	includeCIDRs := os.Getenv(envIncludeSNATCIDRs)
 	if includeCIDRs == "" {
 		return nil
 	}
 	var cidrs []string
-	for _, includeCIDRs := range strings.Split(includeCIDRs, ",") {
-		_, parseCIDR, err := net.ParseCIDR(includeCIDRs)
+	for _, includeCIDR := range strings.Split(includeCIDRs, ",") {
+		_, parseCIDR, err := net.ParseCIDR(includeCIDR)
 		if err != nil {
 			log.Errorf("getIncludeSNATCIDRs : ignoring %v is not a valid IPv4 CIDR", includeCIDR)
 		} else {
@@ -942,7 +942,8 @@ func (n *linuxNetwork) UpdateRuleListBySrc(ruleList []netlink.Rule, src net.IPNe
 	}
 
 	if requiresSNAT {
-		allCIDRs := append(toCIDRs, n.excludeSNATCIDRs..., n.includeSNATCIDRs...)
+		allCIDRs := append(toCIDRs, n.excludeSNATCIDRs...)
+		allCIDRs = append(allCIDRs, n.includeSNATCIDRs...)
 		for _, cidr := range allCIDRs {
 			podRule := n.netLink.NewRule()
 			_, podRule.Dst, _ = net.ParseCIDR(cidr)

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -335,6 +335,14 @@ func TestLoadExcludeSNATCIDRsFromEnv(t *testing.T) {
 	assert.Equal(t, getExcludeSNATCIDRs(), expected)
 }
 
+func TestLoadIncludeSNATCIDRsFromEnv(t *testing.T) {
+	_ = os.Setenv(envExternalSNAT, "false")
+	_ = os.Setenv(envIncludeSNATCIDRs, "10.14.0.0/16")
+
+	expected := []string{"10.14.0.0/16"}
+	assert.Equal(t, getIncludeSNATCIDRs(), expected)
+}
+
 func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
 	defer ctrl.Finish()
@@ -381,6 +389,52 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		}, mockIptables.dataplaneState)
 }
 
+func TestSetupHostNetworkWithIncludeSNATCIDRs(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:         false,
+		includeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func() (iptablesIface, error) {
+			return mockIptables, nil
+		},
+		procSys: mockProcSys,
+	}
+
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
+
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		map[string]map[string][][]string{
+			"nat": {
+				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3"}},
+				"AWS-SNAT-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4"}},
+				"AWS-SNAT-CHAIN-4": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
+			"mangle": {
+				"PREROUTING": [][]string{
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+		}, mockIptables.dataplaneState)
+}
+
 func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
 	defer ctrl.Finish()
@@ -404,10 +458,64 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-4")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
+	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
+	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
+
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false)
+	assert.NoError(t, err)
+
+	assert.Equal(t,
+		map[string]map[string][][]string{
+			"nat": {
+				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"AWS-SNAT-CHAIN-3": [][]string{},
+				"AWS-SNAT-CHAIN-4": [][]string{},
+				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
+			"mangle": {
+				"PREROUTING": [][]string{
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+		}, mockIptables.dataplaneState)
+}
+
+func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:         false,
+		includeSNATCIDRs:        nil,
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func() (iptablesIface, error) {
+			return mockIptables, nil
+		},
+		procSys: mockProcSys,
+	}
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
+
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
 	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
@@ -477,6 +585,60 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
 				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3"}},
 				"AWS-SNAT-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-4"}},
+				"AWS-SNAT-CHAIN-4": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
+			"mangle": {
+				"PREROUTING": [][]string{
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+		}, mockIptables.dataplaneState)
+}
+
+func TestSetupHostNetworkIncludedSNATCIDRsIdempotent(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:         false,
+		includeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func() (iptablesIface, error) {
+			return mockIptables, nil
+		},
+		procSys: mockProcSys,
+	}
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
+
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
+	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
+
+	// remove exclusions
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false)
+	assert.NoError(t, err)
+
+	assert.Equal(t,
+		map[string]map[string][][]string{
+			"nat": {
+				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3"}},
+				"AWS-SNAT-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4"}},
 				"AWS-SNAT-CHAIN-4": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
 				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
 			"mangle": {

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -337,9 +337,20 @@ func TestLoadExcludeSNATCIDRsFromEnv(t *testing.T) {
 
 func TestLoadIncludeSNATCIDRsFromEnv(t *testing.T) {
 	_ = os.Setenv(envExternalSNAT, "false")
-	_ = os.Setenv(envIncludeSNATCIDRs, "10.14.0.0/16")
+	_ = os.Setenv(envExcludeSNATCIDRs, "")
+	_ = os.Setenv(envIncludeSNATCIDRs, "10.14.0.0/16,10.15.0.0/16")
 
-	expected := []string{"10.14.0.0/16"}
+	expected := []string{"10.14.0.0/16","10.15.0.0/16"}
+	assert.Equal(t, getIncludeSNATCIDRs(), expected)
+}
+
+func TestLoadExcludeIncludeSNATCIDRsFromEnv(t *testing.T) {
+	_ = os.Setenv(envExternalSNAT, "false")
+	_ = os.Setenv(envExcludeSNATCIDRs, "10.12.0.0/16,10.13.0.0/16")
+	_ = os.Setenv(envIncludeSNATCIDRs, "10.14.0.0/16,10.15.0.0/16")
+
+	expected := []string{""}
+	assert.Equal(t, getExcludeSNATCIDRs(), expected)
 	assert.Equal(t, getIncludeSNATCIDRs(), expected)
 }
 
@@ -395,7 +406,7 @@ func TestSetupHostNetworkWithIncludeSNATCIDRs(t *testing.T) {
 
 	ln := &linuxNetwork{
 		useExternalSNAT:         false,
-		includeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		includeSNATCIDRs:        []string{"10.14.0.0/16", "10.15.0.0/16"},
 		nodePortSupportEnabled:  true,
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
@@ -419,11 +430,9 @@ func TestSetupHostNetworkWithIncludeSNATCIDRs(t *testing.T) {
 	assert.Equal(t,
 		map[string]map[string][][]string{
 			"nat": {
-				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
-				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
-				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3"}},
-				"AWS-SNAT-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4"}},
-				"AWS-SNAT-CHAIN-4": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"AWS-SNAT-CHAIN-0": [][]string{{"-d", "10.14.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1": [][]string{{"-d", "10.15.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
 				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
 			"mangle": {
 				"PREROUTING": [][]string{
@@ -442,6 +451,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	ln := &linuxNetwork{
 		useExternalSNAT:         false,
 		excludeSNATCIDRs:        nil,
+		includeSNATCIDRs:        nil,
 		nodePortSupportEnabled:  true,
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
@@ -462,60 +472,6 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-4")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
-	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
-	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
-
-	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
-	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false)
-	assert.NoError(t, err)
-
-	assert.Equal(t,
-		map[string]map[string][][]string{
-			"nat": {
-				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
-				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
-				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
-				"AWS-SNAT-CHAIN-3": [][]string{},
-				"AWS-SNAT-CHAIN-4": [][]string{},
-				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
-			"mangle": {
-				"PREROUTING": [][]string{
-					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
-					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
-					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
-				},
-			},
-		}, mockIptables.dataplaneState)
-}
-
-func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
-	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
-	defer ctrl.Finish()
-
-	ln := &linuxNetwork{
-		useExternalSNAT:         false,
-		includeSNATCIDRs:        nil,
-		nodePortSupportEnabled:  true,
-		shouldConfigureRpFilter: true,
-		mainENIMark:             defaultConnmark,
-		mtu:                     testMTU,
-
-		netLink: mockNetLink,
-		ns:      mockNS,
-		newIptables: func() (iptablesIface, error) {
-			return mockIptables, nil
-		},
-		procSys: mockProcSys,
-	}
-	setupNetLinkMocks(ctrl, mockNetLink)
-
-	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
-
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4")
 	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
 	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
@@ -603,7 +559,7 @@ func TestSetupHostNetworkIncludedSNATCIDRsIdempotent(t *testing.T) {
 
 	ln := &linuxNetwork{
 		useExternalSNAT:         false,
-		includeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		includeSNATCIDRs:        []string{"10.14.0.0/16", "10.15.0.0/16"},
 		nodePortSupportEnabled:  true,
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
@@ -620,11 +576,9 @@ func TestSetupHostNetworkIncludedSNATCIDRsIdempotent(t *testing.T) {
 
 	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
 
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4")
-	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "-d", "10.14.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-1")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "-d", "10.15.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-2")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
 	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
 
 	// remove exclusions
@@ -635,11 +589,9 @@ func TestSetupHostNetworkIncludedSNATCIDRsIdempotent(t *testing.T) {
 	assert.Equal(t,
 		map[string]map[string][][]string{
 			"nat": {
-				"AWS-SNAT-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
-				"AWS-SNAT-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
-				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-3"}},
-				"AWS-SNAT-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-4"}},
-				"AWS-SNAT-CHAIN-4": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"AWS-SNAT-CHAIN-0": [][]string{{"-d", "10.14.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1": [][]string{{"-d", "10.15.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN INCLUSION", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2": [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
 				"POSTROUTING":      [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}}},
 			"mangle": {
 				"PREROUTING": [][]string{

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -349,7 +349,7 @@ func TestLoadExcludeIncludeSNATCIDRsFromEnv(t *testing.T) {
 	_ = os.Setenv(envExcludeSNATCIDRs, "10.12.0.0/16,10.13.0.0/16")
 	_ = os.Setenv(envIncludeSNATCIDRs, "10.14.0.0/16,10.15.0.0/16")
 
-	expected := []string{""}
+	expected := []string(nil)
 	assert.Equal(t, getExcludeSNATCIDRs(), expected)
 	assert.Equal(t, getIncludeSNATCIDRs(), expected)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1224

**What does this PR do / Why do we need it**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1224

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Testing done on v1.6.1 (backport)
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
