### PR TITLE
Ignore error on enabling TCP early demux for old kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,10 +431,11 @@ Type: Boolean as a String
 
 Default: `false`
 
-If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to talk to pods using the per pod security group feature,
-`DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection latency slightly, that is why it is not
- on by default. Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
-
+If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to connect via TCP to pods that are using 
+per pod security groups, `DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection 
+latency slightly, that is why it is not on by default. Details on why this is needed can be found in 
+this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
+To use this setting, a Linux kernel version of at least 4.6 is needed on the worker node.
 
 ### ENI tags related to Allocation
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -34,7 +34,7 @@ cat "/proc/sys/net/ipv4/conf/$PRIMARY_IF/rp_filter"
 if [ "${DISABLE_TCP_EARLY_DEMUX:-false}" == "true" ]; then
     sysctl -w "net.ipv4.tcp_early_demux=0"
 else
-    sysctl -w "net.ipv4.tcp_early_demux=1"
+    sysctl -e -w "net.ipv4.tcp_early_demux=1"
 fi
 
 echo "CNI init container done"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#1241

**What does this PR do / Why do we need it**:
For old kernels that do not have the `tcp_early_demux` kernel flag, the init container throws an error:
```
[centos@ip-192-168-9-194 ~]$ sysctl -w "net.ipv4.tcp_early_demux=1"
sysctl: cannot stat /proc/sys/net/ipv4/tcp_early_demux: No such file or directory
```
We need to ignore this warning:
```
[centos@ip-192-168-9-194 ~]$ sysctl -e -w "net.ipv4.tcp_early_demux=1"
```
From https://linux.die.net/man/8/sysctl: 
-e  Use this option to ignore errors about unknown keys.

The "early demux" feature was added in kernel 3.6, but the flag to disable it was not added until 4.6. This means that TCP health checks for pods using per-pod security groups will not work until at least kernel 4.6. UDP or exec checks should still work for pods with ENIs.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Start a CentOS image, run `sysctl -w "net.ipv4.tcp_early_demux=1"`

**Testing done on this change**:
See above

**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
