### PR TITLE
Fixup eni allocation with warm targets

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -421,11 +421,13 @@ func (c *IPAMContext) nodeInit() error {
 		return err
 	}
 
-	//During upgrade or if prefix delgation knob is disabled to enabled then we
-	//might have secondary IPs attached to ENIs so doing a cleanup if not used before moving on
 	if c.enableIpv4PrefixDelegation {
+		//During upgrade or if prefix delgation knob is disabled to enabled then we
+		//might have secondary IPs attached to ENIs so doing a cleanup if not used before moving on
 		c.tryUnassignIPsFromENIs()
 	} else {
+		//When prefix delegation knob is enabled to disabled then we might
+		//have unused prefixes attached to the ENIs so need to cleanup
 		c.tryUnassignPrefixesFromENIs()
 	}
 
@@ -470,8 +472,8 @@ func (c *IPAMContext) nodeInit() error {
 		c.askForTrunkENIIfNeeded()
 	}
 
-	// For a new node, attach IPs
-	increasedPool, err := c.tryAssignIPsOrPrefixes()
+	// For a new node, attach Cidrs (secondary ips/prefixes)
+	increasedPool, err := c.tryAssignCidrs()
 	if err == nil && increasedPool {
 		c.updateLastNodeIPPoolAction()
 	} else if err != nil {
@@ -575,7 +577,7 @@ func (c *IPAMContext) tryFreeENI() {
 		return
 	}
 
-	eni := c.dataStore.RemoveUnusedENIFromStore(c.warmIPTarget, c.minimumIPTarget, c.warmPrefixTarget)
+	eni := c.dataStore.RemoveUnusedENIFromStore(c.warmIPTarget, c.minimumIPTarget)
 	if eni == "" {
 		return
 	}
@@ -633,7 +635,7 @@ func (c *IPAMContext) tryUnassignCidrsFromAll() {
 					deletedCidrs = append(deletedCidrs, toDelete)
 				}
 			}
-			
+
 			// Deallocate Cidrs from the instance if they aren't used by pods.
 			c.DeallocCidrs(eniID, deletedCidrs)
 		}
@@ -651,12 +653,18 @@ func (c *IPAMContext) increaseDatastorePool() {
 		return
 	}
 
+	short, warmTargetDefined = c.datastorePrefixTargetState()
+	if warmTargetDefined && short == 0 {
+		log.Debugf("Skipping increase Datastore pool, warm prefix target reached")
+		return
+	}
+
 	if c.isTerminating() {
 		log.Debug("AWS CNI is terminating, will not try to attach any new IPs or ENIs right now")
 		return
 	}
-	// Try to add more IPs to existing ENIs first.
-	increasedPool, err := c.tryAssignIPsOrPrefixes()
+	// Try to add more Cidrs to existing ENIs first.
+	increasedPool, err := c.tryAssignCidrs()
 	if err != nil {
 		log.Errorf(err.Error())
 	}
@@ -750,10 +758,16 @@ func (c *IPAMContext) tryAllocateENI() error {
 
 // For an ENI, try to fill in missing IPs on an existing ENI with PD disabled
 // try to fill in missing Prefixes on an existing ENI with PD enabled
-func (c *IPAMContext) tryAssignIPsOrPrefixes() (increasedPool bool, err error) {
+func (c *IPAMContext) tryAssignCidrs() (increasedPool bool, err error) {
 	short, _, warmTargetDefined := c.datastoreTargetState()
 	if warmTargetDefined && short == 0 {
-		log.Infof("Warm target set and short is 0 so not assigning IPs or Prefixes")
+		log.Infof("Warm IP target set and short is 0 so not assigning Cidrs (IPs or Prefixes)")
+		return false, nil
+	}
+
+	short, warmTargetDefined = c.datastorePrefixTargetState()
+	if warmTargetDefined && short == 0 {
+		log.Infof("Warm prefix target set and short is 0 so not assigning Cidrs (Prefixes)")
 		return false, nil
 	}
 	if !c.enableIpv4PrefixDelegation {
@@ -792,26 +806,9 @@ func (c *IPAMContext) tryAssignIPs() (increasedPool bool, err error) {
 }
 
 func (c *IPAMContext) tryAssignPrefixes() (increasedPool bool, err error) {
-	short, _, warmIPTargetDefined := c.datastoreTargetState()
-	//By default allocate 1 prefix at a time
-	toAllocate := 1
-	//WARM_IP_TARGET takes precendence over WARM_PREFIX_TARGET
-	if warmIPTargetDefined {
-		toAllocate = max(toAllocate, short)
-	} else if c.warmPrefixTargetDefined() {
-		toAllocate = max(toAllocate, c.warmPrefixTarget)
-	}
-
-	// /28 will consume 16 IPs so let's not allocate if not needed.
-	freePrefixesInStore := c.dataStore.GetFreePrefixes()
-	if toAllocate <= freePrefixesInStore {
-		log.Debugf("DataStore already has %d free prefixes so no need to assign more prefixes", freePrefixesInStore)
-		return true, nil
-	}
-
-	toAllocate -= freePrefixesInStore 
+	toAllocate := c.getPrefixesNeeded()
 	// Returns an ENI which has space for more prefixes to be attached, but this
-	// ENI might not suffice the WARM_IP_TARGET
+	// ENI might not suffice the WARM_IP_TARGET/WARM_PREFIX_TARGET
 	eni := c.dataStore.GetENINeedsIP(c.maxPrefixesPerENI, c.useCustomNetworking)
 	if eni != nil {
 		currentNumberOfAllocatedPrefixes := len(eni.AvailableIPv4Cidrs)
@@ -829,12 +826,11 @@ func (c *IPAMContext) tryAssignPrefixes() (increasedPool bool, err error) {
 		ec2Prefixes, err := c.awsClient.GetIPv4PrefixesFromEC2(eni.ID)
 		if err != nil {
 			ipamdErrInc("increaseIPPoolGetENIprefixedFailed")
-			return true, errors.Wrap(err, "failed to get ENI Prefix addresses during IP allocation")
+			return true, errors.Wrap(err, "failed to get ENI Prefix addresses during IPv4 Prefix allocation")
 		}
 		c.addENIprefixesToDataStore(ec2Prefixes, eni.ID)
 		return true, nil
 	}
-	log.Debugf("Didnt find an ENI")
 	return false, nil
 }
 
@@ -1270,7 +1266,7 @@ func (c *IPAMContext) verifyAndAddIPsToDatastore(eni string, attachedENIIPs []*e
 		}
 
 		// Check if this IP was recently freed
-		ipv4Addr := net.IPNet{IP: net.ParseIP(strPrivateIPv4), Mask: net.IPv4Mask(255, 255, 255, 255)}	
+		ipv4Addr := net.IPNet{IP: net.ParseIP(strPrivateIPv4), Mask: net.IPv4Mask(255, 255, 255, 255)}
 		found, recentlyFreed := c.reconcileCooldownCache.RecentlyFreed(strPrivateIPv4)
 		if found {
 			if recentlyFreed {
@@ -1519,13 +1515,13 @@ func (c *IPAMContext) datastoreTargetState() (short int, over int, enabled bool)
 
 		_, numIPsPerPrefix, _ := datastore.GetPrefixDelegationDefaults()
 		// Number of prefixes IPAMD is short of to achieve warm targets
-		shortPrefix := divCeil(short, numIPsPerPrefix)
+		shortPrefix := datastore.DivCeil(short, numIPsPerPrefix)
 
 		// Over will have number of IPs more than needed but with PD we would have allocated in chunks of /28
 		// Say assigned = 1, warm ip target = 16, this will need 2 prefixes. But over will return 15.
 		// Hence we need to check if 'over' number of IPs are needed to maintain the warm targets
-		prefixNeededForWarmIP := divCeil(assigned+c.warmIPTarget, numIPsPerPrefix)
-		prefixNeededForMinIP := divCeil(c.minimumIPTarget, numIPsPerPrefix)
+		prefixNeededForWarmIP := datastore.DivCeil(assigned+c.warmIPTarget, numIPsPerPrefix)
+		prefixNeededForMinIP := datastore.DivCeil(c.minimumIPTarget, numIPsPerPrefix)
 
 		// over will be number of prefixes over than needed but could be spread across used prefixes,
 		// say, after couple of pod churns, 3 prefixes are allocated with 1 IP each assigned and warm ip target is 15
@@ -1540,6 +1536,20 @@ func (c *IPAMContext) datastoreTargetState() (short int, over int, enabled bool)
 	log.Debugf("Current warm IP stats: target: %d, total: %d, assigned: %d, available: %d, short: %d, over %d", c.warmIPTarget, total, assigned, available, short, over)
 
 	return short, over, true
+}
+
+// datastorePrefixTargetState determines the number of prefixes short to reach WARM_PREFIX_TARGET
+func (c *IPAMContext) datastorePrefixTargetState() (short int, enabled bool) {
+	if !c.warmPrefixTargetDefined() {
+		return 0, false
+	}
+	// /28 will consume 16 IPs so let's not allocate if not needed.
+	freePrefixesInStore := c.dataStore.GetFreePrefixes()
+	toAllocate := max(c.warmPrefixTarget-freePrefixesInStore, 0)
+	log.Debugf("Prefix target is %d, short of %d prefixes, free %d prefixes", c.warmPrefixTarget, toAllocate, freePrefixesInStore)
+
+	toAllocate -= freePrefixesInStore
+	return toAllocate, true
 }
 
 // setTerminating atomically sets the terminating flag.
@@ -1776,7 +1786,7 @@ func (c *IPAMContext) isDatastorePoolTooHigh() bool {
 		total, used, _ := c.dataStore.GetStats()
 		available := total - used
 		_, maxIpsPerPrefix, _ := datastore.GetPrefixDelegationDefaults()
-		poolTooHigh := available > (maxIpsPerPrefix * (c.warmPrefixTarget+1))
+		poolTooHigh := available > (maxIpsPerPrefix * (c.warmPrefixTarget + 1))
 		if poolTooHigh {
 			logPoolStats(total, used, c.maxIPsPerENI, c.enableIpv4PrefixDelegation)
 			log.Debugf("Prefix pool is high: available (%d) > Warm prefix target (%d)+1 * maxIpsPerPrefix (%d)", available, c.warmPrefixTarget, maxIpsPerPrefix)
@@ -1791,10 +1801,6 @@ func (c *IPAMContext) warmPrefixTargetDefined() bool {
 	return c.warmPrefixTarget >= noWarmPrefixTarget && c.enableIpv4PrefixDelegation
 }
 
-func divCeil (x, y int) int {
-	return (x + y - 1) / y
-}
-
 //DeallocCidrs frees IPs and Prefixes from EC2
 func (c *IPAMContext) DeallocCidrs(eniID string, deletableCidrs []datastore.CidrInfo) {
 	var deletableIPs []string
@@ -1802,7 +1808,7 @@ func (c *IPAMContext) DeallocCidrs(eniID string, deletableCidrs []datastore.Cidr
 
 	for _, toDeleteCidr := range deletableCidrs {
 		if toDeleteCidr.IsPrefix {
-			strDeletablePrefix := toDeleteCidr.Cidr.String() 
+			strDeletablePrefix := toDeleteCidr.Cidr.String()
 			deletablePrefixes = append(deletablePrefixes, strDeletablePrefix)
 			// Track the last time we unassigned Cidrs from an ENI. We won't reconcile any Cidrs in this cache
 			// for at least ipReconcileCooldown
@@ -1823,4 +1829,25 @@ func (c *IPAMContext) DeallocCidrs(eniID string, deletableCidrs []datastore.Cidr
 	if err := c.awsClient.DeallocIPAddresses(eniID, deletableIPs); err != nil {
 		log.Warnf("Failed to free IPs %v from ENI %s: %s", deletableIPs, eniID, err)
 	}
+}
+
+// getPrefixesNeeded returns the number of prefixes need to be allocated to the ENI
+func (c *IPAMContext) getPrefixesNeeded() int {
+
+	//By default allocate 1 prefix at a time
+	toAllocate := 1
+
+	//TODO - post GA we can evaluate to see if these two calls can be merged.
+	//datastoreTargetState already has complex math so adding Prefix target will make it
+	//even more complex.
+	short, _, warmIPTargetDefined := c.datastoreTargetState()
+	shortPrefixes, warmPrefixTargetDefined := c.datastorePrefixTargetState()
+
+	//WARM_IP_TARGET takes precendence over WARM_PREFIX_TARGET
+	if warmIPTargetDefined {
+		toAllocate = max(toAllocate, short)
+	} else if warmPrefixTargetDefined {
+		toAllocate = max(toAllocate, shortPrefixes)
+	}
+	return toAllocate
 }

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1515,13 +1515,13 @@ func (c *IPAMContext) datastoreTargetState() (short int, over int, enabled bool)
 
 		_, numIPsPerPrefix, _ := datastore.GetPrefixDelegationDefaults()
 		// Number of prefixes IPAMD is short of to achieve warm targets
-		shortPrefix := datastore.DivCeil(short, numIPsPerPrefix)
+		shortPrefix := divCeil(short, numIPsPerPrefix)
 
 		// Over will have number of IPs more than needed but with PD we would have allocated in chunks of /28
 		// Say assigned = 1, warm ip target = 16, this will need 2 prefixes. But over will return 15.
 		// Hence we need to check if 'over' number of IPs are needed to maintain the warm targets
-		prefixNeededForWarmIP := datastore.DivCeil(assigned+c.warmIPTarget, numIPsPerPrefix)
-		prefixNeededForMinIP := datastore.DivCeil(c.minimumIPTarget, numIPsPerPrefix)
+		prefixNeededForWarmIP := divCeil(assigned+c.warmIPTarget, numIPsPerPrefix)
+		prefixNeededForMinIP := divCeil(c.minimumIPTarget, numIPsPerPrefix)
 
 		// over will be number of prefixes over than needed but could be spread across used prefixes,
 		// say, after couple of pod churns, 3 prefixes are allocated with 1 IP each assigned and warm ip target is 15
@@ -1800,6 +1800,11 @@ func (c *IPAMContext) isDatastorePoolTooHigh() bool {
 func (c *IPAMContext) warmPrefixTargetDefined() bool {
 	return c.warmPrefixTarget >= noWarmPrefixTarget && c.enableIpv4PrefixDelegation
 }
+
+
+func divCeil(x, y int) int {
+	return (x + y - 1) / y
+ }
 
 //DeallocCidrs frees IPs and Prefixes from EC2
 func (c *IPAMContext) DeallocCidrs(eniID string, deletableCidrs []datastore.CidrInfo) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
ENI has max 14 prefixes and WARM_IP_TARGET is 240. This would need 2 ENIs. Say 1st ENI is attached with 14 prefixes and no prefixes are used. Then we would need one more, so reconciler will try attach more prefixes for ENI1 and the call would come herehttps://github.com/aws/amazon-vpc-cni-k8s/blob/prefix-delegation-preview/pkg/ipamd/ipamd.go#L794-L812 but here we will compute `toAllocate = 1 ` [https://github.com/aws/amazon-vpc-cni-k8s/blob/prefix-delegation-preview/pkg/ipamd/ipamd.go#L800] and `toAllocate <= freePrefixesInStore` [https://github.com/aws/amazon-vpc-cni-k8s/blob/prefix-delegation-preview/pkg/ipamd/ipamd.go#L807] hence return will be `true` and we won't allocate another ENI - https://github.com/aws/amazon-vpc-cni-k8s/blob/03f23755b072f3b3ca939569ac34b9a97d9b0db5/pkg/ipamd/ipamd.go#L663.

Also `isRequiredForWarmIPTarget` and `isRequiredForMinimumIPTarget` should not take Len of availableIP4Cidrs since we can have a mix of /28 and /32s, so need to walk and compute the correct value.

**What does this PR do / Why do we need it**:
`tryAssignPrefixes` similar to `tryAssignIPs` should always allocate prefixes based on the number of CIDRS `short` computed in terms of WARM_IP_TARGET/MINIMUM_IP_TARGET or WARM_PREFIX_TARGET. Instead `tryAssignCidrs` should not call `tryAssignPrefix` if the number of prefixes is sufficient to reach the WARM_IP_TARGET or WARM_PREFIX_TARGET.

`getPrefixesNeeded` returns either 1 prefix or number of prefixes needed to reach the warm target.
`datastorePrefixTargetState` returns the number of prefixes short to reach WARM_PREFIX_TARGET.

Post GA, I will see how to combine `datastorePrefixTargetState` and `datastoreTargetState` since already there is lot of logic in `datastoreTargetState` and it will be a disruptive change to achieve in the current timeline.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
WARM_IP_TARGET = 240
MINIMUM_IP_TARGET = 10

Node 1 
5, short(prefixes): 0, over(prefixes): 0"}
{"level":"debug","ts":"2021-06-15T23:25:43.796Z","caller":"ipamd/ipamd.go:1047","msg":"Current warm IP stats : target: 240, total: 256, assigned: 1, available: 255, short(prefixes): 0, over(prefixes): 0"}
{"level":"debug","ts":"2021-06-15T23:25:43.796Z","caller":"datastore/data_store.go:852","msg":"ENI eni-0feab4a86670d407c cannot be deleted because it is primary"}
{"level":"debug","ts":"2021-06-15T23:25:43.796Z","caller":"datastore/data_store.go:774","msg":"Found 13 free cidrs on ENI eni-05eac5de44a62637b"}
{"level":"debug","ts":"2021-06-15T23:25:43.796Z","caller":"datastore/data_store.go:774","msg":"warm target 15"}
{"level":"debug","ts":"2021-06-15T23:25:43.796Z","caller":"datastore/data_store.go:852","msg":"ENI eni-05eac5de44a62637b cannot be deleted because it is required for WARM_IP_TARGET: 240"}

Node 2
{"level":"debug","ts":"2021-06-15T23:37:14.366Z","caller":"ipamd/ipamd.go:1047","msg":"Current warm IP stats : target: 240, total: 240, assigned: 0, available: 240, short(prefixes): 0, over(prefixes): 0"}
{"level":"debug","ts":"2021-06-15T23:37:14.366Z","caller":"datastore/data_store.go:774","msg":"Found 14 free cidrs on ENI eni-06ef2989c38dc3add"}
{"level":"debug","ts":"2021-06-15T23:37:14.366Z","caller":"datastore/data_store.go:774","msg":"warm target 15"}
{"level":"debug","ts":"2021-06-15T23:37:14.366Z","caller":"datastore/data_store.go:852","msg":"ENI eni-06ef2989c38dc3add cannot be deleted because it is required for WARM_IP_TARGET: 240"}
{"level":"debug","ts":"2021-06-15T23:37:14.366Z","caller":"datastore/data_store.go:852","msg":"ENI eni-0283a74052cb94d2f cannot be deleted because it is primary"}
```
```
MINIMUM_IP_TARGET=240

Node 1
{"level":"debug","ts":"2021-06-15T23:52:56.925Z","caller":"ipamd/ipamd.go:1047","msg":"Current warm IP stats : target: 0, total: 240, assigned: 0, available: 240, short(prefixes): 0, over(prefixes): 0"}
{"level":"debug","ts":"2021-06-15T23:52:56.925Z","caller":"datastore/data_store.go:852","msg":"ENI eni-0283a74052cb94d2f cannot be deleted because it is primary"}
{"level":"debug","ts":"2021-06-15T23:52:56.925Z","caller":"datastore/data_store.go:852","msg":"ENI eni-06ef2989c38dc3add cannot be deleted because it is required for MINIMUM_IP_TARGET: 240"}

Node 2
"level":"debug","ts":"2021-06-15T23:55:39.239Z","caller":"ipamd/ipamd.go:1047","msg":"Current warm IP stats : target: 0, total: 240, assigned: 1, available: 239, short(prefixes): 0, over(prefixes): 0"}
{"level":"debug","ts":"2021-06-15T23:55:39.239Z","caller":"datastore/data_store.go:852","msg":"ENI eni-05eac5de44a62637b cannot be deleted because it is required for MINIMUM_IP_TARGET: 240"}
{"level":"debug","ts":"2021-06-15T23:55:39.239Z","caller":"datastore/data_store.go:852","msg":"ENI eni-0feab4a86670d407c cannot be deleted because it is primary"}
```
```
Removed MINIMUM_IP_TARGET=240

Node 1
{"level":"info","ts":"2021-06-15T23:57:27.993Z","caller":"ipamd/ipamd.go:1902","msg":"Trying to unassign the following Prefixes [192.168.30.144/28 192.168.11.0/28 192.168.6.144/28 192.168.0.160/28 192.168.27.0/28 192.168.12.144/28 192.168.19.144/28 192.168.18.16/28 192.168.18.144/28 192.168.4.0/28 192.168.16.0/28 192.168.26.16/28 192.168.10.224/28] from ENI eni-0feab4a86670d407c"}
{"level":"debug","ts":"2021-06-15T23:57:28.493Z","caller":"ipamd/ipamd.go:1902","msg":"Successfully freed Prefixes [192.168.30.144/28 192.168.11.0/28 192.168.6.144/28 192.168.0.160/28 192.168.27.0/28 192.168.12.144/28 192.168.19.144/28 192.168.18.16/28 192.168.18.144/28 192.168.4.0/28 192.168.16.0/28 192.168.26.16/28 192.168.10.224/28] from ENI eni-0feab4a86670d407c"}
{"level":"info","ts":"2021-06-15T23:57:28.493Z","caller":"ipamd/ipamd.go:649","msg":"Deleted ENI(eni-05eac5de44a62637b)'s IP/Prefix 192.168.11.96/28 from datastore"}
{"level":"info","ts":"2021-06-15T23:57:28.493Z","caller":"ipamd/ipamd.go:649","msg":"Deleted ENI(eni-05eac5de44a62637b)'s IP/Prefix 192.168.1.48/28 from datastore"}
{"level":"info","ts":"2021-06-15T23:57:28.493Z","caller":"ipamd/ipamd.go:1902","msg":"Trying to unassign the following Prefixes [192.168.11.96/28 192.168.1.48/28] from ENI eni-05eac5de44a62637b"}
{"level":"debug","ts":"2021-06-15T23:57:28.835Z","caller":"ipamd/ipamd.go:1902","msg":"Successfully freed Prefixes [192.168.11.96/28 192.168.1.48/28] from ENI eni-05eac5de44a62637b"}
{"level":"debug","ts":"2021-06-15T23:57:28.835Z","caller":"ipamd/ipamd.go:564","msg":"Successfully decreased IP pool"}
{"level":"debug","ts":"2021-06-15T23:57:28.835Z","caller":"ipamd/ipamd.go:590","msg":"Prefix pool stats: total = 16, used = 1, c.maxIPsPerENI = 224"}

Node 2
{"level":"debug","ts":"2021-06-15T23:59:05.637Z","caller":"ipamd/ipamd.go:555","msg":"IP/Prefix Address Pool stats: total: 0, assigned: 0, total prefixes: 0"}
{"level":"debug","ts":"2021-06-15T23:59:08.137Z","caller":"ipamd/ipamd.go:1848","msg":"Prefix pool stats: total = 0, used = 0, c.maxIPsPerENI = 224"}
```
```
WARM_PREFIX_TARGET=15
Node 1
{"level":"debug","ts":"2021-06-16T00:02:50.231Z","caller":"ipamd/ipamd.go:879","msg":"Datastore Pool stats: total(/32): 240, assigned(/32): 0, total prefixes(/28): 15"}
{"level":"debug","ts":"2021-06-16T00:02:50.231Z","caller":"ipamd/ipamd.go:706","msg":"Successfully increased Prefix pool, total: 15, used: 0"}
{"level":"debug","ts":"2021-06-16T00:02:50.231Z","caller":"ipamd/ipamd.go:733","msg":"Prefix pool stats: total = 240, used = 0, c.maxIPsPerENI = 224"}

Node 2
{"level":"debug","ts":"2021-06-16T00:02:33.558Z","caller":"ipamd/ipamd.go:879","msg":"Datastore Pool stats: total(/32): 256, assigned(/32): 1, total prefixes(/28): 16"}
{"level":"debug","ts":"2021-06-16T00:02:33.558Z","caller":"ipamd/ipamd.go:706","msg":"Successfully increased Prefix pool, total: 16, used: 1"}
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
