### PR TITLE
Add event recorder utils to raise aws-node pod events

### DIFF
--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -33,3 +33,7 @@ rules:
     resources:
       - '*'
     verbs: ["list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources:
+      - events
+    verbs: ["create", "patch", "list", "get"]

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/eventrecorder"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/version"
 )
@@ -61,6 +62,8 @@ func _main() int {
 		log.Errorf("Failed to create cached kube client: %s", err)
 		return 1
 	}
+
+	eventrecorder.InitEventRecorder(rawK8SClient)
 
 	ipamContext, err := ipamd.New(rawK8SClient, cacheK8SClient)
 	if err != nil {

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -70,6 +70,10 @@ rules:
     resources:
       - '*'
     verbs: ["list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources:
+      - events
+    verbs: ["create", "patch", "list", "get"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -70,6 +70,10 @@ rules:
     resources:
       - '*'
     verbs: ["list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources:
+      - events
+    verbs: ["create", "patch", "list", "get"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -70,6 +70,10 @@ rules:
     resources:
       - '*'
     verbs: ["list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources:
+      - events
+    verbs: ["create", "patch", "list", "get"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -70,6 +70,10 @@ rules:
     resources:
       - '*'
     verbs: ["list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources:
+      - events
+    verbs: ["create", "patch", "list", "get"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -462,8 +462,9 @@ func (c *IPAMContext) nodeInit() error {
 
 	metadataResult, err := c.awsClient.DescribeAllENIs()
 	if err != nil {
-		return errors.New("ipamd init: failed to retrieve attached ENIs info")
+		return errors.Wrap(err, "ipamd init: failed to retrieve attached ENIs info")
 	}
+
 	log.Debugf("DescribeAllENIs success: ENIs: %d, tagged: %d", len(metadataResult.ENIMetadata), len(metadataResult.TagMap))
 	c.awsClient.SetCNIUnmanagedENIs(metadataResult.MultiCardENIIDs)
 	c.setUnmanagedENIs(metadataResult.TagMap)
@@ -938,7 +939,7 @@ func (c *IPAMContext) tryAssignIPs() (increasedPool bool, err error) {
 			err = c.awsClient.AllocIPAddresses(eni.ID, 1)
 			if err != nil {
 				ipamdErrInc("increaseIPPoolAllocIPAddressesFailed")
-				return false, errors.Wrap(err, fmt.Sprintf("failed to allocate one IP addresses on ENI %s, err: %v", eni.ID, err))
+				return false, errors.Wrap(err, fmt.Sprintf("failed to allocate one IP addresses on ENI %s, err ", eni.ID))
 			}
 		}
 		// This call to EC2 is needed to verify which IPs got attached to this ENI.
@@ -1908,13 +1909,13 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 }
 
 // AnnotatePod annotates the pod with the provided key and value
-func (c *IPAMContext) AnnotatePod(podNamespace, podName, key, val string) error {
+func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val string) error {
 	ctx := context.TODO()
 	var err error
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		pod := &corev1.Pod{}
-		if pod, err = c.GetPod(podNamespace, podName); err != nil {
+		if pod, err = c.GetPod(podName, podNamespace); err != nil {
 			return err
 		}
 

--- a/pkg/utils/eventrecorder/eventrecorder.go
+++ b/pkg/utils/eventrecorder/eventrecorder.go
@@ -1,0 +1,100 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package event recorder is used to raise events on aws-node pods
+package eventrecorder
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = logger.Get()
+var myNodeName = os.Getenv("MY_NODE_NAME")
+var eventRecorder *EventRecorder
+
+const (
+	awsNode      = "aws-node"
+	specNodeName = "spec.nodeName"
+	labelK8sapp  = "k8s-app"
+)
+
+type EventRecorder struct {
+	recorder  record.EventRecorder
+	k8sClient client.Client
+}
+
+func InitEventRecorder(k8sClient client.Client) error {
+
+	clientSet, err := k8sapi.GetKubeClientSet()
+	if err != nil {
+		log.Fatalf("Error Fetching Kubernetes Client: %s", err)
+		return err
+	}
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
+		Interface: clientSet.CoreV1().Events(""),
+	})
+
+	recorder := &EventRecorder{}
+	recorder.recorder = eventBroadcaster.NewRecorder(clientgoscheme.Scheme, corev1.EventSource{
+		Component: awsNode,
+		Host:      myNodeName,
+	})
+	recorder.k8sClient = k8sClient
+	eventRecorder = recorder
+	log.Infof("eventrecoder set:", eventRecorder.recorder)
+	return nil
+}
+
+func Get() *EventRecorder {
+	if eventRecorder == nil {
+		err := errors.New("error fetching event recoder, not initialized")
+		panic(err.Error())
+	}
+	return eventRecorder
+}
+
+// BroadcastEvent will raise event on aws-node with given type, reason, & message
+func (e *EventRecorder) BroadcastEvent(eventType, reason, message string) {
+
+	// Get aws-node pod objects with label & field selectors
+	labelSelector := labels.SelectorFromSet(labels.Set{labelK8sapp: awsNode})
+	fieldSelector := fields.SelectorFromSet(fields.Set{specNodeName: myNodeName})
+	listOptions := client.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: fieldSelector,
+	}
+
+	var podList corev1.PodList
+	err := e.k8sClient.List(context.TODO(), &podList, &listOptions)
+	if err != nil {
+		log.Errorf("Failed to get pods, cannot broadcast events: %v", err)
+		return
+	}
+	for _, pod := range podList.Items {
+		log.Debugf("Broadcasting event on pod %s", pod.Name)
+		e.recorder.Event(&pod, eventType, reason, message)
+	}
+}

--- a/pkg/utils/eventrecorder/eventrecorder_test.go
+++ b/pkg/utils/eventrecorder/eventrecorder_test.go
@@ -1,0 +1,105 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eventrecorder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var ctrl *gomock.Controller
+var fakeRecorder *record.FakeRecorder
+
+type testMocks struct {
+	ctrl          *gomock.Controller
+	mockK8sClient client.Client
+}
+
+func setup(t *testing.T) *testMocks {
+	ctrl = gomock.NewController(t)
+	k8sSchema := runtime.NewScheme()
+	k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+	clientgoscheme.AddToScheme(k8sSchema)
+
+	return &testMocks{
+		ctrl:          ctrl,
+		mockK8sClient: k8sClient,
+	}
+}
+
+func TestBroadcastEvents(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+	ctx := context.Background()
+
+	fakeRecorder = record.NewFakeRecorder(3)
+	mockEventRecorder := &EventRecorder{
+		recorder:  fakeRecorder,
+		k8sClient: m.mockK8sClient,
+	}
+
+	labels := map[string]string{"k8s-app": "aws-node"}
+
+	pods := []v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "mockPodWithLabelAndSpec",
+				Labels: labels,
+			},
+			Spec: v1.PodSpec{
+				NodeName: myNodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mockPodWithSpec",
+			},
+			Spec: v1.PodSpec{
+				NodeName: myNodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mockPod",
+			},
+		},
+		// No pod with only label selector in test- this will raise event as fake client does not filter on fields
+	}
+
+	//Create above fake pods
+	for _, mockPod := range pods {
+		_ = mockEventRecorder.k8sClient.Create(ctx, &mockPod)
+	}
+
+	// Testing missing permissions event case: failed to call
+	reason := "MissingIAMPermission"
+	msg := "Failed to call ec2:DescribeNetworkInterfaces due to missing permissions. Please refer to https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md"
+	mockEventRecorder.BroadcastEvent(v1.EventTypeWarning, reason, msg)
+	assert.Len(t, fakeRecorder.Events, 1) // event should be recorded only on pod with req label selector & pod spec
+
+	expected := fmt.Sprintf("%s %s %s", v1.EventTypeWarning, reason, msg)
+	got := <-fakeRecorder.Events
+	assert.Equal(t, expected, got)
+}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -14,6 +14,7 @@
 package framework
 
 import (
+	"context"
 	"log"
 
 	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
@@ -23,6 +24,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s"
 	sgp "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,7 +59,10 @@ func New(options Options) *Framework {
 	stopChan := ctrl.SetupSignalHandler()
 	cache, err := cache.New(config, cache.Options{Scheme: k8sSchema})
 	Expect(err).NotTo(HaveOccurred())
-
+	err = cache.IndexField(context.TODO(), &v1.Event{}, "reason", func(o client.Object) []string {
+		return []string{o.(*v1.Event).Reason}
+	}) // default indexing only on ns, need this for ipamd_event_test
+	Expect(err).NotTo(HaveOccurred())
 	go func() {
 		cache.Start(stopChan)
 	}()

--- a/test/framework/resources/k8s/manager.go
+++ b/test/framework/resources/k8s/manager.go
@@ -32,6 +32,7 @@ type ResourceManagers interface {
 	DaemonSetManager() resources.DaemonSetManager
 	ConfigMapManager() resources.ConfigMapManager
 	NetworkPolicyManager() resources.NetworkPolicyManager
+	EventManager() resources.EventManager
 }
 
 type defaultManager struct {
@@ -45,6 +46,7 @@ type defaultManager struct {
 	daemonSetManager      resources.DaemonSetManager
 	configMapManager      resources.ConfigMapManager
 	networkPolicyManager  resources.NetworkPolicyManager
+	eventManager          resources.EventManager
 }
 
 func NewResourceManager(k8sClient client.Client,
@@ -60,6 +62,7 @@ func NewResourceManager(k8sClient client.Client,
 		daemonSetManager:      resources.NewDefaultDaemonSetManager(k8sClient),
 		configMapManager:      resources.NewConfigMapManager(k8sClient),
 		networkPolicyManager:  resources.NewNetworkPolicyManager(k8sClient),
+		eventManager:          resources.NewEventManager(k8sClient),
 	}
 }
 
@@ -101,4 +104,8 @@ func (m *defaultManager) ConfigMapManager() resources.ConfigMapManager {
 
 func (m *defaultManager) NetworkPolicyManager() resources.NetworkPolicyManager {
 	return m.networkPolicyManager
+}
+
+func (m defaultManager) EventManager() resources.EventManager {
+	return m.eventManager
 }

--- a/test/framework/resources/k8s/resources/events.go
+++ b/test/framework/resources/k8s/resources/events.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type EventManager interface {
+	GetEventsWithOptions(opts *client.ListOptions) (v1.EventList, error)
+}
+
+type defaultEventManager struct {
+	k8sClient client.Client
+}
+
+func NewEventManager(k8sClient client.Client) EventManager {
+	return &defaultEventManager{k8sClient: k8sClient}
+}
+
+func (d defaultEventManager) GetEventsWithOptions(opts *client.ListOptions) (v1.EventList, error) {
+	eventList := v1.EventList{}
+	err := d.k8sClient.List(context.Background(), &eventList, opts)
+	return eventList, err
+}

--- a/test/integration-new/ipamd/ipamd_event_test.go
+++ b/test/integration-new/ipamd/ipamd_event_test.go
@@ -1,0 +1,123 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"strings"
+	"time"
+
+	k8sUtil "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const EKSCNIPolicyARN = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+const AwsNodeLabelKey = "k8s-app"
+
+var _ = Describe("test aws-node pod event", func() {
+
+	// Verifies aws-node pod events works as expected
+	Context("when iam role is missing VPC_CNI policy", func() {
+		var role string
+
+		BeforeEach(func() {
+			// To get the role assumed by CNI, first check the ENV "AWS_ROLE_ARN" on aws-node to get the service account role
+			// If not found, get the node instance role
+			By("getting the iam role")
+			podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
+			Expect(err).ToNot(HaveOccurred())
+			for _, env := range podList.Items[0].Spec.Containers[0].Env {
+				if env.Name == "AWS_ROLE_ARN" {
+					role = strings.Split(env.Value, "/")[1]
+				}
+			}
+
+			if role == "" { // get the node instance role
+				nodeList, err := f.K8sResourceManagers.NodeManager().
+					GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+				Expect(err).ToNot(HaveOccurred())
+
+				instanceID := k8sUtil.GetInstanceIDFromNode(nodeList.Items[0])
+				instance, err := f.CloudServices.EC2().DescribeInstance(instanceID)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("getting the node instance role")
+				instanceProfileRoleName := strings.Split(*instance.IamInstanceProfile.Arn, "instance-profile/")[1]
+				instanceProfileOutput, err := f.CloudServices.IAM().GetInstanceProfile(instanceProfileRoleName)
+				Expect(err).ToNot(HaveOccurred())
+				role = *instanceProfileOutput.InstanceProfile.Roles[0].RoleName
+			}
+
+			By("detaching VPC_CNI policy and restart aws-node pods")
+			err = f.CloudServices.IAM().DetachRolePolicy(EKSCNIPolicyARN, role)
+			Expect(err).ToNot(HaveOccurred())
+			RestartAwsNodePods()
+
+			By("checking aws-node pods not running")
+			time.Sleep(utils.PollIntervalMedium) // allow time for aws-node to restart
+			podList, err = f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, cond := range podList.Items[0].Status.Conditions {
+				if cond.Type == v1.PodReady {
+					Expect(cond.Status).To(BeEquivalentTo(v1.ConditionFalse))
+					break
+				}
+			}
+
+		})
+
+		AfterEach(func() {
+			By("attaching VPC_CNI policy and restart aws-node pods")
+			err = f.CloudServices.IAM().AttachRolePolicy(EKSCNIPolicyARN, role)
+			Expect(err).ToNot(HaveOccurred())
+			RestartAwsNodePods()
+
+			By("checking aws-node pods are running")
+			time.Sleep(utils.PollIntervalMedium * 2) // sleep to allow aws-node to restart
+			podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
+			Expect(err).ToNot(HaveOccurred())
+			for _, cond := range podList.Items[0].Status.Conditions {
+				if cond.Type != v1.PodReady {
+					continue
+				}
+				Expect(cond.Status).To(BeEquivalentTo(v1.ConditionTrue))
+				break
+			}
+		})
+
+		It("unauthorized event must be raised on aws-node pod", func() {
+			listOpts := client.ListOptions{
+				FieldSelector: fields.SelectorFromSet(fields.Set{"reason": "MissingIAMPermissions"}),
+				Namespace:     utils.AwsNodeNamespace,
+			}
+			eventList, err := f.K8sResourceManagers.EventManager().GetEventsWithOptions(&listOpts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(eventList.Items).NotTo(BeEmpty())
+
+		})
+	})
+})
+
+func RestartAwsNodePods() {
+	podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector("k8s-app", utils.AwsNodeName)
+	Expect(err).ToNot(HaveOccurred())
+	for _, pod := range podList.Items {
+		f.K8sResourceManagers.PodManager().DeleteAndWaitTillPodDeleted(&pod)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1520

**What does this PR do / Why do we need it**:
Add event recorder utils to handle raising aws-node pod events for faster triaging. This PR adds missing permissions pod event when EC2 API call fails due to missing CNI policy from the IAM role. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Repro steps: Detach AmazonEKS_CNI_Policy from IAM role and restart aws-node pods. The pods will not be ready due to missing permissions.

**Testing done on this change**:
1. Nodegroup creation when CNI policy is missing 
2. Restart aws-node pods when CNI policy missing

Events can be retrieved with "kubectl describe pod aws-node-xxx" & "kubectl get events":
```
2m29s       Warning   MissingIAMPermissions   pod/aws-node-lps4s   Unauthorized operation: failed to call ec2:DescribeNetworkInterfaces due to missing permissions. Please refer https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md to attach relevant policy to IAM role
```
Ginkgo test run:
```
ipamd git:(addPodEvent) ✗ ginkgo -v -- \                                                       
 --cluster-kubeconfig=$KUBECONFIG \
 --cluster-name=$CLUSTER_NAME \
 --aws-region=$AWS_REGION \
 --aws-vpc-id=$VPC_ID \
 --ng-name-label-key=$NG_NAME_LABEL_KEY \
 --ng-name-label-val=$NG_NAME_LABEL_VAL
Running Suite: VPC IPAMD Test Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd
=========================================================================================================================
Random Seed: 1649808955

Will run 1 of 26 specs
------------------------------
[BeforeSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_suite_test.go:39
STEP: Delete coredns addon if it exists 04/12/22 17:16:22.748
------------------------------
[BeforeSuite] PASSED [4.469 seconds]
[BeforeSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_suite_test.go:39

  Begin Captured GinkgoWriter Output >>
    STEP: Delete coredns addon if it exists 04/12/22 17:16:22.748
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSSS
------------------------------
test aws-node pod event when iam role is missing VPC_CNI policy
  unauthorized event must be raised on aws-node pod
  /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_event_test.go:104
STEP: getting the iam role 04/12/22 17:16:23.151
STEP: getting the node instance role 04/12/22 17:16:23.689
STEP: detaching VPC_CNI policy and restart aws-node pods 04/12/22 17:16:24.07
STEP: checking aws-node pods not running 04/12/22 17:20:23.582
STEP: attaching VPC_CNI policy and restart aws-node pods 04/12/22 17:20:28.6
STEP: checking aws-node pods are running 04/12/22 17:25:04.428
------------------------------
• [SLOW TEST] [531.288 seconds]
test aws-node pod event
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_event_test.go:32
  when iam role is missing VPC_CNI policy
  /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_event_test.go:35
    unauthorized event must be raised on aws-node pod
    /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_event_test.go:104

  Begin Captured GinkgoWriter Output >>
    STEP: getting the iam role 04/12/22 17:16:23.151
    STEP: getting the node instance role 04/12/22 17:16:23.689
    STEP: detaching VPC_CNI policy and restart aws-node pods 04/12/22 17:16:24.07
    STEP: checking aws-node pods not running 04/12/22 17:20:23.582
    STEP: attaching VPC_CNI policy and restart aws-node pods 04/12/22 17:20:28.6
    STEP: checking aws-node pods are running 04/12/22 17:25:04.428
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSSSSSS
------------------------------
[AfterSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_suite_test.go:61
------------------------------
[AfterSuite] PASSED [0.000 seconds]
[AfterSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/ipamd_suite_test.go:61
------------------------------

Ran 1 of 26 Specs in 535.762 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 25 Skipped
PASS | FOCUSED
```
**Automation added to e2e**:
None

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No. Upgrade tested.

**Does this change require updates to the CNI daemonset config files to work?**:
No.

**Does this PR introduce any user-facing change?**:
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
