### PR TITLE
add warm ENI/IP target integration tests

### DIFF
--- a/test/framework/resources/k8s/utils/container.go
+++ b/test/framework/resources/k8s/utils/container.go
@@ -60,6 +60,7 @@ func AddOrUpdateEnvironmentVariable(containers []v1.Container, containerName str
 // RemoveEnvironmentVariables removes the environment variable from the specified container
 func RemoveEnvironmentVariables(containers []v1.Container, containerName string,
 	envVars map[string]struct{}) error {
+	var updatedEnvVar []v1.EnvVar
 	containerIndex := -1
 	for i, container := range containers {
 		if container.Name != containerName {
@@ -67,9 +68,8 @@ func RemoveEnvironmentVariables(containers []v1.Container, containerName string,
 		}
 		containerIndex = i
 		for j := 0; j < len(container.Env); j++ {
-			if _, ok := envVars[container.Env[j].Name]; ok {
-				container.Env = append(container.Env[:j], container.Env[j+1:]...)
-				j--
+			if _, ok := envVars[container.Env[j].Name]; !ok {
+				updatedEnvVar = append(updatedEnvVar, container.Env[j])
 			}
 		}
 	}
@@ -78,6 +78,8 @@ func RemoveEnvironmentVariables(containers []v1.Container, containerName string,
 		return fmt.Errorf("failed to find cotnainer %s in list of containers",
 			containerName)
 	}
+
+	containers[containerIndex].Env = updatedEnvVar
 
 	return nil
 }

--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -17,6 +17,8 @@ import "time"
 
 const (
 	DefaultTestNamespace = "cni-automation"
+	AwsNodeNamespace     = "kube-system"
+	AwsNodeName          = "aws-node"
 )
 
 const (

--- a/test/integration-new/README.md
+++ b/test/integration-new/README.md
@@ -7,6 +7,7 @@ The integration test requires
 - At least 2 nodes in a node group.
 - Nodes in the nodegroup shouldn't have existing pods.
 - Ginkgo installed on your environment. To install `go get github.com/onsi/ginkgo/ginkgo`
+- Supports instance types having at least 3 ENIs and 16+ Secondary IPv4 Addresses across all ENIs.
 
 ####Testing
 Set the environment variables that will be passed to Ginkgo script. If you want to directly pass the arguments you can skip to next step.

--- a/test/integration-new/ipamd/ipamd_suite_test.go
+++ b/test/integration-new/ipamd/ipamd_suite_test.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var err error
+var f *framework.Framework
+var primaryNode v1.Node
+var primaryInstance *ec2.Instance
+
+func TestIPAMD(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VPC IPAMD Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	f = framework.New(framework.GlobalOptions)
+
+	By("creating test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		CreateNamespace(utils.DefaultTestNamespace)
+
+	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey,
+		f.Options.NgNameLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(nodeList.Items)).Should(BeNumerically(">", 1))
+
+	// Nominate the first node as the primary node
+	primaryNode = nodeList.Items[0]
+
+	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)
+	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("deleting test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
+})

--- a/test/integration-new/ipamd/warm_target_test.go
+++ b/test/integration-new/ipamd/warm_target_test.go
@@ -1,0 +1,190 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"strconv"
+	"time"
+
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// IMPORTANT: THE NODEGROUP TO RUN THE TEST MUST NOT HAVE ANY POD
+// Ideally we should drain the node, but drain from go client is non trivial
+// IMPORTANT: Only support nodes that can have 16+ Secondary IPV4s across at least 3 ENI
+var _ = Describe("test warm target variables", func() {
+
+	Context("when warm ENI target is used", func() {
+		var warmENITarget int
+		var maxENI int
+
+		JustBeforeEach(func() {
+			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
+				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
+				map[string]string{
+					"WARM_ENI_TARGET": strconv.Itoa(warmENITarget),
+					"MAX_ENI":         strconv.Itoa(maxENI),
+				})
+
+			// Allow for IPAMD to reconcile it's state
+			time.Sleep(utils.PollIntervalLong * 5)
+
+			primaryInstance, err = f.CloudServices.
+				EC2().DescribeInstance(*primaryInstance.InstanceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(primaryInstance.NetworkInterfaces)).
+				Should(Equal(MinIgnoreZero(warmENITarget, maxENI)))
+		})
+
+		JustAfterEach(func() {
+			k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f,
+				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
+				map[string]struct{}{"WARM_ENI_TARGET": {}, "MAX_ENI": {}})
+		})
+
+		Context("when WARM_ENI_TARGET = 2 and MAX_ENI = 1", func() {
+			BeforeEach(func() {
+				warmENITarget = 2
+				maxENI = 1
+			})
+
+			It("instance should have only 1 ENI", func() {})
+		})
+
+		Context("when WARM_ENI_TARGET = 3", func() {
+			BeforeEach(func() {
+				warmENITarget = 3
+				maxENI = 0
+			})
+
+			It("instance should have only 3 ENIs", func() {})
+		})
+
+		Context("when WARM_ENI_TARGET = 1", func() {
+			BeforeEach(func() {
+				warmENITarget = 1
+				maxENI = 0
+			})
+
+			It("instance should have only 1 ENI", func() {})
+		})
+
+	})
+
+	Context("when warm IP target is set", func() {
+		var warmIPTarget int
+		var minIPTarget int
+
+		JustBeforeEach(func() {
+			var availIPs int
+
+			// Set the WARM IP TARGET
+			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
+				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
+				map[string]string{
+					"WARM_IP_TARGET":    strconv.Itoa(warmIPTarget),
+					"MINIMUM_IP_TARGET": strconv.Itoa(minIPTarget),
+				})
+
+			// Allow for IPAMD to reconcile it's state
+			time.Sleep(utils.PollIntervalLong)
+
+			// Query the EC2 Instance to get the list of available IPs on the instance
+			primaryInstance, err = f.CloudServices.
+				EC2().DescribeInstance(*primaryInstance.InstanceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Sum all the IPs on all network interfaces minus the primary IPv4 address per ENI
+			for _, networkInterface := range primaryInstance.NetworkInterfaces {
+				availIPs += len(networkInterface.PrivateIpAddresses) - 1
+			}
+
+			// Validated avail IP equals the warm IP Size
+			Expect(availIPs).Should(Equal(Max(warmIPTarget, minIPTarget)))
+		})
+
+		JustAfterEach(func() {
+			k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f,
+				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
+				map[string]struct{}{"WARM_IP_TARGET": {}, "MINIMUM_IP_TARGET": {}})
+		})
+
+		Context("when WARM_IP_TARGET = 2", func() {
+			BeforeEach(func() {
+				warmIPTarget = 2
+				minIPTarget = 0
+			})
+
+			It("should have 2 secondary IPv4 addresses", func() {})
+		})
+
+		Context("when WARM_IP_TARGET = 16", func() {
+			BeforeEach(func() {
+				warmIPTarget = 16
+				minIPTarget = 0
+			})
+
+			It("should have 16 secondary IPv4 addresses", func() {})
+		})
+
+		Context("when MINIMUM_IP_TARGET = 2", func() {
+			BeforeEach(func() {
+				warmIPTarget = 0
+				minIPTarget = 2
+			})
+
+			It("should have 2 secondary IPv4 addresses", func() {})
+		})
+
+		Context("when MINIMUM_IP_TARGET = 16", func() {
+			BeforeEach(func() {
+				warmIPTarget = 0
+				minIPTarget = 16
+			})
+
+			It("should have 16 secondary IPv4 addresses", func() {})
+		})
+
+		Context("when MINIMUM_IP_TARGET = 6 and WARM_IP_TARGET = 10", func() {
+			BeforeEach(func() {
+				warmIPTarget = 6
+				minIPTarget = 10
+			})
+
+			It("should have 10 secondary IPv4 addresses", func() {})
+		})
+	})
+})
+
+func Max(x, y int) int {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+// MinIgnoreZero returns smaller of two number, if any number is zero returns the other number
+func MinIgnoreZero(x, y int) int {
+	if x == 0 {return y}
+	if y == 0 {return x}
+	if x < y {
+		return x
+	}
+	return y
+}


### PR DESCRIPTION

**What type of PR is this?**
Integration Tests

**Which issue does this PR fix**:
NA

**What does this PR do / Why do we need it**:
Integration test for the configurable warm target variables given below

- WARM_ENI_TARGET
- WARM_IP_TARGET
- MAX_ENI
- MINIMUM_IP_TARGET

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
```
Running Suite: VPC IPAMD Test Suite
===================================
Random Seed: 1619186249
Will run 8 of 8 specs

STEP: creating test namespace
test warm target variables when warm ENI target is used when WARM_ENI_TARGET = 2 and MAX_ENI = 1 
  instance should have only 1 ENI
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:67
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:1 WARM_ENI_TARGET:2]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:{} WARM_ENI_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:210.788 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm ENI target is used
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:32
    when WARM_ENI_TARGET = 2 and MAX_ENI = 1
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:61
      instance should have only 1 ENI
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:67
------------------------------
test warm target variables when warm ENI target is used when WARM_ENI_TARGET = 3 
  instance should have only 3 ENIs
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:76
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:0 WARM_ENI_TARGET:3]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:{} WARM_ENI_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:196.425 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm ENI target is used
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:32
    when WARM_ENI_TARGET = 3
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:70
      instance should have only 3 ENIs
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:76
------------------------------
test warm target variables when warm ENI target is used when WARM_ENI_TARGET = 1 
  instance should have only 1 ENI
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:85
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:0 WARM_ENI_TARGET:1]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MAX_ENI:{} WARM_ENI_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:202.557 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm ENI target is used
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:32
    when WARM_ENI_TARGET = 1
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:79
      instance should have only 1 ENI
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:85
------------------------------
test warm target variables when warm IP target is set when WARM_IP_TARGET = 2 
  should have 2 secondary IPv4 addresses
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:134
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:0 WARM_IP_TARGET:2]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:120.427 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm IP target is set
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:90
    when WARM_IP_TARGET = 2
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:128
      should have 2 secondary IPv4 addresses
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:134
------------------------------
test warm target variables when warm IP target is set when WARM_IP_TARGET = 16 
  should have 16 secondary IPv4 addresses
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:143
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:0 WARM_IP_TARGET:16]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:98.435 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm IP target is set
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:90
    when WARM_IP_TARGET = 16
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:137
      should have 16 secondary IPv4 addresses
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:143
------------------------------
test warm target variables when warm IP target is set when MINIMUM_IP_TARGET = 2 
  should have 2 secondary IPv4 addresses
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:152
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:2 WARM_IP_TARGET:0]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:114.891 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm IP target is set
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:90
    when MINIMUM_IP_TARGET = 2
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:146
      should have 2 secondary IPv4 addresses
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:152
------------------------------
test warm target variables when warm IP target is set when MINIMUM_IP_TARGET = 16 
  should have 16 secondary IPv4 addresses
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:161
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:16 WARM_IP_TARGET:0]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:132.466 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm IP target is set
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:90
    when MINIMUM_IP_TARGET = 16
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:155
      should have 16 secondary IPv4 addresses
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:161
------------------------------
test warm target variables when warm IP target is set when MINIMUM_IP_TARGET = 6 and WARM_IP_TARGET = 10 
  should have 10 secondary IPv4 addresses
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:170
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:10 WARM_IP_TARGET:6]
STEP: updating the daemon set with new environment variable
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: setting the environment variables on the ds to map[MINIMUM_IP_TARGET:{} WARM_IP_TARGET:{}]
STEP: updating the daemon set with new environment variable

• [SLOW TEST:123.431 seconds]
test warm target variables
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm IP target is set
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:90
    when MINIMUM_IP_TARGET = 6 and WARM_IP_TARGET = 10
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:164
      should have 10 secondary IPv4 addresses
      /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:170
------------------------------
STEP: deleting test namespace

Ran 8 of 8 Specs in 1211.873 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 20m20.331040923s
Test Suite Passed
```

**Automation added to e2e**:
NA

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
NA

**Does this change require updates to the CNI daemonset config files to work?**:
NA

**Does this PR introduce any user-facing change?**:
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.