### PR TITLE
Update ginkgo command example in the doc

### DIFF
--- a/test/integration-new/README.md
+++ b/test/integration-new/README.md
@@ -33,7 +33,7 @@ ginkgo -v --failOnPending -- \
  --cluster-name=$CLUSTER_NAME \
  --aws-region=$AWS_REGION \
  --aws-vpc-id=$VPC_ID \
- --ng-name-label-val=$NG_NAME_LABEL_KEY \
+ --ng-name-label-key=$NG_NAME_LABEL_KEY \
  --ng-name-label-val=$NG_NAME_LABEL_VAL
 ```
 
@@ -49,7 +49,7 @@ In order to test a custom image you need pass the following tags along with the 
 *IMPORTANT*: The CNI Metric test is suitable for release testing of new CNI Metrics Helper manifest only if the manifest and the local helm charts are in sync.
 
 ### Future Work
-Currently the package is named as `integraiton-new` because we already have `integration` directory with existing Ginkgo test cases with a separate `go.mod`. Once the older package is completely deprecated we will rename this package to `integration`.
+Currently the package is named as `integration-new` because we already have `integration` directory with existing Ginkgo test cases with a separate `go.mod`. Once the older package is completely deprecated we will rename this package to `integration`.
 
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
documentation
**Which issue does this PR fix**:
Fixes ginkgo command usage example in https://github.com/aws/amazon-vpc-cni-k8s/tree/master/test/integration-new



**What does this PR do / Why do we need it**:
Fixes ginkgo command usage example in https://github.com/aws/amazon-vpc-cni-k8s/tree/master/test/integration-new



**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
