### PR TITLE
Avoid detaching EFA ENIs

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -302,9 +302,9 @@ func TestDescribeAllENIs(t *testing.T) {
 	for _, tc := range testCases {
 		mockEC2.EXPECT().DescribeNetworkInterfacesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(tc.n).Return(result, tc.awsErr)
 		ins := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2}
-		_, tags, _, err := ins.DescribeAllENIs()
+		metaData, err := ins.DescribeAllENIs()
 		assert.Equal(t, tc.expErr, err, tc.name)
-		assert.Equal(t, tc.exptags, tags, tc.name)
+		assert.Equal(t, tc.exptags, metaData.TagMap, tc.name)
 	}
 }
 

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -108,14 +108,12 @@ func (mr *MockAPIsMockRecorder) DeallocIPAddresses(arg0, arg1 interface{}) *gomo
 }
 
 // DescribeAllENIs mocks base method
-func (m *MockAPIs) DescribeAllENIs() ([]awsutils.ENIMetadata, map[string]awsutils.TagMap, string, error) {
+func (m *MockAPIs) DescribeAllENIs() (awsutils.DescribeAllENIsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAllENIs")
-	ret0, _ := ret[0].([]awsutils.ENIMetadata)
-	ret1, _ := ret[1].(map[string]awsutils.TagMap)
-	ret2, _ := ret[2].(string)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret0, _ := ret[0].(awsutils.DescribeAllENIsResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DescribeAllENIs indicates an expected call of DescribeAllENIs

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -142,6 +142,8 @@ type ENI struct {
 	IsPrimary bool
 	// IsTrunk indicates whether this ENI is used to provide pods with dedicated ENIs
 	IsTrunk bool
+	// IsEFA indicates whether this ENI is tagged as an EFA
+	IsEFA bool
 	// DeviceNumber is the device number of ENI (0 means the primary ENI)
 	DeviceNumber int
 	// IPv4Addresses shows whether each address is assigned, the key is IP address, which must
@@ -397,7 +399,7 @@ func (ds *DataStore) writeBackingStoreUnsafe() error {
 }
 
 // AddENI add ENI to data store
-func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary, isTrunk bool) error {
+func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary, isTrunk, isEFA bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -411,6 +413,7 @@ func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary, isTrunk b
 		createTime:    time.Now(),
 		IsPrimary:     isPrimary,
 		IsTrunk:       isTrunk,
+		IsEFA:         isEFA,
 		ID:            eniID,
 		DeviceNumber:  deviceNumber,
 		IPv4Addresses: make(map[string]*AddressInfo)}
@@ -560,6 +563,19 @@ func (ds *DataStore) GetTrunkENI() string {
 	return ""
 }
 
+// GetEFAENIs returns the a map containing all attached EFA ENIs
+func (ds *DataStore) GetEFAENIs() map[string]bool {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	ret := make(map[string]bool)
+	for _, eni := range ds.eniPool {
+		if eni.IsEFA {
+			ret[eni.ID] = true
+		}
+	}
+	return ret
+}
+
 // IsRequiredForWarmIPTarget determines if this ENI has warm IPs that are required to fulfill whatever WARM_IP_TARGET is
 // set to.
 func (ds *DataStore) isRequiredForWarmIPTarget(warmIPTarget int, eni *ENI) bool {
@@ -618,6 +634,11 @@ func (ds *DataStore) getDeletableENI(warmIPTarget int, minimumIPTarget int) *ENI
 
 		if eni.IsTrunk {
 			ds.log.Debugf("ENI %s cannot be deleted because it is a trunk ENI", eni.ID)
+			continue
+		}
+
+		if eni.IsEFA {
+			ds.log.Debugf("ENI %s cannot be deleted because it is an EFA ENI", eni.ID)
 			continue
 		}
 

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -342,13 +342,13 @@ func (c *IPAMContext) nodeInit() error {
 		return errors.Wrap(err, "ipamd init: failed to set up host network")
 	}
 
-	eniMetadata, tagMap, trunkENI, err := c.awsClient.DescribeAllENIs()
+	metadataResult, err := c.awsClient.DescribeAllENIs()
 	if err != nil {
 		return errors.New("ipamd init: failed to retrieve attached ENIs info")
 	}
-	log.Debugf("DescribeAllENIs success: ENIs: %d, tagged: %d", len(eniMetadata), len(tagMap))
-	c.setUnmanagedENIs(tagMap)
-	enis := c.filterUnmanagedENIs(eniMetadata)
+	log.Debugf("DescribeAllENIs success: ENIs: %d, tagged: %d", len(metadataResult.ENIMetadata), len(metadataResult.TagMap))
+	c.setUnmanagedENIs(metadataResult.TagMap)
+	enis := c.filterUnmanagedENIs(metadataResult.ENIMetadata)
 
 	for _, eni := range enis {
 		log.Debugf("Discovered ENI %s, trying to set it up", eni.ENIID)
@@ -356,7 +356,7 @@ func (c *IPAMContext) nodeInit() error {
 		retry := 0
 		for {
 			retry++
-			if err = c.setupENI(eni.ENIID, eni, trunkENI); err == nil {
+			if err = c.setupENI(eni.ENIID, eni, eni.ENIID == metadataResult.TrunkENI, metadataResult.EFAENIs[eni.ENIID]); err == nil {
 				log.Infof("ENI %s set up.", eni.ENIID)
 				break
 			}
@@ -409,7 +409,7 @@ func (c *IPAMContext) nodeInit() error {
 	}
 
 	// If we started on a node with a trunk ENI already attached, add the node label.
-	if trunkENI != "" {
+	if metadataResult.TrunkENI != "" {
 		// Signal to VPC Resource Controller that the node has a trunk already
 		err := c.SetNodeLabel("vpc.amazonaws.com/has-trunk-attached", "true")
 		if err != nil {
@@ -699,7 +699,8 @@ func (c *IPAMContext) tryAllocateENI() error {
 		return err
 	}
 
-	err = c.setupENI(eni, eniMetadata, c.dataStore.GetTrunkENI())
+	// The CNI does not create trunk or EFA ENIs, so they will always be false here
+	err = c.setupENI(eni, eniMetadata, false, false)
 	if err != nil {
 		ipamdErrInc("increaseIPPoolsetupENIFailed")
 		log.Errorf("Failed to increase pool size: %v", err)
@@ -747,10 +748,10 @@ func (c *IPAMContext) tryAssignIPs() (increasedPool bool, err error) {
 // 1) add ENI to datastore
 // 2) set up linux ENI related networking stack.
 // 3) add all ENI's secondary IP addresses to datastore
-func (c *IPAMContext) setupENI(eni string, eniMetadata awsutils.ENIMetadata, trunkENI string) error {
+func (c *IPAMContext) setupENI(eni string, eniMetadata awsutils.ENIMetadata, isTrunkENI, isEFAENI bool) error {
 	primaryENI := c.awsClient.GetPrimaryENI()
 	// Add the ENI to the datastore
-	err := c.dataStore.AddENI(eni, eniMetadata.DeviceNumber, eni == primaryENI, eni == trunkENI)
+	err := c.dataStore.AddENI(eni, eniMetadata.DeviceNumber, eni == primaryENI, isTrunkENI, isEFAENI)
 	if err != nil && err.Error() != datastore.DuplicatedENIError {
 		return errors.Wrapf(err, "failed to add ENI %s to data store", eni)
 	}
@@ -935,6 +936,8 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 	attachedENIs := c.filterUnmanagedENIs(allENIs)
 	currentENIs := c.dataStore.GetENIInfos().ENIs
 	trunkENI := c.dataStore.GetTrunkENI()
+	// Initialize the set with the known EFA interfaces
+	efaENIs := c.dataStore.GetEFAENIs()
 
 	// Check if a new ENI was added, if so we need to update the tags.
 	needToUpdateTags := false
@@ -945,14 +948,14 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 		}
 	}
 	if needToUpdateTags {
-		log.Debugf("A new ENI added but not by ipamd, updating tags")
-		allENIs, tagMap, trunk, err := c.awsClient.DescribeAllENIs()
+		log.Debugf("A new ENI added but not by ipamd, updating tags by calling EC2")
+		metadataResult, err := c.awsClient.DescribeAllENIs()
 		if err != nil {
 			log.Warnf("Failed to call EC2 to describe ENIs, aborting reconcile: %v", err)
 			return
 		}
 
-		if c.enablePodENI && trunk != "" {
+		if c.enablePodENI && metadataResult.TrunkENI != "" {
 			// Label the node that we have a trunk
 			err = c.SetNodeLabel("vpc.amazonaws.com/has-trunk-attached", "true")
 			if err != nil {
@@ -962,9 +965,11 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 			}
 		}
 		// Update trunk ENI
-		trunkENI = trunk
-		c.setUnmanagedENIs(tagMap)
-		attachedENIs = c.filterUnmanagedENIs(allENIs)
+		trunkENI = metadataResult.TrunkENI
+		// Just copy values of the EFA set
+		efaENIs = metadataResult.EFAENIs
+		c.setUnmanagedENIs(metadataResult.TagMap)
+		attachedENIs = c.filterUnmanagedENIs(metadataResult.ENIMetadata)
 	}
 
 	// Mark phase
@@ -982,7 +987,7 @@ func (c *IPAMContext) nodeIPPoolReconcile(interval time.Duration) {
 
 		// Add new ENI
 		log.Debugf("Reconcile and add a new ENI %s", attachedENI)
-		err = c.setupENI(attachedENI.ENIID, attachedENI, trunkENI)
+		err = c.setupENI(attachedENI.ENIID, attachedENI, attachedENI.ENIID == trunkENI, efaENIs[attachedENI.ENIID])
 		if err != nil {
 			log.Errorf("IP pool reconcile: Failed to set up ENI %s network: %v", attachedENI.ENIID, err)
 			ipamdErrInc("eniReconcileAdd")

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -119,7 +119,13 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
 
 	eniMetadataSlice := []awsutils.ENIMetadata{eni1, eni2}
-	m.awsutils.EXPECT().DescribeAllENIs().Return(eniMetadataSlice, map[string]awsutils.TagMap{}, "", nil)
+	resp := awsutils.DescribeAllENIsResult{
+		ENIMetadata: eniMetadataSlice,
+		TagMap:      map[string]awsutils.TagMap{},
+		TrunkENI:    "",
+		EFAENIs:     make(map[string]bool),
+	}
+	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	m.awsutils.EXPECT().GetLocalIPv4().Return(primaryIP)
@@ -363,7 +369,13 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	m.awsutils.EXPECT().IsUnmanagedENI(primaryENIid).AnyTimes().Return(false)
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
-	m.awsutils.EXPECT().DescribeAllENIs().Return(eniMetadataList, map[string]awsutils.TagMap{}, "", nil)
+	resp := awsutils.DescribeAllENIsResult{
+		ENIMetadata: eniMetadataList,
+		TagMap:      map[string]awsutils.TagMap{},
+		TrunkENI:    "",
+		EFAENIs:     make(map[string]bool),
+	}
+	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 
 	mockContext.nodeIPPoolReconcile(0)
 
@@ -401,7 +413,13 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	// Two ENIs found
 	m.awsutils.EXPECT().GetAttachedENIs().Return(twoENIs, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(secENIid).Times(2).Return(false)
-	m.awsutils.EXPECT().DescribeAllENIs().Return(twoENIs, map[string]awsutils.TagMap{}, "", nil)
+	resp2 := awsutils.DescribeAllENIsResult{
+		ENIMetadata: twoENIs,
+		TagMap:      map[string]awsutils.TagMap{},
+		TrunkENI:    "",
+		EFAENIs:     make(map[string]bool),
+	}
+	m.awsutils.EXPECT().DescribeAllENIs().Return(resp2, nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet)
 
 	mockContext.nodeIPPoolReconcile(0)
@@ -460,7 +478,7 @@ func TestGetWarmIPTargetState(t *testing.T) {
 	assert.Equal(t, 0, over)
 
 	// add 2 addresses to datastore
-	_ = mockContext.dataStore.AddENI("eni-1", 1, true, false)
+	_ = mockContext.dataStore.AddENI("eni-1", 1, true, false, false)
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.1")
 	_ = mockContext.dataStore.AddIPv4AddressToStore("eni-1", "1.1.1.2")
 
@@ -533,7 +551,7 @@ func testDatastore() *datastore.DataStore {
 
 func datastoreWith3FreeIPs() *datastore.DataStore {
 	datastoreWith3FreeIPs := testDatastore()
-	_ = datastoreWith3FreeIPs.AddENI(primaryENIid, 1, true, false)
+	_ = datastoreWith3FreeIPs.AddENI(primaryENIid, 1, true, false, false)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr01)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr02)
 	_ = datastoreWith3FreeIPs.AddIPv4AddressToStore(primaryENIid, ipaddr03)
@@ -655,7 +673,7 @@ func TestNodeIPPoolReconcileBadIMDSData(t *testing.T) {
 	testAddr1 := *primaryENIMetadata.IPv4Addresses[0].PrivateIpAddress
 	// Add ENI and IPs to datastore
 	eniID := primaryENIMetadata.ENIID
-	_ = mockContext.dataStore.AddENI(eniID, primaryENIMetadata.DeviceNumber, true, false)
+	_ = mockContext.dataStore.AddENI(eniID, primaryENIMetadata.DeviceNumber, true, false, false)
 	mockContext.primaryIP[eniID] = testAddr1
 	mockContext.addENIaddressesToDataStore(primaryENIMetadata.IPv4Addresses, eniID)
 	curENIs := mockContext.dataStore.GetENIInfos()
@@ -802,7 +820,7 @@ func TestIPAMContext_setupENI(t *testing.T) {
 		},
 	}
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	err := mockContext.setupENI(primaryENIMetadata.ENIID, primaryENIMetadata, "")
+	err := mockContext.setupENI(primaryENIMetadata.ENIID, primaryENIMetadata, false, false)
 	assert.NoError(t, err)
 	// Primary ENI added
 	assert.Equal(t, 1, len(mockContext.primaryIP))
@@ -811,7 +829,7 @@ func TestIPAMContext_setupENI(t *testing.T) {
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet).Return(errors.New("not able to set route 0.0.0.0/0 via 10.10.10.1 table 2"))
 
-	err = mockContext.setupENI(newENIMetadata.ENIID, newENIMetadata, "")
+	err = mockContext.setupENI(newENIMetadata.ENIID, newENIMetadata, false, false)
 	assert.Error(t, err)
 	assert.Equal(t, 1, len(mockContext.primaryIP))
 }
@@ -840,7 +858,7 @@ func TestIPAMContext_askForTrunkENIIfNeeded(t *testing.T) {
 	}
 	_, _ = m.clientset.CoreV1().Nodes().Create(&fakeNode)
 
-	_ = mockContext.dataStore.AddENI("eni-1", 1, true, false)
+	_ = mockContext.dataStore.AddENI("eni-1", 1, true, false, false)
 	// If ENABLE_POD_ENI is not set, nothing happens
 	mockContext.askForTrunkENIIfNeeded()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement

**What does this PR do / Why do we need it**:
If we have an instance with EFA interfaces, we should make sure to never detach them.

**Testing done on this change**:
Added unit tests

**Automation added to e2e**:
No new tests added. Passing e2e tests: https://app.circleci.com/pipelines/github/mogren/amazon-vpc-cni-k8s/1035/workflows/86d66e2b-d920-44a4-8c4c-10dd54aca78d/jobs/2082

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note
* Do not detach EFA interfaces.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
