### PR TITLE
Add workflow to sync aws-vpc-cni helm chart to eks-charts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: VPC CNI Release
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  DEFAULT_GO_VERSION: ^1.15
+  GITHUB_USERNAME: ${{ secrets.EKS_BOT_GITHUB_USERNAME }}
+  GITHUB_TOKEN: ${{ secrets.EKS_BOT_GITHUB_TOKEN }}
+
+jobs:
+
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    
+    - name: Create eks-charts PR
+      run: make ekscharts-sync-release

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 METRICS_IMAGE = amazon/cni-metrics-helper
 METRICS_IMAGE_NAME = $(METRICS_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
 METRICS_IMAGE_DIST = $(DESTDIR)/$(subst /,_,$(METRICS_IMAGE_NAME)).tar.gz
+REPO_FULL_NAME=aws/amazon-vpc-cni-k8s
+HELM_CHART_NAME ?= "aws-vpc-cni"
 # TEST_IMAGE is the testing environment container image.
 TEST_IMAGE = amazon-k8s-cni-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
@@ -267,6 +269,13 @@ check-format: format
 
 version:
 	@echo ${VERSION}
+
+ekscharts-sync:
+	${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b ${HELM_CHART_NAME} -r ${REPO_FULL_NAME}
+
+ekscharts-sync-release:
+	${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b ${HELM_CHART_NAME} -r ${REPO_FULL_NAME} -n
+
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github

--- a/scripts/sync-to-eks-charts.sh
+++ b/scripts/sync-to-eks-charts.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+set -euo pipefail
+set +x
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="${SCRIPTPATH}/../build"
+
+REPO="aws/amazon-vpc-cni-k8s"
+HELM_CHART_NAME="aws-vpc-cni"
+HELM_CHART_BASE_BIR="${SCRIPTPATH}/../charts"
+
+CHARTS_REPO="aws/eks-charts"
+CHARTS_REPO_NAME=$(echo ${CHARTS_REPO} | cut -d'/' -f2)
+
+HELM_CHART_DIR="${HELM_CHART_BASE_BIR}/${HELM_CHART_NAME}"
+PR_ID=$(uuidgen | cut -d '-' -f1)
+
+SYNC_DIR="${BUILD_DIR}/eks-charts-sync"
+FORK_DIR="${SYNC_DIR}/${CHARTS_REPO_NAME}"
+
+BINARY_BASE=""
+INCLUDE_NOTES=0
+
+GH_CLI_VERSION="0.10.1"
+GH_CLI_CONFIG_PATH="${HOME}/.config/gh/config.yml"
+KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
+OS="${KERNEL}"
+if [[ "${KERNEL}" == "darwin" ]]; then 
+  OS="macOS"
+fi
+
+VERSION=$(make -s -f "${SCRIPTPATH}/../Makefile" version)
+
+USAGE=$(cat << EOM
+  Usage: sync-to-eks-charts  -r <repo>
+  Syncs Helm chart to aws/eks-charts
+
+  Example: sync-to-eks-charts -r "${REPO}"
+          Required:
+            -b          Binary basename (i.e. -b "${HELM_CHART_NAME}")
+
+          Optional:
+            -r          Github repo to sync to in the form of "org/name"  (i.e. -r "${REPO}")
+            -n          Include application release notes in the sync PR
+EOM
+)
+
+# Process our input arguments
+while getopts "b:r:n" opt; do
+  case ${opt} in
+    r ) # Github repo
+        REPO="$OPTARG"
+      ;;
+    b ) # binary basename
+        BINARY_BASE="$OPTARG"
+      ;;
+    n ) # Include release notes
+        INCLUDE_NOTES=1
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+
+if [[ -z "${REPO}" ]]; then 
+  echo "Repo (-r) must be specified if no \"make repo-full-name\" target exists"
+fi
+
+echo $REPO
+
+if [[ -z $(command -v gh) ]] || [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
+  mkdir -p "${BUILD_DIR}"/gh
+  curl -Lo "${BUILD_DIR}"/gh/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${OS}_amd64.tar.gz"
+  tar -C "${BUILD_DIR}"/gh -xvf "${BUILD_DIR}/gh/gh.tar.gz"
+  export PATH="${BUILD_DIR}/gh/gh_${GH_CLI_VERSION}_${OS}_amd64/bin:$PATH"
+  if [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
+    echo "❌ Failed install of github cli"
+    exit 4
+  fi
+fi
+
+function restore_gh_config() {
+  mv -f "${GH_CLI_CONFIG_PATH}.bkup" "${GH_CLI_CONFIG_PATH}" || :
+}
+
+if [[ -n $(env | grep GITHUB_TOKEN) ]] && [[ -n "${GITHUB_TOKEN}" ]]; then
+  trap restore_gh_config EXIT INT TERM ERR
+  mkdir -p "${HOME}/.config/gh"
+  cp -f "${GH_CLI_CONFIG_PATH}" "${GH_CLI_CONFIG_PATH}.bkup" || :
+  cat << EOF > "${GH_CLI_CONFIG_PATH}"
+hosts:
+    github.com:
+        oauth_token: ${GITHUB_TOKEN}
+        user: ${GITHUB_USERNAME}
+EOF
+fi
+
+function fail() {
+  echo "❌ EKS charts sync failed"
+  exit 5
+}
+
+trap fail ERR TERM INT
+
+rm -rf "${SYNC_DIR}"
+mkdir -p "${SYNC_DIR}"
+
+cd "${SYNC_DIR}"
+gh repo fork $CHARTS_REPO --clone --remote
+cd "${FORK_DIR}"
+git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${CHARTS_REPO_NAME}".git
+DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\n')
+
+
+if diff -x ".*" -r "$HELM_CHART_DIR/" "${FORK_DIR}/stable/${HELM_CHART_NAME}/" &> /dev/null ; then
+  echo " ✅  Charts already in sync; no updates needed"
+  exit
+else
+  echo "📊 Charts are NOT in sync proceeding with PR"
+fi
+
+git config user.name "eks-bot"
+git config user.email "eks-bot@users.noreply.github.com"
+
+# Sync the fork
+git pull upstream "${DEFAULT_BRANCH}"
+git push -u origin "${DEFAULT_BRANCH}"
+
+FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
+git checkout -b "${FORK_RELEASE_BRANCH}" upstream/"${DEFAULT_BRANCH}"
+
+rm -rf "${FORK_DIR}"/stable/${HELM_CHART_NAME}/
+cp -r "$HELM_CHART_DIR/" "${FORK_DIR}/stable/${HELM_CHART_NAME}/"
+
+git add --all
+git commit -m "${BINARY_BASE}: ${VERSION}"
+
+PR_BODY=$(cat << EOM
+## ${BINARY_BASE} ${VERSION} Automated Chart Sync! 🤖🤖
+EOM
+)
+
+if [[ "${INCLUDE_NOTES}" -eq 1 ]]; then
+  RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/"${REPO}"/releases | \
+    jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
+
+  RELEASE_NOTES=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+    https://api.github.com/repos/"${REPO}"/releases/"${RELEASE_ID}" | \
+    jq -r '.body')
+
+  PR_BODY=$(cat << EOM
+  ## ${BINARY_BASE} ${VERSION} Automated Chart Sync! 🤖🤖
+
+  ### Release Notes 📝:
+
+  ${RELEASE_NOTES}
+EOM
+)
+fi
+
+  git push -u origin "${FORK_RELEASE_BRANCH}"
+  gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated Release! 🥑" \
+    --body "${PR_BODY}" --repo ${CHARTS_REPO}
+
+echo "✅ EKS charts sync complete"


### PR DESCRIPTION
**What type of PR is this?**

Enhancement

**Which issue does this PR fix**
https://github.com/aws/amazon-vpc-cni-k8s/issues/1319

**What does this PR do / Why do we need it**

Added a workflow to sync aws-vpc-cni Helm chart with eks-charts repo. 

- Added a script to sync charts if there's a diff. This uses eks-bot to open a pull request on eks-charts repo that will need to be reviewed, approved and merged by the authors. In long term, we plan to deprecate the eks-charts repo and host the charts elsewhere (where? to be designed/decided)
- Added make target to sync on-demand and on release (includes release notes)
- Added GitHub Actions workflow to sync aws-vpc-cni Helm to eks-chart repo on VPC CNI release.

Same workflow as appmesh-controller. See ref: https://github.com/aws/eks-charts/pull/444

**Testing**

- Test sync from fawadkhaliq/amazon-vpc-cni-k8s to fawadkhaliq/eks-charts repo:
   - https://github.com/fawadkhaliq/eks-charts/pull/4


**Automation added to e2e**
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A


**Does this change require updates to the CNI daemonset config files to work?**:
Nope

**Does this PR introduce any user-facing change?**
Nope

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
