### PR TITLE
refine ENI tagging logic

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -304,112 +303,6 @@ func TestDescribeAllENIs(t *testing.T) {
 	}
 }
 
-func TestTagEni(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-	mockMetadata := testMetadata(nil)
-
-	ins := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2}
-
-	err := ins.initWithEC2Metadata(ctx)
-	assert.NoError(t, err)
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tagging failed"))
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-
-	ins.tagENI(eniID, time.Millisecond)
-	assert.NoError(t, err)
-}
-
-func TestClusterNameTag(t *testing.T) {
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-	_ = os.Setenv(clusterNameEnvVar, "cni-test")
-	tagKey1 := eniClusterTagKey
-	tagValue1 := "cni-test"
-	additionalEniTags := ec2.Tag{
-		Key:   &tagKey1,
-		Value: &tagValue1,
-	}
-	tags := []*ec2.Tag{
-		{
-			Key:   aws.String(eniNodeTagKey),
-			Value: aws.String(instanceID),
-		},
-	}
-	tags = append(tags, &additionalEniTags)
-	input := &ec2.CreateTagsInput{
-		Resources: []*string{
-			aws.String(eniID),
-		},
-		Tags: tags,
-	}
-
-	ins := &EC2InstanceMetadataCache{instanceID: instanceID, ec2SVC: mockEC2}
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), input, gomock.Any()).Return(nil, nil)
-	ins.tagENI(eniID, time.Millisecond)
-	_ = os.Unsetenv(clusterNameEnvVar)
-}
-
-func TestAdditionalTagsEni(t *testing.T) {
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-	_ = os.Setenv(additionalEniTagsEnvVar, `{"testKey": "testing"}`)
-	tagKey1 := "testKey"
-	tagValue1 := "testing"
-	additionalEniTags := ec2.Tag{
-		Key:   &tagKey1,
-		Value: &tagValue1,
-	}
-	tags := []*ec2.Tag{
-		{
-			Key:   aws.String(eniNodeTagKey),
-			Value: aws.String(instanceID),
-		},
-	}
-	tags = append(tags, &additionalEniTags)
-	input := &ec2.CreateTagsInput{
-		Resources: []*string{
-			aws.String(eniID),
-		},
-		Tags: tags,
-	}
-
-	ins := &EC2InstanceMetadataCache{instanceID: instanceID, ec2SVC: mockEC2}
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), input, gomock.Any()).Return(nil, nil)
-	ins.tagENI(eniID, time.Millisecond)
-	os.Unsetenv(additionalEniTagsEnvVar)
-}
-
-func TestMapToTags(t *testing.T) {
-	tagKey1 := "tagKey1"
-	tagKey2 := "tagKey2"
-	tagValue1 := "tagValue1"
-	tagValue2 := "tagValue2"
-	tagKey3 := "cluster.k8s.amazonaws.com/name"
-	tagValue3 := "clusterName"
-	tagsMap := map[string]string{
-		tagKey1: tagValue1,
-		tagKey2: tagValue2,
-		tagKey3: tagValue3,
-	}
-	tags := make([]*ec2.Tag, 0)
-	tags = mapToTags(tagsMap, tags)
-	assert.Equal(t, 2, len(tags))
-	sort.Slice(tags, func(i, j int) bool {
-		return aws.StringValue(tags[i].Key) < aws.StringValue(tags[j].Key)
-	})
-
-	assert.Equal(t, aws.StringValue(tags[0].Key), tagKey1)
-	assert.Equal(t, aws.StringValue(tags[0].Value), tagValue1)
-	assert.Equal(t, aws.StringValue(tags[1].Key), tagKey2)
-	assert.Equal(t, aws.StringValue(tags[1].Value), tagValue2)
-}
-
 func TestAllocENI(t *testing.T) {
 	ctrl, mockEC2 := setup(t)
 	defer ctrl.Finish()
@@ -438,7 +331,6 @@ func TestAllocENI(t *testing.T) {
 	attachResult := &ec2.AttachNetworkInterfaceOutput{
 		AttachmentId: &attachmentID}
 	mockEC2.EXPECT().AttachNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
-	mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	ins := &EC2InstanceMetadataCache{
@@ -683,66 +575,6 @@ func TestAllocIPAddressesAlreadyFull(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestEC2InstanceMetadataCache_getFilteredListOfNetworkInterfaces_OneResult(t *testing.T) {
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-
-	attachmentID := eniAttachID
-	description := eniDescriptionPrefix + "test"
-	status := "available"
-
-	tag := []*ec2.Tag{
-		{
-			Key:   aws.String(eniNodeTagKey),
-			Value: aws.String("test"),
-		},
-	}
-
-	timein := time.Now().Local().Add(time.Minute * time.Duration(-10))
-
-	tag = append(tag, &ec2.Tag{
-		Key:   aws.String(eniCreatedAtTagKey),
-		Value: aws.String(timein.Format(time.RFC3339)),
-	})
-	attachment := &ec2.NetworkInterfaceAttachment{AttachmentId: &attachmentID}
-	cureniID := eniID
-
-	interfaces := []*ec2.NetworkInterface{{Attachment: attachment, Status: &status, TagSet: tag, Description: &description, NetworkInterfaceId: &cureniID}}
-	setupDescribeNetworkInterfacesPagesWithContextMock(t, mockEC2, interfaces, nil, 1)
-	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	got, err := ins.getFilteredListOfNetworkInterfaces()
-	assert.NotNil(t, got)
-	assert.NoError(t, err)
-}
-
-func TestEC2InstanceMetadataCache_getFilteredListOfNetworkInterfaces_NoResult(t *testing.T) {
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-
-	setupDescribeNetworkInterfacesPagesWithContextMock(t, mockEC2, []*ec2.NetworkInterface{}, nil, 1)
-	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	got, err := ins.getFilteredListOfNetworkInterfaces()
-	assert.Nil(t, got)
-	assert.NoError(t, err)
-}
-
-func TestEC2InstanceMetadataCache_getFilteredListOfNetworkInterfaces_Error(t *testing.T) {
-	ctrl, mockEC2 := setup(t)
-	defer ctrl.Finish()
-
-	interfaces := []*ec2.NetworkInterface{{
-		TagSet: []*ec2.Tag{
-			{Key: aws.String("foo"), Value: aws.String("foo-value")},
-		},
-	}}
-	setupDescribeNetworkInterfacesPagesWithContextMock(t, mockEC2, interfaces, errors.New("dummy error"), 1)
-
-	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
-	got, err := ins.getFilteredListOfNetworkInterfaces()
-	assert.Nil(t, got)
-	assert.Error(t, err)
-}
-
 func Test_badENIID(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -879,4 +711,826 @@ func setupDescribeNetworkInterfacesPagesWithContextMock(
 			}, true))
 			return err
 		})
+}
+
+func TestEC2InstanceMetadataCache_buildENITags(t *testing.T) {
+	type fields struct {
+		instanceID        string
+		clusterName       string
+		additionalENITags map[string]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[string]string
+	}{
+		{
+			name: "without clusterName or additionalENITags",
+			fields: fields{
+				instanceID: "i-xxxxx",
+			},
+			want: map[string]string{
+				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
+			},
+		},
+		{
+			name: "with clusterName",
+			fields: fields{
+				instanceID:  "i-xxxxx",
+				clusterName: "awesome-cluster",
+			},
+			want: map[string]string{
+				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
+				"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
+			},
+		},
+		{
+			name: "with additional ENI tags",
+			fields: fields{
+				instanceID: "i-xxxxx",
+				additionalENITags: map[string]string{
+					"tagKey-1": "tagVal-1",
+					"tagKey-2": "tagVal-2",
+				},
+			},
+			want: map[string]string{
+				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
+				"tagKey-1":                           "tagVal-1",
+				"tagKey-2":                           "tagVal-2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &EC2InstanceMetadataCache{
+				instanceID:        tt.fields.instanceID,
+				clusterName:       tt.fields.clusterName,
+				additionalENITags: tt.fields.additionalENITags,
+			}
+			got := cache.buildENITags()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
+	tenMinuteAgo := time.Now().Local().Add(time.Minute * time.Duration(-10))
+	now := time.Now().Local()
+	type describeNetworkInterfacePagesCall struct {
+		input       *ec2.DescribeNetworkInterfacesInput
+		outputPages []*ec2.DescribeNetworkInterfacesOutput
+		err         error
+	}
+	type fields struct {
+		clusterName                        string
+		describeNetworkInterfacePagesCalls []describeNetworkInterfacePagesCall
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []*ec2.NetworkInterface
+		wantErr error
+	}{
+		{
+			name: "without clusterName - no leaked ENIs",
+			fields: fields{
+				clusterName: "",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: nil,
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "without clusterName - one ENI leaked",
+			fields: fields{
+				clusterName: "",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("aws-K8S-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*ec2.NetworkInterface{
+				{
+					NetworkInterfaceId: aws.String("eni-1"),
+					Description:        aws.String("aws-K8S-i-xxxxx"),
+					Status:             aws.String("available"),
+					TagSet: []*ec2.Tag{
+						{
+							Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+							Value: aws.String("i-xxxxx"),
+						},
+						{
+							Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+							Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "without clusterName - one ENI - description didn't match",
+			fields: fields{
+				clusterName: "",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("non-k8s-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "without clusterName - one ENI - creationTime within deletion coolDown",
+			fields: fields{
+				clusterName: "",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("aws-K8S-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(now.Format(time.RFC3339)),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "without clusterName - no leaked ENIs",
+			fields: fields{
+				clusterName: "",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: nil,
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "with clusterName - one ENI leaked",
+			fields: fields{
+				clusterName: "awesome-cluster",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
+									Values: []*string{aws.String("awesome-cluster")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("aws-K8S-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+											},
+											{
+												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Value: aws.String("awesome-cluster"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*ec2.NetworkInterface{
+				{
+					NetworkInterfaceId: aws.String("eni-1"),
+					Description:        aws.String("aws-K8S-i-xxxxx"),
+					Status:             aws.String("available"),
+					TagSet: []*ec2.Tag{
+						{
+							Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+							Value: aws.String("i-xxxxx"),
+						},
+						{
+							Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+							Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+						},
+						{
+							Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+							Value: aws.String("awesome-cluster"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with clusterName - one ENI - description didn't match",
+			fields: fields{
+				clusterName: "awesome-cluster",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
+									Values: []*string{aws.String("awesome-cluster")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("non-k8s-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
+											},
+											{
+												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Value: aws.String("awesome-cluster"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "with clusterName - one ENI - creationTime within deletion coolDown",
+			fields: fields{
+				clusterName: "awesome-cluster",
+				describeNetworkInterfacePagesCalls: []describeNetworkInterfacePagesCall{
+					{
+						input: &ec2.DescribeNetworkInterfacesInput{
+							Filters: []*ec2.Filter{
+								{
+									Name:   aws.String("tag-key"),
+									Values: []*string{aws.String("node.k8s.amazonaws.com/instance_id")},
+								},
+								{
+									Name:   aws.String("status"),
+									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
+									Values: []*string{aws.String("awesome-cluster")},
+								},
+							},
+							MaxResults: aws.Int64(1000),
+						},
+						outputPages: []*ec2.DescribeNetworkInterfacesOutput{
+							{
+								NetworkInterfaces: []*ec2.NetworkInterface{
+									{
+										NetworkInterfaceId: aws.String("eni-1"),
+										Description:        aws.String("aws-K8S-i-xxxxx"),
+										Status:             aws.String("available"),
+										TagSet: []*ec2.Tag{
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Value: aws.String("i-xxxxx"),
+											},
+											{
+												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Value: aws.String(now.Format(time.RFC3339)),
+											},
+											{
+												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Value: aws.String("awesome-cluster"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, mockEC2 := setup(t)
+			defer ctrl.Finish()
+
+			for _, call := range tt.fields.describeNetworkInterfacePagesCalls {
+				mockEC2.EXPECT().
+					DescribeNetworkInterfacesPagesWithContext(gomock.Any(), call.input, gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ *ec2.DescribeNetworkInterfacesInput,
+						fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+						if call.err != nil {
+							return call.err
+						}
+						for _, output := range call.outputPages {
+							fn(output, true)
+						}
+						return nil
+					})
+			}
+			ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2, clusterName: tt.fields.clusterName}
+			got, err := ins.getLeakedENIs()
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
+	type createTagsCall struct {
+		input *ec2.CreateTagsInput
+		err   error
+	}
+	type fields struct {
+		instanceID        string
+		clusterName       string
+		additionalENITags map[string]string
+
+		createTagsCalls []createTagsCall
+	}
+	type args struct {
+		eniID       string
+		currentTags map[string]string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+	}{
+		{
+			name: "eni currently have no tags",
+			fields: fields{
+				instanceID:  "i-xxxx",
+				clusterName: "awesome-cluster",
+				createTagsCalls: []createTagsCall{
+					{
+						input: &ec2.CreateTagsInput{
+							Resources: []*string{aws.String("eni-xxxx")},
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Value: aws.String("awesome-cluster"),
+								},
+								{
+									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+									Value: aws.String("i-xxxx"),
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				eniID:       "eni-xxxx",
+				currentTags: nil,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "eni currently have all desired tags",
+			fields: fields{
+				instanceID:      "i-xxxx",
+				clusterName:     "awesome-cluster",
+				createTagsCalls: nil,
+			},
+			args: args{
+				eniID: "eni-xxxx",
+				currentTags: map[string]string{
+					"node.k8s.amazonaws.com/instance_id": "i-xxxx",
+					"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "eni currently have partial tags",
+			fields: fields{
+				instanceID:  "i-xxxx",
+				clusterName: "awesome-cluster",
+				createTagsCalls: []createTagsCall{
+					{
+						input: &ec2.CreateTagsInput{
+							Resources: []*string{aws.String("eni-xxxx")},
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Value: aws.String("awesome-cluster"),
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				eniID: "eni-xxxx",
+				currentTags: map[string]string{
+					"node.k8s.amazonaws.com/instance_id": "i-xxxx",
+					"anotherKey":                         "anotherDay",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "create tags fails",
+			fields: fields{
+				instanceID:  "i-xxxx",
+				clusterName: "awesome-cluster",
+				createTagsCalls: []createTagsCall{
+					{
+						input: &ec2.CreateTagsInput{
+							Resources: []*string{aws.String("eni-xxxx")},
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Value: aws.String("awesome-cluster"),
+								},
+								{
+									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+									Value: aws.String("i-xxxx"),
+								},
+							},
+						},
+						err: errors.New("permission denied"),
+					},
+				},
+			},
+			args: args{
+				eniID:       "eni-xxxx",
+				currentTags: nil,
+			},
+			wantErr: errors.New("permission denied"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, mockEC2 := setup(t)
+			defer ctrl.Finish()
+
+			for _, call := range tt.fields.createTagsCalls {
+				mockEC2.EXPECT().CreateTagsWithContext(gomock.Any(), call.input).Return(&ec2.CreateTagsOutput{}, call.err).AnyTimes()
+			}
+
+			cache := &EC2InstanceMetadataCache{
+				ec2SVC:            mockEC2,
+				instanceID:        tt.fields.instanceID,
+				clusterName:       tt.fields.clusterName,
+				additionalENITags: tt.fields.additionalENITags,
+			}
+			err := cache.TagENI(tt.args.eniID, tt.args.currentTags)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_convertTagsToSDKTags(t *testing.T) {
+	type args struct {
+		tags map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*ec2.Tag
+	}{
+		{
+			name: "non-empty tags",
+			args: args{
+				tags: map[string]string{
+					"keyA": "valueA",
+					"keyB": "valueB",
+				},
+			},
+			want: []*ec2.Tag{
+				{
+					Key:   aws.String("keyA"),
+					Value: aws.String("valueA"),
+				},
+				{
+					Key:   aws.String("keyB"),
+					Value: aws.String("valueB"),
+				},
+			},
+		},
+		{
+			name: "nil tags",
+			args: args{tags: nil},
+			want: nil,
+		},
+		{
+			name: "empty tags",
+			args: args{tags: map[string]string{}},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTagsToSDKTags(tt.args.tags)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_convertSDKTagsToTags(t *testing.T) {
+	type args struct {
+		sdkTags []*ec2.Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "non-empty sdk tags",
+			args: args{
+				sdkTags: []*ec2.Tag{
+					{
+						Key:   aws.String("keyA"),
+						Value: aws.String("valueA"),
+					},
+					{
+						Key:   aws.String("keyB"),
+						Value: aws.String("valueB"),
+					},
+				},
+			},
+			want: map[string]string{
+				"keyA": "valueA",
+				"keyB": "valueB",
+			},
+		},
+		{
+			name: "nil sdk tags",
+			args: args{
+				sdkTags: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "empty sdk tags",
+			args: args{
+				sdkTags: []*ec2.Tag{},
+			},
+			want: nil,
+		},
+		{
+			name: "nil sdk tag value",
+			args: args{
+				sdkTags: []*ec2.Tag{
+					{
+						Key:   aws.String("keyA"),
+						Value: nil,
+					},
+				},
+			},
+			want: map[string]string{
+				"keyA": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertSDKTagsToTags(tt.args.sdkTags)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_loadAdditionalENITags(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    map[string]string
+	}{
+		{
+			name: "no ADDITIONAL_ENI_TAGS env",
+			envVars: map[string]string{
+				"ADDITIONAL_ENI_TAGS": "",
+			},
+			want: nil,
+		},
+		{
+			name: "ADDITIONAL_ENI_TAGS is valid format",
+			envVars: map[string]string{
+				"ADDITIONAL_ENI_TAGS": "{\"tagKey1\": \"tagVal1\"}",
+			},
+			want: map[string]string{
+				"tagKey1": "tagVal1",
+			},
+		},
+		{
+			name: "ADDITIONAL_ENI_TAGS is invalid format",
+			envVars: map[string]string{
+				"ADDITIONAL_ENI_TAGS": "xxxx",
+			},
+			want: nil,
+		},
+		{
+			name: "ADDITIONAL_ENI_TAGS is valid format but contains tags with restricted prefix",
+			envVars: map[string]string{
+				"ADDITIONAL_ENI_TAGS": "{\"bla.k8s.amazonaws.com\": \"bla\"}",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "ADDITIONAL_ENI_TAGS is valid format but contains valid tags and tags with restricted prefix",
+			envVars: map[string]string{
+				"ADDITIONAL_ENI_TAGS": "{\"bla.k8s.amazonaws.com\": \"bla\", \"tagKey1\": \"tagVal1\"}",
+			},
+			want: map[string]string{
+				"tagKey1": "tagVal1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.envVars {
+				if value != "" {
+					os.Setenv(key, value)
+				} else {
+					os.Unsetenv(key)
+				}
+			}
+			got := loadAdditionalENITags()
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -321,6 +321,20 @@ func (mr *MockAPIsMockRecorder) SetUnmanagedENIs(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetUnmanagedENIs), arg0)
 }
 
+// TagENI mocks base method
+func (m *MockAPIs) TagENI(arg0 string, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagENI", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TagENI indicates an expected call of TagENI
+func (mr *MockAPIsMockRecorder) TagENI(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagENI", reflect.TypeOf((*MockAPIs)(nil).TagENI), arg0, arg1)
+}
+
 // WaitForENIAndIPsAttached mocks base method
 func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENIMetadata, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -125,6 +125,7 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Addresses, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().IsUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
 
@@ -418,6 +419,7 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
 	m.awsutils.EXPECT().IsUnmanagedENI(primaryENIid).AnyTimes().Return(false)
 	m.awsutils.EXPECT().IsCNIUnmanagedENI(primaryENIid).AnyTimes().Return(false)
+	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
 	resp := awsutils.DescribeAllENIsResult{

--- a/test/agent/cmd/networking/tester/network.go
+++ b/test/agent/cmd/networking/tester/network.go
@@ -172,7 +172,7 @@ func TestNetworkingSetupForRegularPod(podNetworkingValidationInput input.PodNetw
 		}
 		log.Printf("validated route table for secondary ENI %d has right routes", index)
 	}
-  // TODO: validate iptables rules get setup correctly
+	// TODO: validate iptables rules get setup correctly
 
 	return validationErrors
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
/kind cleanup
/kind feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR did following change:
1.  All ENIs created by IPAM-D will be tagged with all desired tags on creation.
2. All ENIs managed by IPAM-D will be tagged with all desired tags if not already tagged with these tags. Other tags on ENI will be kept as it is.
    * Trunk ENI is excluded, as it's lifecycle is managed by vpc-resource-controller.
    * Since we tag ENIs on ENI creation, this backfill logic will only trigger for below cases:
       *  ENIs created by previous versions of ENI and the desired tag set changed.
       *  ENIs attached to instances from external source without the `node.k8s.amazonaws.com/no_manage` tag.
3. The desired tag set is:
    * `node.k8s.amazonaws.com/instance_id: <instance_id>`
    * `cluster.k8s.amazonaws.com/name: <cluster-name>` if `CLUSTER_NAME` envVar is specified.
    *  additional tags specified if `ADDITIONAL_ENI_TAGS` envVar is specified.

This PR gives us below benefit, which allow customers to use a scoped down IAM policy
* If ENI is configured with CLUSTER_NAME environment variable, ensure ENI is tagged with clusterName tag on creation.
* If ENI is configured with CLUSTER_NAME environment variable, ensure managed ENIs have clusterName tag backfilled.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
IPAMD now tag ENIs with desired tags on ENI creation and backfill desired tags for ENIs attached to node.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
