### PR TITLE
cherry-pick #1499 into release-1.8

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -207,11 +207,8 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		if delErr != nil {
 			log.Errorf("Error received from DelNetwork grpc call for container %s: %v",
 				args.ContainerID, delErr)
-		}
-
-		if !r.Success {
-			log.Errorf("Failed to release IP of container %s: %v",
-				args.ContainerID, delErr)
+		} else if !r.Success {
+			log.Errorf("Failed to release IP of container %s", args.ContainerID)
 		}
 		return errors.Wrap(err, "add command: failed to setup network")
 	}

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -139,10 +139,16 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 			NetworkName: in.NetworkName,
 		}
 		addr, deviceNumber, err = s.ipamContext.dataStore.AssignPodIPv4Address(ipamKey)
+		if err != nil {
+			log.Warnf("Send AddNetworkReply: unable to assign IPv4 address for pod, err: %v", err)
+			return &failureResponse, nil
+		}
 	}
+
 	pbVPCcidrs, err := s.ipamContext.awsClient.GetVPCIPv4CIDRs()
 	if err != nil {
-		return nil, err
+		log.Errorf("Send AddNetworkReply: unable to obtain VPC CIDRs, err: %v", err)
+		return &failureResponse, nil
 	}
 	for _, cidr := range pbVPCcidrs {
 		log.Debugf("VPC CIDR %s", cidr)


### PR DESCRIPTION
* Fix two bug in CNI/IPamd code path
1. when IPAMD returns "no ip available error", the err variable get overwritten to nil when get VPCCIDRs
2. when DelNetwork returns err, the r.Success will cause nil-pointer exception and crash CNI

* fix test cases

* address commits

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cherry-pick #1499 into release-1.8
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
