### PR TITLE
Ignore error on enabling TCP early demux for old kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,11 @@ Type: Boolean as a String
 
 Default: `false`
 
-If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to talk to pods using the per pod security group feature,
-`DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection latency slightly, that is why it is not
- on by default. Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
-
+If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to connect via TCP to pods that are using 
+per pod security groups, `DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection 
+latency slightly, that is why it is not on by default. Details on why this is needed can be found in 
+this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
+To use this setting, a Linux kernel version of at least 4.6 is needed on the worker node.
 
 ### ENI tags related to Allocation
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -34,7 +34,7 @@ cat "/proc/sys/net/ipv4/conf/$PRIMARY_IF/rp_filter"
 if [ "${DISABLE_TCP_EARLY_DEMUX:-false}" == "true" ]; then
     sysctl -w "net.ipv4.tcp_early_demux=0"
 else
-    sysctl -w "net.ipv4.tcp_early_demux=1"
+    sysctl -e -w "net.ipv4.tcp_early_demux=1"
 fi
 
 echo "CNI init container done"


### PR DESCRIPTION
(cherry picked from commit a6b0d46c8453cbadd8c1ab34e81e6d3caf6268e6)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry pick 

**Which issue does this PR fix**:
#1241

**What does this PR do / Why do we need it**:
Support kernels older than 4.6, details in #1242

**Testing done on this change**:
Manual test on CentOS instance

**Automation added to e2e**:
e2e tests run https://github.com/aws/amazon-vpc-cni-k8s/runs/1194745267?check_suite_focus=true

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
