### PR TITLE
Update aws-k8s-tester version for integration testing

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -16,7 +16,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.5}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.6}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

We use aws-k8s-tester 1.5.5 for our integration tests, which contains a bug were deleted MNG stacks are left in `DELETE_FAILED` state, which was causing the integration tests to return and exit code of 1.

This PR updates the aws-eks-tester version to 1.5.6, which contains the [bug fix](https://github.com/aws/aws-k8s-tester/pull/196).

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
