### PR TITLE
Update README for DISABLE_TCP_EARLY_DEMUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,10 @@ Type: Boolean as a String
 
 Default: `false`
 
-If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet on the node to connect via TCP to pods that are using 
-per pod security groups, `DISABLE_TCP_EARLY_DEMUX` should be set to `true`. This will increase the local TCP connection 
-latency slightly, that is why it is not on by default. Details on why this is needed can be found in 
-this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
+If `ENABLE_POD_ENI` is set to `true`, in order for the kubelet to connect via TCP (for liveness or readiness probes)
+to pods that are using per pod security groups, `DISABLE_TCP_EARLY_DEMUX` should be set to `true` for `amazon-k8s-cni-init`
+container under `initcontainers`. This will increase the local TCP connection latency slightly.
+Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
 To use this setting, a Linux kernel version of at least 4.6 is needed on the worker node.
 
 ### ENI tags related to Allocation


### PR DESCRIPTION
**What type of PR is this?**
This PR updates the README for DISABLE_TCP_EARLY_DEMUX to explicitly call out that initContainer env variable needs to be updated.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
documentation

**What does this PR do / Why do we need it**:
This PR will clarify the confusion around why liveness or readiness probes are failing for pods using ppsg.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
