### PR TITLE
Added Fix for multus

### DIFF
--- a/test/framework/resources/k8s/utils/daemonset.go
+++ b/test/framework/resources/k8s/utils/daemonset.go
@@ -17,6 +17,9 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -67,6 +70,19 @@ func updateDaemonsetEnvVarsAndWait(f *framework.Framework, dsName string, dsName
 		Expect(err).ToNot(HaveOccurred())
 	}
 	waitTillDaemonSetUpdated(f, ds, updatedDs)
+
+	// update multus daemonset if it exists
+	// to avoid being stuck in recursive loop, we need below check
+	if dsName != utils.MultusNodeName {
+		By("Restarting Multus daemonset if it exists")
+		_, err := f.K8sResourceManagers.DaemonSetManager().GetDaemonSet(dsNamespace, utils.MultusNodeName)
+		if err == nil {
+			td := time.Now()
+			updateDaemonsetEnvVarsAndWait(f, utils.MultusNodeName, dsNamespace, utils.MultusContainerName, map[string]string{
+				"forceUpdatedAt": td.String(),
+			}, nil)
+		}
+	}
 }
 
 func getDaemonSet(f *framework.Framework, dsName string, dsNamespace string) *v1.DaemonSet {

--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -20,12 +20,12 @@ const (
 	AwsNodeNamespace     = "kube-system"
 	AwsNodeName          = "aws-node"
 	AWSInitContainerName = "aws-vpc-cni-init"
+	MultusNodeName       = "kube-multus-ds"
+	MultusContainerName  = "kube-multus"
 
 	// See https://gallery.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper
 	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:66180f40"
-)
 
-const (
 	PollIntervalShort  = time.Second * 2
 	PollIntervalMedium = time.Second * 5
 	PollIntervalLong   = time.Second * 20

--- a/test/integration-new/cni/pod_networking_suite_test.go
+++ b/test/integration-new/cni/pod_networking_suite_test.go
@@ -75,7 +75,8 @@ var _ = BeforeSuite(func() {
 	instanceOutput, err := f.CloudServices.EC2().DescribeInstanceType(instanceType)
 	Expect(err).ToNot(HaveOccurred())
 
-	maxIPPerInterface = int(*instanceOutput[0].NetworkInfo.Ipv4AddressesPerInterface)
+	// Pods often get stuck due insufficient capacity, so adding some buffer to the maxIPPerInterface
+	maxIPPerInterface = int(*instanceOutput[0].NetworkInfo.Ipv4AddressesPerInterface) - 5
 
 	By("describing the VPC to get the VPC CIDRs")
 	describeVPCOutput, err := f.CloudServices.EC2().DescribeVPC(f.Options.AWSVPCID)


### PR DESCRIPTION
**What type of PR is this?**
When Multus is deployed, it needs to be restarted as well to take effect from any changes made to vpc-cni daemonset
Added this fix so that cni tests can work as expected
Refactored some of the test logic 


**Which issue does this PR fix**:
Running cni tests when multus is installed

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
