### PR TITLE
Add metrics for total prefix count and ips used per cidr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ docker-unit-test: build-docker-test     ## Run unit tests inside of the testing 
 
 # Build metrics helper agent.
 build-metrics:     ## Build metrics helper agent.
-	go build -ldflags="-s -w" -o cni-metrics-helper ./cmd/cni-metrics-helper
+	go build $(VENDOR_OVERRIDE_FLAG) -ldflags="-s -w" -o cni-metrics-helper ./cmd/cni-metrics-helper
 
 # Build metrics helper agent Docker image.
 docker-metrics:    ## Build metrics helper agent Docker image.
@@ -188,7 +188,7 @@ docker-metrics:    ## Build metrics helper agent Docker image.
 metrics-unit-test: CGO_ENABLED=1
 metrics-unit-test: GOARCH=
 metrics-unit-test:       ## Run metrics helper unit test suite (must be run natively).
-	go test -v -cover -race -timeout 10s \
+	go test -v $(VENDOR_OVERRIDE_FLAG) -cover -race -timeout 10s \
 		./cmd/cni-metrics-helper/metrics/...
 
 # Run metrics helper unit test suite in a container.

--- a/cmd/cni-metrics-helper/README.md
+++ b/cmd/cni-metrics-helper/README.md
@@ -34,6 +34,8 @@ Adding the CNI metrics helper will publish the following metrics to CloudWatch:
 "podENIErr",
 "reconcileCount",
 "totalIPAddresses",
+"totalIPv4Prefixes",
+"totalAssignedIPv4sPerCidr"
 ```
 
 ### Get cni-metrics-helper logs

--- a/cmd/cni-metrics-helper/metrics/cni_metrics.go
+++ b/cmd/cni-metrics-helper/metrics/cni_metrics.go
@@ -40,6 +40,18 @@ var InterestingCNIMetrics = map[string]metricsConvert{
 				matchFunc:  matchAny,
 				actionFunc: metricsAdd,
 				data:       &dataPoints{}}}},
+	"awscni_total_ipv4_prefixes": {
+		actions: []metricsAction{
+			{cwMetricName: "totalIPv4Prefixes",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{}}}},
+	"awscni_assigned_ip_per_ipv4cidr": {
+		actions: []metricsAction{
+			{cwMetricName: "totalAssignedIPv4sPerCidr",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{}}}},
 	"awscni_eni_allocated": {
 		actions: []metricsAction{
 			{cwMetricName: "eniAllocated",

--- a/cmd/cni-metrics-helper/metrics/cni_test2.data
+++ b/cmd/cni-metrics-helper/metrics/cni_test2.data
@@ -1,0 +1,194 @@
+# HELP awscni_add_ip_req_count The number of add IP address request
+# TYPE awscni_add_ip_req_count counter
+awscni_add_ip_req_count 100
+# HELP awscni_assigned_ip_addresses The number of IP addresses assigned to pods
+# TYPE awscni_assigned_ip_addresses gauge
+awscni_assigned_ip_addresses 1
+# HELP awscni_total_ipv4_prefixes The total number of IPv4 prefixes
+# TYPE awscni_total_ipv4_prefixes gauge
+awscni_total_ipv4_prefixes 1
+# HELP awscni_assigned_ip_per_ipv4cidr The total number of IP addresses assigned per cidr
+# TYPE awscni_assigned_ip_per_ipv4cidr gauge
+awscni_assigned_ip_per_ipv4cidr 1
+# HELP awscni_aws_api_error_count The number of times AWS API returns an error
+# TYPE awscni_aws_api_error_count counter
+awscni_aws_api_error_count{api="DeleteNetworkInterface",error="InvalidParameterValue"} 14
+# HELP awscni_aws_api_latency_ms AWS API call latency in ms
+# TYPE awscni_aws_api_latency_ms summary
+awscni_aws_api_latency_ms{api="AssignPrivateIpAddresses",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="AssignPrivateIpAddresses",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="AssignPrivateIpAddresses",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="AssignPrivateIpAddresses",error="false"} 2938
+awscni_aws_api_latency_ms_count{api="AssignPrivateIpAddresses",error="false"} 10
+awscni_aws_api_latency_ms{api="AttachNetworkInterface",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="AttachNetworkInterface",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="AttachNetworkInterface",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="AttachNetworkInterface",error="false"} 4377
+awscni_aws_api_latency_ms_count{api="AttachNetworkInterface",error="false"} 10
+awscni_aws_api_latency_ms{api="CreateNetworkInterface",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="CreateNetworkInterface",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="CreateNetworkInterface",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="CreateNetworkInterface",error="false"} 1328
+awscni_aws_api_latency_ms_count{api="CreateNetworkInterface",error="false"} 10
+awscni_aws_api_latency_ms{api="CreateTags",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="CreateTags",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="CreateTags",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="CreateTags",error="false"} 1123
+awscni_aws_api_latency_ms_count{api="CreateTags",error="false"} 10
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="DeleteNetworkInterface",error="false"} 2364
+awscni_aws_api_latency_ms_count{api="DeleteNetworkInterface",error="false"} 9
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="true",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="true",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="DeleteNetworkInterface",error="true",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="DeleteNetworkInterface",error="true"} 1806
+awscni_aws_api_latency_ms_count{api="DeleteNetworkInterface",error="true"} 14
+awscni_aws_api_latency_ms{api="DescribeInstances",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="DescribeInstances",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="DescribeInstances",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="DescribeInstances",error="false"} 1330
+awscni_aws_api_latency_ms_count{api="DescribeInstances",error="false"} 10
+awscni_aws_api_latency_ms{api="DescribeNetworkInterfaces",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="DescribeNetworkInterfaces",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="DescribeNetworkInterfaces",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="DescribeNetworkInterfaces",error="false"} 2360
+awscni_aws_api_latency_ms_count{api="DescribeNetworkInterfaces",error="false"} 20
+awscni_aws_api_latency_ms{api="DetachNetworkInterface",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="DetachNetworkInterface",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="DetachNetworkInterface",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="DetachNetworkInterface",error="false"} 1828
+awscni_aws_api_latency_ms_count{api="DetachNetworkInterface",error="false"} 9
+awscni_aws_api_latency_ms{api="GetMetadata",error="false",quantile="0.5"} 0
+awscni_aws_api_latency_ms{api="GetMetadata",error="false",quantile="0.9"} 0
+awscni_aws_api_latency_ms{api="GetMetadata",error="false",quantile="0.99"} 1
+awscni_aws_api_latency_ms_sum{api="GetMetadata",error="false"} 4384
+awscni_aws_api_latency_ms_count{api="GetMetadata",error="false"} 82716
+awscni_aws_api_latency_ms{api="ModifyNetworkInterfaceAttribute",error="false",quantile="0.5"} NaN
+awscni_aws_api_latency_ms{api="ModifyNetworkInterfaceAttribute",error="false",quantile="0.9"} NaN
+awscni_aws_api_latency_ms{api="ModifyNetworkInterfaceAttribute",error="false",quantile="0.99"} NaN
+awscni_aws_api_latency_ms_sum{api="ModifyNetworkInterfaceAttribute",error="false"} 1551
+awscni_aws_api_latency_ms_count{api="ModifyNetworkInterfaceAttribute",error="false"} 10
+# HELP awscni_del_ip_req_count The number of delete IP address request
+# TYPE awscni_del_ip_req_count counter
+awscni_del_ip_req_count{reason="PodDeleted"} 106
+awscni_del_ip_req_count{reason="SetupNSFailed"} 2
+# HELP awscni_eni_allocated The number of ENIs allocated
+# TYPE awscni_eni_allocated gauge
+awscni_eni_allocated 2
+# HELP awscni_eni_max The maximum number of ENIs that can be attached to the instance
+# TYPE awscni_eni_max gauge
+awscni_eni_max 3
+# HELP awscni_ip_max The maximum number of IP addresses that can be allocated to the instance
+# TYPE awscni_ip_max gauge
+awscni_ip_max 15
+# HELP awscni_ipamd_action_inprogress The number of ipamd actions in progress
+# TYPE awscni_ipamd_action_inprogress gauge
+awscni_ipamd_action_inprogress{fn="decreaseIPPool"} 0
+awscni_ipamd_action_inprogress{fn="increaseIPPool"} 0
+awscni_ipamd_action_inprogress{fn="nodeIPPoolReconcile"} 0
+awscni_ipamd_action_inprogress{fn="nodeInit"} 0
+awscni_ipamd_action_inprogress{fn="retryAllocENIIP"} 0
+# HELP awscni_total_ip_addresses The total number of IP addresses
+# TYPE awscni_total_ip_addresses gauge
+awscni_total_ip_addresses 16
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 1.7901e-05
+go_gc_duration_seconds{quantile="0.25"} 3.2781e-05
+go_gc_duration_seconds{quantile="0.5"} 5.1354e-05
+go_gc_duration_seconds{quantile="0.75"} 0.00013115
+go_gc_duration_seconds{quantile="1"} 0.005550315
+go_gc_duration_seconds_sum 0.797514698
+go_gc_duration_seconds_count 9895
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 25
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 7.710456e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.778966304e+10
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.775926e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 1.80537453e+08
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 712704
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 7.710456e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 4.620288e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 1.0387456e+07
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 43550
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 1.073152e+06
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 1.5007744e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5562085013141422e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 226723
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 1.80581003e+08
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 128896
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 163840
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 1.1965008e+07
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 589762
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 720896
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 720896
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.8987256e+07
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 1391.13
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 65536
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 10
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 3.9559168e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.5550271644e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 5.1757056e+07

--- a/cmd/cni-metrics-helper/metrics/metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/metrics_test.go
@@ -94,3 +94,26 @@ func TestAPIServerMetric(t *testing.T) {
 	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
 	assert.Equal(t, 0.0, actions[0].data.lastSingleDataPoint)
 }
+
+func TestAPIServerMetricwithPDenabled(t *testing.T) {
+	testTarget := newTestMetricsTarget("cni_test2.data", InterestingCNIMetrics)
+	ctx := context.Background()
+	_, _, _, err := metricsListGrabAggregateConvert(ctx, testTarget)
+	assert.NoError(t, err)
+
+	actions := InterestingCNIMetrics["awscni_assigned_ip_addresses"].actions
+	// verify awscni_assigned_ip_addresses value
+	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
+
+	actions = InterestingCNIMetrics["awscni_total_ip_addresses"].actions
+	// verify awscni_total_ip_addresses value
+	assert.Equal(t, 16.0, actions[0].data.curSingleDataPoint)
+
+	actions = InterestingCNIMetrics["awscni_total_ipv4_prefixes"].actions
+	// verify awscni_total_ipv4_prefixes value
+	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
+
+	actions = InterestingCNIMetrics["awscni_assigned_ip_per_ipv4cidr"].actions
+	// verify awscni_assigned_ip_per_ipv4cidr value
+	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
+}

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1346,9 +1346,9 @@ func (cache *EC2InstanceMetadataCache) AllocIPAddresses(eniID string, numIPs int
 				"Returning without an error here since we will verify the actual state by calling EC2 to see what addresses have already assigned to this ENI.")
 			return nil
 		}
-		log.Errorf("Failed to allocate a private IP addresses on ENI %v: %v", eniID, err)
+		log.Errorf("Failed to allocate a private IP/Prefix addresses on ENI %v: %v", eniID, err)
 		awsAPIErrInc("AssignPrivateIpAddresses", err)
-		return errors.Wrap(err, "allocate IP address: failed to allocate a private IP address")
+		return errors.Wrap(err, "allocate IP/Prefix address: failed to allocate a private IP/Prefix address")
 	}
 	if output != nil {
 		if cache.enableIpv4PrefixDelegation {

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -601,7 +601,7 @@ func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (ipv4address string, 
 				}
 				//Update prometheus for ips per cidr
 				//Secondary IP mode will have /32:1 and Prefix mode will have /28:<number of /32s>
-				ipsPerCidr.With(prometheus.Labels{"cidr": availableCidr.Cidr.String()}).Inc()	
+				ipsPerCidr.With(prometheus.Labels{"cidr": availableCidr.Cidr.String()}).Inc()
 			} else {
 				//This can happen during upgrade or PD enable/disable knob toggle
 				//ENI can have prefixes attached and no space for SIPs or vice versa

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -169,7 +169,7 @@ var (
 	reconcileCnt = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "awscni_reconcile_count",
-			Help: "The number of times ipamd reconciles on ENIs and IP addresses",
+			Help: "The number of times ipamd reconciles on ENIs and IP/Prefix addresses",
 		},
 		[]string{"fn"},
 	)

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -11,6 +11,7 @@ ENV GOPROXY=direct
 # Copy modules in before the rest of the source to only expire cache on module
 # changes:
 COPY go.mod go.sum ./
+COPY vendor/ vendor/
 RUN go mod download
 
 COPY . ./


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Add metrics to export total prefix count and number of IPs consumer per cidr

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
With few default pods - 
```
# HELP awscni_total_ipv4_prefixes The total number of IPv4 prefixes\n
# TYPE awscni_total_ipv4_prefixes gauge\nawscni_total_ipv4_prefixes 1
# HELP awscni_assigned_ip_per_ipv4cidr The total number of IP addresses assigned per cidr
# TYPE awscni_assigned_ip_per_ipv4cidr gauge\nawscni_assigned_ip_per_ipv4cidr{cidr=\"192.168.42.48/28\"} 1
```
<img width="1524" alt="Screen Shot 2021-07-09 at 11 33 17 AM" src="https://user-images.githubusercontent.com/1111446/125121901-790e3080-e0a9-11eb-8012-2513a590c995.png">

Added few pods in PD mode - 

<img width="1531" alt="Screen Shot 2021-07-09 at 12 14 03 PM" src="https://user-images.githubusercontent.com/1111446/125125918-2afc2b80-e0af-11eb-88a4-56968033c29a.png">

Deleted few pods in PD mode -

<img width="1531" alt="Screen Shot 2021-07-09 at 12 14 47 PM" src="https://user-images.githubusercontent.com/1111446/125126005-53842580-e0af-11eb-986f-c189c7ef7e22.png">

Enabled secondary IP mode with pods behind few prefixes

<img width="1534" alt="Screen Shot 2021-07-09 at 12 23 10 PM" src="https://user-images.githubusercontent.com/1111446/125126823-811d9e80-e0b0-11eb-9bb1-d6cd08c06bfe.png">

Deleted pods behind prefixes and prefixes got cleaned up 

<img width="1523" alt="Screen Shot 2021-07-09 at 12 29 55 PM" src="https://user-images.githubusercontent.com/1111446/125127503-74e61100-e0b1-11eb-966b-808986637ace.png">

Scale with secondary mode - 

<img width="1521" alt="Screen Shot 2021-07-09 at 12 42 46 PM" src="https://user-images.githubusercontent.com/1111446/125128699-3cdfcd80-e0b3-11eb-9f23-c4dd1a8b4df1.png">
<img width="419" alt="Screen Shot 2021-07-09 at 12 42 52 PM" src="https://user-images.githubusercontent.com/1111446/125128704-3ea99100-e0b3-11eb-8059-b1a95b1e76cc.png">

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
