### PR TITLE
Use primary ENI SGs if SG is null for Custom networking

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -700,7 +700,11 @@ func (cache *EC2InstanceMetadataCache) createENI(useCustomCfg bool, sg []*string
 
 	if useCustomCfg {
 		log.Info("Using a custom network config for the new ENI")
-		input.Groups = sg
+		if len(sg) != 0 {
+			input.Groups = sg
+		} else {
+			log.Warnf("No custom networking security group found, will use the node's primary ENI's SG: %s", input.Groups)
+		}
 		input.SubnetId = aws.String(subnet)
 	} else {
 		log.Info("Using same config as the primary interface for the new ENI")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1124 

**What does this PR do / Why do we need it**:
If SG is not provided in the ENIConfig then use the primary ENI SGs.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Created ENI config -
```
cat <<EOF  | kubectl apply -f -
apiVersion: crd.k8s.amazonaws.com/v1alpha1
kind: ENIConfig
metadata:
 name: $AZ1
spec:
  subnet: $CUST_SNET1
EOF
```

Before fix SG list is empty-
```
{"level":"info","ts":"2020-10-12T21:11:32.781Z","caller":"awsutils/awsutils.go:610","msg":"Using a custom network config for the new ENI"}
{"level":"info","ts":"2020-10-12T21:11:32.781Z","caller":"awsutils/awsutils.go:610","msg":"Creating ENI with security groups: [] in subnet: subnet-0ac93d8034479e1cf"}
{"level":"info","ts":"2020-10-12T21:11:33.157Z","caller":"awsutils/awsutils.go:610","msg":"Created a new ENI: eni-014407d03b4c13b5f"}
```
Terminated the nodes and new nodes after fix -

```
{"level":"info","ts":"2020-10-12T20:55:44.350Z","caller":"ipamd/ipamd.go:638","msg":"ipamd: using custom network config: [], subnet-0ac93d8034479e1cf"}
{"level":"info","ts":"2020-10-12T20:55:44.350Z","caller":"awsutils/awsutils.go:610","msg":"Using a custom network config for the new ENI"}
{"level":"info","ts":"2020-10-12T20:55:44.350Z","caller":"awsutils/awsutils.go:610","msg":"Creating ENI with security groups: [sg-04b933767a4f1d5a0 sg-0c23b7680a45ebfa0] in subnet: subnet-0ac93d8034479e1cf"}
{"level":"info","ts":"2020-10-12T20:55:44.833Z","caller":"awsutils/awsutils.go:610","msg":"Created a new ENI: eni-04344bd43a8d9af7d"}
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Upgrades and downgrades should not be impacted. One thing to call out, eni should be deleted and added back for the change to take into effect like terminating the node. Just upgrade will find the existing ENI and re-use it so SG won't be updated.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
