### PR TITLE
set requests/limits for initcontainer

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -202,6 +202,13 @@
           "value": "false"
         "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.0"
         "name": "aws-vpc-cni-init"
+        "resources":
+          "limits":
+            "cpu": "50m"
+            "memory": "64Mi"
+          "requests":
+            "cpu": "10m"
+            "memory": "32Mi"
         "securityContext":
           "privileged": true
         "volumeMounts":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -202,6 +202,13 @@
           "value": "false"
         "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
         "name": "aws-vpc-cni-init"
+        "resources":
+          "limits":
+            "cpu": "50m"
+            "memory": "64Mi"
+          "requests":
+            "cpu": "10m"
+            "memory": "32Mi"
         "securityContext":
           "privileged": true
         "volumeMounts":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -202,6 +202,13 @@
           "value": "false"
         "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
         "name": "aws-vpc-cni-init"
+        "resources":
+          "limits":
+            "cpu": "50m"
+            "memory": "64Mi"
+          "requests":
+            "cpu": "10m"
+            "memory": "32Mi"
         "securityContext":
           "privileged": true
         "volumeMounts":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -202,6 +202,13 @@
           "value": "false"
         "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
         "name": "aws-vpc-cni-init"
+        "resources":
+          "limits":
+            "cpu": "50m"
+            "memory": "64Mi"
+          "requests":
+            "cpu": "10m"
+            "memory": "32Mi"
         "securityContext":
           "privileged": true
         "volumeMounts":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -233,6 +233,10 @@ local awsnode = {
                   name: "DISABLE_TCP_EARLY_DEMUX", value: "false",
                 },
               ],
+              resources: {
+                requests: {cpu: "10m", memory: "32Mi"},
+                limits: {cpu: "50m", memory: "64Mi"},
+              },
               volumeMounts: [
                 {mountPath: "/host/opt/cni/bin", name: "cni-bin-dir"},
               ],


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1554

**What does this PR do / Why do we need it**:
adds requests/limits for initcontainer so it does not get rejected when cluster requires it and serves as example for users that want to set it, also prevents cni from consuming too much cpu/memory


**Testing done on this change**:
deployed to our clusters and did not see oomkills or slow boot

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
yes

**Does this PR introduce any user-facing change?**:

```release-note
set default init container requests and limits
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
