### PR TITLE
Deprecate v1beta1 for CRD eniconfig

### DIFF
--- a/charts/aws-vpc-cni/templates/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/templates/customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"
@@ -62,10 +62,15 @@
     "plural": "eniconfigs"
     "singular": "eniconfig"
   "scope": "Cluster"
+  "preserveUnknownFields": false
   "versions":
-  - "name": "v1alpha1"
-    "served": true
-    "storage": true
+    - "name": "v1alpha1"
+      "served": true
+      "storage": true
+      "schema":
+        "openAPIV3Schema":
+          "type": object
+          "x-kubernetes-preserve-unknown-fields": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"
@@ -62,10 +62,15 @@
     "plural": "eniconfigs"
     "singular": "eniconfig"
   "scope": "Cluster"
+  "preserveUnknownFields": false
   "versions":
-  - "name": "v1alpha1"
-    "served": true
-    "storage": true
+    - "name": "v1alpha1"
+      "served": true
+      "storage": true
+      "schema":
+        "openAPIV3Schema":
+          "type": object
+          "x-kubernetes-preserve-unknown-fields": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"
@@ -62,10 +62,15 @@
     "plural": "eniconfigs"
     "singular": "eniconfig"
   "scope": "Cluster"
+  "preserveUnknownFields": false
   "versions":
-  - "name": "v1alpha1"
-    "served": true
-    "storage": true
+    - "name": "v1alpha1"
+      "served": true
+      "storage": true
+      "schema":
+        "openAPIV3Schema":
+          "type": object
+          "x-kubernetes-preserve-unknown-fields": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -51,7 +51,7 @@
   - "list"
   - "watch"
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
+"apiVersion": "apiextensions.k8s.io/v1"
 "kind": "CustomResourceDefinition"
 "metadata":
   "name": "eniconfigs.crd.k8s.amazonaws.com"
@@ -62,10 +62,15 @@
     "plural": "eniconfigs"
     "singular": "eniconfig"
   "scope": "Cluster"
+  "preserveUnknownFields": false
   "versions":
-  - "name": "v1alpha1"
-    "served": true
-    "storage": true
+    - "name": "v1alpha1"
+      "served": true
+      "storage": true
+      "schema":
+        "openAPIV3Schema":
+          "type": object
+          "x-kubernetes-preserve-unknown-fields": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -248,7 +248,7 @@ local awsnode = {
   },
 
   crd: {
-    apiVersion: "apiextensions.k8s.io/v1beta1",
+    apiVersion: "apiextensions.k8s.io/v1",
     kind: "CustomResourceDefinition",
     metadata: {
       name: "eniconfigs.crd.k8s.amazonaws.com",
@@ -256,10 +256,16 @@ local awsnode = {
     spec: {
       scope: "Cluster",
       group: "crd.k8s.amazonaws.com",
+      preserveUnknownFields: false,
       versions: [{
         name: "v1alpha1",
         served: true,
         storage: true,
+        schema: {
+            openAPIV3Schema: {
+              type: "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+            }},
       }],
       names: {
         plural: "eniconfigs",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Update ENICONFIG API Version to v1
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1074 

**What does this PR do / Why do we need it**:
Kubernetes will stop serving v1beta1 on CustomResourceDefinition. AWS EKS starts using the apiextensions.k8s.io/v1 API version from EKS 1.21. We want to update the version accordingly at GitHub as well.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Applied the aws-k8s-cni.yaml to
- EKS 1.20 cluster to update the ENICONFIG API version.
- EKS 1.21 cluster to verify no error.

Test result
```
 % kubectl apply -f config/master/aws-k8s-cni.yaml
\clusterrolebinding.rbac.authorization.k8s.io/aws-node unchanged
clusterrole.rbac.authorization.k8s.io/aws-node unchanged
customresourcedefinition.apiextensions.k8s.io/eniconfigs.crd.k8s.amazonaws.com configured
daemonset.apps/aws-node configured
serviceaccount/aws-node unchanged
```
```
Status:
  Accepted Names:
    Kind:       ENIConfig
    List Kind:  ENIConfigList
    Plural:     eniconfigs
    Singular:   eniconfig
  Conditions:
    Last Transition Time:  2021-06-28T18:26:06Z
    Message:               no conflicts found
    Reason:                NoConflicts
    Status:                True
    Type:                  NamesAccepted
    Last Transition Time:  2021-06-28T18:26:06Z
    Message:               the initial names have been accepted
    Reason:                InitialNamesAccepted
    Status:                True
    Type:                  Established
  Stored Versions:
    v1alpha1

```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no 

Updating a running cluster has been tested in EKS 1.20 and EKS 1.21 clusters.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
