### PR TITLE
Update the v1.7 calico manifest to Calico v3.17.1

### DIFF
--- a/config/v1.7/calico.yaml
+++ b/config/v1.7/calico.yaml
@@ -32,7 +32,12 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.15.1
+          image: docker.io/calico/node:v3.17.1
+          envFrom:
+          - configMapRef:
+              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+              name: kubernetes-services-endpoint
+              optional: true
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -114,6 +119,13 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
+            # parent directory.
+            - name: sysfs
+              mountPath: /sys/fs/
+              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
+              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
+              mountPropagation: Bidirectional
       volumes:
         # Used to ensure proper kmods are installed.
         - name: lib-modules
@@ -129,6 +141,10 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+        - name: sysfs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
       tolerations:
         # Make sure calico/node gets scheduled on all nodes.
         - effect: NoSchedule
@@ -373,13 +389,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
-  # The CNI plugin needs to get pods, nodes, configmaps, and namespaces.
+  # The CNI plugin needs to get pods, nodes, configmaps and namespaces.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
-      - namespaces
       - configmaps
+      - namespaces
     verbs:
       - get
   - apiGroups: [""]
@@ -549,12 +565,17 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.15.1
+        - image: docker.io/calico/typha:v3.17.1
           name: calico-typha
           ports:
             - containerPort: 5473
               name: calico-typha
               protocol: TCP
+          envFrom:
+          - configMapRef:
+              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+              name: kubernetes-services-endpoint
+              optional: true
           env:
             # Use eni not cali for interface prefix
             - name: FELIX_INTERFACEPREFIX
@@ -686,7 +707,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1
+        - image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3 
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup - updating Calico manifest in v1.7 from calico v3.15.1 to v3.17.1
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
This PR updates Calico.  Calico v3.16 introduced the ability BPF mode and v3.17 contained several bugfixes for EKS when running in BPF mode.

These changes are present in `config/master/calico.yaml` already.  This PR attempts to bring them into the v1.7 calico manifest too.  TBH, I'm not sure I understand why there are `config/<version>` directories - if this isn't the right way to go about getting this change into 1.7, please tell me what I should be doing instead. 

I'm basing this all on the fact that https://docs.aws.amazon.com/eks/latest/userguide/calico.html links to https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.5/config/v1.7/calico.yaml

So this PR basically applies the changes from #1235, #1282 and #1326 to `config/v1.7/calico.yaml`.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
I've set up an EKS cluster using eksctl, applied this manifest and created various pods/services and checked they work as expected.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Existing Calico test cases should cover this?

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Not explicitly tested, but no breakages expected.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
This PR is itself an update of the CNI daemonset.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
I think a release note isn't required since the PRs it combines already have release notes?

```release-note
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
