### PR TITLE
Add awscni_build_info metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ export GO111MODULE = on
 export GOPROXY = direct
 
 # LDFLAGS is the set of flags used when building golang executables.
-LDFLAGS = -X main.version=$(VERSION) -X pkg/awsutils/awssession.version=$(VERSION)
+LDFLAGS = -X pkg/version/info.Version=$(VERSION) -X pkg/awsutils/awssession.version=$(VERSION)
 # ALLPKGS is the set of packages provided in source.
 ALLPKGS = $(shell go list ./... | grep -v cmd/packet-verifier)
 # BINS is the set of built command executables.

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -21,9 +21,8 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/version"
 )
-
-var version string
 
 func main() {
 	os.Exit(_main())
@@ -37,7 +36,8 @@ func _main() int {
 	}
 	log := logger.New(&logConfig)
 
-	log.Infof("Starting L-IPAMD %s  ...", version)
+	log.Infof("Starting L-IPAMD %s  ...", version.Version)
+	version.RegisterMetric()
 
 	kubeClient, err := k8sapi.CreateKubeClient()
 	if err != nil {
@@ -67,7 +67,7 @@ func _main() int {
 	go ipamContext.ServeIntrospection()
 
 	// Start the RPC listener
-	err = ipamContext.RunRPCHandler(version)
+	err = ipamContext.RunRPCHandler(version.Version)
 	if err != nil {
 		log.Errorf("Failed to set up gRPC handler: %v", err)
 		return 1

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -9,7 +9,6 @@ import (
 // Build information. Populated at build-time.
 var (
 	Version   string
-	Revision  string
 	GoVersion = runtime.Version()
 )
 
@@ -19,8 +18,8 @@ func RegisterMetric() {
 			Name: "awscni_build_info",
 			Help: "A metric with a constant '1' value labeled by version, revision, and goversion from which amazon-vpc-cni-k8s was built.",
 		},
-		[]string{"version", "revision", "goversion"},
+		[]string{"version", "goversion"},
 	)
-	buildInfo.WithLabelValues(Version, Revision, GoVersion).Set(1)
+	buildInfo.WithLabelValues(Version, GoVersion).Set(1)
 	prometheus.MustRegister(buildInfo)
 }

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	GoVersion = runtime.Version()
+)
+
+func RegisterMetric() {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "awscni_build_info",
+			Help: "A metric with a constant '1' value labeled by version, revision, and goversion from which amazon-vpc-cni-k8s was built.",
+		},
+		[]string{"version", "revision", "goversion"},
+	)
+	buildInfo.WithLabelValues(Version, Revision, GoVersion).Set(1)
+	prometheus.MustRegister(buildInfo)
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do / Why do we need it**:

This PR introduces a new metric called `awscni_build_info`, this metric have a constant '1' as value labeled by version and goversion from which amazon-vpc-cni-k8s was built.

**Automation added to e2e**: No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No

**Does this change require updates to the CNI daemonset config files to work?**: No

**Does this PR introduce any user-facing change?**:

```release-note
Add awscni_build_info metric
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
