### PR TITLE
Configuration update to v1.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## v1.7.9-rc1
+## v1.7.9
 
-* Bug - Fix deletion of hostVeth rule for pods using security group (#1376 by SaranBalaji90)
 * Improvement - Adds http timeout to aws sessions (#1370 by couralex6)
-* Improvement - Switch calico to be deployed with the Tigera operator
+* Improvement - Switch calico to be deployed with the Tigera operator (#1297 by tmjd)
 * Improvement - Update calico to v3.17.1 (#1328 by lwr20)
 * Improvement - update plugins to v0.9.0 (#1362 by fr0stbyte)
 * Improvement - update github.com/containernetworking/plugins to v0.9.0 (#1350 by fr0stbyte)
 * Bug - Fix regex match for getting primary interface (#1311 by Jayanthvn)
 * Bug - Output to stderr when no log file path is passed (#1275 by couralex6)
+* Bug - Fix deletion of hostVeth rule for pods using security group (#1376 by SaranBalaji90)
 
 
 ## v1.7.8

--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.8"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.9"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.8"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.8"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.9"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.8"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.8"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.9"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.8"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.8"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.9"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.8"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/config/v1.7/calico.yaml
+++ b/config/v1.7/calico.yaml
@@ -1,781 +1,4358 @@
 ---
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: calico-node
-  namespace: kube-system
-  labels:
-    k8s-app: calico-node
-spec:
-  selector:
-    matchLabels:
-      k8s-app: calico-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-  template:
-    metadata:
-      labels:
-        k8s-app: calico-node
-    spec:
-      priorityClassName: system-node-critical
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      hostNetwork: true
-      serviceAccountName: calico-node
-      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-      terminationGracePeriodSeconds: 0
-      containers:
-        # Runs calico/node container on each Kubernetes node.  This
-        # container programs network policy and routes on each
-        # host.
-        - name: calico-node
-          image: docker.io/calico/node:v3.17.1
-          envFrom:
-          - configMapRef:
-              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
-              name: kubernetes-services-endpoint
-              optional: true
-          env:
-            # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "kubernetes"
-            # Use eni not cali for interface prefix
-            - name: FELIX_INTERFACEPREFIX
-              value: "eni"
-            # Enable felix info logging.
-            - name: FELIX_LOGSEVERITYSCREEN
-              value: "info"
-            # Don't enable BGP.
-            - name: CALICO_NETWORKING_BACKEND
-              value: "none"
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "k8s,ecs"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
-            - name: FELIX_TYPHAK8SSERVICENAME
-              value: "calico-typha"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
-            # This will make Felix honor AWS VPC CNI's mangle table
-            # rules.
-            - name: FELIX_IPTABLESMANGLEALLOWACTION
-              value: Return
-            # Disable IPV6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "false"
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "true"
-            - name: FELIX_LOGSEVERITYSYS
-              value: "none"
-            - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "true"
-            - name: FELIX_ROUTESOURCE
-              value: "WorkloadIPs"
-            - name: NO_DEFAULT_POOLS
-              value: "true"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # No IP address needed.
-            - name: IP
-              value: ""
-            - name: FELIX_HEALTHENABLED
-              value: "true"
-          securityContext:
-            privileged: true
-          livenessProbe:
-            exec:
-              command:
-              - /bin/calico-node
-              - -felix-live
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - /bin/calico-node
-                - -felix-ready
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: lib-modules
-              readOnly: true
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
-              readOnly: false
-            - mountPath: /var/run/calico
-              name: var-run-calico
-              readOnly: false
-            - mountPath: /var/lib/calico
-              name: var-lib-calico
-              readOnly: false
-            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
-            # parent directory.
-            - name: sysfs
-              mountPath: /sys/fs/
-              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
-              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
-              mountPropagation: Bidirectional
-      volumes:
-        # Used to ensure proper kmods are installed.
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: var-run-calico
-          hostPath:
-            path: /var/run/calico
-        - name: var-lib-calico
-          hostPath:
-            path: /var/lib/calico
-        - name: xtables-lock
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
-        - name: sysfs
-          hostPath:
-            path: /sys/fs/
-            type: DirectoryOrCreate
-      tolerations:
-        # Make sure calico/node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-
----
-
-# Create all the CustomResourceDefinitions needed for
-# Calico policy-only mode.
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: felixconfigurations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
-  names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamblocks.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
-  names:
-    kind: IPAMBlock
-    plural: ipamblocks
-    singular: ipamblock
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: blockaffinities.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
-  names:
-    kind: BlockAffinity
-    plural: blockaffinities
-    singular: blockaffinity
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
+# Source: crds/calico/kdd/crd.projectcalico.org_bgpconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: BGPConfiguration
+    listKind: BGPConfigurationList
     plural: bgpconfigurations
     singular: bgpconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BGPConfiguration contains the configuration for any BGP routing.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPConfigurationSpec contains the values of the BGP configuration.
+            properties:
+              asNumber:
+                description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                format: int32
+                type: integer
+              communities:
+                description: Communities is a list of BGP community values and their
+                  arbitrary names for tagging routes.
+                items:
+                  description: Community contains standard or large community value
+                    and its name.
+                  properties:
+                    name:
+                      description: Name given to community value.
+                      type: string
+                    value:
+                      description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                        For standard community use `aa:nn` format, where `aa` and
+                        `nn` are 16 bit number. For large community use `aa:nn:mm`
+                        format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                        `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                      pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                      type: string
+                  type: object
+                type: array
+              listenPort:
+                description: ListenPort is the port where BGP protocol should listen.
+                  Defaults to 179
+                maximum: 65535
+                minimum: 1
+                type: integer
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                type: string
+              nodeToNodeMeshEnabled:
+                description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                type: boolean
+              prefixAdvertisements:
+                description: PrefixAdvertisements contains per-prefix advertisement
+                  configuration.
+                items:
+                  description: PrefixAdvertisement configures advertisement properties
+                    for the specified CIDR.
+                  properties:
+                    cidr:
+                      description: CIDR for which properties should be advertised.
+                      type: string
+                    communities:
+                      description: Communities can be list of either community names
+                        already defined in `Specs.Communities` or community value
+                        of format `aa:nn` or `aa:nn:mm`. For standard community use
+                        `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                        large community use `aa:nn:mm` format, where `aa`, `nn` and
+                        `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                        `mm` are per-AS identifier.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              serviceClusterIPs:
+                description: ServiceClusterIPs are the CIDR blocks from which service
+                  cluster IPs are allocated. If specified, Calico will advertise these
+                  blocks, as well as any cluster IPs within them.
+                items:
+                  description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                    CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceExternalIPs:
+                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                  Service External IPs. Kubernetes Service ExternalIPs will only be
+                  advertised if they are within one of these blocks.
+                items:
+                  description: ServiceExternalIPBlock represents a single allowed
+                    External IP CIDR block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+# Source: crds/calico/kdd/crd.projectcalico.org_bgppeers.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: BGPPeer
+    listKind: BGPPeerList
     plural: bgppeers
     singular: bgppeer
----
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec contains the specification for a BGPPeer resource.
+            properties:
+              asNumber:
+                description: The AS Number of the peer.
+                format: int32
+                type: integer
+              keepOriginalNextHop:
+                description: Option to keep the original nexthop field when routes
+                  are sent to a BGP Peer. Setting "true" configures the selected BGP
+                  Peers node to use the "next hop keep;" instead of "next hop self;"(default)
+                  in the specific branch of the Node on "bird.cfg".
+                type: boolean
+              node:
+                description: The node name identifying the Calico node instance that
+                  is targeted by this peer. If this is not set, and no nodeSelector
+                  is specified, then this BGP peer selects all nodes in the cluster.
+                type: string
+              nodeSelector:
+                description: Selector for the nodes that should have this peering.  When
+                  this is set, the Node field must be empty.
+                type: string
+              password:
+                description: Optional BGP password for the peerings generated by this
+                  BGPPeer resource.
+                properties:
+                  secretKeyRef:
+                    description: Selects a key of a secret in the node pod's namespace.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                type: object
+              peerIP:
+                description: The IP address of the peer followed by an optional port
+                  number to peer with. If port number is given, format should be `[<IPv6>]:port`
+                  or `<IPv4>:<port>` for IPv4. If optional port number is not set,
+                  and this peer IP and ASNumber belongs to a calico/node with ListenPort
+                  set in BGPConfiguration, then we use that port to peer.
+                type: string
+              peerSelector:
+                description: Selector for the remote nodes to peer with.  When this
+                  is set, the PeerIP and ASNumber fields must be empty.  For each
+                  peering between the local node and selected remote nodes, we configure
+                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                  remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
+                  or the global default if that is not set.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_blockaffinities.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools.crd.projectcalico.org
+  name: blockaffinities.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
-    kind: IPPool
-    plural: ippools
-    singular: ippool
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BlockAffinitySpec contains the specification for a BlockAffinity
+              resource.
+            properties:
+              cidr:
+                type: string
+              deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
+                type: string
+              node:
+                type: string
+              state:
+                type: string
+            required:
+            - cidr
+            - deleted
+            - node
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: hostendpoints.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
-  names:
-    kind: HostEndpoint
-    plural: hostendpoints
-    singular: hostendpoint
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
+# Source: crds/calico/kdd/crd.projectcalico.org_clusterinformations.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: ClusterInformation
+    listKind: ClusterInformationList
     plural: clusterinformations
     singular: clusterinformation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
+# Source: crds/calico/kdd/crd.projectcalico.org_felixconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Felix Configuration contains the configuration for Felix.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FelixConfigurationSpec contains the values of the Felix configuration.
+            properties:
+              allowIPIPPacketsFromWorkloads:
+                description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              allowVXLANPacketsFromWorkloads:
+                description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              awsSrcDstCheck:
+                description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                enum:
+                - DoNothing
+                - Enable
+                - Disable
+                type: string
+              bpfConnectTimeLoadBalancingEnabled:
+                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                type: boolean
+              bpfDataIfacePattern:
+                description: BPFDataIfacePattern is a regular expression that controls
+                  which interfaces Felix should attach BPF programs to in order to
+                  catch traffic to/from the network.  This needs to match the interfaces
+                  that Calico workload traffic flows over as well as any interfaces
+                  that handle incoming traffic to nodeports and services from outside
+                  the cluster.  It should not match the workload interfaces (usually
+                  named cali...).
+                type: string
+              bpfDisableUnprivileged:
+                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                type: boolean
+              bpfEnabled:
+                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                type: boolean
+              bpfExternalServiceMode:
+                description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                type: string
+              bpfKubeProxyEndpointSlicesEnabled:
+                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                type: boolean
+              bpfKubeProxyIptablesCleanupEnabled:
+                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                type: boolean
+              bpfKubeProxyMinSyncPeriod:
+                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfLogLevel:
+                description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                type: string
+              chainInsertMode:
+                description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico''s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                type: string
+              dataplaneDriver:
+                type: string
+              debugDisableLogDropping:
+                type: boolean
+              debugMemoryProfilePath:
+                type: string
+              debugSimulateCalcGraphHangAfter:
+                type: string
+              debugSimulateDataplaneHangAfter:
+                type: string
+              defaultEndpointToHostAction:
+                description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables “DROP” action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables “INPUT” chain;
+                  Calico will insert its rules at the top of that chain, then “RETURN”
+                  packets to the “INPUT” chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                type: string
+              deviceRouteProtocol:
+                description: This defines the route protocol added to programmed device
+                  routes, by default this will be RTPROT_BOOT when left blank.
+                type: integer
+              deviceRouteSourceAddress:
+                description: This is the source address to use on programmed device
+                  routes. By default the source address is left blank, leaving the
+                  kernel to choose the source address used.
+                type: string
+              disableConntrackInvalidCheck:
+                type: boolean
+              endpointReportingDelay:
+                type: string
+              endpointReportingEnabled:
+                type: boolean
+              externalNodesList:
+                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                  which may source tunnel traffic and have the tunneled traffic be
+                  accepted at calico nodes.
+                items:
+                  type: string
+                type: array
+              failsafeInboundHostPorts:
+                description: 'FailsafeInboundHostPorts is a comma-delimited list of
+                  UDP/TCP ports that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. Each
+                  port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all inbound host ports, use the value none.
+                  The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              failsafeOutboundHostPorts:
+                description: 'FailsafeOutboundHostPorts is a comma-delimited list
+                  of UDP/TCP ports that Felix will allow outgoing traffic from host
+                  endpoints to irrespective of the security policy. This is useful
+                  to avoid accidentally cutting off a host with incorrect configuration.
+                  Each port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all outbound host ports, use the value none.
+                  The default value opens etcd''s standard ports to ensure that Felix
+                  does not get cut off from etcd as well as allowing DHCP and DNS.
+                  [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
+                  udp:53, udp:67]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              featureDetectOverride:
+                description: FeatureDetectOverride is used to override the feature
+                  detection. Values are specified in a comma separated list with no
+                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                  "true" or "false" will force the feature, empty or omitted values
+                  are auto-detected.
+                type: string
+              genericXDPEnabled:
+                description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                type: boolean
+              healthEnabled:
+                type: boolean
+              healthHost:
+                type: string
+              healthPort:
+                type: integer
+              interfaceExclude:
+                description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                type: string
+              interfacePrefix:
+                description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
+                type: string
+              interfaceRefreshInterval:
+                description: InterfaceRefreshInterval is the period at which Felix
+                  rescans local interfaces to verify their state. The rescan can be
+                  disabled by setting the interval to 0.
+                type: string
+              ipipEnabled:
+                type: boolean
+              ipipMTU:
+                description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              ipsetsRefreshInterval:
+                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                type: string
+              iptablesBackend:
+                description: IptablesBackend specifies which backend of iptables will
+                  be used. The default is legacy.
+                type: string
+              iptablesFilterAllowAction:
+                type: string
+              iptablesLockFilePath:
+                description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix''s
+                  container at a different path). [Default: /run/xtables.lock]'
+                type: string
+              iptablesLockProbeInterval:
+                description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                type: string
+              iptablesLockTimeout:
+                description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                type: string
+              iptablesMangleAllowAction:
+                type: string
+              iptablesMarkMask:
+                description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                format: int32
+                type: integer
+              iptablesNATOutgoingInterfaceFilter:
+                type: string
+              iptablesPostWriteCheckInterval:
+                description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn''t
+                  respect the iptables lock. [Default: 1s]'
+                type: string
+              iptablesRefreshInterval:
+                description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                type: string
+              ipv6Support:
+                type: boolean
+              kubeNodePortRanges:
+                description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                items:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                type: array
+              logFilePath:
+                description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                type: string
+              logPrefix:
+                description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                type: string
+              logSeverityFile:
+                description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              logSeveritySys:
+                description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                type: string
+              maxIpsetSize:
+                type: integer
+              metadataAddr:
+                description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                type: string
+              metadataPort:
+                description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                type: integer
+              mtuIfacePattern:
+                description: MTUIfacePattern is a regular expression that controls
+                  which interfaces Felix should scan in order to calculate the host's
+                  MTU. This should not match workload interfaces (usually named cali...).
+                type: string
+              natOutgoingAddress:
+                description: NATOutgoingAddress specifies an address to use when performing
+                  source NAT for traffic in a natOutgoing pool that is leaving the
+                  network. By default the address used is an address on the interface
+                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                type: string
+              natPortRange:
+                anyOf:
+                - type: integer
+                - type: string
+                description: NATPortRange specifies the range of ports that is used
+                  for port mapping when doing outgoing NAT. When unset the default
+                  behavior of the network stack is used.
+                pattern: ^.*
+                x-kubernetes-int-or-string: true
+              netlinkTimeout:
+                type: string
+              openstackRegion:
+                description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                type: string
+              policySyncPathPrefix:
+                description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                type: string
+              prometheusGoMetricsEnabled:
+                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusMetricsEnabled:
+                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                type: boolean
+              prometheusMetricsHost:
+                description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                type: integer
+              prometheusProcessMetricsEnabled:
+                description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              removeExternalRoutes:
+                description: Whether or not to remove device routes that have not
+                  been programmed by Felix. Disabling this will allow external applications
+                  to also add device routes. This is enabled by default which means
+                  we will remove externally added routes.
+                type: boolean
+              reportingInterval:
+                description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                type: string
+              reportingTTL:
+                description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                type: string
+              routeRefreshInterval:
+                description: 'RouteRefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                type: string
+              routeSource:
+                description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                type: string
+              routeTableRange:
+                description: Calico programs additional Linux route tables for various
+                  purposes.  RouteTableRange specifies the indices of the route tables
+                  that Calico should use.
+                properties:
+                  max:
+                    type: integer
+                  min:
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              serviceLoopPrevention:
+                description: 'When service IP advertisement is enabled, prevent routing
+                  loops to service IPs that are not in use, by dropping or rejecting
+                  packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                  in which case such routing loops continue to be allowed. [Default:
+                  Drop]'
+                type: string
+              sidecarAccelerationEnabled:
+                description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                type: boolean
+              usageReportingEnabled:
+                description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                type: boolean
+              usageReportingInitialDelay:
+                description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                type: string
+              usageReportingInterval:
+                description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                type: string
+              useInternalDataplaneDriver:
+                type: boolean
+              vxlanEnabled:
+                type: boolean
+              vxlanMTU:
+                description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              vxlanPort:
+                type: integer
+              vxlanVNI:
+                type: integer
+              wireguardEnabled:
+                description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                type: boolean
+              wireguardInterfaceName:
+                description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                type: string
+              wireguardListeningPort:
+                description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                type: integer
+              wireguardMTU:
+                description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                type: integer
+              wireguardRoutingRulePriority:
+                description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                type: integer
+              xdpEnabled:
+                description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                type: boolean
+              xdpRefreshInterval:
+                description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
-
-apiVersion: apiextensions.k8s.io/v1beta1
+# Source: crds/calico/kdd/crd.projectcalico.org_globalnetworksets.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
     plural: globalnetworksets
     singular: globalnetworkset
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+          that share labels to allow rules to refer to them via selectors.  The labels
+          of GlobalNetworkSet are not namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
+# Source: crds/calico/kdd/crd.projectcalico.org_hostendpoints.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec contains the specification for a HostEndpoint
+              resource.
+            properties:
+              expectedIPs:
+                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                items:
+                  type: string
+                type: array
+              interfaceName:
+                description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                type: string
+              node:
+                description: The node name identifying the Calico node instance.
+                type: string
+              ports:
+                description: Ports contains the endpoint's named ports, which may
+                  be referenced in security policy rules.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              profiles:
+                description: A list of identifiers of security Profile objects that
+                  apply to this endpoint. Each profile is applied in the order that
+                  they appear in this list.  Profile rules are applied after the selector-based
+                  security policy.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_ipamblocks.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMBlockSpec contains the specification for an IPAMBlock
+              resource.
+            properties:
+              affinity:
+                type: string
+              allocations:
+                items:
+                  type: integer
+                  # TODO: This nullable is manually added in. We should update controller-gen
+                  # to handle []*int properly itself.
+                  nullable: true
+                type: array
+              attributes:
+                items:
+                  properties:
+                    handle_id:
+                      type: string
+                    secondary:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              cidr:
+                type: string
+              deleted:
+                type: boolean
+              strictAffinity:
+                type: boolean
+              unallocated:
+                items:
+                  type: integer
+                type: array
+            required:
+            - allocations
+            - attributes
+            - cidr
+            - strictAffinity
+            - unallocated
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_ipamconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              maxBlocksPerHost:
+                description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                  that can be affine to each host.
+                type: integer
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_ipamhandles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMHandleSpec contains the specification for an IPAMHandle
+              resource.
+            properties:
+              block:
+                additionalProperties:
+                  type: integer
+                type: object
+              deleted:
+                type: boolean
+              handleID:
+                type: string
+            required:
+            - block
+            - handleID
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_ippools.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec contains the specification for an IPPool resource.
+            properties:
+              blockSize:
+                description: The block size to use for IP address assignments from
+                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                type: integer
+              cidr:
+                description: The pool CIDR.
+                type: string
+              disabled:
+                description: When disabled is true, Calico IPAM will not assign addresses
+                  from this pool.
+                type: boolean
+              ipip:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                properties:
+                  enabled:
+                    description: When enabled is true, ipip tunneling will be used
+                      to deliver packets to destinations within this pool.
+                    type: boolean
+                  mode:
+                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                      mode of "always" will also use IPIP tunneling for routing to
+                      destination IP addresses within this pool.  A mode of "cross-subnet"
+                      will only use IPIP tunneling when the destination node is on
+                      a different subnet to the originating node.  The default value
+                      (if not specified) is "always".
+                    type: string
+                type: object
+              ipipMode:
+                description: Contains configuration for IPIP tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                  is disabled).
+                type: string
+              nat-outgoing:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                type: boolean
+              natOutgoing:
+                description: When nat-outgoing is true, packets sent from Calico networked
+                  containers in this pool to destinations outside of this pool will
+                  be masqueraded.
+                type: boolean
+              nodeSelector:
+                description: Allows IPPool to allocate for a specific node by label
+                  selector.
+                type: string
+              vxlanMode:
+                description: Contains configuration for VXLAN tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                  tunneling is disabled).
+                type: string
+            required:
+            - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeControllersConfigurationSpec contains the values of the
+              Kubernetes controllers configuration.
+            properties:
+              controllers:
+                description: Controllers enables and configures individual Kubernetes
+                  controllers
+                properties:
+                  namespace:
+                    description: Namespace enables and configures the namespace controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  node:
+                    description: Node enables and configures the node controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      hostEndpoint:
+                        description: HostEndpoint controls syncing nodes to host endpoints.
+                          Disabled by default, set to nil to disable.
+                        properties:
+                          autoCreate:
+                            description: 'AutoCreate enables automatic creation of
+                              host endpoints for every node. [Default: Disabled]'
+                            type: string
+                        type: object
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                      syncLabels:
+                        description: 'SyncLabels controls whether to copy Kubernetes
+                          node labels to Calico nodes. [Default: Enabled]'
+                        type: string
+                    type: object
+                  policy:
+                    description: Policy enables and configures the policy controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ServiceAccount enables and configures the service
+                      account controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  workloadEndpoint:
+                    description: WorkloadEndpoint enables and configures the workload
+                      endpoint controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                type: object
+              etcdV3CompactionPeriod:
+                description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                  compaction requests. Set to 0 to disable. [Default: 10m]'
+                type: string
+              healthChecks:
+                description: 'HealthChecks enables or disables support for health
+                  checks [Default: Enabled]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+            required:
+            - controllers
+            type: object
+          status:
+            description: KubeControllersConfigurationStatus represents the status
+              of the configuration. It's useful for admins to be able to see the actual
+              config that was applied, which can be modified by environment variables
+              on the kube-controllers process.
+            properties:
+              environmentVars:
+                additionalProperties:
+                  type: string
+                description: EnvironmentVars contains the environment variables on
+                  the kube-controllers that influenced the RunningConfig.
+                type: object
+              runningConfig:
+                description: RunningConfig contains the effective config that is running
+                  in the kube-controllers pod, after merging the API resource with
+                  any environment variables.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace
+                          controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host
+                              endpoints. Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation
+                                  of host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which
+                      logs are sent to the stdout. [Default: Info]'
+                    type: string
+                required:
+                - controllers
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/calico/kdd/crd.projectcalico.org_networkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
-  scope: Namespaced
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: NetworkPolicy
+    listKind: NetworkPolicyList
     plural: networkpolicies
     singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
-
-apiVersion: apiextensions.k8s.io/v1beta1
+# Source: crds/calico/kdd/crd.projectcalico.org_networksets.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
 spec:
-  scope: Namespaced
   group: crd.projectcalico.org
-  versions:
-    - name: v1
-      served: true
-      storage: true
   names:
     kind: NetworkSet
+    listKind: NetworkSetList
     plural: networksets
     singular: networkset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
+# Source: crds/operator.tigera.io_installations_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: installations.operator.tigera.io
+spec:
+  group: operator.tigera.io
+  names:
+    kind: Installation
+    listKind: InstallationList
+    plural: installations
+    singular: installation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Installation configures an installation of Calico or Calico Enterprise.
+          At most one instance of this resource is supported. It must be named "default".
+          The Installation API installs core networking and network policy components,
+          and provides general install-time configuration.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired state for the Calico or Calico
+              Enterprise installation.
+            properties:
+              calicoNetwork:
+                description: CalicoNetwork specifies networking configuration options
+                  for Calico.
+                properties:
+                  bgp:
+                    description: BGP configures whether or not to enable Calico's
+                      BGP capabilities.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  containerIPForwarding:
+                    description: 'ContainerIPForwarding configures whether ip forwarding
+                      will be enabled for containers in the CNI configuration. Default:
+                      Disabled'
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  hostPorts:
+                    description: 'HostPorts configures whether or not Calico will
+                      support Kubernetes HostPorts. Valid only when using the Calico
+                      CNI plugin. Default: Enabled'
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  ipPools:
+                    description: IPPools contains a list of IP pools to create if
+                      none exist. At most one IP pool of each address family may be
+                      specified. If omitted, a single pool will be configured if needed.
+                    items:
+                      properties:
+                        blockSize:
+                          description: 'BlockSize specifies the CIDR prefex length
+                            to use when allocating per-node IP blocks from the main
+                            IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                          format: int32
+                          type: integer
+                        cidr:
+                          description: CIDR contains the address range for the IP
+                            Pool in classless inter-domain routing format.
+                          type: string
+                        encapsulation:
+                          description: 'Encapsulation specifies the encapsulation
+                            type that will be used with the IP Pool. Default: IPIP'
+                          enum:
+                          - IPIPCrossSubnet
+                          - IPIP
+                          - VXLAN
+                          - VXLANCrossSubnet
+                          - None
+                          type: string
+                        natOutgoing:
+                          description: 'NATOutgoing specifies if NAT will be enabled
+                            or disabled for outgoing traffic. Default: Enabled'
+                          enum:
+                          - Enabled
+                          - Disabled
+                          type: string
+                        nodeSelector:
+                          description: 'NodeSelector specifies the node selector that
+                            will be set for the IP Pool. Default: ''all()'''
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  mtu:
+                    description: MTU specifies the maximum transmission unit to use
+                      on the pod network. If not specified, Calico will perform MTU
+                      auto-detection based on the cluster network.
+                    format: int32
+                    type: integer
+                  multiInterfaceMode:
+                    description: 'MultiInterfaceMode configures what will configure
+                      multiple interface per pod. Only valid for Calico Enterprise
+                      installations using the Calico CNI plugin. Default: None'
+                    enum:
+                    - None
+                    - Multus
+                    type: string
+                  nodeAddressAutodetectionV4:
+                    description: NodeAddressAutodetectionV4 specifies an approach
+                      to automatically detect node IPv4 addresses. If not specified,
+                      will use default auto-detection settings to acquire an IPv4
+                      address for each node.
+                    properties:
+                      canReach:
+                        description: CanReach enables IP auto-detection based on which
+                          source address on the node is used to reach the specified
+                          IP or domain.
+                        type: string
+                      cidrs:
+                        description: CIDRS enables IP auto-detection based on which
+                          addresses on the nodes are within one of the provided CIDRs.
+                        items:
+                          type: string
+                        type: array
+                      firstFound:
+                        description: FirstFound uses default interface matching parameters
+                          to select an interface, performing best-effort filtering
+                          based on well-known interface names.
+                        type: boolean
+                      interface:
+                        description: Interface enables IP auto-detection based on
+                          interfaces that match the given regex.
+                        type: string
+                      skipInterface:
+                        description: SkipInterface enables IP auto-detection based
+                          on interfaces that do not match the given regex.
+                        type: string
+                    type: object
+                  nodeAddressAutodetectionV6:
+                    description: NodeAddressAutodetectionV6 specifies an approach
+                      to automatically detect node IPv6 addresses. If not specified,
+                      IPv6 addresses will not be auto-detected.
+                    properties:
+                      canReach:
+                        description: CanReach enables IP auto-detection based on which
+                          source address on the node is used to reach the specified
+                          IP or domain.
+                        type: string
+                      cidrs:
+                        description: CIDRS enables IP auto-detection based on which
+                          addresses on the nodes are within one of the provided CIDRs.
+                        items:
+                          type: string
+                        type: array
+                      firstFound:
+                        description: FirstFound uses default interface matching parameters
+                          to select an interface, performing best-effort filtering
+                          based on well-known interface names.
+                        type: boolean
+                      interface:
+                        description: Interface enables IP auto-detection based on
+                          interfaces that match the given regex.
+                        type: string
+                      skipInterface:
+                        description: SkipInterface enables IP auto-detection based
+                          on interfaces that do not match the given regex.
+                        type: string
+                    type: object
+                type: object
+              cni:
+                description: CNI specifies the CNI that will be used by this installation.
+                properties:
+                  ipam:
+                    description: IPAM specifies the pod IP address management that
+                      will be used in the Calico or Calico Enterprise installation.
+                    properties:
+                      type:
+                        description: "Specifies the IPAM plugin that will be used
+                          in the Calico or Calico Enterprise installation. * For CNI
+                          Plugin Calico, this field defaults to Calico. * For CNI
+                          Plugin GKE, this field defaults to HostLocal. * For CNI
+                          Plugin AzureVNET, this field defaults to AzureVNET. * For
+                          CNI Plugin AmazonVPC, this field defaults to AmazonVPC.
+                          \n The IPAM plugin is installed and configured only if the
+                          CNI plugin is set to Calico, for all other values of the
+                          CNI plugin the plugin binaries and CNI config is a dependency
+                          that is expected to be installed separately. \n Default:
+                          Calico"
+                        enum:
+                        - Calico
+                        - HostLocal
+                        - AmazonVPC
+                        - AzureVNET
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type:
+                    description: "Specifies the CNI plugin that will be used in the
+                      Calico or Calico Enterprise installation. * For KubernetesProvider
+                      GKE, this field defaults to GKE. * For KubernetesProvider AKS,
+                      this field defaults to AzureVNET. * For KubernetesProvider EKS,
+                      this field defaults to AmazonVPC. * If aws-node daemonset exists
+                      in kube-system when the Installation resource is created, this
+                      field defaults to AmazonVPC. * For all other cases this field
+                      defaults to Calico. \n For the value Calico, the CNI plugin
+                      binaries and CNI config will be installed as part of deployment,
+                      for all other values the CNI plugin binaries and CNI config
+                      is a dependency that is expected to be installed separately.
+                      \n Default: Calico"
+                    enum:
+                    - Calico
+                    - GKE
+                    - AmazonVPC
+                    - AzureVNET
+                    type: string
+                required:
+                - type
+                type: object
+              componentResources:
+                description: ComponentResources can be used to customize the resource
+                  requirements for each component.
+                items:
+                  description: The ComponentResource struct associates a ResourceRequirements
+                    with a component by name
+                  properties:
+                    componentName:
+                      description: ComponentName is an enum which identifies the component
+                      enum:
+                      - Node
+                      - Typha
+                      - KubeControllers
+                      type: string
+                    resourceRequirements:
+                      description: ResourceRequirements allows customization of limits
+                        and requests for compute resources such as cpu and memory.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  required:
+                  - componentName
+                  - resourceRequirements
+                  type: object
+                type: array
+              controlPlaneNodeSelector:
+                additionalProperties:
+                  type: string
+                description: ControlPlaneNodeSelector is used to select control plane
+                  nodes on which to run specific Calico components. This currently
+                  only applies to kube-controllers and the apiserver.
+                type: object
+              flexVolumePath:
+                description: FlexVolumePath optionally specifies a custom path for
+                  FlexVolume. If not specified, FlexVolume will be enabled by default.
+                  If set to 'None', FlexVolume will be disabled. The default is based
+                  on the kubernetesProvider.
+                type: string
+              imagePath:
+                description: "ImagePath allows for the path part of an image to be
+                  specified. If specified then the specified value will be used as
+                  the image path for each image. If not specified or empty, the default
+                  for each image will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                  \n This option allows configuring the `<imagePath>` portion of the
+                  above format."
+                type: string
+              imagePullSecrets:
+                description: ImagePullSecrets is an array of references to container
+                  registry pull secrets to use. These are applied to all images to
+                  be pulled.
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              kubernetesProvider:
+                description: KubernetesProvider specifies a particular provider of
+                  the Kubernetes platform and enables provider-specific configuration.
+                  If the specified value is empty, the Operator will attempt to automatically
+                  determine the current provider. If the specified value is not empty,
+                  the Operator will still attempt auto-detection, but will additionally
+                  compare the auto-detected value to the specified value to confirm
+                  they match.
+                enum:
+                - ""
+                - EKS
+                - GKE
+                - AKS
+                - OpenShift
+                - DockerEnterprise
+                type: string
+              nodeMetricsPort:
+                description: NodeMetricsPort specifies which port calico/node serves
+                  prometheus metrics on. By default, metrics are not enabled. If specified,
+                  this overrides any FelixConfiguration resources which may exist.
+                  If omitted, then prometheus metrics may still be configured through
+                  FelixConfiguration.
+                format: int32
+                type: integer
+              nodeUpdateStrategy:
+                description: NodeUpdateStrategy can be used to customize the desired
+                  update strategy, such as the MaxUnavailable field.
+                properties:
+                  rollingUpdate:
+                    description: 'Rolling update config params. Present only if type
+                      = "RollingUpdate". --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
+                      See https://github.com/kubernetes/kubernetes/issues/35345'
+                    properties:
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of DaemonSet pods that can
+                          be unavailable during the update. Value can be an absolute
+                          number (ex: 5) or a percentage of total number of DaemonSet
+                          pods at the start of the update (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This cannot
+                          be 0. Default value is 1. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
+                    type: string
+                type: object
+              registry:
+                description: "Registry is the default Docker registry used for component
+                  Docker images. If specified, all images will be pulled from this
+                  registry. If not specified then the default registries will be used.
+                  \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                  \n This option allows configuring the `<registry>` portion of the
+                  above format."
+                type: string
+              variant:
+                description: 'Variant is the product to install - one of Calico or
+                  TigeraSecureEnterprise Default: Calico'
+                enum:
+                - Calico
+                - TigeraSecureEnterprise
+                type: string
+            type: object
+          status:
+            description: Most recently observed state for the Calico or Calico Enterprise
+              installation.
+            properties:
+              computed:
+                description: Computed is the final installation including overlaid
+                  resources.
+                properties:
+                  calicoNetwork:
+                    description: CalicoNetwork specifies networking configuration
+                      options for Calico.
+                    properties:
+                      bgp:
+                        description: BGP configures whether or not to enable Calico's
+                          BGP capabilities.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      containerIPForwarding:
+                        description: 'ContainerIPForwarding configures whether ip
+                          forwarding will be enabled for containers in the CNI configuration.
+                          Default: Disabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      hostPorts:
+                        description: 'HostPorts configures whether or not Calico will
+                          support Kubernetes HostPorts. Valid only when using the
+                          Calico CNI plugin. Default: Enabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      ipPools:
+                        description: IPPools contains a list of IP pools to create
+                          if none exist. At most one IP pool of each address family
+                          may be specified. If omitted, a single pool will be configured
+                          if needed.
+                        items:
+                          properties:
+                            blockSize:
+                              description: 'BlockSize specifies the CIDR prefex length
+                                to use when allocating per-node IP blocks from the
+                                main IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                              format: int32
+                              type: integer
+                            cidr:
+                              description: CIDR contains the address range for the
+                                IP Pool in classless inter-domain routing format.
+                              type: string
+                            encapsulation:
+                              description: 'Encapsulation specifies the encapsulation
+                                type that will be used with the IP Pool. Default:
+                                IPIP'
+                              enum:
+                              - IPIPCrossSubnet
+                              - IPIP
+                              - VXLAN
+                              - VXLANCrossSubnet
+                              - None
+                              type: string
+                            natOutgoing:
+                              description: 'NATOutgoing specifies if NAT will be enabled
+                                or disabled for outgoing traffic. Default: Enabled'
+                              enum:
+                              - Enabled
+                              - Disabled
+                              type: string
+                            nodeSelector:
+                              description: 'NodeSelector specifies the node selector
+                                that will be set for the IP Pool. Default: ''all()'''
+                              type: string
+                          required:
+                          - cidr
+                          type: object
+                        type: array
+                      mtu:
+                        description: MTU specifies the maximum transmission unit to
+                          use on the pod network. If not specified, Calico will perform
+                          MTU auto-detection based on the cluster network.
+                        format: int32
+                        type: integer
+                      multiInterfaceMode:
+                        description: 'MultiInterfaceMode configures what will configure
+                          multiple interface per pod. Only valid for Calico Enterprise
+                          installations using the Calico CNI plugin. Default: None'
+                        enum:
+                        - None
+                        - Multus
+                        type: string
+                      nodeAddressAutodetectionV4:
+                        description: NodeAddressAutodetectionV4 specifies an approach
+                          to automatically detect node IPv4 addresses. If not specified,
+                          will use default auto-detection settings to acquire an IPv4
+                          address for each node.
+                        properties:
+                          canReach:
+                            description: CanReach enables IP auto-detection based
+                              on which source address on the node is used to reach
+                              the specified IP or domain.
+                            type: string
+                          cidrs:
+                            description: CIDRS enables IP auto-detection based on
+                              which addresses on the nodes are within one of the provided
+                              CIDRs.
+                            items:
+                              type: string
+                            type: array
+                          firstFound:
+                            description: FirstFound uses default interface matching
+                              parameters to select an interface, performing best-effort
+                              filtering based on well-known interface names.
+                            type: boolean
+                          interface:
+                            description: Interface enables IP auto-detection based
+                              on interfaces that match the given regex.
+                            type: string
+                          skipInterface:
+                            description: SkipInterface enables IP auto-detection based
+                              on interfaces that do not match the given regex.
+                            type: string
+                        type: object
+                      nodeAddressAutodetectionV6:
+                        description: NodeAddressAutodetectionV6 specifies an approach
+                          to automatically detect node IPv6 addresses. If not specified,
+                          IPv6 addresses will not be auto-detected.
+                        properties:
+                          canReach:
+                            description: CanReach enables IP auto-detection based
+                              on which source address on the node is used to reach
+                              the specified IP or domain.
+                            type: string
+                          cidrs:
+                            description: CIDRS enables IP auto-detection based on
+                              which addresses on the nodes are within one of the provided
+                              CIDRs.
+                            items:
+                              type: string
+                            type: array
+                          firstFound:
+                            description: FirstFound uses default interface matching
+                              parameters to select an interface, performing best-effort
+                              filtering based on well-known interface names.
+                            type: boolean
+                          interface:
+                            description: Interface enables IP auto-detection based
+                              on interfaces that match the given regex.
+                            type: string
+                          skipInterface:
+                            description: SkipInterface enables IP auto-detection based
+                              on interfaces that do not match the given regex.
+                            type: string
+                        type: object
+                    type: object
+                  cni:
+                    description: CNI specifies the CNI that will be used by this installation.
+                    properties:
+                      ipam:
+                        description: IPAM specifies the pod IP address management
+                          that will be used in the Calico or Calico Enterprise installation.
+                        properties:
+                          type:
+                            description: "Specifies the IPAM plugin that will be used
+                              in the Calico or Calico Enterprise installation. * For
+                              CNI Plugin Calico, this field defaults to Calico. *
+                              For CNI Plugin GKE, this field defaults to HostLocal.
+                              * For CNI Plugin AzureVNET, this field defaults to AzureVNET.
+                              * For CNI Plugin AmazonVPC, this field defaults to AmazonVPC.
+                              \n The IPAM plugin is installed and configured only
+                              if the CNI plugin is set to Calico, for all other values
+                              of the CNI plugin the plugin binaries and CNI config
+                              is a dependency that is expected to be installed separately.
+                              \n Default: Calico"
+                            enum:
+                            - Calico
+                            - HostLocal
+                            - AmazonVPC
+                            - AzureVNET
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type:
+                        description: "Specifies the CNI plugin that will be used in
+                          the Calico or Calico Enterprise installation. * For KubernetesProvider
+                          GKE, this field defaults to GKE. * For KubernetesProvider
+                          AKS, this field defaults to AzureVNET. * For KubernetesProvider
+                          EKS, this field defaults to AmazonVPC. * If aws-node daemonset
+                          exists in kube-system when the Installation resource is
+                          created, this field defaults to AmazonVPC. * For all other
+                          cases this field defaults to Calico. \n For the value Calico,
+                          the CNI plugin binaries and CNI config will be installed
+                          as part of deployment, for all other values the CNI plugin
+                          binaries and CNI config is a dependency that is expected
+                          to be installed separately. \n Default: Calico"
+                        enum:
+                        - Calico
+                        - GKE
+                        - AmazonVPC
+                        - AzureVNET
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  componentResources:
+                    description: ComponentResources can be used to customize the resource
+                      requirements for each component.
+                    items:
+                      description: The ComponentResource struct associates a ResourceRequirements
+                        with a component by name
+                      properties:
+                        componentName:
+                          description: ComponentName is an enum which identifies the
+                            component
+                          enum:
+                          - Node
+                          - Typha
+                          - KubeControllers
+                          type: string
+                        resourceRequirements:
+                          description: ResourceRequirements allows customization of
+                            limits and requests for compute resources such as cpu
+                            and memory.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                      required:
+                      - componentName
+                      - resourceRequirements
+                      type: object
+                    type: array
+                  controlPlaneNodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: ControlPlaneNodeSelector is used to select control
+                      plane nodes on which to run specific Calico components. This
+                      currently only applies to kube-controllers and the apiserver.
+                    type: object
+                  flexVolumePath:
+                    description: FlexVolumePath optionally specifies a custom path
+                      for FlexVolume. If not specified, FlexVolume will be enabled
+                      by default. If set to 'None', FlexVolume will be disabled. The
+                      default is based on the kubernetesProvider.
+                    type: string
+                  imagePath:
+                    description: "ImagePath allows for the path part of an image to
+                      be specified. If specified then the specified value will be
+                      used as the image path for each image. If not specified or empty,
+                      the default for each image will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                      \n This option allows configuring the `<imagePath>` portion
+                      of the above format."
+                    type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets is an array of references to container
+                      registry pull secrets to use. These are applied to all images
+                      to be pulled.
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
+                  kubernetesProvider:
+                    description: KubernetesProvider specifies a particular provider
+                      of the Kubernetes platform and enables provider-specific configuration.
+                      If the specified value is empty, the Operator will attempt to
+                      automatically determine the current provider. If the specified
+                      value is not empty, the Operator will still attempt auto-detection,
+                      but will additionally compare the auto-detected value to the
+                      specified value to confirm they match.
+                    enum:
+                    - ""
+                    - EKS
+                    - GKE
+                    - AKS
+                    - OpenShift
+                    - DockerEnterprise
+                    type: string
+                  nodeMetricsPort:
+                    description: NodeMetricsPort specifies which port calico/node
+                      serves prometheus metrics on. By default, metrics are not enabled.
+                      If specified, this overrides any FelixConfiguration resources
+                      which may exist. If omitted, then prometheus metrics may still
+                      be configured through FelixConfiguration.
+                    format: int32
+                    type: integer
+                  nodeUpdateStrategy:
+                    description: NodeUpdateStrategy can be used to customize the desired
+                      update strategy, such as the MaxUnavailable field.
+                    properties:
+                      rollingUpdate:
+                        description: 'Rolling update config params. Present only if
+                          type = "RollingUpdate". --- TODO: Update this to follow
+                          our convention for oneOf, whatever we decide it to be. Same
+                          as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345'
+                        properties:
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of DaemonSet pods that
+                              can be unavailable during the update. Value can be an
+                              absolute number (ex: 5) or a percentage of total number
+                              of DaemonSet pods at the start of the update (ex: 10%).
+                              Absolute number is calculated from percentage by rounding
+                              up. This cannot be 0. Default value is 1. Example: when
+                              this is set to 30%, at most 30% of the total number
+                              of nodes that should be running the daemon pod (i.e.
+                              status.desiredNumberScheduled) can have their pods stopped
+                              for an update at any given time. The update starts by
+                              stopping at most 30% of those DaemonSet pods and then
+                              brings up new DaemonSet pods in their place. Once the
+                              new pods are available, it then proceeds onto other
+                              DaemonSet pods, thus ensuring that at least 70% of original
+                              number of DaemonSet pods are available at all times
+                              during the update.'
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of daemon set update. Can be "RollingUpdate"
+                          or "OnDelete". Default is RollingUpdate.
+                        type: string
+                    type: object
+                  registry:
+                    description: "Registry is the default Docker registry used for
+                      component Docker images. If specified, all images will be pulled
+                      from this registry. If not specified then the default registries
+                      will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                      \n This option allows configuring the `<registry>` portion of
+                      the above format."
+                    type: string
+                  variant:
+                    description: 'Variant is the product to install - one of Calico
+                      or TigeraSecureEnterprise Default: Calico'
+                    enum:
+                    - Calico
+                    - TigeraSecureEnterprise
+                    type: string
+                type: object
+              mtu:
+                description: MTU is the most recently observed value for pod network
+                  MTU. This may be an explicitly configured value, or based on Calico's
+                  native auto-detetion.
+                format: int32
+                type: integer
+              variant:
+                description: Variant is the most recently observed installed variant
+                  - one of Calico or TigeraSecureEnterprise
+                enum:
+                - Calico
+                - TigeraSecureEnterprise
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 
-# Create the ServiceAccount and roles necessary for Calico.
+---
+# Source: crds/operator.tigera.io_tigerastatuses_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tigerastatuses.operator.tigera.io
+spec:
+  group: operator.tigera.io
+  names:
+    kind: TigeraStatus
+    listKind: TigeraStatusList
+    plural: tigerastatuses
+    singular: tigerastatus
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Whether the component running and stable.
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Whether the component is processing changes.
+      jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - description: Whether the component is degraded.
+      jsonPath: .status.conditions[?(@.type=='Degraded')].status
+      name: Degraded
+      type: string
+    - description: The time the component's Available status last changed.
+      jsonPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
+      name: Since
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TigeraStatus represents the most recently observed status for
+          Calico or a Calico Enterprise functional area.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            description: TigeraStatusStatus defines the observed state of TigeraStatus
+            properties:
+              conditions:
+                description: Conditions represents the latest observed set of conditions
+                  for this component. A component may be one or more of Available,
+                  Progressing, or Degraded.
+                items:
+                  description: TigeraStatusCondition represents a condition attached
+                    to a particular component.
+                  properties:
+                    lastTransitionTime:
+                      description: The timestamp representing the start time for the
+                        current status.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Optionally, a detailed message providing additional
+                        context.
+                      type: string
+                    reason:
+                      description: A brief reason explaining the condition.
+                      type: string
+                    status:
+                      description: The status of the condition. May be True, False,
+                        or Unknown.
+                      type: string
+                    type:
+                      description: The type of condition. May be Available, Progressing,
+                        or Degraded.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 
+---
+# Source: tigera-operator/templates/tigera-operator/00-namespace-tigera-operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tigera-operator
+  annotations:
+  labels:
+    name: tigera-operator
+---
+# Source: tigera-operator/templates/tigera-operator/02-podsecuritypolicy-tigera-operator.yaml
+# This should not be rendered for an OpenShift install.
+# OpenShift uses SecurityContextConstraints instead.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: tigera-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+  - 'hostPath'
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  # Assume that persistentVolumes set up by the cluster admin are safe to use.
+  - 'persistentVolumeClaim'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+# Source: tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-node
-  namespace: kube-system
-
+  name: tigera-operator
+  namespace: tigera-operator
 ---
-
-kind: ClusterRole
+# Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: calico-node
+  name: tigera-operator
 rules:
-  # The CNI plugin needs to get pods, nodes, configmaps and namespaces.
-  - apiGroups: [""]
+  - apiGroups:
+      - ""
     resources:
-      - pods
-      - nodes
-      - configmaps
       - namespaces
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - endpoints
+      - pods
+      - podtemplates
       - services
-    verbs:
-      # Used to discover service IPs for advertisement.
-      - watch
-      - list
-      # Used to discover Typhas.
-      - get
-  - apiGroups: [""]
-    resources:
-      - nodes/status
-    verbs:
-      # Needed for clearing NodeNetworkUnavailable flag.
-      - patch
-      # Calico stores some configuration information in node annotations.
-      - update
-  # Watch for changes to Kubernetes NetworkPolicies.
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs:
-      - watch
-      - list
-  # Used by Calico for policy information.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - namespaces
+      - endpoints
+      - events
+      - configmaps
+      - secrets
       - serviceaccounts
     verbs:
-      - list
-      - watch
-  # The CNI plugin patches pods/status.
-  - apiGroups: [""]
-    resources:
-      - pods/status
-    verbs:
-      - patch
-  # Calico monitors various CRDs for config.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - globalfelixconfigs
-      - felixconfigurations
-      - bgppeers
-      - globalbgpconfigs
-      - bgpconfigurations
-      - ippools
-      - ipamblocks
-      - globalnetworkpolicies
-      - globalnetworksets
-      - networkpolicies
-      - networksets
-      - clusterinformations
-      - hostendpoints
-      - blockaffinities
-    verbs:
+      - create
       - get
       - list
-      - watch
-  # Calico must create and update some CRDs on startup.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-      - felixconfigurations
-      - clusterinformations
-    verbs:
-      - create
       - update
-  # Calico stores some configuration information on the node.
-  - apiGroups: [""]
+      - delete
+      - watch
+  - apiGroups:
+      - ""
     resources:
       - nodes
     verbs:
-      - get
-      - list
-      - watch
-  # These permissions are only requried for upgrade from v2.6, and can
-  # be removed after upgrade or on fresh installations.
-  - apiGroups: ["crd.projectcalico.org"]
+      # Need to update node labels when migrating nodes.
+      - 'get'
+      - 'patch'
+      - 'list'
+      # We need this for Typha autoscaling
+      - 'watch'
+  - apiGroups:
+      - rbac.authorization.k8s.io
     resources:
-      - bgpconfigurations
-      - bgppeers
+      - clusterroles
+      - clusterrolebindings
+      - rolebindings
+      - roles
     verbs:
       - create
-      - update
-  # These permissions are required for Calico CNI to perform IPAM allocations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
       - get
       - list
-      - create
       - update
       - delete
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ipamconfigs
-    verbs:
-      - get
-  # Block affinities must also be watchable by confd for route aggregation.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-    verbs:
       - watch
-  # The Calico IPAM migration needs to get daemonsets. These permissions can be
-  # removed if not upgrading from an installation using host-local IPAM.
-  - apiGroups: ["apps"]
+      - bind
+      - escalate
+  - apiGroups:
+      - apps
     resources:
+      - deployments
       - daemonsets
+      - statefulsets
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - tigera-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - operator.tigera.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+      - watch
+  - apiGroups:
+    - crd.projectcalico.org
+    resources:
+    - felixconfigurations
+    verbs:
+    - patch
+  - apiGroups:
+    - crd.projectcalico.org
+    resources:
+    - ippools
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
     verbs:
       - get
-
+      - create
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - list
+      - watch
+  # Add the appropriate pod security policy permissions
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - tigera-operator
+    verbs:
+      - use
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
+# Source: tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator.yaml
 kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-node
+  name: tigera-operator
 subjects:
-  - kind: ServiceAccount
-    name: calico-node
-    namespace: kube-system
-
+- kind: ServiceAccount
+  name: tigera-operator
+  namespace: tigera-operator
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator
+  apiGroup: rbac.authorization.k8s.io
 ---
-
+# Source: tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: calico-typha
-  namespace: kube-system
+  name: tigera-operator
+  namespace: tigera-operator
   labels:
-    k8s-app: calico-typha
+    k8s-app: tigera-operator
 spec:
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      k8s-app: calico-typha
-  template:
-    metadata:
-      labels:
-        k8s-app: calico-typha
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
-    spec:
-      priorityClassName: system-cluster-critical
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-      hostNetwork: true
-      serviceAccountName: calico-node
-      # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
-      securityContext:
-        fsGroup: 65534
-      containers:
-        - image: docker.io/calico/typha:v3.17.1
-          name: calico-typha
-          ports:
-            - containerPort: 5473
-              name: calico-typha
-              protocol: TCP
-          envFrom:
-          - configMapRef:
-              # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
-              name: kubernetes-services-endpoint
-              optional: true
-          env:
-            # Use eni not cali for interface prefix
-            - name: FELIX_INTERFACEPREFIX
-              value: "eni"
-            - name: TYPHA_LOGFILEPATH
-              value: "none"
-            - name: TYPHA_LOGSEVERITYSYS
-              value: "none"
-            - name: TYPHA_LOGSEVERITYSCREEN
-              value: "info"
-            - name: TYPHA_PROMETHEUSMETRICSENABLED
-              value: "true"
-            - name: TYPHA_CONNECTIONREBALANCINGMODE
-              value: "kubernetes"
-            - name: TYPHA_PROMETHEUSMETRICSPORT
-              value: "9093"
-            - name: TYPHA_DATASTORETYPE
-              value: "kubernetes"
-            - name: TYPHA_MAXCONNECTIONSLOWERLIMIT
-              value: "1"
-            - name: TYPHA_HEALTHENABLED
-              value: "true"
-            # This will make Felix honor AWS VPC CNI's mangle table
-            # rules.
-            - name: FELIX_IPTABLESMANGLEALLOWACTION
-              value: Return
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9098
-              host: localhost
-            periodSeconds: 30
-            initialDelaySeconds: 30
-          securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9098
-              host: localhost
-            periodSeconds: 10
-
----
-
-# This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: calico-typha
-  namespace: kube-system
-  labels:
-    k8s-app: calico-typha
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      k8s-app: calico-typha
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: typha-cpha
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: typha-cpha
-subjects:
-  - kind: ServiceAccount
-    name: typha-cpha
-    namespace: kube-system
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: typha-cpha
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["watch", "list"]
-
----
-
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: calico-typha-horizontal-autoscaler
-  namespace: kube-system
-data:
-  ladder: |-
-    {
-      "coresToReplicas": [],
-      "nodesToReplicas":
-      [
-        [1, 1],
-        [10, 2],
-        [100, 3],
-        [250, 4],
-        [500, 5],
-        [1000, 6],
-        [1500, 7],
-        [2000, 8]
-      ]
-    }
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: calico-typha-horizontal-autoscaler
-  namespace: kube-system
-  labels:
-    k8s-app: calico-typha-autoscaler
-spec:
-  selector:
-    matchLabels:
-      k8s-app: calico-typha-autoscaler
   replicas: 1
+  selector:
+    matchLabels:
+      name: tigera-operator
   template:
     metadata:
       labels:
-        k8s-app: calico-typha-autoscaler
+        name: tigera-operator
+        k8s-app: tigera-operator
     spec:
-      priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+      serviceAccountName: tigera-operator
+      hostNetwork: true
+      # This must be set when hostNetwork is true or else the cluster services won't resolve
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3 
-          name: autoscaler
+        - name: tigera-operator
+          image: quay.io/tigera/operator:v1.13.2
+          imagePullPolicy: IfNotPresent
           command:
-            - /cluster-proportional-autoscaler
-            - --namespace=kube-system
-            - --configmap=calico-typha-horizontal-autoscaler
-            - --target=deployment/calico-typha
-            - --logtostderr=true
-            - --v=2
-          resources:
-            requests:
-              cpu: 10m
-            limits:
-              cpu: 10m
-      serviceAccountName: typha-cpha
+            - operator
+          volumeMounts:
+            - name: var-lib-calico
+              readOnly: true
+              mountPath: /var/lib/calico
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "tigera-operator"
+            - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
+              value: v1.13.2
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
+      volumes:
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
 
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+# This section includes base Calico installation configuration.
+# For more information, see: https://docs.projectcalico.org/v3.17/reference/installation/api#operator.tigera.io/v1.Installation
+apiVersion: operator.tigera.io/v1
+kind: Installation
 metadata:
-  name: typha-cpha
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get"]
-  - apiGroups: ["extensions", "apps"]
-    resources: ["deployments/scale"]
-    verbs: ["get", "update"]
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: typha-cpha
-  namespace: kube-system
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: typha-cpha
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: typha-cpha
-subjects:
-  - kind: ServiceAccount
-    name: typha-cpha
-    namespace: kube-system
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: calico-typha
-  namespace: kube-system
-  labels:
-    k8s-app: calico-typha
+  name: default
 spec:
-  ports:
-    - port: 5473
-      protocol: TCP
-      targetPort: calico-typha
-      name: calico-typha
-  selector:
-    k8s-app: calico-typha
+  # Configures Calico policy configured to work with AmazonVPC CNI networking.
+  cni:
+    type: AmazonVPC

--- a/config/v1.7/cni-metrics-helper-cn.yaml
+++ b/config/v1.7/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.8"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.8"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.8"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"

--- a/config/v1.7/cni-metrics-helper.yaml
+++ b/config/v1.7/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.8"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.9"
         "imagePullPolicy": "Always"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"


### PR DESCRIPTION
Release v1.7.9 configuration files and change log.

I overwrote the v1.7.9-rc1 change log with the v1.7.9 as it seems like it was done for the previous releases.

**What type of PR is this?**

Release

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
