### PR TITLE
CNI release 1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.7.5
+
+* Bug - [Match primary ENI IP correctly](https://github.com/aws/amazon-vpc-cni-k8s/pull/1247) (#1247 , @mogren)
+
 ## v1.7.4
 
 * Bug - [Ignore error on enabling TCP early demux for old kernels](https://github.com/aws/amazon-vpc-cni-k8s/pull/1242) (#1242, @mogren)

--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.4"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.5"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.4"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.4"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.5"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.4"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.4"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.5"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.4"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.4"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.5"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.4"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/cni-metrics-helper-cn.yaml
+++ b/config/v1.7/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.4"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.4"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.4"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper.yaml
+++ b/config/v1.7/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.4"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.5"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
This PR is for releasing CNI v1.7.5
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Bug fix

**What does this PR do / Why do we need it**:
We need this release to fix some clients' reported issue.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Yes
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
