### PR TITLE
Use symmetric return path for non-VPC traffic - alternate solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Type: String
 
 Default: `eni`
 
-Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long.
+Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long. The prefixes `eth` or `vlan` or `lo` are reserved and cannot be specified. We recommend using exclusive prefix for the host side veth device names.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Type: String
 
 Default: `eni`
 
-Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long. The prefixes `eth` or `vlan` or `lo` are reserved and cannot be specified. We recommend using exclusive prefix for the host side veth device names.
+Specifies the veth prefix used to generate the host-side veth device name for the CNI. The prefix can be at most 4 characters long. The prefixes `eth`, `vlan` and `lo` are reserved by the CNI plugin and cannot be specified. We recommend using prefix name not shared by any other network interfaces on the worker node instance.
 
 ---
 

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -217,40 +217,13 @@ func setupNS(hostVethName string, contVethName string, netnsPath string, addr *n
 	if deviceNumber > 0 {
 		// To be backwards compatible, we will have to keep this off-by one setting
 		tableNumber := deviceNumber + 1
-		if useExternalSNAT {
-			// add rule: 1536: from <podIP> use table <table>
-			err = addContainerRule(netLink, false, addr, tableNumber)
-			if err != nil {
-				log.Errorf("Failed to add fromContainer rule for %s err: %v", addr.String(), err)
-				return errors.Wrap(err, "add NS network: failed to add fromContainer rule")
-			}
-			log.Infof("Added rule priority %d from %s table %d", fromContainerRulePriority, addr.String(), tableNumber)
-		} else {
-			// add rule: 1536: list of from <podIP> to <vpcCIDR> use table <table>
-			for _, cidr := range vpcCIDRs {
-				podRule := netLink.NewRule()
-				_, podRule.Dst, _ = net.ParseCIDR(cidr)
-				podRule.Src = addr
-				podRule.Table = tableNumber
-				podRule.Priority = fromContainerRulePriority
-
-				err = netLink.RuleAdd(podRule)
-				if isRuleExistsError(err) {
-					log.Warnf("Rule already exists [%v]", podRule)
-				} else {
-					if err != nil {
-						log.Errorf("Failed to add pod IP rule [%v]: %v", podRule, err)
-						return errors.Wrapf(err, "setupNS: failed to add pod rule [%v]", podRule)
-					}
-				}
-				var toDst string
-
-				if podRule.Dst != nil {
-					toDst = podRule.Dst.String()
-				}
-				log.Infof("Successfully added pod rule[%v] to %s", podRule, toDst)
-			}
+		// add rule: 1536: from <podIP> use table <table>
+		err = addContainerRule(netLink, false, addr, tableNumber)
+		if err != nil {
+			log.Errorf("Failed to add fromContainer rule for %s err: %v", addr.String(), err)
+			return errors.Wrap(err, "add NS network: failed to add fromContainer rule")
 		}
+		log.Infof("Added rule priority %d from %s table %d", fromContainerRulePriority, addr.String(), tableNumber)
 	}
 	return nil
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -152,8 +152,7 @@ func TestNodeInit(t *testing.T) {
 	var rules []netlink.Rule
 	m.network.EXPECT().GetRuleList().Return(rules, nil)
 
-	m.network.EXPECT().UseExternalSNAT().Return(false)
-	m.network.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any(), gomock.Any(), true)
+	m.network.EXPECT().UpdateRuleListBySrc(gomock.Any(), gomock.Any())
 
 	fakeNode := v1.Node{
 		TypeMeta:   metav1.TypeMeta{Kind: "Node"},

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -151,18 +151,32 @@ func (mr *MockNetworkAPIsMockRecorder) SetupHostNetwork(arg0, arg1, arg2, arg3 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHostNetwork", reflect.TypeOf((*MockNetworkAPIs)(nil).SetupHostNetwork), arg0, arg1, arg2, arg3)
 }
 
-// UpdateRuleListBySrc mocks base method
-func (m *MockNetworkAPIs) UpdateRuleListBySrc(arg0 []netlink.Rule, arg1 net.IPNet, arg2 []string, arg3 bool) error {
+// UpdateHostIptablesRules mocks base method
+func (m *MockNetworkAPIs) UpdateHostIptablesRules(arg0 []string, arg1 string, arg2 *net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRuleListBySrc", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdateHostIptablesRules", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateHostIptablesRules indicates an expected call of UpdateHostIptablesRules
+func (mr *MockNetworkAPIsMockRecorder) UpdateHostIptablesRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostIptablesRules", reflect.TypeOf((*MockNetworkAPIs)(nil).UpdateHostIptablesRules), arg0, arg1, arg2)
+}
+
+// UpdateRuleListBySrc mocks base method
+func (m *MockNetworkAPIs) UpdateRuleListBySrc(arg0 []netlink.Rule, arg1 net.IPNet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRuleListBySrc", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateRuleListBySrc indicates an expected call of UpdateRuleListBySrc
-func (mr *MockNetworkAPIsMockRecorder) UpdateRuleListBySrc(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockNetworkAPIsMockRecorder) UpdateRuleListBySrc(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuleListBySrc", reflect.TypeOf((*MockNetworkAPIs)(nil).UpdateRuleListBySrc), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuleListBySrc", reflect.TypeOf((*MockNetworkAPIs)(nil).UpdateRuleListBySrc), arg0, arg1)
 }
 
 // UseExternalSNAT mocks base method

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -45,7 +45,8 @@ const (
 	testeniSubnet = "10.10.0.0/16"
 	// Default MTU of ENI and veth
 	// defined in plugins/routed-eni/driver/driver.go, pkg/networkutils/network.go
-	testMTU = 9001
+	testMTU   = 9001
+	eniPrefix = "eni"
 )
 
 var (
@@ -262,6 +263,7 @@ func TestSetupHostNetworkNodePortEnabled(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -336,6 +338,7 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -392,6 +395,7 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -452,6 +456,78 @@ func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 		}, mockIptables.dataplaneState)
 }
 
+func TestSetupHostNetworkWithDifferentVethPrefix(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:         false,
+		excludeSNATCIDRs:        []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled:  true,
+		shouldConfigureRpFilter: true,
+		mainENIMark:             defaultConnmark,
+		mtu:                     testMTU,
+		vethPrefix:              "veth",
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func() (iptablesIface, error) {
+			return mockIptables, nil
+		},
+		procSys: mockProcSys,
+	}
+
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	mockProcSys.EXPECT().Set("net/ipv4/conf/lo/rp_filter", "2").Return(nil)
+
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAN", "-j", "AWS-SNAT-CHAIN-1") //AWS SNAT CHAN proves backwards compatibility
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-4")
+	_ = mockIptables.Append("nat", "AWS-SNAT-CHAIN-4", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20")
+	_ = mockIptables.NewChain("nat", "AWS-SNAT-CHAIN-5")
+	_ = mockIptables.Append("nat", "POSTROUTING", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0")
+	_ = mockIptables.Append("nat", "AWS-CONNMARK-CHAIN-0", "!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-1")
+	_ = mockIptables.Append("nat", "AWS-CONNMARK-CHAIN-1", "!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-2")
+	_ = mockIptables.Append("nat", "AWS-CONNMARK-CHAIN-2", "!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, EXCLUDED CIDR", "-j", "AWS-CONNMARK-CHAIN-3")
+	_ = mockIptables.Append("nat", "AWS-CONNMARK-CHAIN-3", "!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, EXCLUDED CIDR", "-j", "AWS-CONNMARK-CHAIN-4")
+	_ = mockIptables.Append("nat", "AWS-CONNMARK-CHAIN-4", "-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--set-xmark", "0x80/0x80")
+	_ = mockIptables.Append("nat", "PREROUTING", "-i", "eni+", "-m", "comment", "--comment", "AWS, outbound connections", "-m", "state", "--state", "NEW", "-j", "AWS-CONNMARK-CHAIN-0")
+	_ = mockIptables.Append("nat", "PREROUTING", "-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80")
+
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16"}
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		map[string]map[string][][]string{
+			"nat": {
+				"AWS-SNAT-CHAIN-0":     [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1":     [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2":     [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-3"}},
+				"AWS-SNAT-CHAIN-3":     [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN EXCLUSION", "-j", "AWS-SNAT-CHAIN-4"}},
+				"AWS-SNAT-CHAIN-4":     [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"POSTROUTING":          [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}},
+				"AWS-CONNMARK-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-1"}},
+				"AWS-CONNMARK-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-2"}},
+				"AWS-CONNMARK-CHAIN-2": [][]string{{"!", "-d", "10.12.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, EXCLUDED CIDR", "-j", "AWS-CONNMARK-CHAIN-3"}},
+				"AWS-CONNMARK-CHAIN-3": [][]string{{"!", "-d", "10.13.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, EXCLUDED CIDR", "-j", "AWS-CONNMARK-CHAIN-4"}},
+				"AWS-CONNMARK-CHAIN-4": [][]string{{"-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--set-xmark", "0x80/0x80"}},
+				"PREROUTING": [][]string{
+					{"-i", "eni+", "-m", "comment", "--comment", "AWS, outbound connections", "-m", "state", "--state", "NEW", "-j", "AWS-CONNMARK-CHAIN-0"},
+					{"-i", "veth+", "-m", "comment", "--comment", "AWS, outbound connections", "-m", "state", "--state", "NEW", "-j", "AWS-CONNMARK-CHAIN-0"},
+					{"-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+			"mangle": {
+				"PREROUTING": [][]string{
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "veth+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+		}, mockIptables.dataplaneState)
+}
 func TestSetupHostNetworkExternalNATCleanupConnmark(t *testing.T) {
 	ctrl, mockNetLink, _, mockNS, mockIptables, mockProcSys := setup(t)
 	defer ctrl.Finish()
@@ -463,6 +539,7 @@ func TestSetupHostNetworkExternalNATCleanupConnmark(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -530,6 +607,7 @@ func TestSetupHostNetworkExcludedSNATCIDRsIdempotent(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -600,6 +678,7 @@ func TestSetupHostNetworkMultipleCIDRs(t *testing.T) {
 		shouldConfigureRpFilter: true,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -653,6 +732,7 @@ func TestSetupHostNetworkIgnoringRpFilterUpdate(t *testing.T) {
 		shouldConfigureRpFilter: false,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,
@@ -678,6 +758,7 @@ func TestSetupHostNetworkUpdateLocalRule(t *testing.T) {
 		shouldConfigureRpFilter: false,
 		mainENIMark:             defaultConnmark,
 		mtu:                     testMTU,
+		vethPrefix:              eniPrefix,
 
 		netLink: mockNetLink,
 		ns:      mockNS,

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -42,6 +42,18 @@ validate_env_var()
         log_in_json error "AWS_VPC_K8S_PLUGIN_LOG_FILE cannot be set to stdout"
         exit 1     
     fi 
+
+    if [[ ${#AWS_VPC_K8S_CNI_VETHPREFIX} -gt 4 ]]; then
+        log_in_json error "AWS_VPC_K8S_CNI_VETHPREFIX cannot be longer than 4 characters"
+        exit 1
+    fi
+
+    case ${AWS_VPC_K8S_CNI_VETHPREFIX} in
+        eth|vlan|lo)
+          log_in_json error "AWS_VPC_K8S_CNI_VETHPREFIX cannot be set to reserved values eth or vlan or lo"
+          exit 1
+          ;;
+    esac
 }
 
 # Check for all the required binaries before we go forward

--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -22,7 +22,7 @@ const (
 	AWSInitContainerName = "aws-vpc-cni-init"
 
 	// See https://gallery.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper
-	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:143009a3"
+	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:66180f40"
 )
 
 const (

--- a/test/integration-new/cni/host_networking_test.go
+++ b/test/integration-new/cni/host_networking_test.go
@@ -105,12 +105,6 @@ var _ = Describe("test host networking", func() {
 				Build()
 
 			By("Configuring Veth Prefix and MTU value on aws-node daemonset")
-			ds, err := f.K8sResourceManagers.DaemonSetManager().GetDaemonSet(utils.AwsNodeNamespace, utils.AwsNodeName)
-			Expect(err).NotTo(HaveOccurred())
-
-			oldMTU := utils.GetEnvValueForKeyFromDaemonSet(AWS_VPC_ENI_MTU, ds)
-			oldVethPrefix := utils.GetEnvValueForKeyFromDaemonSet(AWS_VPC_K8S_CNI_VETHPREFIX, ds)
-
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
 				AWS_VPC_ENI_MTU:            strconv.Itoa(NEW_MTU_VAL),
 				AWS_VPC_K8S_CNI_VETHPREFIX: NEW_VETH_PREFIX,
@@ -135,13 +129,6 @@ var _ = Describe("test host networking", func() {
 
 			By("validating host networking setup is setup correctly with MTU check as well")
 			ValidateHostNetworking(NetworkingSetupSucceeds, input)
-
-			// Restore MTU and Veth Prefix
-			By("Restoring MTU value and Veth Prefix to old values")
-			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
-				AWS_VPC_ENI_MTU:            oldMTU,
-				AWS_VPC_K8S_CNI_VETHPREFIX: oldVethPrefix,
-			})
 
 			By("deleting the deployment to test teardown")
 			err = f.K8sResourceManagers.DeploymentManager().
@@ -244,7 +231,6 @@ func ValidateHostNetworking(testType TestType, podValidationInputString string) 
 	By("creating pod to test host networking setup")
 	testPod, err := f.K8sResourceManagers.PodManager().
 		CreateAndWaitTillPodCompleted(testPod)
-
 	logs, errLogs := f.K8sResourceManagers.PodManager().
 		PodLogs(testPod.Namespace, testPod.Name)
 	Expect(errLogs).ToNot(HaveOccurred())

--- a/test/integration-new/cni/host_networking_test.go
+++ b/test/integration-new/cni/host_networking_test.go
@@ -45,6 +45,8 @@ const (
 	AWS_VPC_K8S_CNI_VETHPREFIX = "AWS_VPC_K8S_CNI_VETHPREFIX"
 	NEW_MTU_VAL                = 1300
 	NEW_VETH_PREFIX            = "veth"
+	DEFAULT_MTU_VAL            = "9001"
+	DEFAULT_VETH_PREFIX        = "eni"
 )
 
 var _ = Describe("test host networking", func() {
@@ -53,6 +55,12 @@ var _ = Describe("test host networking", func() {
 	var podLabelVal = "host-networking-test"
 
 	Context("when pods using IP from primary and secondary ENI are created", func() {
+		AfterEach(func() {
+			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+				AWS_VPC_ENI_MTU:            DEFAULT_MTU_VAL,
+				AWS_VPC_K8S_CNI_VETHPREFIX: DEFAULT_VETH_PREFIX,
+			})
+		})
 		It("should have correct host networking setup when running and cleaned up once terminated", func() {
 			// Launch enough pods so some pods end up using primary ENI IP and some using secondary
 			// ENI IP

--- a/test/integration-new/cni/pod_networking_suite_test.go
+++ b/test/integration-new/cni/pod_networking_suite_test.go
@@ -95,6 +95,13 @@ var _ = AfterSuite(func() {
 	f.K8sResourceManagers.NamespaceManager().
 		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 
-	k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",
-		"aws-node", map[string]struct{}{"WARM_IP_TARGET": {}, "WARM_ENI_TARGET": {}})
+	k8sUtils.UpdateEnvVarOnDaemonSetAndWaitUntilReady(f, "aws-node", "kube-system",
+		"aws-node", map[string]string{
+			AWS_VPC_ENI_MTU:            "9001",
+			AWS_VPC_K8S_CNI_VETHPREFIX: "eni",
+		},
+		map[string]struct{}{
+			"WARM_IP_TARGET":  {},
+			"WARM_ENI_TARGET": {},
+		})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->


**Which issue does this PR fix**:
Fixes #1392, #1423

**What does this PR do / Why do we need it**:
When external SNAT is disabled, this PR does the following
- setup iptables rules to mark egress traffic from pods that are destined to external network
- external traffic will be sent through the primary interface

This is an alternate fix. It doesn't require permissive rp filter configuration on the secondary ENIs, or a new connmark. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
- When external SNAT is enabled, the iptables conmark rules added to the nat table get cleaned up
- With External SNAT disabled
   - connmark rules get added to the nat table
   - pods are able to initiate connections to hosts outside the VPC, traffic is through the primary interface
   - in case of NLB-IP, verify traffic flows as expected for client IP preservation enabled/disabled, pods on primary/secondary interfaces
   - UDP traffic works fine
   - instance mode NLB works as expected - verified externalTrafficPolicy Cluster, Local, IP preservation enabled/disabled, pods on primary/secondary interfaces
   - in-cluster traffic works as expected
   - enabled security group per pod, verified pods can communicate within the cluster, pods can receive client IP preserved traffic from the NLB

- With External SNAT enabled
    - connmark and SNAT rules get removed from the nat table
    - instance mode NLB works fine with IP preserve enabled/disabled, pods on primary/secondary interfaces
    - IP mode NLB works as expected with IP preserve enabled/disabled, pods on primary/secondary interfaces
    - pod can communicate to hosts within or outside VPC
    - enabled security group per pod, verified traffic flows

- New integration tests pass after some modification 

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No impact on upgrade/downgrade. On, downgrade conn mark rules in the nat table remain until node is rebooted, but there is no impact on the functionality.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Fixes the issue with non-VPC traffic ingress from secondary ENIs when external SNAT feature is not used.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
