### PR TITLE
Fix deletion of hostVeth rule for pods using security group

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -312,12 +312,26 @@ func (os *linuxNetwork) SetupPodENINetwork(hostVethName string, contVethName str
 	vlanTableID := vlanID + 100
 	vlanLink := buildVlanLink(vlanID, parentIfIndex, eniMAC)
 
-	// 1. clean up if vlan already exists (necessary when trunk ENI changes).
+	// 1a. clean up if vlan already exists (necessary when trunk ENI changes).
 	if oldVlan, err := os.netLink.LinkByName(vlanLink.Name); err == nil {
 		if err = os.netLink.LinkDel(oldVlan); err != nil {
 			return errors.Wrapf(err, "SetupPodENINetwork: failed to delete old vlan %s", vlanLink.Name)
 		}
 		log.Debugf("Cleaned up old vlan: %s", vlanLink.Name)
+	}
+
+	// 1b. clean up any previous hostVeth ip rule
+	oldVlanRule := os.netLink.NewRule()
+	oldVlanRule.IifName = hostVethName
+	oldVlanRule.Priority = vlanRulePriority
+	// loop is required to clean up all existing rules created on the host (when pod with same name are recreated multiple times)
+	for {
+		if err := os.netLink.RuleDel(oldVlanRule); err != nil {
+			if !containsNoSuchRule(err) {
+				return errors.Wrapf(err, "SetupPodENINetwork: failed to delete hostveth rule for %s", hostVeth.Attrs().Name)
+			}
+			break
+		}
 	}
 
 	// 2. add new vlan link


### PR DESCRIPTION
Cherry picked from PR #1376 

**What type of PR is this?**
bug

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1375
https://github.com/aws/amazon-vpc-cni-k8s/issues/1374

**What does this PR do / Why do we need it**:
This cleans up any dangling resources for old pods using same name. This might happen if pods are force deleted.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

**Testing done on this change**:
Tested on dev cluster and verified the dangling rules are deleted before adding new routes.
```
[ec2-user@ip-192-168-65-167 ~]$ ip rule
10:	from all iif vlan.eth.1 lookup 101 
10:	from all iif vlan.eth.2 lookup 102 
10:	from all iif vlanaad671050aa [detached] lookup 101 
20:	from all lookup local 
[ec2-user@ip-192-168-65-167 ~]$ ip rule
10:	from all iif vlan.eth.1 lookup 101 
10:	from all iif vlan.eth.2 lookup 102 
10:	from all iif vlanaad671050aa lookup 102 
20:	from all lookup local 
[ec2-user@ip-192-168-65-167 ~]$ 
```

**Automation added to e2e**:
NA

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
