### PR TITLE
Cherry pick #1210 for Rel 1.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Type: Boolean as a String
 Default: `false`
 
 To enable security groups for pods you need to have at least an EKS 1.17 eks.3 cluster. Setting `ENABLE_POD_ENI` to `true`
-will add the `vpc.amazonaws.com/has-trunk-attached` label to the node, signifying that the feature is enabled. 
+will add the `vpc.amazonaws.com/has-trunk-attached` label to the node if it is possible to attach an additional ENI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,6 @@ Default: `""`
 
 Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag" section below.
 
-
 ---
 
 `ENABLE_POD_ENI` (Since v1.7.0)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -827,13 +827,17 @@ func logPoolStats(total, used, maxAddrsPerENI int) {
 
 func (c *IPAMContext) askForTrunkENIIfNeeded() {
 	if c.enablePodENI && c.dataStore.GetTrunkENI() == "" {
+		// Check that there is room for a trunk ENI to be attached:
+		if c.dataStore.GetENIs() >= (c.maxENI - c.unmanagedENI) {
+			log.Debug("No slot available for a trunk ENI to be attached. Not labeling the node")
+			return
+		}
 		// We need to signal that VPC Resource Controller needs to attach a trunk ENI
 		err := c.SetNodeLabel("vpc.amazonaws.com/has-trunk-attached", "false")
 		if err != nil {
 			podENIErrInc("askForTrunkENIIfNeeded")
 			log.Errorf("Failed to set node label", err)
 		}
-		return
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry pick #1210
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1210 

**What does this PR do / Why do we need it**:
N/A

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Not needed

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note
Will be added as part of 1.7.6 release
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
