### PR TITLE
cherry-pick - Update changelog for rel-1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.7.6
+
+* Improvement - [Avoid detaching EFA ENIs](https://github.com/aws/amazon-vpc-cni-k8s/pull/1237) (#1237 , @mogren)
+* Improvement - [Add t4g instance type](https://github.com/aws/amazon-vpc-cni-k8s/pull/1219) (#1219 , @mogren)
+* Improvement - [Add p4d.24xlarge instance type](https://github.com/aws/amazon-vpc-cni-k8s/pull/1238) (#1238 , @mogren)
+* Improvement - [Update calico to v3.16.2](https://github.com/aws/amazon-vpc-cni-k8s/pull/1235) (#1235 , @lwr20)
+* Improvement - [Update readme on stdout support for plugin log file](https://github.com/aws/amazon-vpc-cni-k8s/pull/1251) (#1251 , @jayanthvn)
+* Bug - [Make p3dn.24xlarge examples more realistic](https://github.com/aws/amazon-vpc-cni-k8s/pull/1263) (#1263 , @mogren)
+* Bug - [Make sure we have space for a trunk ENI](https://github.com/aws/amazon-vpc-cni-k8s/pull/1210) (#1210 , @mogren)
+* Bug - [Update README for DISABLE_TCP_EARLY_DEMUX](https://github.com/aws/amazon-vpc-cni-k8s/pull/1273) (#1273 , @SaranBalaji90)
+* Bug - [Update p4 instance limits](https://github.com/aws/amazon-vpc-cni-k8s/pull/1289) (#1289 , @varavaj)
+
 ## v1.7.5
 
 * Bug - [Match primary ENI IP correctly](https://github.com/aws/amazon-vpc-cni-k8s/pull/1247) (#1247 , @mogren)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Update changelog

**What does this PR do / Why do we need it**:
cherrypick from rel 1.7 branch

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
