### PR TITLE
set multus log level to panic instead of debug

### DIFF
--- a/config/multus/README.md
+++ b/config/multus/README.md
@@ -19,3 +19,10 @@ kubectl logs -f pod/kube-multus-ds-677mq -n kube-system
 { "cniVersion": "0.3.1", "name": "multus-cni-network", "type": "multus", "capabilities": {"portMappings": true}, "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig", "delegates": [ { "cniVersion": "0.3.1", "name": "aws-cni", "plugins": [ { "name": "aws-cni", "type": "aws-cni", "vethPrefix": "eni", "mtu": "9001", "pluginLogFile": "/var/log/aws-routed-eni/plugin.log", "pluginLogLevel": "DEBUG" }, { "type": "portmap", "capabilities": {"portMappings": true}, "snat": true } ] } ] }
 2021-07-27T08:02:00+0000 Entering sleep (success)...
 ```
+
+### Multus Logging
+The log level for multus has been set to error. It will log only the errors.
+
+If you want a more verbose logging you can change it to verbose. You can also use debug for your development but it can quickly fill up disk space
+
+You can find more info [here](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/configuration.md#logging-level)

--- a/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-cn.yaml
+++ b/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-cn.yaml
@@ -193,7 +193,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
         - "--multus-master-cni-file-name=10-aws.conflist"
-        - "--multus-log-level=debug"
+        - "--multus-log-level=error"
         - "--multus-log-file=/var/log/aws-routed-eni/multus.log"
         resources:
           requests:

--- a/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-us-gov-east-1.yaml
+++ b/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-us-gov-east-1.yaml
@@ -193,7 +193,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
         - "--multus-master-cni-file-name=10-aws.conflist"
-        - "--multus-log-level=debug"
+        - "--multus-log-level=error"
         - "--multus-log-file=/var/log/aws-routed-eni/multus.log"
         resources:
           requests:

--- a/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-us-gov-west-1.yaml
+++ b/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus-us-gov-west-1.yaml
@@ -193,7 +193,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
         - "--multus-master-cni-file-name=10-aws.conflist"
-        - "--multus-log-level=debug"
+        - "--multus-log-level=error"
         - "--multus-log-file=/var/log/aws-routed-eni/multus.log"
         resources:
           requests:

--- a/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus.yaml
+++ b/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus.yaml
@@ -193,7 +193,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
         - "--multus-master-cni-file-name=10-aws.conflist"
-        - "--multus-log-level=debug"
+        - "--multus-log-level=error"
         - "--multus-log-file=/var/log/aws-routed-eni/multus.log"
         resources:
           requests:


### PR DESCRIPTION
Updated Readme for Multus logging info

**What type of PR is this?**
cleanup
documentation

**Which issue does this PR fix**:
#1566 

**What does this PR do / Why do we need it**:
We need to fix log level in multus else it can fill up disk space as pointed out in the Issue


**Testing done on this change**:
```
kubectl edit pod/kube-multus-ds-46pbp -n kube-system 

containers:
  - args:
    - --multus-conf-file=auto
    - --cni-version=0.3.1
    - --multus-master-cni-file-name=10-aws.conflist
    - --multus-log-level=error
    - --multus-log-file=/var/log/aws-routed-eni/multus.log
```
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes, updated Readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
