### PR TITLE
Update the v1.7 calico manifest to Calico v3.17.1

### DIFF
--- a/config/v1.7/calico.yaml
+++ b/config/v1.7/calico.yaml
@@ -32,7 +32,12 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.15.1
+          image: docker.io/calico/node:v3.17.1
+          envFrom:
+          - configMapRef:
+              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+              name: kubernetes-services-endpoint
+              optional: true
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -114,6 +119,13 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
+            # parent directory.
+            - name: sysfs
+              mountPath: /sys/fs/
+              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
+              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
+              mountPropagation: Bidirectional
       volumes:
         # Used to ensure proper kmods are installed.
         - name: lib-modules
@@ -129,6 +141,10 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+        - name: sysfs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
       tolerations:
         # Make sure calico/node gets scheduled on all nodes.
         - effect: NoSchedule
@@ -373,13 +389,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
-  # The CNI plugin needs to get pods, nodes, configmaps, and namespaces.
+  # The CNI plugin needs to get pods, nodes, configmaps and namespaces.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
-      - namespaces
       - configmaps
+      - namespaces
     verbs:
       - get
   - apiGroups: [""]
@@ -549,12 +565,17 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.15.1
+        - image: docker.io/calico/typha:v3.17.1
           name: calico-typha
           ports:
             - containerPort: 5473
               name: calico-typha
               protocol: TCP
+          envFrom:
+          - configMapRef:
+              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+              name: kubernetes-services-endpoint
+              optional: true
           env:
             # Use eni not cali for interface prefix
             - name: FELIX_INTERFACEPREFIX
@@ -686,7 +707,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1
+        - image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3 
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/config/v1.7/calico.yaml
+++ b/config/v1.7/calico.yaml
@@ -373,13 +373,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
-  # The CNI plugin needs to get pods, nodes, configmaps and namespaces.
+  # The CNI plugin needs to get pods, nodes, configmaps, and namespaces.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
-      - configmaps
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]


### PR DESCRIPTION
This PR fixes error caused by cherry picking PR #1328


**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1328 

**What does this PR do / Why do we need it**:
Cherry-pick changes to release 1.7.9

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
