### PR TITLE
Release v1.7.7 in Github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.7.7
+
+* Bug - [Rearrange Pod deletion workflow](https://github.com/aws/amazon-vpc-cni-k8s/pull/1315) (#1315, @SaranBalaji90)
+
 ## v1.7.6
 
 * Improvement - [Avoid detaching EFA ENIs](https://github.com/aws/amazon-vpc-cni-k8s/pull/1237) (#1237 , @mogren)

--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.6"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.7"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.6"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.6"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.7"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.6"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.6"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.7"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.6"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.6"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.7"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.6"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/cni-metrics-helper-cn.yaml
+++ b/config/v1.7/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.6"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.6"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.6"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper.yaml
+++ b/config/v1.7/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.6"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.7"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"


### PR DESCRIPTION
**What type of PR is this?**
New CNI Release

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/pull/1315

**What does this PR do / Why do we need it**:
This rearranges the pod deletion workflow.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Tested by deleting regular and branch ENI pods and verified resources are cleaned up on the host. Also, ran integration test.

**Automation added to e2e**:
NA

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
