### PR TITLE
Use 'exec' ENTRYPOINTs

### DIFF
--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -28,4 +28,4 @@ COPY --from=builder \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni-support.sh \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/init.sh /init/
 
-ENTRYPOINT /init/init.sh
+ENTRYPOINT ["/init/init.sh"]

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -28,4 +28,4 @@ WORKDIR /app
 
 COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/cni-metrics-helper /app
 
-ENTRYPOINT /app/cni-metrics-helper --cloudwatch=false
+ENTRYPOINT ["/app/cni-metrics-helper", "--cloudwatch=false"]

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -36,4 +36,4 @@ COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/grpc-health-probe \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/entrypoint.sh /app/
 
-ENTRYPOINT /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
Switch from 'shell' to 'exec' ENTRYPOINTs.  This removes an
unnecessary intermediate shell process, and ensures that k8s
termination signals are delivered to the correct process[*].

[*] We don't need graceful shutdown, so this is mostly a best-practices cleanup and not a bugfix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
