### PR TITLE
Output to stderr when no log file path is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ Default: `/var/log/aws-routed-eni/plugin.log`
 Valid Values: `stderr` or a file path
 
 Specifies where to write the logging output for `aws-cni` plugin. Either to `stderr` or to override the default file (i.e., `/var/log/aws-routed-eni/plugin.log`).
-`Stdout` cannot be supported for plugin log, please refer to #1248 for more details.
+`Stdout` cannot be supported for plugin log, please refer to [#1248](https://github.com/aws/amazon-vpc-cni-k8s/issues/1248) for more details.
+
+Note: If chaining an external plugin (i.e Cilium) that does not provide a `pluginLogFile` in its config file, the CNI plugin will by default write to `os.Stderr`. The output of `cmdAdd` are available in the Kubelet logs.
 
 ---
 

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestEnvLogFilePath(t *testing.T) {
@@ -57,4 +58,28 @@ func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
 	inputLogLevel := GetLogLevel()
 	expectedLogLevel = zapcore.DebugLevel
 	assert.Equal(t, expectedLogLevel, getZapLevel(inputLogLevel))
+}
+
+func TestGetPluginLogFilePathEmpty(t *testing.T) {
+	expectedWriter := zapcore.Lock(os.Stderr)
+	inputPluginLogFile := ""
+	assert.Equal(t, expectedWriter, getPluginLogFilePath(inputPluginLogFile))
+}
+
+func TestGetPluginLogFilePathStdout(t *testing.T) {
+	expectedWriter := zapcore.Lock(os.Stdout)
+	inputPluginLogFile := "stdout"
+	assert.Equal(t, expectedWriter, getPluginLogFilePath(inputPluginLogFile))
+}
+
+func TestGetPluginLogFilePath(t *testing.T) {
+	inputPluginLogFile := "/var/log/aws-routed-eni/plugin.log"
+	expectedLumberJackLogger := &lumberjack.Logger{
+		Filename:   "/var/log/aws-routed-eni/plugin.log",
+		MaxSize:    100,
+		MaxBackups: 5,
+		MaxAge:     30,
+		Compress:   true,
+	}
+	assert.Equal(t, zapcore.AddSync(expectedLumberJackLogger), getPluginLogFilePath(inputPluginLogFile))
 }

--- a/pkg/utils/logger/zaplogger.go
+++ b/pkg/utils/logger/zaplogger.go
@@ -105,17 +105,11 @@ func getEncoder() zapcore.Encoder {
 
 func (logConfig *Configuration) newZapLogger() *structuredLogger {
 	var cores []zapcore.Core
-	var writer zapcore.WriteSyncer
 
 	logLevel := getZapLevel(logConfig.LogLevel)
 
-	logFilePath := logConfig.LogLocation
+	writer := getPluginLogFilePath(logConfig.LogLocation)
 
-	if logFilePath != "" && strings.ToLower(logFilePath) != "stdout" {
-		writer = getLogWriter(logFilePath)
-	} else {
-		writer = zapcore.Lock(os.Stdout)
-	}
 	cores = append(cores, zapcore.NewCore(getEncoder(), writer, logLevel))
 
 	combinedCore := zapcore.NewTee(cores...)
@@ -130,6 +124,21 @@ func (logConfig *Configuration) newZapLogger() *structuredLogger {
 	return &structuredLogger{
 		zapLogger: sugar,
 	}
+}
+
+// getPluginLogFilePath returns the writer
+func getPluginLogFilePath(logFilePath string) zapcore.WriteSyncer {
+	var writer zapcore.WriteSyncer
+
+	if logFilePath == "" {
+		writer = zapcore.Lock(os.Stderr)
+	} else if strings.ToLower(logFilePath) != "stdout" {
+		writer = getLogWriter(logFilePath)
+	} else {
+		writer = zapcore.Lock(os.Stdout)
+	}
+
+	return writer
 }
 
 //getLogWriter is for lumberjack


### PR DESCRIPTION
Cherry picked PR #1275 :

**What type of PR is this?**
Bug fix
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1265 

**What does this PR do / Why do we need it**:
Customers using Cilium in chaining mode were unable to create new pods after upgrading to CNI v1.7.x. Because no log file path was passed, zaplogger.go would default to stdout. 
This change ensures that logs are being written to stderr when no log file path is passed.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
This was tested on a cluster with [Cilium enabled in chaining mode ](https://docs.cilium.io/en/v1.9.0-rc2/gettingstarted/cni-chaining-aws-cni/). I reproduced the bug by installing CNI v1.7.5, which prevented new pods from being created. Pods were able to come up with this fix.

**Automation added to e2e**:
Added Unit Tests to test the following scenarios:
* Empty log file path > log to `zapcore.Lock(os.Stderr)`
* Actual file path > log to file path
* String set to 'stdout' > log to `zapcore.Lock(os.Stdout)`

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
