### PR TITLE
Use codecov github action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:
-        go-version: '1.14.3' 
+        go-version: '1.14.3'
       id: go
 
     - name: Check out code into the Go module directory
@@ -41,4 +41,4 @@ jobs:
       run: make unit-test
 
     - name: Upload code coverage
-      run: bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v1


### PR DESCRIPTION
In particular, this avoids `curl | bash` (the bash script is simply
embedded in the github action image).

It also provides a trivial upgrade path to the new nodejs-based
uploader (`@v1` -> `@v2`), when we decide that is ready (perhaps now).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
