### PR TITLE
Support mixed instances with PD

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -505,7 +505,7 @@ func (ds *DataStore) DelIPv4CidrFromStore(eniID string, cidr net.IPNet, force bo
 	}
 	strIPv4Cidr := cidr.String()
 
-	var deletableCidr *CidrInfo 
+	var deletableCidr *CidrInfo
 	deletableCidr, ok = curENI.AvailableIPv4Cidrs[strIPv4Cidr]
 	if !ok {
 		ds.log.Debugf("Unknown %s CIDR", strIPv4Cidr)
@@ -1020,9 +1020,9 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 		tmpENIInfo.AvailableIPv4Cidrs = make(map[string]*CidrInfo, len(eniInfo.AvailableIPv4Cidrs))
 		for cidr, _ := range eniInfo.AvailableIPv4Cidrs {
 			tmpENIInfo.AvailableIPv4Cidrs[cidr] = &CidrInfo{
-				Cidr: eniInfo.AvailableIPv4Cidrs[cidr].Cidr, 
+				Cidr:          eniInfo.AvailableIPv4Cidrs[cidr].Cidr,
 				IPv4Addresses: make(map[string]*AddressInfo, len(eniInfo.AvailableIPv4Cidrs[cidr].IPv4Addresses)),
-				IsPrefix: eniInfo.AvailableIPv4Cidrs[cidr].IsPrefix, 
+				IsPrefix:      eniInfo.AvailableIPv4Cidrs[cidr].IsPrefix,
 			}
 			// Since IP Addresses might get removed, we need to make a deep copy here.
 			for ip, ipAddrInfoRef := range eniInfo.AvailableIPv4Cidrs[cidr].IPv4Addresses {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -322,7 +322,7 @@ func New(k8sapiClient kubernetes.Interface, eniConfig *eniconfig.ENIConfigContro
 		return nil, err
 	}
 	if hypervisorType != "nitro" && c.enableIpv4PrefixDelegation {
-		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to secondary mode", c.awsClient.GetInstanceType())
+		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to default (secondary IP) mode", c.awsClient.GetInstanceType())
 		c.enableIpv4PrefixDelegation = false
 	}
 	c.myNodeName = os.Getenv("MY_NODE_NAME")

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -322,8 +322,8 @@ func New(k8sapiClient kubernetes.Interface, eniConfig *eniconfig.ENIConfigContro
 		return nil, err
 	}
 	if hypervisorType != "nitro" && c.enableIpv4PrefixDelegation {
-		log.Error("Prefix delegation is not supported non-nitro instance - " + c.awsClient.GetInstanceType())
-		return nil, err
+		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to secondary mode", c.awsClient.GetInstanceType())
+		c.enableIpv4PrefixDelegation = false
 	}
 	c.myNodeName = os.Getenv("MY_NODE_NAME")
 	checkpointer := datastore.NewJSONFile(dsBackingStorePath())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
We need to support mixed instance types and on non-nitro need to fallback to secondary mode.

**What does this PR do / Why do we need it**:
Fallback to secondary on non-nitro

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
