### PR TITLE
Adding flags to support overriding container runtime endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ value for the Kubelet's `--max-pods` configuration option. Consider also
 updating the `MAX_ENI` and `--max-pods` configuration options on this plugin
 and the kubelet respectively if you are making use of this tag.
 
+### Container Runtime 
+
+Currently IPAMD uses dockershim socket to pull pod sandboxes information upon its starting. The runtime can be set to others.
+The mountPath should be changed to `/var/run/cri.sock` and hostPath should be pointed to the wanted socket, such as 
+`/var/run/containerd/containerd.sock` for containerd. If using helm chart, the flag `--set cri.hostPath=/var/run/containerd/containerd.sock`
+can set the paths for you.
+
+*Note*: When using other container runtime instead of dockershim, make sure also setting kubelet in instances.
+
 ### Notes
 
 `L-IPAMD`(aws-node daemonSet) running on every worker node requires access to kubernetes API server. If it can **not** reach

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.4
+version: 1.1.5
 appVersion: "v1.7.5"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -66,6 +66,8 @@ The following table lists the configurable parameters for this chart and their d
 | `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
+| `cri.enabled`           | Enable alternative container runtime                    | `false`                             |
+| `cri.hostPath`          | Required if cri.enabled is true                         | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -66,8 +66,7 @@ The following table lists the configurable parameters for this chart and their d
 | `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
-| `cri.enabled`           | Enable alternative container runtime                    | `false`                             |
-| `cri.hostPath`          | Required if cri.enabled is true                         | `nil`                               |
+| `cri.hostPath`          | Optional use alternative container runtime              | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -98,8 +98,13 @@ spec:
 {{- end }}
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
+{{- if .Values.cri.enabled }}
+          - mountPath: /var/run/cri.sock
+            name: cri
+{{- else }}
           - mountPath: /var/run/dockershim.sock
             name: dockershim
+{{- end }}
           - mountPath: /var/run/aws-node
             name: run-dir
           - mountPath: /run/xtables.lock
@@ -116,9 +121,15 @@ spec:
         configMap:
           name: {{ include "aws-vpc-cni.fullname" . }}
 {{- end }}
+{{- if .Values.cri.enabled }}
+      - name: cri
+        hostPath:
+          path: {{- toYaml .Values.cri.hostPath | nindent 18 }}
+{{- else }}
       - name: dockershim
         hostPath:
           path: /var/run/dockershim.sock
+{{- end }}
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -98,7 +98,7 @@ spec:
 {{- end }}
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
-{{- if .Values.cri.enabled }}
+{{- if .Values.cri.hostPath }}
           - mountPath: /var/run/cri.sock
             name: cri
 {{- else }}
@@ -121,7 +121,7 @@ spec:
         configMap:
           name: {{ include "aws-vpc-cni.fullname" . }}
 {{- end }}
-{{- if .Values.cri.enabled }}
+{{- if .Values.cri.hostPath }}
       - name: cri
         hostPath:
           path: {{- toYaml .Values.cri.hostPath | nindent 18 }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -161,3 +161,7 @@ eniConfig:
     #   id: subnet-789
     #   securityGroups:
     #   - sg-789
+
+cri:
+  enabled: false
+  hostPath: ""

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -163,5 +163,4 @@ eniConfig:
     #   - sg-789
 
 cri:
-  enabled: false
-  hostPath: ""
+  hostPath: # "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
We want to add a flag to let user able to override dockershim.sock with alternative runtime endpoint mounted at cri.sock.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature
**Which issue does this PR fix**:
AWS VPC CNI Helm Chart doesn't have a flag to set container runtime mounting path.

**What does this PR do / Why do we need it**:
- adding a new flag to enable the overriding
- adding a new flag to input the path of new runtime socket
- updating README accordlingly
- bump chart version to 1.1.5

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
- helm install AWS VPC CNI with new flags enabled
```
amazon-vpc-cni-k8s % helm install aws-vpc-cni --namespace kube-system charts/aws-vpc-cni --set cri.enabled=true --set cri.hostPath=/var/run/containerd/containerd.sock
NAME: aws-vpc-cni
LAST DEPLOYED: Sat Apr 24 16:28:50 2021
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-vpc-cni has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"

amazon-vpc-cni-k8s % kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
NAME             READY   STATUS    RESTARTS   AGE
aws-node-gwmcr   1/1     Running   0          9s
aws-node-m9csq   1/1     Running   0          9s

```
- verified mountPath and hostPath
```
- mountPath: /var/run/cri.sock
        name: cri
- hostPath:
    path: /var/run/containerd/containerd.sock
    type: ""
  name: cri
```
- verified IPAMD logging endpoint as cri.sock and able to pull Pod Sandbox info from containerd socket
- helm uninstalled the AWS VPC CNI
- helm install without the new flags
```
amazon-vpc-cni-k8s % helm install aws-vpc-cni --namespace kube-system charts/aws-vpc-cni
NAME: aws-vpc-cni
LAST DEPLOYED: Sat Apr 24 16:20:46 2021
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-vpc-cni has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
amazon-vpc-cni-k8s % kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
NAME             READY   STATUS    RESTARTS   AGE
aws-node-dbqr8   1/1     Running   0          12s
aws-node-rbsrm   1/1     Running   0          12s
```
- verified dockershim.sock was mounted as expected
- verified aws-node up and running and IPAMD logs endpoint as dockershim.sock and able to pull Pod Sandbox info.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
