### PR TITLE
Rearrange Pod deletion workflow

### DIFF
--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -190,7 +190,14 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 		return nil, err
 	}
 
-	if s.ipamContext.enablePodENI {
+	ipamKey := datastore.IPAMKey{
+		ContainerID: in.ContainerID,
+		IfName:      in.IfName,
+		NetworkName: in.NetworkName,
+	}
+	ip, deviceNumber, err := s.ipamContext.dataStore.UnassignPodIPv4Address(ipamKey)
+
+	if err == datastore.ErrUnknownPod && s.ipamContext.enablePodENI {
 		pod, err := s.ipamContext.GetPod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE)
 		if err != nil {
 			if k8serror.IsNotFound(err) {
@@ -214,12 +221,6 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 				IPv4Addr:  podENIData[0].PrivateIP}, err
 		}
 	}
-	ipamKey := datastore.IPAMKey{
-		ContainerID: in.ContainerID,
-		IfName:      in.IfName,
-		NetworkName: in.NetworkName,
-	}
-	ip, deviceNumber, err := s.ipamContext.dataStore.UnassignPodIPv4Address(ipamKey)
 
 	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)
 


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
If regular pods are force deleted when PPSG is used then it will clean up the regular pods.

**What does this PR do / Why do we need it**:
If we do make this change, then force deleting regular pods will not be supported with PPSG.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
This doesn't change any existing functionality.

**Testing done on this change**:
Created and deleted regular pods.

Created and deleted branch eni pods -
```
{"level":"info","ts":"2020-12-08T00:46:39.198Z","caller":"rpc/rpc.pb.go:520","msg":"Received DelNetwork for Sandbox 7e8fa75d4ccb574d391d5e72b6d07c395ed344cd95984135ddfc74e7c9316c89"}
{"level":"debug","ts":"2020-12-08T00:46:39.198Z","caller":"rpc/rpc.pb.go:520","msg":"DelNetworkRequest: ClientVersion:\"varavaj-init-v2-67-g8bd8af2c\" K8S_POD_NAME:\"gw-74464d8645-vz4b9\" K8S_POD_NAMESPACE:\"default\" K8S_POD_INFRA_CONTAINER_ID:\"7e8fa75d4ccb574d391d5e72b6d07c395ed344cd95984135ddfc74e7c9316c89\" Reason:\"PodDeleted\" ContainerID:\"7e8fa75d4ccb574d391d5e72b6d07c395ed344cd95984135ddfc74e7c9316c89\" IfName:\"eth0\" NetworkName:\"aws-cni\" "}
{"level":"debug","ts":"2020-12-08T00:46:39.198Z","caller":"ipamd/rpc_handler.go:198","msg":"UnassignPodIPv4Address: IP address pool stats: total:28, assigned 1, sandbox aws-cni/7e8fa75d4ccb574d391d5e72b6d07c395ed344cd95984135ddfc74e7c9316c89/eth0"}
{"level":"debug","ts":"2020-12-08T00:46:39.198Z","caller":"ipamd/rpc_handler.go:198","msg":"UnassignPodIPv4Address: Failed to find IPAM entry under full key, trying CRI-migrated version"}
{"level":"warn","ts":"2020-12-08T00:46:39.198Z","caller":"ipamd/rpc_handler.go:198","msg":"UnassignPodIPv4Address: Failed to find sandbox _migrated-from-cri/7e8fa75d4ccb574d391d5e72b6d07c395ed344cd95984135ddfc74e7c9316c89/unknown"}
```
Branch ENI deleted successfully.

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No this doesn't break on upgrades/downgrades

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
