### PR TITLE
Integration test for custom networking and weekly runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,36 @@ jobs:
           when: always
       - store_artifacts:
           path: /tmp/cni-test
+  custom_networking_test:
+    docker:
+      - image: circleci/golang:1.14-stretch
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    environment:
+      <<: *env
+      RUN_CUSTOM_NETWORKING_TESTS: "true"
+    steps:
+      - checkout
+      - setup_remote_docker
+      - aws-cli/setup:
+          profile-name: awstester
+      - restore_cache:
+          keys:
+            - dependency-packages-store-{{ checksum "test/integration/go.mod" }}
+            - dependency-packages-store-
+      - k8s/install-kubectl:
+          # requires 1.14.9+ for k8s testing, since it uses log api.
+          kubectl-version: v1.17.9
+      - run:
+          name: Run the integration tests
+          command: ./scripts/run-integration-tests.sh
+          no_output_timeout: 20m
+      - save_cache:
+          key: dependency-packages-store-{{ checksum "test/integration/go.mod" }}
+          paths:
+            - /go/pkg
+          when: always
+      - store_artifacts:
+          path: /tmp/cni-test
           
 workflows:
   version: 2
@@ -337,3 +367,6 @@ workflows:
       - calico_test:
           requires:
             - bottlerocket_test      
+      - custom_networking_test:
+          requires:
+            - calico_test

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -1,0 +1,41 @@
+name: Weekly tests
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # every sunday at 00:00
+
+jobs:
+  custom-networking:
+    runs-on: self-hosted
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Clean up stale docker images
+        run: docker image prune -f
+
+      - name: Get dependencies
+        run: |
+          go get -u golang.org/x/lint/golint
+          go get -u golang.org/x/tools/cmd/goimports
+
+      - name: Run e2e tests with custom networking
+        env:
+          DISABLE_PROMPT: true
+          ROLE_CREATE: false
+          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
+          RUN_CONFORMANCE: true
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          RUN_TESTER_LB_ADDONS: true
+          S3_BUCKET_CREATE: false
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          CUSTOM_NETWORKING_TESTS: true
+        run: |
+          ./scripts/run-integration-tests.sh

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -16,7 +16,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.7}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.5.8}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet

--- a/scripts/lib/custom_networking.sh
+++ b/scripts/lib/custom_networking.sh
@@ -1,0 +1,86 @@
+#This function will setup custom networking for the cluster
+function configure_custom_networking(){
+    local VPC_ID=$(aws eks describe-cluster --name "$CLUSTER_NAME" | grep -iwo 'vpc-[a-zA-z0-9]*' | xargs)
+    echo "VPC $VPC_ID"
+
+    local RTASSOC_ID=$(aws ec2 describe-route-tables --filters Name=vpc-id,Values=$VPC_ID Name=tag:"aws:cloudformation:logical-id",Values=PublicRouteTable | jq -r '.RouteTables[].RouteTableId')
+    
+    echo "RT table $RTASSOC_ID"
+    aws ec2 associate-vpc-cidr-block --vpc-id $VPC_ID --cidr-block 100.64.0.0/16
+
+    local AZ1=us-west-2a
+    local AZ2=us-west-2b
+    local AZ3=us-west-2c
+
+    CUST_SNET1=$(aws ec2 create-subnet --cidr-block 100.64.0.0/19 --vpc-id $VPC_ID --availability-zone $AZ1 | jq -r .Subnet.SubnetId)
+    CUST_SNET2=$(aws ec2 create-subnet --cidr-block 100.64.32.0/19 --vpc-id $VPC_ID --availability-zone $AZ2 | jq -r .Subnet.SubnetId)
+    CUST_SNET3=$(aws ec2 create-subnet --cidr-block 100.64.64.0/19 --vpc-id $VPC_ID --availability-zone $AZ3 | jq -r .Subnet.SubnetId)
+
+    echo "Subnets - $CUST_SNET1 $CUST_SNET2 $CUST_SNET3"
+    aws ec2 create-tags --resources $CUST_SNET1 --tags Key=kubernetes.io/cluster/$CLUSTER_NAME,Value=shared
+    aws ec2 create-tags --resources $CUST_SNET2 --tags Key=kubernetes.io/cluster/$CLUSTER_NAME,Value=shared
+    aws ec2 create-tags --resources $CUST_SNET3 --tags Key=kubernetes.io/cluster/$CLUSTER_NAME,Value=shared
+
+    aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CUST_SNET1
+    aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CUST_SNET2
+    aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CUST_SNET3
+
+    #Enable custom networking
+    $KUBECTL_PATH set env daemonset aws-node -n kube-system AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true
+    $KUBECTL_PATH set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone
+    echo "Sleep until all aws-nodes are available"
+    while [[ $($KUBECTL_PATH describe ds aws-node -n=kube-system | grep "Available Pods: 0") ]]
+    do
+        sleep 5
+        echo "Waiting for daemonset update"
+    done
+    echo "Updated!"
+    
+
+cat <<EOF  | $KUBECTL_PATH apply -f -
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+ name: $AZ1
+spec:
+  subnet: $CUST_SNET1
+EOF
+
+cat <<EOF | $KUBECTL_PATH apply -f -
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+ name: $AZ2
+spec:
+  subnet: $CUST_SNET2
+EOF
+
+cat <<EOF | $KUBECTL_PATH apply -f -
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+ name: $AZ3
+spec:
+  subnet: $CUST_SNET3
+EOF
+  
+  #no need to set max-pods since it is already configured while creating the ASG
+  ASG_NAME="$CLUSTER_NAME-cn-mng-for-cni"
+  echo $ASG_NAME
+  INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=Name" "Name=tag-value,Values=$ASG_NAME" --output text` )
+  for i in "${INSTANCE_IDS[@]}"
+  do
+	    echo "Terminating EC2 instance $i ..."
+	    aws ec2 terminate-instances --instance-ids $i
+  done
+  echo "Terminated instances successfully. Now wait to let ASG create a new instance."
+  DESIRED_SIZE=(`aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name $ASG_NAME --query "AutoScalingGroups[].DesiredCapacity" --output text` )
+  nodes_ready=0
+  while [ $nodes_ready -lt $DESIRED_SIZE ]
+  do
+    sleep 100
+    nodes_ready=$(kubectl get nodes -o json | jq -r '.items[] | select(.status.conditions[].type=="Ready") | .metadata.name ' | wc -l)
+    echo "Waiting for nodes to be ready, current status $nodes_ready and desired size $DESIRED_SIZE"
+  done
+
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -10,6 +10,7 @@ source "$DIR"/lib/aws.sh
 source "$DIR"/lib/cluster.sh
 source "$DIR"/lib/integration.sh
 source "$DIR"/lib/performance_tests.sh
+source "$DIR"/lib/custom_networking.sh
 
 # Variables used in /lib/aws.sh
 OS=$(go env GOOS)
@@ -27,6 +28,7 @@ ARCH=$(go env GOARCH)
 : "${RUN_PERFORMANCE_TESTS:=false}"
 : "${RUNNING_PERFORMANCE:=false}"
 : "${RUN_CALICO_TEST:=false}"
+: "${RUN_CUSTOM_NETWORKING_TESTS:=false}"
 
 
 __cluster_created=0
@@ -250,6 +252,14 @@ if [[ $RUN_CALICO_TEST == true ]]; then
     done
     echo "Updated calico daemonset!"
     sleep 5
+fi
+
+
+if [[ "$RUN_CUSTOM_NETWORKING_TESTS" == true ]]; then
+    echo "*******************************************************************************"
+    echo "Enabling custom networking tests on current image:"
+    echo ""
+    configure_custom_networking
 fi
 
 echo "*******************************************************************************"

--- a/scripts/run-release-tests.sh
+++ b/scripts/run-release-tests.sh
@@ -25,3 +25,10 @@ export RUN_CALICO_TEST=true
 echo "Running calico test"
 ./scripts/run-integration-tests.sh
 unset RUN_CALICO_TEST
+
+export RUN_CUSTOM_NETWORKING_TEST=true
+echo "Running custom networking test"
+./scripts/run-integration-tests.sh
+unset RUN_CUSTOM_NETWORKING_TEST
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Integration test for custom networking and GitHub weekly runners.

**What does this PR do / Why do we need it**:
1. Setup custom networking and run IT
2. Add weekly runner for custom networking.
3. Bump up k8s tester version to 1.5.8 to fix ASG issue.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

Test 1 - Setup Custom networking and run integration test 

```
Enabling custom networking tests on current image:

VPC vpc-09acf86bc51cd937a
RT table rtb-08be0b194a9239884
{
    "CidrBlockAssociation": {
        "AssociationId": "vpc-cidr-assoc-02fda9204c7259ba8", 
        "CidrBlock": "100.64.0.0/16", 
        "CidrBlockState": {
            "State": "associating"
        }
    }, 
    "VpcId": "vpc-09acf86bc51cd937a"
}
Subnets - subnet-0d26e3817f61d5b27 subnet-032034cb0dd0992b2 subnet-0b24ee3a37333e2ce
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-0f0b4b95cef28a5bb"
}
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-08884468a721700c0"
}
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-0adf671ea05e8f5af"
}
daemonset.apps/aws-node env updated
daemonset.apps/aws-node env updated
Sleep until all aws-nodes are available
Waiting for daemonset update
Waiting for daemonset update
Waiting for daemonset update
Updated!
eniconfig.crd.k8s.amazonaws.com/*********a created
eniconfig.crd.k8s.amazonaws.com/*********b created
eniconfig.crd.k8s.amazonaws.com/*********c created
cni-test-30872-cn-mng-for-cni
Terminating EC2 instance i-036b41bf529fbc3ba ...
{
    "TerminatingInstances": [
        {
            "InstanceId": "i-036b41bf529fbc3ba", 
            "CurrentState": {
                "Code": 32, 
                "Name": "shutting-down"
            }, 
            "PreviousState": {
                "Code": 16, 
                "Name": "running"
            }
        }
    ]
}
Terminated instances successfully. Now wait 400s to let ASG create a new instance.
*******************************************************************************
Running integration tests on current image:

/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
=== RUN   TestIntegration
Feb  5 02:17:08.347: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: Amazon VPC CNI Integration Tests
===============================================
Random Seed: 1612491428 - Will randomize all specs
Will run 2 of 2 specs

Using KUBECONFIG="/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-30872/kubeconfig"
[cni-integration] 
  should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
[BeforeEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:150
STEP: Creating a kubernetes client
Feb  5 02:17:08.348: INFO: >>> kubeConfig: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-30872/kubeconfig
STEP: Building a namespace api object, basename cni-integration
Feb  5 02:17:09.930: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Feb  5 02:17:10.233: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in cni-integration-5313
Feb  5 02:17:10.488: INFO: Skipping waiting for service account
[It] should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
Feb  5 02:17:14.919: INFO: Waiting up to 5m0s for pod "client-pod" in namespace "cni-integration-5313" to be "success or failure"
Feb  5 02:17:14.995: INFO: Pod "client-pod": Phase="Pending", Reason="", readiness=false. Elapsed: 76.4463ms
Feb  5 02:17:17.072: INFO: Pod "client-pod": Phase="Running", Reason="", readiness=true. Elapsed: 2.153325498s
Feb  5 02:17:19.149: INFO: Pod "client-pod": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.229633335s
STEP: Saw pod success
Feb  5 02:17:19.149: INFO: Pod "client-pod" satisfied condition "success or failure"
[AfterEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:151
Feb  5 02:17:19.230: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
Feb  5 02:17:19.307: INFO: Found DeleteNamespace=false, skipping namespace deletion!

• [SLOW TEST:10.959 seconds]
[cni-integration]
/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:70
  should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
------------------------------
[cni-integration] 
  should enable pod-node communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:88
[BeforeEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:150
STEP: Creating a kubernetes client
Feb  5 02:17:19.307: INFO: >>> kubeConfig: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-30872/kubeconfig
STEP: Building a namespace api object, basename cni-integration
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in cni-integration-9023
Feb  5 02:17:19.712: INFO: Skipping waiting for service account
[It] should enable pod-node communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:88
Feb  5 02:17:19.875: INFO: Waiting up to 5m0s for pod "client-pod" in namespace "cni-integration-9023" to be "success or failure"
Feb  5 02:17:19.952: INFO: Pod "client-pod": Phase="Pending", Reason="", readiness=false. Elapsed: 76.27286ms
Feb  5 02:17:22.028: INFO: Pod "client-pod": Phase="Running", Reason="", readiness=true. Elapsed: 2.153113896s
Feb  5 02:17:24.105: INFO: Pod "client-pod": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.230140309s
STEP: Saw pod success
Feb  5 02:17:24.105: INFO: Pod "client-pod" satisfied condition "success or failure"
[AfterEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:151
Feb  5 02:17:24.105: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
Feb  5 02:17:24.181: INFO: Found DeleteNamespace=false, skipping namespace deletion!
•
Ran 2 of 2 Specs in 15.834 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (15.83s)
PASS
ok  	github.com/aws/amazon-vpc-cni-k8s/test/integration	15.933s
/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
TIMELINE: Current image integration tests took 22 seconds.

```

Test 2 - added node status check at the end instead of just sleep

```
*******************************************************************************
Enabling custom networking tests on current image:

VPC vpc-0fa1c643577c9dd65
RT table rtb-018ae2c3546c042de
{
    "CidrBlockAssociation": {
        "AssociationId": "vpc-cidr-assoc-0b48b153730ee1917", 
        "CidrBlock": "100.64.0.0/16", 
        "CidrBlockState": {
            "State": "associating"
        }
    }, 
    "VpcId": "vpc-0fa1c643577c9dd65"
}
Subnets - subnet-0a1d45ffa8e03f280 subnet-0bd0b98dc113b8f77 subnet-0cfac4b5e355c29ca
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-05cf802e2a2c23791"
}
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-0becb0f39bc539b01"
}
{
    "AssociationState": {
        "State": "associated"
    }, 
    "AssociationId": "rtbassoc-0ab4dd2291b887303"
}
daemonset.apps/aws-node env updated
daemonset.apps/aws-node env updated
Sleep until all aws-nodes are available
Waiting for daemonset update
Updated!
eniconfig.crd.k8s.amazonaws.com/*********a created
eniconfig.crd.k8s.amazonaws.com/*********b created
eniconfig.crd.k8s.amazonaws.com/*********c created
cni-test-25183-cn-mng-for-cni
Terminating EC2 instance i-05f7cb9eaed66365a ...
{
    "TerminatingInstances": [
        {
            "InstanceId": "i-05f7cb9eaed66365a", 
            "CurrentState": {
                "Code": 32, 
                "Name": "shutting-down"
            }, 
            "PreviousState": {
                "Code": 16, 
                "Name": "running"
            }
        }
    ]
}
Terminated instances successfully. Now wait to let ASG create a new instance.
Waiting for nodes to be ready, current status 0 and desired size 1
Waiting for nodes to be ready, current status 0 and desired size 1
Waiting for nodes to be ready, current status 1 and desired size 1
*******************************************************************************
Running integration tests on current image:

/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
=== RUN   TestIntegration
Feb  8 20:26:53.515: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: Amazon VPC CNI Integration Tests
===============================================
Random Seed: 1612816013 - Will randomize all specs
Will run 2 of 2 specs

Using KUBECONFIG="/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-25183/kubeconfig"
[cni-integration] 
  should enable pod-node communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:88
[BeforeEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:150
STEP: Creating a kubernetes client
Feb  8 20:26:53.515: INFO: >>> kubeConfig: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-25183/kubeconfig
STEP: Building a namespace api object, basename cni-integration
Feb  8 20:26:54.698: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Feb  8 20:26:55.002: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in cni-integration-9861
Feb  8 20:26:55.257: INFO: Skipping waiting for service account
[It] should enable pod-node communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:88
Feb  8 20:26:55.439: INFO: Waiting up to 5m0s for pod "client-pod" in namespace "cni-integration-9861" to be "success or failure"
Feb  8 20:26:55.516: INFO: Pod "client-pod": Phase="Pending", Reason="", readiness=false. Elapsed: 77.4662ms
Feb  8 20:26:57.593: INFO: Pod "client-pod": Phase="Pending", Reason="", readiness=false. Elapsed: 2.154529162s
Feb  8 20:26:59.671: INFO: Pod "client-pod": Phase="Running", Reason="", readiness=true. Elapsed: 4.231845598s
Feb  8 20:27:01.748: INFO: Pod "client-pod": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.309258388s
STEP: Saw pod success
Feb  8 20:27:01.748: INFO: Pod "client-pod" satisfied condition "success or failure"
[AfterEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:151
Feb  8 20:27:01.748: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
Feb  8 20:27:01.825: INFO: Found DeleteNamespace=false, skipping namespace deletion!

• [SLOW TEST:8.310 seconds]
[cni-integration]
/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:70
  should enable pod-node communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:88
------------------------------
[cni-integration] 
  should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
[BeforeEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:150
STEP: Creating a kubernetes client
Feb  8 20:27:01.825: INFO: >>> kubeConfig: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/scripts/cni-test/cluster-cni-test-25183/kubeconfig
STEP: Building a namespace api object, basename cni-integration
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in cni-integration-3560
Feb  8 20:27:02.234: INFO: Skipping waiting for service account
[It] should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
Feb  8 20:27:04.635: INFO: Waiting up to 5m0s for pod "client-pod" in namespace "cni-integration-3560" to be "success or failure"
Feb  8 20:27:04.712: INFO: Pod "client-pod": Phase="Pending", Reason="", readiness=false. Elapsed: 76.910319ms
Feb  8 20:27:06.789: INFO: Pod "client-pod": Phase="Running", Reason="", readiness=true. Elapsed: 2.153691727s
Feb  8 20:27:08.866: INFO: Pod "client-pod": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.2308546s
STEP: Saw pod success
Feb  8 20:27:08.866: INFO: Pod "client-pod" satisfied condition "success or failure"
[AfterEach] [cni-integration]
  /go/pkg/mod/k8s.io/kubernetes@v1.15.3/test/e2e/framework/framework.go:151
Feb  8 20:27:08.947: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
Feb  8 20:27:09.026: INFO: Found DeleteNamespace=false, skipping namespace deletion!

• [SLOW TEST:7.201 seconds]
[cni-integration]
/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:70
  should enable pod-pod communication
  /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/test/integration/integration_test.go:74
------------------------------

Ran 2 of 2 Specs in 15.511 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (15.51s)
PASS
ok  	github.com/aws/amazon-vpc-cni-k8s/test/integration	15.557s
/go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
TIMELINE: Current image integration tests took 19 seconds.

```
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
