### PR TITLE
aws-node does not perform ip unassignment properly

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -123,9 +123,16 @@ type IPAMKey struct {
 	IfName      string `json:"ifName"`
 }
 
-// IsZero returns true iff object is equal to the golang zero/null value.
+// IsZero returns true if object is equal to the golang zero/null value.
 func (k IPAMKey) IsZero() bool {
 	return k == IPAMKey{}
+}
+
+// NoContainer returns true if IPAMKey exists but there is not ContainerID associated
+// Eventually it should be t // should be processed by tryUnassignIPsFromAll in ipamd.go
+// Which will decrease DS usage counter
+func (k IPAMKey) NoContainer() bool {
+       return k.ContainerID == ""
 }
 
 // String() implements the fmt.Stringer interface.
@@ -178,9 +185,12 @@ func (e *ENI) AssignedIPv4Addresses() int {
 	return count
 }
 
-// Assigned returns true iff the address is allocated to a pod/sandbox.
+// Assigned returns true if the address is allocated to a pod/sandbox.
 func (addr AddressInfo) Assigned() bool {
-	return !addr.IPAMKey.IsZero()
+	if addr.IPAMKey.IsZero() {
+		return false
+	}
+	return !addr.IPAMKey.NoContainer()
 }
 
 // InCoolingPeriod checks whether an addr is in addressCoolingPeriod

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -132,7 +132,7 @@ func (k IPAMKey) IsZero() bool {
 // Eventually it should be t // should be processed by tryUnassignIPsFromAll in ipamd.go
 // Which will decrease DS usage counter
 func (k IPAMKey) NoContainer() bool {
-       return k.ContainerID == ""
+	return k.ContainerID == ""
 }
 
 // String() implements the fmt.Stringer interface.

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -129,7 +129,7 @@ func (k IPAMKey) IsZero() bool {
 }
 
 // NoContainer returns true if IPAMKey exists but there is not ContainerID associated
-// Eventually it should be t // should be processed by tryUnassignIPsFromAll in ipamd.go
+// Eventually it should be processed by tryUnassignIPsFromAll in ipamd.go
 // Which will decrease DS usage counter
 func (k IPAMKey) NoContainer() bool {
 	return k.ContainerID == ""

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -300,9 +300,14 @@ func TestPodIPv4Address(t *testing.T) {
 	key4 := IPAMKey{"net0", "sandbox-4", "eth0"}
 	_, _, err = ds.AssignPodIPv4Address(key4)
 	assert.Error(t, err)
+
 	// Unassign unknown Pod
 	_, _, err = ds.UnassignPodIPv4Address(key4)
 	assert.Error(t, err)
+
+        // IPAddress not associated with any container should be considered freeable
+	ds.eniPool["eni-1"].IPv4Addresses["1.1.1.2"].IPAMKey.ContainerID = ""
+	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 1)
 
 	_, deviceNum, err := ds.UnassignPodIPv4Address(key2)
 	assert.NoError(t, err)
@@ -311,7 +316,7 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, deviceNum, pod1Ns2Device)
 	assert.Equal(t, len(ds.eniPool["eni-2"].IPv4Addresses), 1)
 	assert.Equal(t, ds.eniPool["eni-2"].AssignedIPv4Addresses(), 0)
-	assert.Equal(t, len(checkpoint.Data.(*CheckpointData).Allocations), 2)
+	assert.Equal(t, len(checkpoint.Data.(*CheckpointData).Allocations), 1)
 
 	noWarmIPTarget := 0
 	noMinimumIPTarget := 0

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -305,7 +305,7 @@ func TestPodIPv4Address(t *testing.T) {
 	_, _, err = ds.UnassignPodIPv4Address(key4)
 	assert.Error(t, err)
 
-        // IPAddress not associated with any container should be considered freeable
+	// IPAddress not associated with any container should be considered freeable
 	ds.eniPool["eni-1"].IPv4Addresses["1.1.1.2"].IPAMKey.ContainerID = ""
 	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 1)
 


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
[#59](https://github.com/aws/amazon-vpc-cni-k8s/issues/59)

**What does this PR do / Why do we need it**:
Sometimes aws-node pod from aws-node daemonset does not perform unassignment of non-existing docker containers.
This commit marks IPAMKey data structures where ContainerID is empty as unassigned.
I believe sometimes there is a race condition when container being deleted without releasing its ip address back to the pool.

```
Example of ipamd output:
"192.168.9.204": {
  "Address": "192.168.9.204",
  "IPAMKey": {
    "containerID": "d74e85090b40c25325b82289ad335287ab9467784ea4014052e49f3032c4e9e8",
    "ifName": "unknown",
    "networkName": "_migrated-from-cri"
  },
  "UnassignedTime": "0001-01-01T00:00:00Z"
},
"192.168.9.25": {
  "Address": "192.168.9.25",
  "IPAMKey": {
    "containerID": "",
    "ifName": "",
    "networkName": ""
  },
  "UnassignedTime": "0001-01-01T00:00:00Z"
},
"192.168.9.46": {
  "Address": "192.168.9.46",
  "IPAMKey": {
    "containerID": "",
    "ifName": "",
    "networkName": ""
  },
  "UnassignedTime": "0001-01-01T00:00:00Z"
},
```
Eventually we are facing situation when we have free IP addresses but because ipamd thinks it is still assigned we are not able to add new containers.
After we re-deploy aws-node daemonset everything is back to normal again for couple of days.

More details will be provided soon


**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No testing on a running cluster has been performed yet

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.