### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Type: Integer
 
 Default: None
 
-Specifies the number of free IP addresses that the `ipamd` daemon should attempt to keep available for pod assignment on the node. 
+Specifies the number of free IP addresses that the `ipamd` daemon should attempt to keep available for pod assignment on the node. Setting this to a non-positive value is same as setting this to 0 or not setting the variable.
 With `ENABLE_PREFIX_DELEGATION` set to `true` then `ipamd` daemon will check if the existing (/28) prefixes are enough to maintain the
 `WARM_IP_TARGET` if it is not sufficent then more prefixes will be attached.
 
@@ -268,7 +268,8 @@ Default: None
 
 Specifies the number of total IP addresses that the `ipamd` daemon should attempt to allocate for pod assignment on the node.
 `MINIMUM_IP_TARGET` behaves identically to `WARM_IP_TARGET` except that instead of setting a target number of free IP
-addresses to keep available at all times, it sets a target number for a floor on how many total IP addresses are allocated.
+addresses to keep available at all times, it sets a target number for a floor on how many total IP addresses are allocated. Setting to a 
+non-positive value is same as setting this to 0 or not setting the variable.
 
 `MINIMUM_IP_TARGET` is for pre-scaling, `WARM_IP_TARGET` is for dynamic scaling. For example, suppose a cluster has an
 expected pod density of approximately 30 pods per node. If `WARM_IP_TARGET` is set to 30 to ensure there are enough IPs
@@ -436,7 +437,7 @@ To enable security groups for pods you need to have at least an EKS 1.17 eks.3 c
 
 Setting `ENABLE_POD_ENI` to `true` will allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI.
 
-The label notifies vpc-resource-controller (https://github.com/aws/amazon-vpc-resource-controller-k8s) to attach a Trunk ENI to the instance. The label value is initially set to `false` and is marked to `true` by IPAMD when vpc-resource-controller attaches a Trunk ENI to the instance. However, there might be cases where the label value will remain `false` if the instance doesn't support ENI Trunking.
+The label notifies vpc-resource-controller (https://github.com/aws/amazon-vpc-resource-controller-k8s) to attach a Trunk ENI to the instance. The label value is initially set to `false` and is marked to `true` by IPAMD when vpc-resource-controller attaches a Trunk ENI to the instance. However, there might be cases where the label value will remain `false` if the instance doesn't support ENI Trunking. Once enabled the [VPC resource controller](https://github.com/aws/amazon-vpc-resource-controller-k8s)  will then advertise branch network interfaces as extended resources on these nodes in your cluster. Branch interface capacity is additive to existing instance type limits for secondary IP addresses. For example, a c5.4xlarge can continue to have up to 234 secondary IP addresses assigned to standard network interfaces and up to 54 branch network interfaces. Each branch network interface only receives a single primary IP address. If you are having the cluster mostly using pods with security group consider setting `WARM_IP_TARGET` instead of default `WARM_ENI_TARGET` to reduce wastage of IPs/ENIs.
 
 **NOTE!** Toggling `ENABLE_POD_ENI` from `true` to `false` will not detach the Trunk ENI from instance. To delete/detach the Trunk ENI from instance, you need recycle the instance.
 
@@ -453,6 +454,8 @@ to pods that are using per pod security groups, `DISABLE_TCP_EARLY_DEMUX` should
 container under `initcontainers`. This will increase the local TCP connection latency slightly.
 Details on why this is needed can be found in this [#1212 comment](https://github.com/aws/amazon-vpc-cni-k8s/pull/1212#issuecomment-693540666).
 To use this setting, a Linux kernel version of at least 4.6 is needed on the worker node.
+
+Setting `ENABLE_PREFIX_DELEGATION` starting v1.9.0+ will not impact the branch pods density.
 
 You can use the below command to enable `DISABLE_TCP_EARLY_DEMUX` to `true` -
 
@@ -472,6 +475,7 @@ To enable IPv4 prefix delegation on nitro instances. Setting `ENABLE_PREFIX_DELE
 instead of a secondary IP in the ENIs subnet. The total number of prefixes and private IP addresses will be less than the
 limit on private IPs allowed by your instance. Setting or resetting of `ENABLE_PREFIX_DELEGATION` while pods are running or if ENIs are attached is supported and the new pods allocated will get IPs based on the mode of IPAMD but the max pods of kubelet should be updated which would need either kubelet restart or node recycle.
 
+The feature doesn't increase the pod density of branch pods since we are limited by the number of branch network interfaces - https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#supported-instance-types.
 ---
 
 #### `WARM_PREFIX_TARGET` (v1.9.0+)
@@ -480,7 +484,7 @@ Type: Integer
 
 Default: None
 
-Specifies the number of free IPv4(/28) prefixes that the `ipamd` daemon should attempt to keep available for pod assignment on the node.
+Specifies the number of free IPv4(/28) prefixes that the `ipamd` daemon should attempt to keep available for pod assignment on the node. Setting to a non-positive value is same as setting this to 0 or not setting the variable.
 This environment variable works when `ENABLE_PREFIX_DELEGATION` is set to `true` and is overriden when `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are configured.
 
 ### ENI tags related to Allocation

--- a/docs/cni-proposal.md
+++ b/docs/cni-proposal.md
@@ -214,7 +214,7 @@ Right now, ENIs are allocated or freed by L-IPAM on each instance.  All ENIs on 
 
 #### Pod IP address cooling period
 
-When a Pod is deleted, we will keep the Pod IP address in "cooling mode" for cooling period. When the cooling period expires, we will return this Pod IP to the warm-pool. The cooling period is used to prevent CNI plugin recycle this Pod's IP address and assign to a new Pod before controller has finished updating all nodes in the cluster about this deleted pod.
+When a Pod is deleted, we will keep the Pod IP address in "cooling mode" for cooling period of 30 seconds. When the cooling period expires, we will return this Pod IP to the warm-pool. The cooling period is used to prevent CNI plugin recycle this Pod's IP address and assign to a new Pod before controller has finished updating all nodes in the cluster about this deleted pod.
 
 #### Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,9 @@ You can verify if you are in this situation by running the cni-metrics-helper:
 
 To avoid Pod deployment delay, you can configure ipamD to have a higher [**WARM\_ENI\_TARGET**](https://github.com/aws/amazon-vpc-cni-k8s/pull/68).
 
+### Tip: Running CNI on non-EKS AMI
+If ping between pods are not working, please make sure to check if FORWARD policy is set to ACCEPT since by default in iptables it is set to DROP. With EKS AMI, the policy is updated to set ACCEPT in [kubelet.service](https://github.com/awslabs/amazon-eks-ami/blob/master/files/kubelet.service#L8). Please ref: https://github.com/aws/amazon-vpc-cni-k8s/pull/535 and https://github.com/awslabs/amazon-eks-ami/issues/332 for more details.
+
 ## Troubleshooting CNI/ipamD at node level
 
 ### debugging logs are stored in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Update Cx facing docs

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1557 #1548 #1537 #995 #619 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
