### PR TITLE
Cherrypick #1251

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,10 @@ Type: String
 
 Default: `/var/log/aws-routed-eni/plugin.log`
 
-Valid Values: `stdout` or a file path
+Valid Values: `stderr` or a file path
 
-Specifies where to write the logging output for `aws-cni` plugin. Either to stdout or to override the default file (i.e., `/var/log/aws-routed-eni/plugin.log`).
+Specifies where to write the logging output for `aws-cni` plugin. Either to `stderr` or to override the default file (i.e., `/var/log/aws-routed-eni/plugin.log`).
+`Stdout` cannot be supported for plugin log, please refer to #1248 for more details.
 
 ---
 

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1156,6 +1156,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (eniMetadata []ENIMetad
 		eniID := aws.StringValue(ec2res.NetworkInterfaceId)
 		eniMetadata := eniMap[eniID]
 		interfaceType := aws.StringValue(ec2res.InterfaceType)
+
+		log.Infof("%s is of type: %s", eniID, interfaceType)
+
 		// This assumes we only have one trunk attached to the node..
 		if interfaceType == "trunk" {
 			trunkENI = eniID

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -35,6 +35,15 @@ log_in_json()
     printf '{"level":"%s","ts":"%s","caller":"%s","msg":"%s"}\n' "$LOGTYPE" "$TIMESTAMP" "$FILENAME" "$MSG"
 }
 
+validate_env_var()
+{
+    log_in_json info "Validating env variables ..."
+    if [[ "${AWS_VPC_K8S_PLUGIN_LOG_FILE,,}" == "stdout" ]]; then
+        log_in_json error "AWS_VPC_K8S_PLUGIN_LOG_FILE cannot be set to stdout"
+        exit 1     
+    fi 
+}
+
 # Check for all the required binaries before we go forward
 if [ ! -f aws-k8s-agent ]; then
     log_in_json error "Required aws-k8s-agent executable not found."
@@ -54,6 +63,8 @@ AWS_VPC_K8S_PLUGIN_LOG_FILE=${AWS_VPC_K8S_PLUGIN_LOG_FILE:-"/var/log/aws-routed-
 AWS_VPC_K8S_PLUGIN_LOG_LEVEL=${AWS_VPC_K8S_PLUGIN_LOG_LEVEL:-"Debug"}
 
 AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER=${AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:-"true"}
+
+validate_env_var
 
 # Check for ipamd connectivity on localhost port 50051
 wait_for_ipam() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
cherry pick #1251 for rel 1.7.6

**What does this PR do / Why do we need it**:
n/a

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1251 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
