### PR TITLE
Cherry-pick of Release artifacts for v1.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog
 
+## v1.7.10
+
+* Improvement - Multi card support - Prevent route override for primary ENI across multi-cards ENAs (#1396 , [@jayanthvn](https://github.com/Jayanthvn))
+
 ## v1.7.9
 
-* Improvement - [Adds http timeout to aws sessions](https://github.com/aws/amazon-vpc-cni-k8s/pull/1370) (#1370 by [@couralex6](https://github.com/couralex6))
+* Improvement - [Adds http timeout to aws sessions](https://github.com/aws/amazon-vpc-cni-k8s/pull/1370) (#1370 , [@couralex6](https://github.com/couralex6))
 * Improvement - [Switch calico to be deployed with the Tigera operator](https://github.com/aws/amazon-vpc-cni-k8s/pull/1297) (#1297 by [@tmjd](https://github.com/tmjd))
-* Improvement - [Update calico to v3.17.1](https://github.com/aws/amazon-vpc-cni-k8s/pull/1328) (#1328 by [@lwr20](https://github.com/lwr20))
-* Improvement - [update plugins to v0.9.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/1362) (#1362 by [@fr0stbyte](https://github.com/fr0stbyte))
-* Improvement - [update github.com/containernetworking/plugins to v0.9.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/1350) (#1350 by [@fr0stbyte](https://github.com/fr0stbyte))
-* Bug - [Fix regex match for getting primary interface](https://github.com/aws/amazon-vpc-cni-k8s/pull/1311) (#1311 by [@Jayanthvn](https://github.com/Jayanthvn))
-* Bug - [Output to stderr when no log file path is passed](https://github.com/aws/amazon-vpc-cni-k8s/pull/1275) (#1275 by [@couralex6](https://github.com/couralex6))
-* Bug - [Fix deletion of hostVeth rule for pods using security group](https://github.com/aws/amazon-vpc-cni-k8s/pull/1376) (#1376 by [@SaranBalaji90](https://github.com/SaranBalaji90))
+* Improvement - [Update calico to v3.17.1](https://github.com/aws/amazon-vpc-cni-k8s/pull/1328) (#1328 , [@lwr20](https://github.com/lwr20))
+* Improvement - [update plugins to v0.9.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/1362) (#1362 , [@fr0stbyte](https://github.com/fr0stbyte))
+* Improvement - [update github.com/containernetworking/plugins to v0.9.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/1350) (#1350 , [@fr0stbyte](https://github.com/fr0stbyte))
+* Bug - [Fix regex match for getting primary interface](https://github.com/aws/amazon-vpc-cni-k8s/pull/1311) (#1311 , [@jayanthvn](https://github.com/Jayanthvn))
+* Bug - [Output to stderr when no log file path is passed](https://github.com/aws/amazon-vpc-cni-k8s/pull/1275) (#1275 , [@couralex6](https://github.com/couralex6))
+* Bug - [Fix deletion of hostVeth rule for pods using security group](https://github.com/aws/amazon-vpc-cni-k8s/pull/1376) (#1376 , [@SaranBalaji90](https://github.com/SaranBalaji90))
 
 ## v1.7.8
 
@@ -29,7 +33,7 @@
 * Bug - [Make p3dn.24xlarge examples more realistic](https://github.com/aws/amazon-vpc-cni-k8s/pull/1263) (#1263 , [@mogren](https://github.com/mogren))
 * Bug - [Make sure we have space for a trunk ENI](https://github.com/aws/amazon-vpc-cni-k8s/pull/1210) (#1210 , [@mogren](https://github.com/mogren))
 * Bug - [Update README for DISABLE_TCP_EARLY_DEMUX](https://github.com/aws/amazon-vpc-cni-k8s/pull/1273) (#1273 , [@SaranBalaji90](https://github.com/SaranBalaji90))
-* Bug - [Update p4 instance limits](https://github.com/aws/amazon-vpc-cni-k8s/pull/1289) (#1289 , @varavaj)
+* Bug - [Update p4 instance limits](https://github.com/aws/amazon-vpc-cni-k8s/pull/1289) (#1289 , [@jayanthvn](https://github.com/Jayanthvn))
 
 ## v1.7.5
 

--- a/config/v1.7/aws-k8s-cni-cn.yaml
+++ b/config/v1.7/aws-k8s-cni-cn.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.9"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.10"
         "livenessProbe":
           "exec":
             "command":
@@ -195,7 +195,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.9"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.10"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.9"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.7.10"
         "livenessProbe":
           "exec":
             "command":
@@ -195,7 +195,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.10"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.9"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.7.10"
         "livenessProbe":
           "exec":
             "command":
@@ -195,7 +195,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.10"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.7/aws-k8s-cni.yaml
+++ b/config/v1.7/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.9"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.10"
         "livenessProbe":
           "exec":
             "command":
@@ -195,7 +195,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.9"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.10"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.7/cni-metrics-helper-cn.yaml
+++ b/config/v1.7/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.9"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.7.10"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.9"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.7.10"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.7/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.9"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.7.10"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.7/cni-metrics-helper.yaml
+++ b/config/v1.7/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.9"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.10"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick was missing after 1.7.10 release to master

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
Cherry-pick/release

**Which issue does this PR fix**:
#1408 

**What does this PR do / Why do we need it**:
Cherry pick of release 1.7.10 config files and change log. Change log format is different in master hence had to manually merge the cherry pick conflicts.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
