### PR TITLE
Update README with sample cmd to set DISABLE_TCP_EARLY_DEMUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,12 @@ container under `initcontainers`. This will increase the local TCP connection la
 Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
 To use this setting, a Linux kernel version of at least 4.6 is needed on the worker node.
 
+You can use the below command to enable `DISABLE_TCP_EARLY_DEMUX` to `true` -
+
+```
+kubectl patch daemonset aws-node -n kube-system -p '{"spec": {"template": {"spec": {"initContainers": [{"env":[{"name":"DISABLE_TCP_EARLY_DEMUX","value":"true"}],"name":"aws-vpc-cni-init"}]}}}}'
+```
+
 ### ENI tags related to Allocation
 
 This plugin interacts with the following tags on ENIs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
DISABLE_TCP_EALY_DEMUX should be enabled under initContainers. Kubectl set doesn't work for initContainers and it easy for someone to miss this and enable it under aws-node which will not disable/enable the feature. Hence updated the doc to use kubectl patch instead.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
 % [~]
dev-dsk-varavaj-2b-72f02457 % kubectl describe daemonset aws-node -n kube-system | grep TCP_EARLY
      DISABLE_TCP_EARLY_DEMUX:  false
 % [~]
dev-dsk-varavaj-2b-72f02457 % kubectl patch daemonset aws-node -n kube-system -p '{"spec": {"template": {"spec": {"initContainers": [{"env":[{"name":"DISABLE_TCP_EARLY_DEMUX","value":"true"}],"name":"aws-vpc-cni-init"}]}}}}'
daemonset.apps/aws-node patched
 % [~]
dev-dsk-varavaj-2b-72f02457 % kubectl describe daemonset aws-node -n kube-system | grep TCP_EARLY
      DISABLE_TCP_EARLY_DEMUX:  true
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
