### PR TITLE
Fix lint issues and enable test check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
   - make check-format
   - make build-linux
-  - make lint LINT_FLAGS=
+  - make lint
   - make vet
   - make unit-test
 

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// CNI network driver setting up iptables, routes and rules
+// Package driver is the CNI network driver setting up iptables, routes and rules
 package driver
 
 import (

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Util package to interact with EC2
+// Package awsutils is a utility package for calling EC2 or IMDS
 package awsutils
 
 import (

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Package to get running sandboxes from the CRI socket
+// Package cri is used to get running sandboxes from the CRI socket
 package cri
 
 import (

--- a/pkg/grpcwrapper/client.go
+++ b/pkg/grpcwrapper/client.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper for the ipamd client Dial interface
+// Package grpcwrapper is a wrapper for the ipamd client Dial interface
 package grpcwrapper
 
 import (

--- a/pkg/ipwrapper/ip.go
+++ b/pkg/ipwrapper/ip.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper interface for the containernetworking ip plugin
+// Package ipwrapper is a wrapper interface for the containernetworking ip plugin
 package ipwrapper
 
 import (

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper methods for the netlink package
+// Package netlinkwrapper is a wrapper methods for the netlink package
 package netlinkwrapper
 
 import (

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Collection of iptables and netlink functions
+// Package networkutils is a collection of iptables and netlink functions
 package networkutils
 
 import (

--- a/pkg/nswrapper/ns.go
+++ b/pkg/nswrapper/ns.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper interface for the containernetworking ns plugin
+// Package nswrapper is a wrapper interface for the containernetworking ns plugin
 package nswrapper
 
 import (

--- a/pkg/procsyswrapper/procsys.go
+++ b/pkg/procsyswrapper/procsys.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper package for doing /proc/sys calls
+// Package procsyswrapper contains helper functions for doing /proc/sys calls
 package procsyswrapper
 
 import (

--- a/pkg/rpcwrapper/client.go
+++ b/pkg/rpcwrapper/client.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper for the CNI IPAMD pod connection
+// Package rpcwrapper is a wrapper for the CNI IPAMD pod connection
 package rpcwrapper
 
 import (

--- a/pkg/typeswrapper/client.go
+++ b/pkg/typeswrapper/client.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Wrapper interface for containernetworking types package
+// Package typeswrapper is a wrapper interface for containernetworking types package
 package typeswrapper
 
 import (

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// CNI Logger interface, using zap
+// Package logger is the CNI Logger interface, using zap
 package logger
 
 //Log is global variable so that log functions can be directly accessed

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Retry with backoff implementation
+// Package retry is a retry with backoff implementation
 package retry
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
documentation

**What does this PR do / Why do we need it**:
Lint warnings in https://goreportcard.com/report/github.com/aws/amazon-vpc-cni-k8s
Also enabling the `make lint` test check, now that the code is passing the test

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Before change:
```
> make lint
find . \
  -type f -name '*.go' \
  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" -not -name "eniconfig.go" \
  -print0 | sort -z | xargs -0 -L1 -- golint -set_exit_status 2>/dev/null
./cmd/routed-eni-cni-plugin/driver/driver.go:14:1: package comment should be of the form "Package driver ..."
./pkg/awsutils/awsutils.go:14:1: package comment should be of the form "Package awsutils ..."
./pkg/cri/cri.go:14:1: package comment should be of the form "Package cri ..."
./pkg/grpcwrapper/client.go:14:1: package comment should be of the form "Package grpcwrapper ..."
./pkg/ipwrapper/ip.go:14:1: package comment should be of the form "Package ipwrapper ..."
./pkg/netlinkwrapper/netlink.go:14:1: package comment should be of the form "Package netlinkwrapper ..."
./pkg/networkutils/network.go:14:1: package comment should be of the form "Package networkutils ..."
./pkg/nswrapper/ns.go:14:1: package comment should be of the form "Package nswrapper ..."
./pkg/procsyswrapper/procsys.go:14:1: package comment should be of the form "Package procsyswrapper ..."
./pkg/rpcwrapper/client.go:14:1: package comment should be of the form "Package rpcwrapper ..."
./pkg/typeswrapper/client.go:14:1: package comment should be of the form "Package typeswrapper ..."
./pkg/utils/logger/logger.go:14:1: package comment should be of the form "Package logger ..."
./pkg/utils/retry/retry.go:14:1: package comment should be of the form "Package retry ..."
make: *** [Makefile:236: lint] Error 123
```
After change
```
> make lint
find . \
  -type f -name '*.go' \
  -not -name 'mock_*' -not -name '*mocks.go' -not -name "cni.go" -not -name "eniconfig.go" \
  -print0 | sort -z | xargs -0 -L1 -- golint -set_exit_status 2>/dev/null

```

**Automation added to e2e**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No, just fixed package level comments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
