### PR TITLE
Split Calico manifest into two

### DIFF
--- a/config/master/calico-crs.yaml
+++ b/config/master/calico-crs.yaml
@@ -1,0 +1,10 @@
+# This section includes base Calico installation configuration.
+# For more information, see: https://docs.projectcalico.org/v3.17/reference/installation/api#operator.tigera.io/v1.Installation
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  # Configures Calico policy configured to work with AmazonVPC CNI networking.
+  cni:
+    type: AmazonVPC

--- a/config/master/calico-operator.yaml
+++ b/config/master/calico-operator.yaml
@@ -1,5 +1,4 @@
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_bgpconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -131,7 +130,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_bgppeers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -234,7 +232,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_blockaffinities.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -296,7 +293,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -361,7 +357,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_felixconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -914,7 +909,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1686,7 +1680,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_globalnetworksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1740,7 +1733,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_hostendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1849,7 +1841,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_ipamblocks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1931,7 +1922,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_ipamconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1988,7 +1978,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_ipamhandles.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2045,7 +2034,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_ippools.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2145,7 +2133,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2369,7 +2356,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_networkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3122,7 +3108,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/calico/kdd/crd.projectcalico.org_networksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3174,7 +3159,6 @@ status:
   storedVersions: []
 
 ---
-# Source: crds/operator.tigera.io_installations_crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3954,7 +3938,6 @@ spec:
       status: {}
 
 ---
-# Source: crds/operator.tigera.io_tigerastatuses_crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4052,7 +4035,6 @@ spec:
       status: {}
 
 ---
-# Source: tigera-operator/templates/tigera-operator/00-namespace-tigera-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -4061,9 +4043,6 @@ metadata:
   labels:
     name: tigera-operator
 ---
-# Source: tigera-operator/templates/tigera-operator/02-podsecuritypolicy-tigera-operator.yaml
-# This should not be rendered for an OpenShift install.
-# OpenShift uses SecurityContextConstraints instead.
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -4108,14 +4087,12 @@ spec:
         max: 65535
   readOnlyRootFilesystem: false
 ---
-# Source: tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
 ---
-# Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -4271,7 +4248,6 @@ rules:
       - create
       - update
 ---
-# Source: tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -4285,7 +4261,6 @@ roleRef:
   name: tigera-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -4343,15 +4318,3 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
-
----
-# This section includes base Calico installation configuration.
-# For more information, see: https://docs.projectcalico.org/v3.17/reference/installation/api#operator.tigera.io/v1.Installation
-apiVersion: operator.tigera.io/v1
-kind: Installation
-metadata:
-  name: default
-spec:
-  # Configures Calico policy configured to work with AmazonVPC CNI networking.
-  cni:
-    type: AmazonVPC


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

As mentioned in this discussion: https://github.com/aws/amazon-vpc-cni-k8s/pull/1297#issuecomment-801472720

The current manifest includes both the Installation CRD as well as an
instance of an Insatllation CR. Since they are both in the same
manfiest, the API server doesn't have time to register the CRD before
the CR is sent, and so the CR is rejected.

They should be in two manfiests, so the user can apply the CRD first and
then apply the CR.

This change will include a corresponding documentation change. 


**What does this PR do / Why do we need it**:

Splits calico.yaml into two so they can be properly ordered.


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
calico.yaml is split into two manifests - calico-operator.yaml and calico-crs.yaml
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.