### PR TITLE
Optimization for prefixes allocation

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -816,7 +816,7 @@ func (c *IPAMContext) tryAssignPrefixes() (increasedPool bool, err error) {
 	if eni != nil {
 		currentNumberOfAllocatedPrefixes := len(eni.AvailableIPv4Cidrs)
 		log.Debugf("Adding prefix to ENI %s ", eni.ID)
-		err = c.awsClient.AllocIPAddresses(eni.ID, min((c.maxPrefixesPerENI-currentNumberOfAllocatedPrefixes), max(toAllocate, 0)))
+		err = c.awsClient.AllocIPAddresses(eni.ID, min((c.maxPrefixesPerENI-currentNumberOfAllocatedPrefixes), toAllocate))
 		if err != nil {
 			log.Warnf("failed to allocate all available IPv4 Prefixes on ENI %s, err: %v", eni.ID, err)
 			// Try to just get one more prefix

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -809,13 +809,14 @@ func (c *IPAMContext) tryAssignPrefixes() (increasedPool bool, err error) {
 		return true, nil
 	}
 
+	toAllocate -= freePrefixesInStore 
 	// Returns an ENI which has space for more prefixes to be attached, but this
 	// ENI might not suffice the WARM_IP_TARGET
 	eni := c.dataStore.GetENINeedsIP(c.maxPrefixesPerENI, c.useCustomNetworking)
 	if eni != nil {
 		currentNumberOfAllocatedPrefixes := len(eni.AvailableIPv4Cidrs)
 		log.Debugf("Adding prefix to ENI %s ", eni.ID)
-		err = c.awsClient.AllocIPAddresses(eni.ID, min((c.maxPrefixesPerENI-currentNumberOfAllocatedPrefixes), toAllocate))
+		err = c.awsClient.AllocIPAddresses(eni.ID, min((c.maxPrefixesPerENI-currentNumberOfAllocatedPrefixes), max(toAllocate, 0)))
 		if err != nil {
 			log.Warnf("failed to allocate all available IPv4 Prefixes on ENI %s, err: %v", eni.ID, err)
 			// Try to just get one more prefix


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Attaching extra prefixes

**What does this PR do / Why do we need it**:
When prefix count is set to X and if ENI has Y free prefixes then we should be allocating `max(X-Y, 0)` prefixes. This will save up attaching extra prefixes.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

```
WARM_IP_TARGET=0,
MINIMUM_IP_TARGET=0,
WARM_PREFIX_TARGET=10

Node 1 : {"level":"debug","ts":"2021-06-09T22:48:29.990Z","caller":"ipamd/ipamd.go:533","msg":"Successfully Reconciled ENI/IP pool"}
{"level":"debug","ts":"2021-06-09T22:48:29.990Z","caller":"ipamd/ipamd.go:533","msg":"IP/Prefix Address Pool stats: total: 160, assigned: 0, total prefixes: 10"}

Node 2:{"level":"debug","ts":"2021-06-09T22:49:54.510Z","caller":"ipamd/ipamd.go:533","msg":"Successfully Reconciled ENI/IP pool"}
{"level":"debug","ts":"2021-06-09T22:49:54.510Z","caller":"ipamd/ipamd.go:533","msg":"IP/Prefix Address Pool stats: total: 176, assigned: 1, total prefixes: 11"}
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
