### PR TITLE
Update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
 Andrew Rudoi <andrewrudoi@gmail.com> <arudoi@newrelic.com>
-Claes Mogren <claes.mogren@gmail.com> <mogren@amazon.com>
+Claes Mogren <mogren@amazon.com> <claes.mogren@gmail.com> 
 Kit Ewbank <Christopher.Ewbank@capitalone.com> <Kit_Ewbank@hotmail.com>
 Liwen Wu <liwenwu@amazon.com> liwen wu <liwenwu@amazon.com> <ubuntu@ip-10-0-1-11.ec2.internal>
 Nick Turner <nic@amazon.com> Nicholas Turner <1205393+nckturner@users.noreply.github.com>


### PR DESCRIPTION
Make my contributions map to my GitHub account email. Right now the repo contributors graph is missing data.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
- 

**What does this PR do / Why do we need it**:
Fix the [contributors graph](https://github.com/aws/amazon-vpc-cni-k8s/graphs/contributors) by pointing my Amazon email to my GitHub account email instead of the other way around.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Look at the graph

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Just update the mail alias file.

**Does this change require updates to the CNI daemonset config files to work?**:
no

**Does this PR introduce any user-facing change?**:
no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
