### PR TITLE
Checkpoint Migration 2 - Remove read from CRI

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -187,8 +187,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
         - "mountPath": "/run/xtables.lock"
           "name": "xtables-lock"
       "hostNetwork": true
@@ -216,9 +214,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/dockershim.sock"
-        "name": "dockershim"
       - "hostPath":
           "path": "/run/xtables.lock"
         "name": "xtables-lock"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -187,8 +187,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
         - "mountPath": "/run/xtables.lock"
           "name": "xtables-lock"
       "hostNetwork": true
@@ -216,9 +214,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/dockershim.sock"
-        "name": "dockershim"
       - "hostPath":
           "path": "/run/xtables.lock"
         "name": "xtables-lock"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -187,8 +187,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
         - "mountPath": "/run/xtables.lock"
           "name": "xtables-lock"
       "hostNetwork": true
@@ -216,9 +214,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/dockershim.sock"
-        "name": "dockershim"
       - "hostPath":
           "path": "/run/xtables.lock"
         "name": "xtables-lock"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -187,8 +187,6 @@
           "name": "log-dir"
         - "mountPath": "/var/run/aws-node"
           "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
         - "mountPath": "/run/xtables.lock"
           "name": "xtables-lock"
       "hostNetwork": true
@@ -216,9 +214,6 @@
       - "hostPath":
           "path": "/etc/cni/net.d"
         "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/dockershim.sock"
-        "name": "dockershim"
       - "hostPath":
           "path": "/run/xtables.lock"
         "name": "xtables-lock"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -197,7 +197,6 @@ local awsnode = {
                 {mountPath: "/host/etc/cni/net.d", name: "cni-net-dir"},
                 {mountPath: "/host/var/log/aws-routed-eni", name: "log-dir"},
                 {mountPath: "/var/run/aws-node", name: "run-dir"},
-                {mountPath: "/var/run/dockershim.sock", name: "dockershim"},
                 {mountPath: "/run/xtables.lock", name: "xtables-lock"},
               ],
             },
@@ -206,7 +205,6 @@ local awsnode = {
           volumes: [
             {name: "cni-bin-dir", hostPath: {path: "/opt/cni/bin"}},
             {name: "cni-net-dir", hostPath: {path: "/etc/cni/net.d"}},
-            {name: "dockershim", hostPath: {path: "/var/run/dockershim.sock"}},
             {name: "xtables-lock", hostPath: {path: "/run/xtables.lock"}},
             {name: "log-dir",
               hostPath: {

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -71,7 +71,7 @@ const (
 // Note phase3 is not necessary since writes to CRI are implicit.
 // At/after phase2, we can remove any code protected by
 // checkpointMigrationPhase<2.
-const checkpointMigrationPhase = 1
+const checkpointMigrationPhase = 2
 
 // Placeholders used for unknown values when reading from CRI.
 const backfillNetworkName = "_migrated-from-cri"


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do / Why do we need it**:

This PR enables `Checkpoint Migration 2`, which disables reads from CRI. Instead, IPAMD will read and write to a file in JSON format to keep track of pods and their IPs on reload: `/var/run/aws-node/ipam.json`. 

Removing access to CRI from unprivileged pod like aws-node will improve the security posture for the customer and would allow Cx to add SELinux policy restrictions so unprivileged pods couldn't connect to host sockets. Aws-node pod is a kube-system pod and the node can be accessed only by cluster admin and the IPAM.json file created will have read-write access only to root user. Hence this would make the system more secure.

This PR also removes the dockershim.sock mounts from `manifest.jsonnet` and the aws-node manifests under `config/master/`.

**Testing done on this change**:

This change need significant testing before merging. Here is the current lists of tests performed:

_Deleting file_
1. Add pods > OK
2. Delete pods > OK
3. Restart node > OK

_Manually modifying IPs in the file_
1. Add pods > OK
2. Delete pods > OK
3. Restart node > OK

_Changing JSON format of file_
1. Add pods > OK
2. Delete pods > OK
3. Restart node > OK

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

This PR will break upgrades from CNI v1.6.x to CNI v1.8.x. Customers will need to upgrade to CNI v1.7.x before upgrading to CNI v1.8.

This is due to the move from using the CRI as storage for allocated IPs to a file based approach. In CNI v1.6 we read from CRI to keep track of allocated IPs. In v1.8, we only read from the file. This means that IPAMD will not know which IPs have already been allocated to existing pods.

To enable this transition, we started writing allocated IPs to `/var/run/aws-node/ipam.json` in CNI v1.7, but keep reading from CRI. Hence, clusters running CNI v1.7 already have the allocated IPs stored in the file to allow IPAMD to operate without querying CRI in v1.8.

**Does this change require updates to the CNI daemonset config files to work?**:

Yes, this PR modifies the CNI deamonset config files to remove the dockershim.sock mounts. The new config files will be release with CNI v1.8.

**Does this PR introduce any user-facing change?**:

Action required: Customers running CNI v1.6 will need to upgrade to CNI v1.7 before upgrading to CNI v1.8.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
