### PR TITLE
Update SDK Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ export GOPROXY = direct
 
 VENDOR_OVERRIDE_FLAG =
 # aws-sdk-go override in case we need to build against a custom version
-EC2_SDK_OVERRIDE ?= "y"
+EC2_SDK_OVERRIDE ?= "n"
 
 ifeq ($(EC2_SDK_OVERRIDE), "y")
 VENDOR_OVERRIDE_FLAG = -mod=mod

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -6,7 +6,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.7.5
+    tag: v1.9.0
     region: us-west-2
     pullPolicy: Always
     # Set to use custom image
@@ -18,7 +18,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.7.5
+  tag: v1.9.0
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.8.0
+    tag: v1.9.0
     region: us-west-2
     pullPolicy: Always
     # Set to use custom image
@@ -20,7 +20,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.8.0
+  tag: v1.9.0
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/amazon-vpc-cni-k8s
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.37.23
+	github.com/aws/aws-sdk-go v1.40.6
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.9.0
 	github.com/coreos/go-iptables v0.4.5
@@ -19,7 +19,7 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	go.uber.org/zap v1.15.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/tools v0.1.3 // indirect
 	google.golang.org/grpc v1.29.0

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -11,7 +11,6 @@ ENV GOPROXY=direct
 # Copy modules in before the rest of the source to only expire cache on module
 # changes:
 COPY go.mod go.sum ./
-COPY vendor/ vendor/
 RUN go mod download
 
 COPY . ./

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -10,7 +10,6 @@ ENV GOPROXY=direct
 
 # Copy modules in before the rest of the source to only expire cache on module changes:
 COPY go.mod go.sum ./
-COPY vendor/ vendor/
 RUN go mod download
 
 COPY Makefile ./

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/amazon-vpc-cni-k8s v1.7.10
 	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
 	github.com/aws/amazon-vpc-resource-controller-k8s v1.0.7
-	github.com/aws/aws-sdk-go v1.37.23
+	github.com/aws/aws-sdk-go v1.40.6
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Update the SDK go version

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
