### PR TITLE
add network connectivity test

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -74,6 +74,6 @@ func New(options Options) *Framework {
 		Options:             options,
 		K8sClient:           k8sClient,
 		CloudServices:       aws.NewCloud(cloudConfig),
-		K8sResourceManagers: k8s.NewResourceManager(k8sClient),
+		K8sResourceManagers: k8s.NewResourceManager(k8sClient, k8sSchema, config),
 	}
 }

--- a/test/framework/resources/aws/services/ec2.go
+++ b/test/framework/resources/aws/services/ec2.go
@@ -24,13 +24,18 @@ import (
 
 type EC2 interface {
 	DescribeInstanceType(instanceType string) ([]*ec2.InstanceTypeInfo, error)
+	DescribeInstance(instanceID string) (*ec2.Instance, error)
+	AuthorizeSecurityGroupIngress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error
+	RevokeSecurityGroupIngress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error
+	AuthorizeSecurityGroupEgress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error
+	RevokeSecurityGroupEgress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error
 }
 
 type defaultEC2 struct {
 	ec2iface.EC2API
 }
 
-func (d defaultEC2) DescribeInstanceType(instanceType string) ([]*ec2.InstanceTypeInfo, error) {
+func (d *defaultEC2) DescribeInstanceType(instanceType string) ([]*ec2.InstanceTypeInfo, error) {
 	describeInstanceTypeIp := &ec2.DescribeInstanceTypesInput{
 		InstanceTypes: aws.StringSlice([]string{instanceType}),
 	}
@@ -42,6 +47,98 @@ func (d defaultEC2) DescribeInstanceType(instanceType string) ([]*ec2.InstanceTy
 		return nil, fmt.Errorf("no instance type found in the output %s", instanceType)
 	}
 	return describeInstanceOp.InstanceTypes, nil
+}
+
+func (d *defaultEC2) DescribeInstance(instanceID string) (*ec2.Instance, error) {
+	describeInstanceInput := &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+	describeInstanceOutput, err := d.EC2API.DescribeInstances(describeInstanceInput)
+	if err != nil {
+		return nil, err
+	}
+	if describeInstanceOutput == nil || len(describeInstanceOutput.Reservations) == 0 ||
+		len(describeInstanceOutput.Reservations[0].Instances) == 0 {
+		return nil, fmt.Errorf("failed to find instance %s", instanceID)
+	}
+	return describeInstanceOutput.Reservations[0].Instances[0], nil
+}
+
+func (d *defaultEC2) AuthorizeSecurityGroupIngress(groupID string, protocol string,
+	fromPort int, toPort int, cidrIP string) error {
+	ipPermissions := &ec2.IpPermission{
+		FromPort:   aws.Int64(int64(fromPort)),
+		ToPort:     aws.Int64(int64(toPort)),
+		IpProtocol: aws.String(protocol),
+		IpRanges: []*ec2.IpRange{
+			{
+				CidrIp: aws.String(cidrIP),
+			},
+		},
+	}
+	authorizeSecurityGroupIngressInput := &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:       aws.String(groupID),
+		IpPermissions: []*ec2.IpPermission{ipPermissions},
+	}
+	_, err := d.EC2API.AuthorizeSecurityGroupIngress(authorizeSecurityGroupIngressInput)
+	return err
+}
+
+func (d *defaultEC2) RevokeSecurityGroupIngress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error {
+	ipPermissions := &ec2.IpPermission{
+		FromPort:   aws.Int64(int64(fromPort)),
+		ToPort:     aws.Int64(int64(toPort)),
+		IpProtocol: aws.String(protocol),
+		IpRanges: []*ec2.IpRange{
+			{
+				CidrIp: aws.String(cidrIP),
+			},
+		},
+	}
+	revokeSecurityGroupIngressInput := &ec2.RevokeSecurityGroupIngressInput{
+		GroupId:       aws.String(groupID),
+		IpPermissions: []*ec2.IpPermission{ipPermissions},
+	}
+	_, err := d.EC2API.RevokeSecurityGroupIngress(revokeSecurityGroupIngressInput)
+	return err
+}
+
+func (d *defaultEC2) AuthorizeSecurityGroupEgress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error {
+	ipPermissions := &ec2.IpPermission{
+		FromPort:   aws.Int64(int64(fromPort)),
+		ToPort:     aws.Int64(int64(toPort)),
+		IpProtocol: aws.String(protocol),
+		IpRanges: []*ec2.IpRange{
+			{
+				CidrIp: aws.String(cidrIP),
+			},
+		},
+	}
+	authorizeSecurityGroupEgressInput := &ec2.AuthorizeSecurityGroupEgressInput{
+		GroupId:       aws.String(groupID),
+		IpPermissions: []*ec2.IpPermission{ipPermissions},
+	}
+	_, err := d.EC2API.AuthorizeSecurityGroupEgress(authorizeSecurityGroupEgressInput)
+	return err
+}
+
+func (d *defaultEC2) RevokeSecurityGroupEgress(groupID string, protocol string, fromPort int, toPort int, cidrIP string) error {
+	ipPermissions := &ec2.IpPermission{
+		FromPort:   aws.Int64(int64(fromPort)),
+		ToPort:     aws.Int64(int64(toPort)),
+		IpProtocol: aws.String(protocol),
+		IpRanges: []*ec2.IpRange{
+			{
+				CidrIp: aws.String(cidrIP),
+			},
+		},
+	}
+	revokeSecurityGroupEgressInput := &ec2.RevokeSecurityGroupEgressInput{
+		GroupId:       aws.String(groupID),
+		IpPermissions: []*ec2.IpPermission{ipPermissions},
+	}
+	_, err := d.EC2API.RevokeSecurityGroupEgress(revokeSecurityGroupEgressInput)
+	return err
 }
 
 func NewEC2(session *session.Session) EC2 {

--- a/test/framework/resources/k8s/manager.go
+++ b/test/framework/resources/k8s/manager.go
@@ -16,6 +16,8 @@ package k8s
 import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/resources"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,6 +28,8 @@ type ResourceManagers interface {
 	NamespaceManager() resources.NamespaceManager
 	ServiceManager() resources.ServiceManager
 	NodeManager() resources.NodeManager
+	PodManager() resources.PodManager
+	DaemonSetManager() resources.DaemonSetManager
 }
 
 type defaultManager struct {
@@ -35,9 +39,12 @@ type defaultManager struct {
 	namespaceManager      resources.NamespaceManager
 	serviceManager        resources.ServiceManager
 	nodeManager           resources.NodeManager
+	podManager            resources.PodManager
+	daemonSetManager      resources.DaemonSetManager
 }
 
-func NewResourceManager(k8sClient client.DelegatingClient) ResourceManagers {
+func NewResourceManager(k8sClient client.DelegatingClient,
+	scheme *runtime.Scheme, config *rest.Config) ResourceManagers {
 	return &defaultManager{
 		jobManager:            resources.NewDefaultJobManager(k8sClient),
 		deploymentManager:     resources.NewDefaultDeploymentManager(k8sClient),
@@ -45,6 +52,8 @@ func NewResourceManager(k8sClient client.DelegatingClient) ResourceManagers {
 		namespaceManager:      resources.NewDefaultNamespaceManager(k8sClient),
 		serviceManager:        resources.NewDefaultServiceManager(k8sClient),
 		nodeManager:           resources.NewDefaultNodeManager(k8sClient),
+		podManager:            resources.NewDefaultPodManager(k8sClient, scheme, config),
+		daemonSetManager:      resources.NewDefaultDaemonSetManager(k8sClient),
 	}
 }
 
@@ -70,4 +79,12 @@ func (m *defaultManager) ServiceManager() resources.ServiceManager {
 
 func (m *defaultManager) NodeManager() resources.NodeManager {
 	return m.nodeManager
+}
+
+func (m *defaultManager) PodManager() resources.PodManager {
+	return m.podManager
+}
+
+func (m *defaultManager) DaemonSetManager() resources.DaemonSetManager {
+	return m.daemonSetManager
 }

--- a/test/framework/resources/k8s/manifest/deployment.go
+++ b/test/framework/resources/k8s/manifest/deployment.go
@@ -14,7 +14,7 @@
 package manifest
 
 import (
-	utils "github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	v1 "k8s.io/api/apps/v1"
@@ -38,8 +38,16 @@ func NewBusyBoxDeploymentBuilder() *DeploymentBuilder {
 		name:                   "deployment-test",
 		replicas:               10,
 		container:              NewBusyBoxContainerBuilder().Build(),
-		labels:                 map[string]string{"d": "d"},
+		labels:                 map[string]string{"role": "test"},
 		terminationGracePeriod: 0,
+	}
+}
+
+func NewDefaultDeploymentBuilder() *DeploymentBuilder {
+	return &DeploymentBuilder{
+		namespace:              utils.DefaultTestNamespace,
+		terminationGracePeriod: 0,
+		labels:                 map[string]string{"role": "test"},
 	}
 }
 

--- a/test/framework/resources/k8s/resources/daemonset.go
+++ b/test/framework/resources/k8s/resources/daemonset.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DaemonSetManager interface {
+	GetDaemonSet(namespace string, name string) (*v1.DaemonSet, error)
+	UpdateAndWaitTillDaemonSetReady(old *v1.DaemonSet, new *v1.DaemonSet) (*v1.DaemonSet, error)
+}
+
+type defaultDaemonSetManager struct {
+	k8sClient client.DelegatingClient
+}
+
+func NewDefaultDaemonSetManager(k8sClient client.DelegatingClient) DaemonSetManager {
+	return &defaultDaemonSetManager{k8sClient: k8sClient}
+}
+
+func (d *defaultDaemonSetManager) GetDaemonSet(namespace string, name string) (*v1.DaemonSet, error) {
+	ctx := context.Background()
+	daemonSet := &v1.DaemonSet{}
+	err := d.k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, daemonSet)
+	return daemonSet, err
+}
+
+func (d *defaultDaemonSetManager) UpdateAndWaitTillDaemonSetReady(old *v1.DaemonSet, new *v1.DaemonSet) (*v1.DaemonSet, error) {
+	ctx := context.Background()
+	err := d.k8sClient.Patch(ctx, new, client.MergeFrom(old))
+	if err != nil {
+		return nil, err
+	}
+
+	observed := &v1.DaemonSet{}
+	return observed, wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := d.k8sClient.Get(ctx, utils.NamespacedName(new), observed); err != nil {
+			return false, err
+		}
+		if observed.Status.NumberReady == (new.Status.DesiredNumberScheduled) &&
+			observed.Status.NumberAvailable == (new.Status.DesiredNumberScheduled) &&
+			observed.Status.UpdatedNumberScheduled == (new.Status.DesiredNumberScheduled) &&
+			observed.Status.ObservedGeneration >= new.Generation {
+			return true, nil
+		}
+		return false, nil
+	}, ctx.Done())
+}

--- a/test/framework/resources/k8s/utils/container.go
+++ b/test/framework/resources/k8s/utils/container.go
@@ -1,0 +1,83 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// AddOrUpdateEnvironmentVariable adds or updates existing Environment variable to the
+// specified container name
+func AddOrUpdateEnvironmentVariable(containers []v1.Container, containerName string,
+	envVars map[string]string) error {
+
+	containerIndex := -1
+	// Update existing environment variable first
+	for i, container := range containers {
+		if container.Name != containerName {
+			continue
+		}
+		containerIndex = i
+		for j, env := range container.Env {
+			if val, alreadyPresent := envVars[env.Name]; alreadyPresent {
+				container.Env[j].Value = val
+				// Delete, so we don't add the environment variable multiple times
+				delete(envVars, env.Name)
+			}
+		}
+	}
+
+	if containerIndex < 0 {
+		return fmt.Errorf("failed to find container %s in the passed containers",
+			containerName)
+	}
+
+	// Add the environment variables that were not already present
+	for key, val := range envVars {
+		containers[containerIndex].Env = append(containers[containerIndex].Env,
+			v1.EnvVar{
+				Name:  key,
+				Value: val,
+			})
+	}
+
+	return nil
+}
+
+// RemoveEnvironmentVariables removes the environment variable from the specified container
+func RemoveEnvironmentVariables(containers []v1.Container, containerName string,
+	envVars map[string]struct{}) error {
+	containerIndex := -1
+	for i, container := range containers {
+		if container.Name != containerName {
+			continue
+		}
+		containerIndex = i
+		for j := 0; j < len(container.Env); j++ {
+			if _, ok := envVars[container.Env[j].Name]; ok {
+				container.Env = append(container.Env[:j], container.Env[j+1:]...)
+				j--
+			}
+		}
+	}
+
+	if containerIndex < 0 {
+		return fmt.Errorf("failed to find cotnainer %s in list of containers",
+			containerName)
+	}
+
+	return nil
+}

--- a/test/framework/resources/k8s/utils/daemonset.go
+++ b/test/framework/resources/k8s/utils/daemonset.go
@@ -1,0 +1,70 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+)
+
+func AddEnvVarToDaemonSetAndWaitTillUpdated(f *framework.Framework, dsName string, dsNamespace string,
+	containerName string, envVars map[string]string) {
+
+	ds := getDaemonSet(f, dsName, dsNamespace)
+	updatedDs := ds.DeepCopy()
+
+	By(fmt.Sprintf("setting the environment variables on the ds to %+v", envVars))
+	err := AddOrUpdateEnvironmentVariable(updatedDs.Spec.Template.Spec.Containers,
+		containerName, envVars)
+	Expect(err).ToNot(HaveOccurred())
+
+	waitTillDaemonSetUpdated(f, ds, updatedDs)
+}
+
+func RemoveVarFromDaemonSetAndWaitTillUpdated(f *framework.Framework, dsName string, dsNamespace string,
+	containerName string, envVars map[string]struct{}) {
+
+	ds := getDaemonSet(f, dsName, dsNamespace)
+	updatedDs := ds.DeepCopy()
+
+	By(fmt.Sprintf("setting the environment variables on the ds to %+v", envVars))
+	err := RemoveEnvironmentVariables(updatedDs.Spec.Template.Spec.Containers,
+		containerName, envVars)
+	Expect(err).ToNot(HaveOccurred())
+
+	waitTillDaemonSetUpdated(f, ds, updatedDs)
+}
+
+func getDaemonSet(f *framework.Framework, dsName string, dsNamespace string) *v1.DaemonSet {
+	By(fmt.Sprintf("getting the %s daemon set in namesapce %s", dsName, dsNamespace))
+	ds, err := f.K8sResourceManagers.
+		DaemonSetManager().
+		GetDaemonSet(dsNamespace, dsName)
+	Expect(err).ToNot(HaveOccurred())
+	return ds
+}
+
+func waitTillDaemonSetUpdated(f *framework.Framework, oldDs *v1.DaemonSet, updatedDs *v1.DaemonSet) *v1.DaemonSet {
+	By("updating the daemon set with new environment variable")
+	updatedDs, err := f.K8sResourceManagers.
+		DaemonSetManager().
+		UpdateAndWaitTillDaemonSetReady(oldDs, updatedDs)
+	Expect(err).ToNot(HaveOccurred())
+	return updatedDs
+}

--- a/test/framework/resources/k8s/utils/node.go
+++ b/test/framework/resources/k8s/utils/node.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func GetInstanceIDFromNode(node v1.Node) string {
+	id := strings.Split(node.Spec.ProviderID, "/")
+	return id[len(id)-1]
+}

--- a/test/go.sum
+++ b/test/go.sum
@@ -121,6 +121,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/test/integration-new/README.md
+++ b/test/integration-new/README.md
@@ -1,0 +1,45 @@
+##CNI Integration Test Suites
+
+The package contains automated integration tests suites for `amazon-vpc-cni-k8s` .
+
+###Prerequisites
+The integration test requires 
+- At least 2 nodes in a node group.
+- Nodes in the nodegroup shouldn't have existing pods.
+- Ginkgo installed on your environment. To install `go get github.com/onsi/ginkgo/ginkgo`
+
+####Testing
+Set the environment variables that will be passed to Ginkgo script. If you want to directly pass the arguments you can skip to next step.
+```
+CLUSTER_NAME=<eks-cluster-name>
+VPC_ID=<vpc-id>
+KUBECONFIG=<path-to-kubeconfig>
+AWS_REGION=<cluster-region>
+NG_NAME_LABEL_KEY=<ng-name-label-tag-on-ec2>
+# Example, NG_NAME_LABEL_KEY="eks.amazonaws.com/nodegroup"
+NG_NAME_LABEL_VAL=<ng-name-label-tag-value-on-ec2>
+# Example, NG_NAME_LABEL_VAL="nodegroup-name"
+```
+
+To run the test switch to the integration folder. For instance running the cni integration test from root of the project.
+```bash
+cd test/integration-new/cni
+```
+Run Ginkgo test suite
+```bash
+ginkgo -v --failOnPending -- \
+ --cluster-kubeconfig=$KUBECONFIG \
+ --cluster-name=$CLUSTER_NAME \
+ --aws-region=$AWS_REGION \
+ --aws-vpc-id=$VPC_ID \
+ --ng-name-label-val=$NG_NAME_LABEL_KEY \
+ --ng-name-label-val=$NG_NAME_LABEL_VAL
+```
+
+###Future Work
+Currently the package is named as `integraiton-new` because we already have `integration` directory with existing Ginkgo test cases with a separate `go.mod`. Once the older package is completely deprecated we will rename this package to `integration`.
+
+
+
+
+

--- a/test/integration-new/cni/pod_networking_suite_test.go
+++ b/test/integration-new/cni/pod_networking_suite_test.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cni
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+const InstanceTypeNodeLabelKey = "beta.kubernetes.io/instance-type"
+
+var f *framework.Framework
+var maxIPPerInterface int
+var primaryNode v1.Node
+var secondaryNode v1.Node
+var instanceSecurityGroupID string
+
+func TestCNIPodNetworking(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CNI Pod Networking Suite")
+}
+
+var _ = BeforeSuite(func() {
+	f = framework.New(framework.GlobalOptions)
+
+	By("creating test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		CreateNamespace(utils.DefaultTestNamespace)
+
+	By(fmt.Sprintf("getting the node with the node label key %s and value %s",
+		f.Options.NgNameLabelKey, f.Options.NgNameLabelVal))
+	nodes, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("verifying more than 1 nodes are present for the test")
+	Expect(len(nodes.Items)).Should(BeNumerically(">", 1))
+
+	// Set the primary and secondary node for testing
+	primaryNode = nodes.Items[0]
+	secondaryNode = nodes.Items[1]
+
+	// Get the node security group
+	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)
+	primaryInstance, err := f.CloudServices.EC2().DescribeInstance(instanceID)
+	Expect(err).ToNot(HaveOccurred())
+
+	// This won't work if the first SG is only associated with the primary instance.
+	// Need a robust substring in the SGP name to identify node SGP
+	instanceSecurityGroupID = *primaryInstance.NetworkInterfaces[0].Groups[0].GroupId
+
+	By("getting the instance type from node label " + InstanceTypeNodeLabelKey)
+	instanceType := primaryNode.Labels[InstanceTypeNodeLabelKey]
+
+	By("getting the network interface details from ec2")
+	instanceOutput, err := f.CloudServices.EC2().DescribeInstanceType(instanceType)
+	Expect(err).ToNot(HaveOccurred())
+
+	maxIPPerInterface = int(*instanceOutput[0].NetworkInfo.Ipv4AddressesPerInterface)
+
+	// Set the WARM_ENI_TARGET to 0 to prevent all pods being scheduled on secondary ENI
+	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",
+		"aws-node", map[string]string{"WARM_IP_TARGET": "3", "WARM_ENI_TARGET": "0"})
+})
+
+var _ = AfterSuite(func() {
+	By("deleting test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
+
+	k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",
+		"aws-node", map[string]struct{}{"WARM_IP_TARGET": {}, "WARM_ENI_TARGET": {}})
+})

--- a/test/integration-new/cni/pod_networking_test.go
+++ b/test/integration-new/cni/pod_networking_test.go
@@ -1,0 +1,358 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cni
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+// Verifies network connectivity across Pods placed on different combination of
+// primary and second Elastic Networking Interface on two nodes. The test verifies
+// different traffic type for instance TCP, UDP, ICMP
+var _ = Describe("test pod networking", func() {
+
+	var (
+		err error
+		// The command to run on server pods, to allow incoming
+		// connections for different traffic type
+		serverListenCmd []string
+		// Arguments to the server listen command
+		serverListenCmdArgs []string
+		// The function that generates command which will be sent from
+		// tester pod to receiver pod
+		testConnectionCommandFunc func(serverPod coreV1.Pod, port int) []string
+		// Expected stdout from the exec command on testing connection
+		// from tester to server
+		testerExpectedStdOut string
+		// Expected stderr from the exec command on testing connection
+		// from tester to server
+		testerExpectedStdErr string
+		// The port on which server is listening for new connections
+		serverPort int
+		// Protocol for establishing connection to server
+		protocol string
+
+		// Primary node server deployment
+		primaryNodeDeployment *v1.Deployment
+		// Secondary node Server deployment
+		secondaryNodeDeployment *v1.Deployment
+
+		// Map of Pods placed on primary/secondary ENI IP on primary node
+		interfaceToPodListOnPrimaryNode InterfaceTypeToPodList
+		// Map of Pods placed on primary/secondary ENI IP on secondary node
+		interfaceToPodListOnSecondaryNode InterfaceTypeToPodList
+	)
+
+	JustBeforeEach(func() {
+		By("authorizing security group ingress on instance security group")
+		err = f.CloudServices.EC2().
+			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("authorizing security group egress on instance security group")
+		err = f.CloudServices.EC2().
+			AuthorizeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		serverContainer := manifest.
+			NewNetCatAlpineContainer().
+			Command(serverListenCmd).
+			Args(serverListenCmdArgs).
+			Build()
+
+		By("creating server deployment on the primary node")
+		primaryNodeDeployment = manifest.
+			NewDefaultDeploymentBuilder().
+			Container(serverContainer).
+			Replicas(maxIPPerInterface*2). // X2 so Pods are created on secondary ENI too
+			NodeName(primaryNode.Name).
+			PodLabel("node", "primary").
+			Name("primary-node-server").
+			Build()
+
+		primaryNodeDeployment, err = f.K8sResourceManagers.
+			DeploymentManager().
+			CreateAndWaitTillDeploymentIsReady(primaryNodeDeployment)
+		Expect(err).ToNot(HaveOccurred())
+
+		interfaceToPodListOnPrimaryNode =
+			GetPodsOnPrimaryAndSecondaryInterface(primaryNode, "node", "primary")
+
+		// At least two Pods should be placed on the Primary and Secondary Interface
+		// on the Primary and Secondary Node in order to test all possible scenarios
+		Expect(len(interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI)).
+			Should(BeNumerically(">", 1))
+		Expect(len(interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI)).
+			Should(BeNumerically(">", 1))
+
+		By("creating server deployment on secondary node")
+		secondaryNodeDeployment = manifest.
+			NewDefaultDeploymentBuilder().
+			Container(serverContainer).
+			Replicas(maxIPPerInterface*2). // X2 so Pods are created on secondary ENI too
+			NodeName(secondaryNode.Name).
+			PodLabel("node", "secondary").
+			Name("secondary-node-server").
+			Build()
+
+		secondaryNodeDeployment, err = f.K8sResourceManagers.
+			DeploymentManager().
+			CreateAndWaitTillDeploymentIsReady(secondaryNodeDeployment)
+		Expect(err).ToNot(HaveOccurred())
+
+		interfaceToPodListOnSecondaryNode =
+			GetPodsOnPrimaryAndSecondaryInterface(secondaryNode, "node", "secondary")
+
+		// Same reason as mentioned above
+		Expect(len(interfaceToPodListOnSecondaryNode.PodsOnPrimaryENI)).
+			Should(BeNumerically(">", 1))
+		Expect(len(interfaceToPodListOnSecondaryNode.PodsOnSecondaryENI)).
+			Should(BeNumerically(">", 1))
+	})
+
+	JustAfterEach(func() {
+		By("revoking security group ingress on instance security group")
+		err = f.CloudServices.EC2().
+			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("revoking security group egress on instance security group")
+		err = f.CloudServices.EC2().
+			RevokeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("deleting the primary node server deployment")
+		err = f.K8sResourceManagers.DeploymentManager().
+			DeleteAndWaitTillDeploymentIsDeleted(primaryNodeDeployment)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("deleting the secondary node server deployment")
+		err = f.K8sResourceManagers.DeploymentManager().
+			DeleteAndWaitTillDeploymentIsDeleted(secondaryNodeDeployment)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when testing ICMP traffic", func() {
+		BeforeEach(func() {
+			// The number of packets to be sent
+			packetCount := 5
+			// Protocol needs to be set allow ICMP traffic on the EC2 SG
+			protocol = "ICMP"
+			// ICMP doesn't need any port to be opened on the SG
+			serverPort = 0
+			// Since ping doesn't need any server, just sleep on the server pod
+			serverListenCmd = []string{"sleep"}
+			serverListenCmdArgs = []string{"1000"}
+
+			// Verify all the packets were transmitted and received successfully
+			testerExpectedStdOut = fmt.Sprintf("%d packets transmitted, "+
+				"%d packets received", packetCount, packetCount)
+			testerExpectedStdErr = ""
+
+			testConnectionCommandFunc = func(receiverPod coreV1.Pod, port int) []string {
+				return []string{"ping", "-c", strconv.Itoa(packetCount), receiverPod.Status.PodIP}
+			}
+		})
+
+		It("should allow ICMP traffic", func() {
+			CheckConnectivityForMultiplePodPlacement(
+				interfaceToPodListOnPrimaryNode, interfaceToPodListOnSecondaryNode,
+				serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
+		})
+	})
+
+	Context("when establishing UDP connection from tester to server", func() {
+		BeforeEach(func() {
+			serverPort = 2273
+			protocol = ec2.ProtocolUdp
+			serverListenCmd = []string{"nc"}
+			// The nc flag "-l" for listen mode, "-k" to keep server up and not close
+			// connection after each connection, "-u" for udp
+			serverListenCmdArgs = []string{"-u", "-l", "-k", strconv.Itoa(serverPort)}
+
+			// Verbose output from nc is being redirected to stderr instead of stdout
+			testerExpectedStdErr = "succeeded!"
+			testerExpectedStdOut = ""
+
+			// The nc flag "-u" for UDP traffic, "-v" for verbose output and "-wn" for timing out
+			// in n seconds
+			testConnectionCommandFunc = func(receiverPod coreV1.Pod, port int) []string {
+				return []string{"nc", "-u", "-v", "-w2", receiverPod.Status.PodIP, strconv.Itoa(port)}
+			}
+		})
+
+		It("connection should be established", func() {
+			CheckConnectivityForMultiplePodPlacement(
+				interfaceToPodListOnPrimaryNode, interfaceToPodListOnSecondaryNode,
+				serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
+		})
+	})
+
+	Context("when establishing TCP connection from tester to server", func() {
+
+		BeforeEach(func() {
+			serverPort = 2273
+			protocol = ec2.ProtocolTcp
+			// Test tcp connection using netcat
+			serverListenCmd = []string{"nc"}
+			// The nc flag "-l" for listen mode, "-k" to keep server up and not close
+			// connection after each connection
+			serverListenCmdArgs = []string{"-k", "-l", strconv.Itoa(serverPort)}
+
+			// netcat verbose output is being redirected to stderr instead of stdout
+			testerExpectedStdErr = "succeeded!"
+			testerExpectedStdOut = ""
+
+			// The nc flag "-v" for verbose output and "-wn" for timing out in n seconds
+			testConnectionCommandFunc = func(receiverPod coreV1.Pod, port int) []string {
+				return []string{"nc", "-v", "-w2", receiverPod.Status.PodIP, strconv.Itoa(port)}
+			}
+		})
+
+		It("should allow connection across nodes and across interface types", func() {
+			CheckConnectivityForMultiplePodPlacement(
+				interfaceToPodListOnPrimaryNode, interfaceToPodListOnSecondaryNode,
+				serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
+		})
+	})
+})
+
+// CheckConnectivityForMultiplePodPlacement checks connectivity for various scenarios, an example
+// connection from Pod on Node 1 having IP from Primary Network Interface to Pod on Node 2 having
+// IP from Secondary Network Interface
+func CheckConnectivityForMultiplePodPlacement(interfaceToPodListOnPrimaryNode InterfaceTypeToPodList,
+	interfaceToPodListOnSecondaryNode InterfaceTypeToPodList, port int,
+	testerExpectedStdOut string, testerExpectedStdErr string,
+	getTestCommandFunc func(receiverPod coreV1.Pod, port int) []string) {
+
+	By("checking connection on same node, primary to primary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI[0],
+		interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[1],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+	By("checking connection on same node, primary to secondary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI[0],
+		interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[0],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+	By("checking connection on same node, secondary to secondary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[0],
+		interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[1],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+	By("checking connection on different node, primary to primary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI[0],
+		interfaceToPodListOnSecondaryNode.PodsOnPrimaryENI[0],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+	By("checking connection on different node, primary to secondary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI[0],
+		interfaceToPodListOnSecondaryNode.PodsOnSecondaryENI[0],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+	By("checking connection on different node, secondary to secondary")
+	testConnectivity(
+		interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[0],
+		interfaceToPodListOnSecondaryNode.PodsOnSecondaryENI[0],
+		testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+}
+
+// testConnectivity verifies connectivity between tester and server
+func testConnectivity(senderPod coreV1.Pod, receiverPod coreV1.Pod, expectedStdout string,
+	expectedStderr string, port int, getTestCommandFunc func(receiverPod coreV1.Pod, port int) []string) {
+
+	testerCommand := getTestCommandFunc(receiverPod, port)
+
+	fmt.Fprintf(GinkgoWriter, "verifying connectivity from pod %s on node %s with IP %s to pod"+
+		" %s on node %s with IP %s\n", senderPod.Name, senderPod.Spec.NodeName, senderPod.Status.PodIP,
+		receiverPod.Name, receiverPod.Spec.NodeName, receiverPod.Status.PodIP)
+
+	stdOut, stdErr, err := f.K8sResourceManagers.PodManager().
+		PodExec(senderPod.Namespace, senderPod.Name, testerCommand)
+	Expect(err).ToNot(HaveOccurred())
+
+	fmt.Fprintf(GinkgoWriter, "stdout: %s and stderr: %s\n", stdOut, stdErr)
+
+	Expect(stdErr).To(ContainSubstring(expectedStderr))
+	Expect(stdOut).To(ContainSubstring(expectedStdout))
+}
+
+type InterfaceTypeToPodList struct {
+	PodsOnPrimaryENI   []coreV1.Pod
+	PodsOnSecondaryENI []coreV1.Pod
+}
+
+// GetPodsOnPrimaryAndSecondaryInterface returns the list of Pods on Primary Networking
+// Interface and Secondary Network Interface on a given Node
+func GetPodsOnPrimaryAndSecondaryInterface(node coreV1.Node,
+	podLabelKey string, podLabelVal string) InterfaceTypeToPodList {
+	podList, err := f.K8sResourceManagers.
+		PodManager().
+		GetPodsWithLabelSelector(podLabelKey, podLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+	instance, err := f.CloudServices.EC2().
+		DescribeInstance(k8sUtils.GetInstanceIDFromNode(node))
+	Expect(err).ToNot(HaveOccurred())
+
+	interfaceToPodList := InterfaceTypeToPodList{
+		PodsOnPrimaryENI:   []coreV1.Pod{},
+		PodsOnSecondaryENI: []coreV1.Pod{},
+	}
+
+	ipToPod := map[string]coreV1.Pod{}
+	for _, pod := range podList.Items {
+		ipToPod[pod.Status.PodIP] = pod
+	}
+
+	for _, nwInterface := range instance.NetworkInterfaces {
+		isPrimary := IsPrimaryENI(nwInterface, instance.PrivateIpAddress)
+		for _, ip := range nwInterface.PrivateIpAddresses {
+			if pod, found := ipToPod[*ip.PrivateIpAddress]; found {
+				if isPrimary {
+					interfaceToPodList.PodsOnPrimaryENI =
+						append(interfaceToPodList.PodsOnPrimaryENI, pod)
+				} else {
+					interfaceToPodList.PodsOnSecondaryENI =
+						append(interfaceToPodList.PodsOnSecondaryENI, pod)
+				}
+			}
+		}
+	}
+	return interfaceToPodList
+}
+
+func IsPrimaryENI(nwInterface *ec2.InstanceNetworkInterface, instanceIPAddr *string) bool {
+	for _, privateIPAddress := range nwInterface.PrivateIpAddresses {
+		if *privateIPAddress.PrivateIpAddress == *instanceIPAddr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Integration test for verifying networking connectivity for TCP, UDP, ICMP in the following scenarios

N = Node
P = Pod using IP from Primary ENI
S = Pod using IP from Secondary ENI

N1P1 - N1P2 // Example, connection from Node 1, Pod 1 using Primary ENI IP to Node 1, Pod 2 using Primary ENI IP 
N1P1 - N1S1
N1S1 - N1S2
N1P1 - N2P1 
N1P1 - N2S1
N1S1 - N2S1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Adds integration test.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

Output
```
ginkgo -v --failOnPending -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID  --ng-name-label-val="trunk-node"
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1618325377
Will run 3 of 3 specs

STEP: creating test namespace
STEP: getting the node with the node label key eks.amazonaws.com/nodegroup and value trunk-node
STEP: verifying more than 1 nodes are present for the test
STEP: getting the instance type from node label beta.kubernetes.io/instance-type
STEP: getting the network interface details from ec2
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3]
STEP: updating the daemon set with new environment variable
test pod networking when testing ICMP traffic 
  should allow ICMP traffic
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:178
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-6d887b786f-zcnft on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.1.102 to pod primary-node-server-6d887b786f-wjwl8 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.32.129
stdout: PING 10.2.32.129 (10.2.32.129): 56 data bytes
64 bytes from 10.2.32.129: seq=0 ttl=254 time=0.339 ms
64 bytes from 10.2.32.129: seq=1 ttl=254 time=0.316 ms
64 bytes from 10.2.32.129: seq=2 ttl=254 time=0.332 ms
64 bytes from 10.2.32.129: seq=3 ttl=254 time=0.319 ms
64 bytes from 10.2.32.129: seq=4 ttl=254 time=0.332 ms

--- 10.2.32.129 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 0.316/0.327/0.339 ms
 and stderr: 
STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-6d887b786f-zcnft on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.1.102 to pod primary-node-server-6d887b786f-8dq7q on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.235.192
stdout: PING 10.2.235.192 (10.2.235.192): 56 data bytes
64 bytes from 10.2.235.192: seq=0 ttl=254 time=0.335 ms
64 bytes from 10.2.235.192: seq=1 ttl=254 time=0.342 ms
64 bytes from 10.2.235.192: seq=2 ttl=254 time=0.328 ms
64 bytes from 10.2.235.192: seq=3 ttl=254 time=0.326 ms
64 bytes from 10.2.235.192: seq=4 ttl=254 time=0.333 ms

--- 10.2.235.192 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 0.326/0.332/0.342 ms
 and stderr: 
STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-6d887b786f-8dq7q on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.235.192 to pod primary-node-server-6d887b786f-wjwl8 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.32.129
stdout: PING 10.2.32.129 (10.2.32.129): 56 data bytes
64 bytes from 10.2.32.129: seq=0 ttl=254 time=0.311 ms
64 bytes from 10.2.32.129: seq=1 ttl=254 time=0.316 ms
64 bytes from 10.2.32.129: seq=2 ttl=254 time=0.321 ms
64 bytes from 10.2.32.129: seq=3 ttl=254 time=0.353 ms
64 bytes from 10.2.32.129: seq=4 ttl=254 time=0.315 ms

--- 10.2.32.129 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 0.311/0.323/0.353 ms
 and stderr: 
STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-6d887b786f-zcnft on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.1.102 to pod secondary-node-server-795459df6c-5djr9 on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.155.242
stdout: PING 10.2.155.242 (10.2.155.242): 56 data bytes
64 bytes from 10.2.155.242: seq=0 ttl=253 time=1.940 ms
64 bytes from 10.2.155.242: seq=1 ttl=253 time=1.536 ms
64 bytes from 10.2.155.242: seq=2 ttl=253 time=1.333 ms
64 bytes from 10.2.155.242: seq=3 ttl=253 time=1.507 ms
64 bytes from 10.2.155.242: seq=4 ttl=253 time=1.457 ms

--- 10.2.155.242 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 1.333/1.554/1.940 ms
 and stderr: 
STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-6d887b786f-zcnft on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.1.102 to pod secondary-node-server-795459df6c-fk6q9 on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.124.133
stdout: PING 10.2.124.133 (10.2.124.133): 56 data bytes
64 bytes from 10.2.124.133: seq=0 ttl=253 time=2.331 ms
64 bytes from 10.2.124.133: seq=1 ttl=253 time=1.402 ms
64 bytes from 10.2.124.133: seq=2 ttl=253 time=1.364 ms
64 bytes from 10.2.124.133: seq=3 ttl=253 time=1.627 ms
64 bytes from 10.2.124.133: seq=4 ttl=253 time=1.171 ms

--- 10.2.124.133 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 1.171/1.579/2.331 ms
 and stderr: 
STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-6d887b786f-8dq7q on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.235.192 to pod secondary-node-server-795459df6c-fk6q9 on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.124.133
stdout: PING 10.2.124.133 (10.2.124.133): 56 data bytes
64 bytes from 10.2.124.133: seq=0 ttl=253 time=2.074 ms
64 bytes from 10.2.124.133: seq=1 ttl=253 time=1.554 ms
64 bytes from 10.2.124.133: seq=2 ttl=253 time=1.624 ms
64 bytes from 10.2.124.133: seq=3 ttl=253 time=1.624 ms
64 bytes from 10.2.124.133: seq=4 ttl=253 time=1.629 ms

--- 10.2.124.133 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 1.554/1.701/2.074 ms
 and stderr: 
STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:107.142 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:33
  when testing ICMP traffic
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:156
    should allow ICMP traffic
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:178
------------------------------
test pod networking when establishing UDP connection from tester to server 
  connection should be established
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:205
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-6b64c865dc-nhwpq on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.35.2 to pod primary-node-server-6b64c865dc-w9l64 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.199.224
stdout:  and stderr: Connection to 10.2.199.224 2271 port [udp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-6b64c865dc-nhwpq on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.35.2 to pod primary-node-server-6b64c865dc-9txb2 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.153.0
stdout:  and stderr: Connection to 10.2.153.0 2271 port [udp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-6b64c865dc-9txb2 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.153.0 to pod primary-node-server-6b64c865dc-w9l64 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.199.224
stdout:  and stderr: Connection to 10.2.199.224 2271 port [udp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-6b64c865dc-nhwpq on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.35.2 to pod secondary-node-server-584b8bf-86gbk on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.56.226
stdout:  and stderr: Connection to 10.2.56.226 2271 port [udp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-6b64c865dc-nhwpq on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.35.2 to pod secondary-node-server-584b8bf-8wq8h on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.209.2
stdout:  and stderr: Connection to 10.2.209.2 2271 port [udp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-6b64c865dc-9txb2 on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.153.0 to pod secondary-node-server-584b8bf-8wq8h on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.209.2
stdout:  and stderr: Connection to 10.2.209.2 2271 port [udp/*] succeeded!

STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:120.529 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:33
  when establishing UDP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:185
    connection should be established
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:205
------------------------------
test pod networking when establishing TCP connection from tester to server 
  should allow connection across nodes and across interface types
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:233
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-84548779c9-kr8gs on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.23.67 to pod primary-node-server-84548779c9-bdm2c on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.48.230
stdout:  and stderr: Connection to 10.2.48.230 2271 port [tcp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-84548779c9-kr8gs on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.23.67 to pod primary-node-server-84548779c9-n7nzd on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.240.67
stdout:  and stderr: Connection to 10.2.240.67 2271 port [tcp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-84548779c9-n7nzd on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.240.67 to pod primary-node-server-84548779c9-bdm2c on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.48.230
stdout:  and stderr: Connection to 10.2.48.230 2271 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-84548779c9-kr8gs on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.23.67 to pod secondary-node-server-c95498bdf-pwzdd on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.8.16
stdout:  and stderr: Connection to 10.2.8.16 2271 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-84548779c9-kr8gs on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.23.67 to pod secondary-node-server-c95498bdf-7fscm on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.194.163
stdout:  and stderr: Connection to 10.2.194.163 2271 port [tcp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-84548779c9-n7nzd on node ip-10-2-234-181.us-west-2.compute.internal with IP 10.2.240.67 to pod secondary-node-server-c95498bdf-7fscm on node ip-10-2-242-100.us-west-2.compute.internal with IP 10.2.194.163
stdout:  and stderr: Connection to 10.2.194.163 2271 port [tcp/*] succeeded!

STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:87.079 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:33
  when establishing TCP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:212
    should allow connection across nodes and across interface types
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_networking_test.go:233
------------------------------
STEP: deleting test namespace
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

Ran 3 of 3 Specs in 437.937 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 7m24.400603565s
Test Suite Passed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
