### PR TITLE
Upgrades aws-eks-tester to v1.5.7

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -16,7 +16,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.6}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.7}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
**What type of PR is this?**

bug


**Which issue does this PR fix**:
https://github.com/aws/aws-k8s-tester/pull/199

**What does this PR do / Why do we need it**:
Fixes a bug introduced by K8stester with v15.6

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Need to run integration test

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
