### PR TITLE
no longer refer to potential CLA requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,3 @@ If you discover a potential security issue in this project we ask that you notif
 ## Licensing
 
 See the [LICENSE](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
Our legal team has asked that the wording included in the
CONTRIBUTING.md document referring to potentially requiring a CLA to be
signed for certain contributions be removed.

This phrase was added out of an abundance of caution originally and has
been determined to be unnecessary and inhibiting external contribution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
