### PR TITLE
Default WARM_PREFIX_TARGET to 1

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,27 +37,9 @@ log_in_json()
 
 unsupported_prefix_target_conf()
 {
-   if [ "${WARM_PREFIX_TARGET}" == "0" ];then
+   if [ "${WARM_PREFIX_TARGET}" == "0" ] && [ "${WARM_IP_TARGET}" == "0" ] && [ "${MINIMUM_IP_TARGET}" == "0" ];then
         true
    else
-        false
-    fi    
-}
-
-warm_ip_target_not_configured()
-{
-    if [ "${WARM_IP_TARGET}" == "0" ];then
-        true
-    else
-        false
-    fi    
-}
-
-min_ip_target_not_configured()
-{
-    if [ "${MINIMUM_IP_TARGET}" == "0" ]; then
-        true
-    else
         false
     fi    
 }
@@ -79,7 +61,7 @@ validate_env_var()
         exit 1     
     fi 
 
-    if is_prefix_delegation_enabled && unsupported_prefix_target_conf && warm_ip_target_not_configured && min_ip_target_not_configured ; then
+    if is_prefix_delegation_enabled && unsupported_prefix_target_conf ; then
        log_in_json error "Setting WARM_PREFIX_TARGET = 0 is not supported while WARM_IP_TARGET/MINIMUM_IP_TARGET is not set. Please configure either one of the WARM_{PREFIX/IP}_TARGET or MINIMUM_IP_TARGET env variables"
        exit 1
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
WARM_PREFIX_TARGET is implemented similar to WARM_ENI_TARGET. Today we do support WARM_ENI_TARGET to 0 but the problem with this [1] with custom networking we allocate secondary ENI since primary ENI is not used and if there are no pods then IPAMD will determine this as an extra ENI since the target is 0 and free the ENI. Later IPAMD will see "available is 0 and WARM_ENI_TARGET is 0" so allocates a new ENI. This happens continuously by the reconciler adding to more EC2 calls on the account. This is tracked with this issue - #1451 [2] Without custom networking, scaling will be very slow - Initially on nodeInit and ENI will allocated Max secondary IPs and once those IPs are used, the next ENI will be allocated after the next reconciler starts and enters here - https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/ipamd/ipamd.go#L911 and then few more seconds for IPs to be available in IMDS so until then pods will be stuck in container creating. Similar fix done in this PR should be done even for WARM_ENI_TARGET but that will break upgrades if someone is already using this so it would need reach out and documentation update.

Similar issue will happen with WARM_PREFIX TARGET, prefixes will be attached and removed in a loop by the reconciler and when more prefixes are needed we need to wait for the reconciler.

<Sorry @anguslees copying your explanation below since it will help our documentation :D :D >
[1]"I am IP constrained" (allocate/free to maintain a small warm pool -> WARM_IP_TARGET=$small; WARM_ENI/PREFIX=$small or 0; possibly choose SIP-mode)
[2]"I am AWS-API-calls constrained" (allocate/free in large batches -> WARM_ENI/PREFIX=$small or $big)
[3]"I want to burst as quickly as I can" (maintain a large warm pool -> WARM_ENI/PREFIX=$big)

**What does this PR do / Why do we need it**:
[1] With prefix delegation, we won't support WARM_{PREFIX,IP}_TARGET = 0 and MINIMUM_IP_TARGET=0.
[2] default WARM_PREFIX_TARGET to 1.

If WARM_{PREFIX,IP}_TARGET = 0/unset and MINIMUM_IP_TARGET=0/unset, then aws-node will fail to start with an error.

WARM_PREFIX_TARGET = 0 but WARM_IP_TARGET or MINIMUM_IP_TARGET is non zero will work since WARM_IP_TARGET /MINIMUM_IP_TARGET overrides WARM_PREFIX_TARGET

One combination which this PR won't handle is WARM_PREFIX_TARGET = non-zero but WARM_IP_TARGET or MINIMUM_IP_TARGET is zero, since this is supported with secondary mode and this will be evaluated along with WARM_ENI_TARGET.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
kubectl logs aws-node-ppwcj -n kube-system
{"level":"info","ts":"2021-06-17T19:43:57.967Z","caller":"entrypoint.sh","msg":"Validating env variables ..."}
{"level":"error","ts":"2021-06-17T19:43:57.968Z","caller":"entrypoint.sh","msg":"Setting WARM_PREFIX_TARGET = 0 is not supported while WARM_IP_TARGET/MINIMUM_IP_TARGET is not set. Please configure either one of the WARM_{PREFIX/IP}_TARGET or MINIMUM_IP_TARGET env variables"}
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
WARM_{PREFIX,IP}_TARGET = 0/unset and MINIMUM_IP_TARGET=0/unset is not supported with PD.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
