### PR TITLE
Update calico to v3.17.1

### DIFF
--- a/config/master/calico.yaml
+++ b/config/master/calico.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.16.2
+          image: docker.io/calico/node:v3.17.1
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -565,7 +565,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: docker.io/calico/typha:v3.16.2
+        - image: docker.io/calico/typha:v3.17.1
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup (updating images)

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Updates Calico images to v3.17.1.  Release notes here: https://docs.projectcalico.org/release-notes/ 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually set up an eks cluster following https://docs.aws.amazon.com/eks/latest/userguide/calico.html but substituting this calico.yaml. Then ran some workloads and verified that pod and service connectivity was working.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
If this updated calico.yaml doesn't get picked up by existing tests, happy to work with someone to make that happen.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Not expected to break upgrades or downgrades, but I've not explicitly tested that.


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
This change is itself an update to a CNI daemonset.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Calico config has been updated to v3.17.1.  
This release contains several fixes for BPF mode in AWS environments.
Full release notes for Calico v3.17.1 can be found at https://docs.projectcalico.org/release-notes/
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
