### PR TITLE
update plugins to v0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ generate-limits:
 	go run scripts/gen_vpc_ip_limits.go
 
 # Fetch the CNI plugins
-plugins: FETCH_VERSION=0.8.6
+plugins: FETCH_VERSION=0.9.0
 plugins: FETCH_URL=https://github.com/containernetworking/plugins/releases/download/v$(FETCH_VERSION)/cni-plugins-$(GOOS)-$(GOARCH)-v$(FETCH_VERSION).tgz
 plugins: VISIT_URL=https://github.com/containernetworking/plugins/tree/v$(FETCH_VERSION)/plugins/
 plugins:


### PR DESCRIPTION
Cherry picked PR #1362 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
complementary PR for https://github.com/aws/amazon-vpc-cni-k8s/pull/1350

**What does this PR do / Why do we need it**:
although the dependencies pull in the correct version for `containernetworkking/plugins` the actual binaries are not built, but fetch from the release page of the project. This bumps the project version to bring everything inline.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
We have rolled the patched cni to an internal cluster and verified that we're not seeing the drop of UDP traffic upon restart of the destination pods.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
