### PR TITLE
Modify integ test workflow

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 3 * * *"  # every night
 
+permissions:
+  contents: read
+
 jobs:
   # Run nightly e2e tests on self-hosted runner
   integration-cron:

--- a/.github/workflows/forked-pr-tests.yml
+++ b/.github/workflows/forked-pr-tests.yml
@@ -8,6 +8,9 @@ on:
         default: ''
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # Repo owner has triggered this run
   integration-fork:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,12 +1,16 @@
 name: Integration tests
 
 on:
-  # Run on every pull request
-  pull_request_target:
-    branches: [ master ]
+  # Runs on push to master or release branches
+  push:
+    branches:
+      - 'master'
+      - 'release*'
+
+permissions:
+  contents: read
 
 jobs:
-  # Branch-based pull request from this repo
   integration-trusted:
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
- Change github_token permission
- Modified permissions for github_token in cron and integ test workflow - Modified integ test workflow to run on push to master and release branches

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Github_token permission fix

**What does this PR do / Why do we need it**:
Modified integ test workflow to run on master and release branches

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
