### PR TITLE
Match primary ENI IP correctly

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -25,7 +25,7 @@ done
 echo "Configure rp_filter loose... "
 TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
 HOST_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
-PRIMARY_IF=$(ip -4 -o a | grep "$HOST_IP" | awk '{print $2}')
+PRIMARY_IF=$(ip -4 -o a | grep "$HOST_IP/" | awk '{print $2}')
 sysctl -w "net.ipv4.conf.$PRIMARY_IF.rp_filter=2"
 cat "/proc/sys/net/ipv4/conf/$PRIMARY_IF/rp_filter"
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
Fixes #1246

**What does this PR do / Why do we need it**:
For the example in the issue:
```
eth0: 192.168.0.10
eth1: 192.168.0.100
```
Trying to grep for `192.168.0.10` will match both. We need to add the trailing `/` to the `grep` argument. This won't happen on new nodes, only when updating running nodes.

**Testing done on this change**:
Inside a pod with multiple ENIs attached:
```
bash-4.2# ip -4 -o a
1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
2: eth0    inet 192.168.116.5/19 brd 192.168.127.255 scope global dynamic eth0\       valid_lft 1924sec preferred_lft 1924sec
5: eth1    inet 192.168.118.65/19 brd 192.168.127.255 scope global eth1\       valid_lft forever preferred_lft forever
6: eth2    inet 192.168.100.237/19 brd 192.168.127.255 scope global eth2\       valid_lft forever preferred_lft forever
bash-4.2# HOST_IP=192.168.11...
bash-4.2# ip -4 -o a | grep "$HOST_IP" | awk '{print $2}'
eth0
eth1
bash-4.2# ip -4 -o a | grep "$HOST_IP/" | awk '{print $2}'
eth0
```

**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, fix updates when multiple ENIs with only a trailing number in the IP is different.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
