### PR TITLE
Cni-metrics-helper was missing because of gitignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,12 +278,12 @@ ekscharts-sync-release:
 
 
 upload-resources-to-github:
-	${MAKEFILE_PATH}/scripts/upload-resources-to-github
+	${MAKEFILE_PATH}/scripts/upload-resources-to-github.sh
 
-generate-k8s-yaml:
-	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
+generate-cni-yaml:
+	${MAKEFILE_PATH}/scripts/generate-cni-yaml.sh
 
-release: generate-k8s-yaml upload-resources-to-github
+release: generate-cni-yaml upload-resources-to-github
 
 # Clean temporary files and build artifacts from the project.
 clean:    ## Clean temporary files and build artifacts from the project.

--- a/charts/cni-metrics-helper/.helmignore
+++ b/charts/cni-metrics-helper/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: cni-metrics-helper
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/cni-metrics-helper/templates/NOTES.txt
+++ b/charts/cni-metrics-helper/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cni-metrics-helper.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/charts/cni-metrics-helper/templates/_helpers.tpl
+++ b/charts/cni-metrics-helper/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cni-metrics-helper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cni-metrics-helper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cni-metrics-helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cni-metrics-helper.labels" -}}
+helm.sh/chart: {{ include "cni-metrics-helper.chart" . }}
+{{ include "cni-metrics-helper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cni-metrics-helper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cni-metrics-helper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cni-metrics-helper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cni-metrics-helper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cni-metrics-helper/templates/clusterrole.yaml
+++ b/charts/cni-metrics-helper/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/proxy
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]       

--- a/charts/cni-metrics-helper/templates/clusterrolebinding.yaml
+++ b/charts/cni-metrics-helper/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cni-metrics-helper.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/cni-metrics-helper/templates/deployment.yaml
+++ b/charts/cni-metrics-helper/templates/deployment.yaml
@@ -1,0 +1,24 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      containers:
+      - env:
+{{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+        name: cni-metrics-helper
+        image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.image.region }}.amazonaws.com/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
+      serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/charts/cni-metrics-helper/templates/serviceaccount.yaml
+++ b/charts/cni-metrics-helper/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -1,0 +1,23 @@
+# This default name override is to maintain backwards compatability with
+# existing naming
+nameOverride: cni-metrics-helper
+
+image:
+  region: us-west-2
+  tag: v1.7.10
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+
+env:
+  USE_CLOUDWATCH: "true"
+
+fullnameOverride: "cni-metrics-helper"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/a

**What does this PR do / Why do we need it**:
Auto gen of cni metrics helper yaml

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

```
make generate-cni-yaml
/local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s//scripts/generate-cni-yaml.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11.5M  100 11.5M    0     0  15.7M      0 --:--:-- --:--:-- --:--:-- 15.7M
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-vpc-cni/templates/serviceaccount.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-vpc-cni/templates/customresourcedefinition.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-vpc-cni/templates/clusterrole.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-vpc-cni/templates/clusterrolebinding.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-vpc-cni/templates/daemonset.yaml

wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//cni-metrics-helper/templates/serviceaccount.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//cni-metrics-helper/templates/clusterrole.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//cni-metrics-helper/templates/clusterrolebinding.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//cni-metrics-helper/templates/deployment.yaml

wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/pod-disruption-budget.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/config-map.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/service-accounts.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/service-accounts.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/rbac.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/service.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/daemon-set.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/deployment.yaml
wrote /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/individual-resources//aws-calico/templates/deployment.yaml

templates/clusterrolebinding.yaml
templates/clusterrole.yaml
templates/customresourcedefinition.yaml
templates/daemonset.yaml
templates/serviceaccount.yaml
templates/clusterrolebinding.yaml
templates/clusterrole.yaml
templates/deployment.yaml
templates/serviceaccount.yaml
templates/config-map.yaml
templates/daemon-set.yaml
templates/deployment.yaml
templates/pod-disruption-budget.yaml
templates/rbac.yaml
templates/service-accounts.yaml
templates/service.yaml
Generated aws-vpc-cni and cni-metrics-helper kubernetes yaml resources files in:
    - /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/aws-vpc-cni
    - /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/cni-metrics-helper
    - /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/cni_individual-resources.tar
    - /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/cni_metrics_individual-resources.tar
    - /local/home/varavaj/src/cni-metrics-helper/amazon-vpc-cni-k8s/scripts/../build/cni-rel-yamls/v1.6.4-rc1-155-g98395831-dirty/calico_individual-resources.tar

 % [cni-rel-yamls]
dev-dsk-varavaj-2b-72f02457 % cd v1.6.4-rc1-155-g98395831-dirty

 % [v1.6.4-rc1-155-g98395831-dirty]
dev-dsk-varavaj-2b-72f02457 % ls
aws-vpc-cni-cn.yaml             calico_individual-resources.tar  cni-metrics-helper-us-gov-east-1.yaml  helm
aws-vpc-cni-us-gov-east-1.yaml  calico.yaml                      cni-metrics-helper-us-gov-west-1.yaml  individual-resources
aws-vpc-cni-us-gov-west-1.yaml  cni_individual-resources.tar     cni-metrics-helper.yaml
aws-vpc-cni.yaml                cni-metrics-helper-cn.yaml       cni_metrics_individual-resources.tar

```

```
helm install cni-metrics-helper --namespace kube-system --generate-name
NAME: cni-metrics-helper-1623114961
LAST DEPLOYED: Tue Jun  8 01:16:02 2021
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
cni-metrics-helper-1623114961 has been installed or updated. To check the status of pods, run:
kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=cni-metrics-helper,app.kubernetes.io/instance=cni-metrics-helper-1623114961"
 % [charts]
dev-dsk-varavaj-2b-72f02457 % kgpsys
NAME                                  READY   STATUS        RESTARTS   AGE   IP               NODE                                          NOMINATED NODE   READINESS GATES
aws-node-dt8p9                        1/1     Terminating   0          31d   192.168.77.49    ip-192-168-77-49.us-west-2.compute.internal   <none>           <none>
aws-node-fswmv                        1/1     Running       0          31d   192.168.6.73     ip-192-168-6-73.us-west-2.compute.internal    <none>           <none>
cni-metrics-helper-57cbb76f75-cv5sj   1/1     Running       0          9s    192.168.20.242   ip-192-168-6-73.us-west-2.compute.internal    <none>           <none>
```
```
kubectl logs cni-metrics-helper-57cbb76f75-cv5sj -n kube-system
{"level":"info","ts":"2021-06-08T01:16:10.869Z","caller":"runtime/proc.go:203","msg":"Starting CNIMetricsHelper. Sending metrics to CloudWatch: true, LogLevel Debug"}
{"level":"info","ts":"2021-06-08T01:16:41.229Z","caller":"runtime/proc.go:203","msg":"Collecting metrics ..."}
{"level":"debug","ts":"2021-06-08T01:16:41.238Z","caller":"metrics/metrics.go:377","msg":"cni-metrics text output: # HELP awscni_add_ip_req_count The number of add IP address requests\n# TYPE awscni_add_ip_req_count counter\nawscni_add_ip_req_count 1803\n# HELP awscni_assigned_ip_addresses The number of IP addresses assigned to pods\n# TYPE awscni_assigned_ip_addresses gauge\nawscni_assigned_ip_addresses 10\n# HELP awscni_aws_api_latency_ms AWS API call latency in ms\n# TYPE awscni_aws_api_latency_ms summary\nawscni_aws_api_latency_ms{api=\"AssignPrivateIpAddresses\",error=\"false\",quantile=\"0.5\"} NaN\nawscni_aws_api_latency_ms{api=\"AssignPrivateIpAddresses\",error=\"false\",quantile=\"0.9\"} NaN\nawscni_aws_api_latency_ms{api=\"AssignPrivateIpAddresses\",error=\"false\",quantile=\"0.99\"} NaN\nawscni_aws_api_latency_ms_sum{api=\"AssignPrivateIpAddresses\",error=\"false\"} 848\nawscni_aws_api_latency_ms_count{api=\"AssignPrivateIpAddresses\",error=\"false\"} 2\nawscni_aws_api_latency_ms{api=\"DescribeNetworkInterfaces\",error=\"false\",quantile=\"0.5\"} NaN\nawscni_aws_api_latency_ms{api=\"DescribeN
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
