### PR TITLE
non-nitro instances init issues

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -180,8 +180,8 @@ type APIs interface {
 	//GetInstanceType returns the EC2 instance type
 	GetInstanceType() string
 
-        //Update cached prefix delegation flag
-	InitCachedPrefixDelegation (bool)
+	//Update cached prefix delegation flag
+	InitCachedPrefixDelegation(bool)
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -384,7 +384,7 @@ func New(useCustomNetworking bool) (*EC2InstanceMetadataCache, error) {
 	return cache, nil
 }
 
-func (cache *EC2InstanceMetadataCache) InitCachedPrefixDelegation (enableIpv4PrefixDelegation bool) {
+func (cache *EC2InstanceMetadataCache) InitCachedPrefixDelegation(enableIpv4PrefixDelegation bool) {
 	cache.enableIpv4PrefixDelegation = enableIpv4PrefixDelegation
 	log.Infof("Prefix Delegation enabled %v", cache.enableIpv4PrefixDelegation)
 }

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -179,6 +179,9 @@ type APIs interface {
 
 	//GetInstanceType returns the EC2 instance type
 	GetInstanceType() string
+
+        //Update cached prefix delegation flag
+	InitCachedPrefixDelegation (bool)
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -339,7 +342,7 @@ func (i instrumentedIMDS) GetMetadataWithContext(ctx context.Context, p string) 
 }
 
 // New creates an EC2InstanceMetadataCache
-func New(useCustomNetworking, enableIpv4PrefixDelegation bool) (*EC2InstanceMetadataCache, error) {
+func New(useCustomNetworking bool) (*EC2InstanceMetadataCache, error) {
 	//ctx is passed to initWithEC2Metadata func to cancel spawned go-routines when tests are run
 	ctx := context.Background()
 
@@ -365,9 +368,6 @@ func New(useCustomNetworking, enableIpv4PrefixDelegation bool) (*EC2InstanceMeta
 	cache.useCustomNetworking = useCustomNetworking
 	log.Infof("Custom networking enabled %v", cache.useCustomNetworking)
 
-	cache.enableIpv4PrefixDelegation = enableIpv4PrefixDelegation
-	log.Infof("Prefix Delegation enabled %v", cache.enableIpv4PrefixDelegation)
-
 	awsCfg := aws.NewConfig().WithRegion(region)
 	sess = sess.Copy(awsCfg)
 
@@ -382,6 +382,11 @@ func New(useCustomNetworking, enableIpv4PrefixDelegation bool) (*EC2InstanceMeta
 	go wait.Forever(cache.cleanUpLeakedENIs, time.Hour)
 
 	return cache, nil
+}
+
+func (cache *EC2InstanceMetadataCache) InitCachedPrefixDelegation (enableIpv4PrefixDelegation bool) {
+	cache.enableIpv4PrefixDelegation = enableIpv4PrefixDelegation
+	log.Infof("Prefix Delegation enabled %v", cache.enableIpv4PrefixDelegation)
 }
 
 // InitWithEC2metadata initializes the EC2InstanceMetadataCache with the data retrieved from EC2 metadata service

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -19,11 +19,12 @@
 package mock_awsutils
 
 import (
+	net "net"
+	reflect "reflect"
+
 	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
-	net "net"
-	reflect "reflect"
 )
 
 // MockAPIs is a mock of APIs interface

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -19,12 +19,11 @@
 package mock_awsutils
 
 import (
-	net "net"
-	reflect "reflect"
-
 	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
+	net "net"
+	reflect "reflect"
 )
 
 // MockAPIs is a mock of APIs interface
@@ -91,20 +90,6 @@ func (m *MockAPIs) AllocIPAddresses(arg0 string, arg1 int) error {
 func (mr *MockAPIsMockRecorder) AllocIPAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocIPAddresses", reflect.TypeOf((*MockAPIs)(nil).AllocIPAddresses), arg0, arg1)
-}
-
-// DeallocCidrs mocks base method
-func (m *MockAPIs) DeallocCidrs(arg0 string, arg1 []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeallocCidrs", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeallocCidrs indicates an expected call of DeallocCidrs
-func (mr *MockAPIsMockRecorder) DeallocCidrs(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeallocCidrs", reflect.TypeOf((*MockAPIs)(nil).DeallocCidrs), arg0, arg1)
 }
 
 // DeallocIPAddresses mocks base method
@@ -323,6 +308,18 @@ func (m *MockAPIs) GetVPCIPv4CIDRs() ([]string, error) {
 func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv4CIDRs", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv4CIDRs))
+}
+
+// InitCachedPrefixDelegation mocks base method
+func (m *MockAPIs) InitCachedPrefixDelegation(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InitCachedPrefixDelegation", arg0)
+}
+
+// InitCachedPrefixDelegation indicates an expected call of InitCachedPrefixDelegation
+func (mr *MockAPIsMockRecorder) InitCachedPrefixDelegation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitCachedPrefixDelegation", reflect.TypeOf((*MockAPIs)(nil).InitCachedPrefixDelegation), arg0)
 }
 
 // IsCNIUnmanagedENI mocks base method

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -329,7 +329,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to default (secondary IP) mode", c.awsClient.GetInstanceType())
 		c.enableIpv4PrefixDelegation = false
 	}
-        c.awsClient.InitCachedPrefixDelegation(c.enableIpv4PrefixDelegation)
+	c.awsClient.InitCachedPrefixDelegation(c.enableIpv4PrefixDelegation)
 	c.myNodeName = os.Getenv("MY_NODE_NAME")
 	checkpointer := datastore.NewJSONFile(dsBackingStorePath())
 	c.dataStore = datastore.NewDataStore(log, checkpointer, c.enableIpv4PrefixDelegation)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -304,7 +304,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.useCustomNetworking = UseCustomNetworkCfg()
 	c.enableIpv4PrefixDelegation = useIpv4PrefixDelegation()
 
-	client, err := awsutils.New(c.useCustomNetworking, c.enableIpv4PrefixDelegation)
+	client, err := awsutils.New(c.useCustomNetworking)
 	if err != nil {
 		return nil, errors.Wrap(err, "ipamd: can not initialize with AWS SDK interface")
 	}
@@ -329,6 +329,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to default (secondary IP) mode", c.awsClient.GetInstanceType())
 		c.enableIpv4PrefixDelegation = false
 	}
+        c.awsClient.InitCachedPrefixDelegation(c.enableIpv4PrefixDelegation)
 	c.myNodeName = os.Getenv("MY_NODE_NAME")
 	checkpointer := datastore.NewJSONFile(dsBackingStorePath())
 	c.dataStore = datastore.NewDataStore(log, checkpointer, c.enableIpv4PrefixDelegation)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Non-nitro instances were getting initialized as PD enabled

**What does this PR do / Why do we need it**:
Had multiple internal branches and during the merge to master this got overwritten.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:315","msg":"Using WARM_ENI_TARGET 1"}
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:318","msg":"Using WARM_PREFIX_TARGET 1"}
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:323","msg":"Instance hypervisor family xen"}
{"level":"warn","ts":"2021-07-02T00:02:28.791Z","caller":"aws-k8s-agent/main.go:56","msg":"Prefix delegation is not supported on non-nitro instance r4.xlarge hence falling back to default
(secondary IP) mode"}
{"level":"info","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:333","msg":"Prefix Delegation enabled false"}
{"level":"info","ts":"2021-07-02T00:02:28.791Z","caller":"awsutils/awsutils.go:1480","msg":"Will attempt to clean up AWS CNI leaked ENIs after waiting 4m41s."}
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:338","msg":"Start node init"}
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:365","msg":"Using MAX_ENI 2"}
{"level":"debug","ts":"2021-07-02T00:02:28.791Z","caller":"ipamd/ipamd.go:338","msg":"Max ip per ENI 14 and max prefixes per ENI 0"}
{"level":"info","ts":"2021-07-02T00:02:28.792Z","caller":"ipamd/ipamd.go:382","msg":"Setting up host network... "}
```

```
dev-dsk-varavaj-2b-72f02457 % kgpsys | grep aws-node
aws-node-56kcp             1/1     Running   0          50m     10.0.14.94     ip-10-0-14-94.us-west-2.compute.internal     <none>           <none>
aws-node-b8d5z             1/1     Running   0          50m     10.0.38.223    ip-10-0-38-223.us-west-2.compute.internal    <none>           <none>
aws-node-fm9f6             1/1     Running   0          50m     10.0.89.170    ip-10-0-89-170.us-west-2.compute.internal    <none>           <none>
aws-node-fs6v2             1/1     Running   0          50m     10.0.126.61    ip-10-0-126-61.us-west-2.compute.internal    <none>           <none>
aws-node-hlngf             1/1     Running   0          50m     10.0.210.189   ip-10-0-210-189.us-west-2.compute.internal   <none>           <none>
aws-node-jc6bd             1/1     Running   0          50m     10.0.194.183   ip-10-0-194-183.us-west-2.compute.internal   <none>           <none>
aws-node-rwsbb             1/1     Running   0          50m     10.0.234.160   ip-10-0-234-160.us-west-2.compute.internal   <none>           <none>
aws-node-sqcjs             1/1     Running   0          50m     10.0.147.38    ip-10-0-147-38.us-west-2.compute.internal    <none>           <none>
aws-node-vvmg6             1/1     Running   0          50m     10.0.7.26      ip-10-0-7-26.us-west-2.compute.internal      <none>           <none>
aws-node-wjpm5             1/1     Running   0          50m     10.0.12.85     ip-10-0-12-85.us-west-2.compute.internal     <none>           <none>
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No, will add it.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
