### PR TITLE
Setting non-positive value for WARM targets not supported with PD

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ log_in_json()
 
 unsupported_prefix_target_conf()
 {
-   if [ "${WARM_PREFIX_TARGET}" == "0" ] && [ "${WARM_IP_TARGET}" == "0" ] && [ "${MINIMUM_IP_TARGET}" == "0" ];then
+   if [ "${WARM_PREFIX_TARGET}" <= "0" ] && [ "${WARM_IP_TARGET}" <= "0" ] && [ "${MINIMUM_IP_TARGET}" <= "0" ];then
         true
    else
         false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
WARM targets can be set with negative values and in IPAMD this is considered as 0. With PD we don't support setting all warm targets to 0.

**What does this PR do / Why do we need it**:
 The reason for not supporting 0 for these environment variables is they will impact pod launch times when IPs or ENIs are to be allocated. So if a pod is scheduled and IPs are not available then the pod will be stuck in container creating until the next reconciler allocates more IPs. This will be even more slow when new ENI has to be allocated since we need to create+attach an ENI and wait for it to be synced to IMDS.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1548 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
