### PR TITLE
Unnecessary logging for each CNI invocation

### DIFF
--- a/cmd/cni-metrics-helper/metrics/pod_watcher.go
+++ b/cmd/cni-metrics-helper/metrics/pod_watcher.go
@@ -43,7 +43,7 @@ func (d *defaultPodWatcher) GetCNIPods(ctx context.Context) ([]string, error) {
 	}
 
 	listOptions := client.ListOptions{
-		Namespace: metav1.NamespaceSystem,
+		Namespace:     metav1.NamespaceSystem,
 		LabelSelector: labelSelector,
 	}
 

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -332,7 +332,6 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 func main() {
 	log := logger.DefaultLogger()
-	log.Debugf("CNI Plugin version: %s ...", version)
 	about := fmt.Sprintf("AWS CNI %s", version)
 	exitCode := 0
 	if e := skel.PluginMainWithError(cmdAdd, nil, cmdDel, cniSpecVersion.All, about); e != nil {

--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -17,8 +17,9 @@ package eniconfig
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -2,6 +2,7 @@ package k8sapi
 
 import (
 	"fmt"
+
 	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1342 

**What does this PR do / Why do we need it**:
This log is printed each time CNI is invoked. Each node will produce lot of these logs if cloudwatch or any other logging service is used.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
