### PR TITLE
Adds timeout to HTTP clients

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -79,7 +79,7 @@ var (
 	ErrNoNetworkInterfaces = errors.New("No network interfaces found for ENI")
 	// Custom user agent
 	userAgent = request.WithAppendUserAgent("amazon-vpc-cni-k8s")
-	// HTTP timeout default value in seconds (5 seconds)
+	// HTTP timeout default value in seconds (10 seconds)
 	httpTimeoutValue = 10 * time.Second
 )
 

--- a/pkg/ec2wrapper/ec2wrapper.go
+++ b/pkg/ec2wrapper/ec2wrapper.go
@@ -29,7 +29,7 @@ const (
 var (
 	log = logger.Get()
 
-	// HTTP timeout default value in seconds (5 seconds)
+	// HTTP timeout default value in seconds (10 seconds)
 	httpTimeoutValue = 10 * time.Second
 )
 

--- a/pkg/ec2wrapper/ec2wrapper.go
+++ b/pkg/ec2wrapper/ec2wrapper.go
@@ -10,6 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/pkg/errors"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
 )
 
 const (
@@ -17,9 +21,17 @@ const (
 	resourceID   = "resource-id"
 	resourceKey  = "key"
 	clusterIDTag = "CLUSTER_ID"
+
+	// Http client timeout env for sessions
+	httpTimeoutEnv = "HTTP_TIMEOUT"
 )
 
-var log = logger.Get()
+var (
+	log = logger.Get()
+
+	// HTTP timeout default value in seconds (5 seconds)
+	httpTimeoutValue = 10 * time.Second
+)
 
 // EC2Wrapper is used to wrap around EC2 service APIs to obtain ClusterID from
 // the ec2 instance tags
@@ -30,7 +42,24 @@ type EC2Wrapper struct {
 
 //NewMetricsClient returns an instance of the EC2 wrapper
 func NewMetricsClient() (*EC2Wrapper, error) {
-	metricsSession := session.Must(session.NewSession())
+
+	httpTimeoutEnvInput := os.Getenv(httpTimeoutEnv)
+	// if httpTimeout is not empty, we convert value to int and overwrite default httpTimeoutValue
+	if httpTimeoutEnvInput != "" {
+		if input, err := strconv.Atoi(httpTimeoutEnvInput); err == nil && input >= 1 {
+			log.Debugf("Using HTTP_TIMEOUT %v", input)
+			httpTimeoutValue = time.Duration(input) * time.Second
+		}
+	}
+
+	metricsSession := session.Must(session.NewSession(
+		&aws.Config{
+			MaxRetries: aws.Int(15),
+			HTTPClient: &http.Client{
+				Timeout: httpTimeoutValue,
+			},
+		},
+	))
 	ec2MetadataClient := ec2metadatawrapper.New(nil)
 
 	instanceIdentityDocument, err := ec2MetadataClient.GetInstanceIdentityDocument()

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -16,6 +16,9 @@ package publisher
 
 import (
 	"context"
+	"net/http"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -51,6 +54,9 @@ const (
 
 	// Default cluster id if unable to detect something more suitable
 	defaultClusterID = "k8s-cluster"
+
+	// Http client timeout env for sessions
+	httpTimeoutEnv = "HTTP_TIMEOUT"
 )
 
 var (
@@ -60,6 +66,9 @@ var (
 		"CLUSTER_ID",
 		"Name",
 	}
+
+	// HTTP timeout default value in seconds (5 seconds)
+	httpTimeoutValue = 10 * time.Second
 )
 
 var log = logger.Get()
@@ -90,8 +99,25 @@ type cloudWatchPublisher struct {
 
 // New returns a new instance of `Publisher`
 func New(ctx context.Context) (Publisher, error) {
+
+	httpTimeoutEnvInput := os.Getenv(httpTimeoutEnv)
+	// if httpTimeout is not empty, we convert value to int and overwrite default httpTimeoutValue
+	if httpTimeoutEnvInput != "" {
+		if input, err := strconv.Atoi(httpTimeoutEnvInput); err == nil && input >= 1 {
+			log.Debugf("Using HTTP_TIMEOUT %v", input)
+			httpTimeoutValue = time.Duration(input) * time.Second
+		}
+	}
+
 	// Get AWS session
-	awsSession := session.Must(session.NewSession())
+	awsSession := session.Must(session.NewSession(
+		&aws.Config{
+			MaxRetries: aws.Int(15),
+			HTTPClient: &http.Client{
+				Timeout: httpTimeoutValue,
+				},
+		},
+	))
 
 	// Get cluster-ID
 	ec2Client, err := ec2wrapper.NewMetricsClient()

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -67,7 +67,7 @@ var (
 		"Name",
 	}
 
-	// HTTP timeout default value in seconds (5 seconds)
+	// HTTP timeout default value in seconds (10 seconds)
 	httpTimeoutValue = 10 * time.Second
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug fix.

**Which issue does this PR fix**:
#1256 

**What does this PR do / Why do we need it**:
Some customers experienced a stuck go routine caused by stuck http requests not timing out. 

**Testing done on this change**:
Manually tested the two following scenarios:
* Setting the env var `HTTP_TIMEOUT` in the yaml and logging the set value.
* Not setting an env var and verifying that the default value of 5 sec is being used for the HTTP client.

**Automation added to e2e**:

None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

Will not break downgrades or upgrades.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Only if we decide to include the HTTP_TIMEOUT var in the config file. 
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
