### PR TITLE
Add check for EFA ENIs - Port #1237

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -131,8 +131,8 @@ type APIs interface {
 	// GetIPv4sFromEC2 returns the IPv4 addresses for a given ENI
 	GetIPv4sFromEC2(eniID string) (addrList []*ec2.NetworkInterfacePrivateIpAddress, err error)
 
-	// DescribeAllENIs calls EC2 and returns the ENIMetadata and a tag map for each ENI
-	DescribeAllENIs() (eniMetadata []ENIMetadata, tagMap map[string]TagMap, trunkENI string, err error)
+	// DescribeAllENIs calls EC2 and returns a fully populated DescribeAllENIsResult struct and an error
+	DescribeAllENIs() (DescribeAllENIsResult, error)
 
 	// AllocIPAddress allocates an IP address for an ENI
 	AllocIPAddress(eniID string) error
@@ -227,6 +227,14 @@ func (eni ENIMetadata) PrimaryIPv4Address() string {
 
 // TagMap keeps track of the EC2 tags on each ENI
 type TagMap map[string]string
+
+// DescribeAllENIsResult contains the fully
+type DescribeAllENIsResult struct {
+	ENIMetadata []ENIMetadata
+	TagMap      map[string]TagMap
+	TrunkENI    string
+	EFAENIs     map[string]bool
+}
 
 // msSince returns milliseconds since start.
 func msSince(start time.Time) float64 {
@@ -1088,12 +1096,12 @@ func (cache *EC2InstanceMetadataCache) GetIPv4sFromEC2(eniID string) (addrList [
 	return firstNI.PrivateIpAddresses, nil
 }
 
-// DescribeAllENIs calls EC2 to refrech the ENIMetadata and tags for all attached ENIs
-func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetadata, tagMap map[string]TagMap, trunkENI string, err error) {
+// DescribeAllENIs calls EC2 to refresh the ENIMetadata and tags for all attached ENIs
+func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (DescribeAllENIsResult, error) {
 	// Fetch all local ENI info from metadata
 	allENIs, err := cache.GetAttachedENIs()
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "DescribeAllENIs: failed to get local ENI metadata")
+		return DescribeAllENIsResult{}, errors.Wrap(err, "DescribeAllENIs: failed to get local ENI metadata")
 	}
 
 	eniMap := make(map[string]ENIMetadata, len(allENIs))
@@ -1138,7 +1146,7 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetad
 	}
 
 	if err != nil {
-		return nil, nil, "", err
+		return DescribeAllENIsResult{}, err
 	}
 
 	// Collect the verified ENIs
@@ -1148,7 +1156,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetad
 	}
 
 	// Collect ENI response into ENI metadata and tags.
-	tagMap = make(map[string]TagMap, len(ec2Response.NetworkInterfaces))
+	var trunkENI string
+	efaENIs := make(map[string]bool, 0)
+	tagMap := make(map[string]TagMap, len(ec2Response.NetworkInterfaces))
 	for _, ec2res := range ec2Response.NetworkInterfaces {
 		if ec2res.Attachment != nil && aws.Int64Value(ec2res.Attachment.DeviceIndex) == 0 && !aws.BoolValue(ec2res.Attachment.DeleteOnTermination) {
 			log.Warn("Primary ENI will not get deleted when node terminates because 'delete_on_termination' is set to false")
@@ -1160,6 +1170,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetad
 		if interfaceType == "trunk" {
 			trunkENI = eniID
 		}
+		if interfaceType == "efa" {
+			efaENIs[eniID] = true
+		}
 		// Check IPv4 addresses
 		logOutOfSyncState(eniID, eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
 		tags := getTags(ec2res, eniMetadata.ENIID)
@@ -1167,7 +1180,12 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetad
 			tagMap[eniMetadata.ENIID] = tags
 		}
 	}
-	return verifiedENIs, tagMap, trunkENI, nil
+	return DescribeAllENIsResult{
+		ENIMetadata: verifiedENIs,
+		TagMap:      tagMap,
+		TrunkENI:    trunkENI,
+		EFAENIs:     efaENIs,
+	}, nil
 }
 
 // getTags collects tags from an EC2 DescribeNetworkInterfaces call

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -400,9 +400,9 @@ func TestDescribeAllENIs(t *testing.T) {
 	for _, tc := range testCases {
 		mockEC2.EXPECT().DescribeNetworkInterfacesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(tc.n).Return(result, tc.awsErr)
 		ins := &EC2InstanceMetadataCache{ec2Metadata: mockMetadata, ec2SVC: mockEC2}
-		_, tags, _, err := ins.DescribeAllENIs()
+		metaData, err := ins.DescribeAllENIs()
 		assert.Equal(t, tc.expErr, err, tc.name)
-		assert.Equal(t, tc.exptags, tags, tc.name)
+		assert.Equal(t, tc.exptags, metaData.TagMap, tc.name)
 	}
 }
 

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -107,14 +107,12 @@ func (mr *MockAPIsMockRecorder) DeallocIPAddresses(arg0, arg1 interface{}) *gomo
 }
 
 // DescribeAllENIs mocks base method
-func (m *MockAPIs) DescribeAllENIs() ([]awsutils.ENIMetadata, map[string]awsutils.TagMap, string, error) {
+func (m *MockAPIs) DescribeAllENIs() (awsutils.DescribeAllENIsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAllENIs")
-	ret0, _ := ret[0].([]awsutils.ENIMetadata)
-	ret1, _ := ret[1].(map[string]awsutils.TagMap)
-	ret2, _ := ret[2].(string)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret0, _ := ret[0].(awsutils.DescribeAllENIsResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DescribeAllENIs indicates an expected call of DescribeAllENIs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick #1237 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Cherry-pick of #1237 had conflicts at 2 places and it is fixed manually. Unit-test are passing.

**What does this PR do / Why do we need it**:
n/a

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Unit-test passes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
