### PR TITLE
Calico multi arch support

### DIFF
--- a/config/master/calico.yaml
+++ b/config/master/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.4
+          image: calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -547,7 +547,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.4
+        - image: calico/typha:v3.15.1
           name: calico-typha
           ports:
             - containerPort: 5473
@@ -684,7 +684,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1
+        - image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3 
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/config/master/calico.yaml
+++ b/config/master/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.15.1
+          image: calico/node:v3.16.2
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -547,7 +547,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: calico/typha:v3.15.1
+        - image: calico/typha:v3.16.2
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1218 

**What does this PR do / Why do we need it**:
Update calico-node and calico-typha to docker images to support ARM and AMD instances
Update autoscalar image - https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/1.8.3

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

AMD instance
```
kubectl describe node | grep Arch
 Architecture:               amd64

kgpsys | grep calico
calico-node-njjl2                                     1/1     Running   0          97m    192.168.7.155   ip-192-168-7-155.us-west-2.compute.internal   <none>           <none>
calico-typha-97c66d8b9-kdrdw                          1/1     Running   0          97m    192.168.7.155   ip-192-168-7-155.us-west-2.compute.internal   <none>           <none>
calico-typha-horizontal-autoscaler-6df548d5d5-5s9pp   1/1     Running   0          97m    192.168.29.9    ip-192-168-7-155.us-west-2.compute.internal   <none>           <none>

kubectl describe pod calico-node-njjl2 -n kube-system | grep Image
    Image:          calico/node:v3.15.1
    Image ID:       docker-pullable://calico/node@sha256:b386769a293d180cb6ee208c8594030128a0810b286a93ae897a231ef247afa8

kubectl describe pod calico-typha-97c66d8b9-kdrdw -n kube-system | grep Image
    Image:          calico/typha:v3.15.1
    Image ID:       docker-pullable://calico/typha@sha256:50830f75be50bb5a835c8705bce8745513374ce1cf1714af9b9321412f9b516f

kubectl describe pod calico-typha-horizontal-autoscaler-6df548d5d5-5s9pp -n kube-system | grep Image
    Image:         k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
    Image ID:      docker-pullable://k8s.gcr.io/cpa/cluster-proportional-autoscaler@sha256:67640771ad9fc56f109d5b01e020f0c858e7c890bb0eb15ba0ebd325df3285e7
```

ARM instance
```
kubectl describe node | grep Arch
 Architecture:               arm64

kgpsys | grep calico
calico-node-26qkn                                     1/1     Running   0          6h9m   192.168.46.224   ip-192-168-46-224.us-west-2.compute.internal   <none>           <none>
calico-typha-6fb6797dc7-mpjtp                         1/1     Running   0          6h9m   192.168.46.224   ip-192-168-46-224.us-west-2.compute.internal   <none>           <none>
calico-typha-horizontal-autoscaler-6f6bd5b5df-ffhk5   1/1     Running   0          6h9m   192.168.42.169   ip-192-168-46-224.us-west-2.compute.internal   <none>           <none>

kubectl describe pod calico-node-26qkn -n kube-system | grep Image
    Image:          calico/node:v3.15.1
    Image ID:       docker-pullable://calico/node@sha256:b386769a293d180cb6ee208c8594030128a0810b286a93ae897a231ef247afa8

 kubectl describe pod calico-typha-6fb6797dc7-mpjtp -n kube-system | grep Image
    Image:          calico/typha:v3.15.1
    Image ID:       docker-pullable://calico/typha@sha256:50830f75be50bb5a835c8705bce8745513374ce1cf1714af9b9321412f9b516f

kubectl describe pod calico-typha-horizontal-autoscaler-6f6bd5b5df-ffhk5 -n kube-system | grep Image
    Image:         k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
    Image ID:      docker-pullable://k8s.gcr.io/cpa/cluster-proportional-autoscaler@sha256:67640771ad9fc56f109d5b01e020f0c858e7c890bb0eb15ba0ebd325df3285e7
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
