### PR TITLE
Cherry-pick the PR #458 from eks-chart to keep them sync

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |
 | `podSecurityContext`    | Pod Security Context                                    | `{}`                                |
 | `podAnnotations`        | annotations to add to each pod                          | `{}`                                |
+| `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
 | `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
 | `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN"`  |

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -14,6 +14,9 @@ spec:
 {{- else }}
       app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 6 }}
+      {{- end }}
 {{- end }}
   template:
     metadata:
@@ -27,6 +30,9 @@ spec:
         app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         k8s-app: aws-node
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
     spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -63,6 +63,8 @@ podSecurityContext: {}
 
 podAnnotations: {}
 
+podLabels: {}
+
 securityContext:
   capabilities:
     add:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
This is a cherry-pick PR for this eks-charts [PR](https://github.com/aws/eks-charts/pull/458) 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup
**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
