### PR TITLE
update templates to use v1 of apiextensions

### DIFF
--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

Update

**What does this PR do / Why do we need it**:

With Kubernetes 1.19, apiextensions.k8s.io/v1beta1 has been deprecated. Latest templates of vpc cni should be using latest api versions which aren't deprecated.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
