### PR TITLE
Adds http timeout to aws sessions

### DIFF
--- a/pkg/awsutils/awssession/session.go
+++ b/pkg/awsutils/awssession/session.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package awssession
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"strconv"
+	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// Http client timeout env for sessions
+const (
+	httpTimeoutEnv = "HTTP_TIMEOUT"
+	maxRetries     = 15
+)
+
+var (
+	version string
+	log     = logger.Get()
+	// HTTP timeout default value in seconds (10 seconds)
+	httpTimeoutValue = 10 * time.Second
+)
+
+func getHTTPTimeout() time.Duration {
+	httpTimeoutEnvInput := os.Getenv(httpTimeoutEnv)
+	// if httpTimeout is not empty, we convert value to int and overwrite default httpTimeoutValue
+	if httpTimeoutEnvInput != "" {
+		input, err := strconv.Atoi(httpTimeoutEnvInput)
+		if err == nil && input >= 10 {
+			log.Debugf("Using HTTP_TIMEOUT %v", input)
+			httpTimeoutValue = time.Duration(input) * time.Second
+			return httpTimeoutValue
+		}
+	}
+	log.Info("HTTP_TIMEOUT env is not set or set to less than 10 seconds, defaulting to httpTimeout to 10sec")
+	return httpTimeoutValue
+}
+
+// New will return an session for service clients
+func New() *session.Session {
+	awsCfg := aws.Config{
+		MaxRetries: aws.Int(maxRetries),
+		HTTPClient: &http.Client{
+			Timeout: getHTTPTimeout(),
+		},
+	}
+	sess := session.Must(session.NewSession(&awsCfg))
+	//injecting session handler info
+	injectUserAgent(&sess.Handlers)
+
+	return sess
+}
+
+// injectUserAgent will inject app specific user-agent into awsSDK
+func injectUserAgent(handlers *request.Handlers) {
+	handlers.Build.PushFrontNamed(request.NamedHandler{
+		Name: fmt.Sprintf("%s/user-agent", "amazon-vpc-cni-k8s"),
+		Fn: request.MakeAddToUserAgentHandler(
+			"amazon-vpc-cni-k8s",
+			fmt.Sprintf("version/%s",version)),
+	})
+}

--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -1,0 +1,23 @@
+package awssession
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpTimeoutReturnDefault(t *testing.T) {
+	os.Setenv(httpTimeoutEnv, "2")
+	defer os.Unsetenv(httpTimeoutEnv)
+	expectedHTTPTimeOut := time.Duration(10) * time.Second
+	assert.Equal(t, expectedHTTPTimeOut, getHTTPTimeout())
+}
+
+func TestHttpTimeoutWithValueAbove10(t *testing.T) {
+	os.Setenv(httpTimeoutEnv, "12")
+	defer os.Unsetenv(httpTimeoutEnv)
+	expectedHTTPTimeOut := time.Duration(12) * time.Second
+	assert.Equal(t, expectedHTTPTimeOut, getHTTPTimeout())
+}

--- a/pkg/ec2metadatawrapper/ec2metadatawrapper.go
+++ b/pkg/ec2metadatawrapper/ec2metadatawrapper.go
@@ -2,9 +2,8 @@
 package ec2metadatawrapper
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/awssession"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const (
@@ -32,9 +31,7 @@ type ec2MetadataClientImpl struct {
 // New creates an ec2metadata client to retrieve metadata
 func New(client HTTPClient) EC2MetadataClient {
 	if client == nil {
-		awsSession := session.Must(session.NewSession(aws.NewConfig().
-			WithMaxRetries(metadataRetries),
-		))
+		awsSession := awssession.New()
 		return &ec2MetadataClientImpl{client: ec2metadata.New(awsSession)}
 	}
 	return &ec2MetadataClientImpl{client: client}

--- a/pkg/ec2wrapper/ec2wrapper.go
+++ b/pkg/ec2wrapper/ec2wrapper.go
@@ -2,11 +2,11 @@
 package ec2wrapper
 
 import (
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/awssession"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadatawrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/pkg/errors"
@@ -30,7 +30,7 @@ type EC2Wrapper struct {
 
 //NewMetricsClient returns an instance of the EC2 wrapper
 func NewMetricsClient() (*EC2Wrapper, error) {
-	metricsSession := session.Must(session.NewSession())
+	sess := awssession.New()
 	ec2MetadataClient := ec2metadatawrapper.New(nil)
 
 	instanceIdentityDocument, err := ec2MetadataClient.GetInstanceIdentityDocument()
@@ -38,7 +38,9 @@ func NewMetricsClient() (*EC2Wrapper, error) {
 		return &EC2Wrapper{}, err
 	}
 
-	ec2ServiceClient := ec2.New(metricsSession, aws.NewConfig().WithMaxRetries(maxRetries).WithRegion(instanceIdentityDocument.Region))
+	awsCfg := aws.NewConfig().WithRegion(instanceIdentityDocument.Region)
+	sess = sess.Copy(awsCfg)
+	ec2ServiceClient := ec2.New(sess)
 
 	return &EC2Wrapper{
 		ec2ServiceClient:         ec2ServiceClient,

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -53,6 +53,7 @@ replace k8s.io/sample-controller => k8s.io/sample-controller v0.0.0-201908191433
 require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0


### PR DESCRIPTION
This pr manually imports the changes brought by PR #1331 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug fix.

**Which issue does this PR fix**:
#1256 

**What does this PR do / Why do we need it**:
Some customers experienced a stuck go routine caused by stuck http requests not timing out. 

**Testing done on this change**:
Manually tested the two following scenarios:
* Setting the env var `HTTP_TIMEOUT` in the yaml and logging the set value.
* Not setting an env var and verifying that the default value of 5 sec is being used for the HTTP client.

**Automation added to e2e**:

None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

Will not break downgrades or upgrades.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Only if we decide to include the HTTP_TIMEOUT var in the config file. 
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
