### PR TITLE
Updated agent version

### DIFF
--- a/test/agent/README.md
+++ b/test/agent/README.md
@@ -30,8 +30,8 @@ One way to run the traffic test is as follows
 Networking testing binary must be invoked on a pod that runs in Host Networking mode. It is capable of testing the Pod networking is setup correctly and once the Pod has been deleted the networking has been teared down correctly by the CNI Plugin.
 
 ### Using the local changes to Agent inside ginkgo 
-Ginkgo tests take dependency on the Agent module for supplying PodValidationInput as of now.
-If you are making changes to the PodValidationValidationInput then gingko must use local copy of agent with your modifications instead of downloading the upstream module to reflect those changes.
+Ginkgo tests take dependency on the Agent module for supplying PodNetworkingValidationInput as of now.
+If you are making changes to the PodNetworkingValidationInput then gingko must use local copy of agent with your modifications instead of downloading the upstream module to reflect those changes.
 You can modify the go.mod file located inside test folder as below to enable ginkgo to use local copy of the agent
 ```
 replace github.com/aws/amazon-vpc-cni-k8s/test/agent => <absolute local path>/amazon-vpc-cni-k8s/test/agent>

--- a/test/agent/README.md
+++ b/test/agent/README.md
@@ -29,6 +29,14 @@ One way to run the traffic test is as follows
 #### Networking Testing
 Networking testing binary must be invoked on a pod that runs in Host Networking mode. It is capable of testing the Pod networking is setup correctly and once the Pod has been deleted the networking has been teared down correctly by the CNI Plugin.
 
+### Using the local changes to Agent inside ginkgo 
+Ginkgo tests take dependency on the Agent module for supplying PodValidationInput as of now.
+If you are making changes to the PodValidationValidationInput then gingko must use local copy of agent with your modifications instead of downloading the upstream module to reflect those changes.
+You can modify the go.mod file located inside test folder as below to enable ginkgo to use local copy of the agent
+```
+replace github.com/aws/amazon-vpc-cni-k8s/test/agent => <absolute local path>/amazon-vpc-cni-k8s/test/agent>
+```
+
 ### How to test the Agent locally
 Apart from running the tests on your local environment. For some test cases where we want to run test on Pod (for instance Pod networking tests) we can copy over the binary to the Pod and execute it. For e2e testing, we can push docker image to ECR and use the image in automation test suite.
 
@@ -64,6 +72,19 @@ Change the agent image in the Go code and run the test case as usual.
 
 #### Finalizing the changes
 - Submit PR with the change to Agent.
+- Once the PR is merged get the commit hash and generate a new version for the agent changes 
+```
+go get -d github.com/aws/amazon-vpc-cni-k8s/test/agent@<commit_hash>
+```
+Sample Output
+```
+go: github.com/aws/amazon-vpc-cni-k8s/test/agent 4d1931b480a23d2c6cb0eee8adef5bd3b2fbefac => v0.0.0-20210519174950-4d1931b480a2
+go: downloading github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
+```
+- Update the version in the go.mod file under test folder
+```
+github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
+```
 - One of the AWS Maintainer will push the image to ECR (Till we have pipeline that does this for us)
 - Use the updated image tag wherever you want to update the docker image in automation tests.
 

--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -22,7 +22,7 @@ const (
 	AWSInitContainerName = "aws-vpc-cni-init"
 
 	// See https://gallery.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper
-	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:07ac7548"
+	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:143009a3"
 )
 
 const (

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/apparentlymart/go-cidr v1.0.1
 	github.com/aws/amazon-vpc-cni-k8s v1.7.10
-	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210504235351-07ac754880d8
+	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
 	github.com/aws/amazon-vpc-resource-controller-k8s v1.0.7
 	github.com/aws/aws-sdk-go v1.37.23
 	github.com/onsi/ginkgo v1.12.1


### PR DESCRIPTION
Updated Readme for agent update instructions

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
N/A

2. Ensure you have included output of manual testing done in the Testing section.
```
go get -d github.com/aws/amazon-vpc-cni-k8s/test/agent@4d1931b480a23d2c6cb0eee8adef5bd3b2fbefac    
go: github.com/aws/amazon-vpc-cni-k8s/test/agent 4d1931b480a23d2c6cb0eee8adef5bd3b2fbefac => v0.0.0-20210519174950-4d1931b480a2
go: downloading github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
```

3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Updating agent version which is an internal module used by ginkgo 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Agent related errors while running ginkgo test

**What does this PR do / Why do we need it**:
PodNetworkingValidationInput in agent package was modified but the ginkgo was still using the older agent version

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
