### PR TITLE
Respect existing eniConfig label if set on node. 

### DIFF
--- a/pkg/eniconfig/eniconfig.go
+++ b/pkg/eniconfig/eniconfig.go
@@ -34,6 +34,10 @@ const (
 	eniConfigDefault              = "default"
 	eniConfigLabel                = "vpc.amazonaws.com/eniConfig"
 
+	// when this is defined, it is to be treated as the source of truth for the eniconfig.
+	// it is meant to be used for out-of-band mananagement of the eniConfig - i.e. on the kubelet or elsewhere
+	externalEniConfigLabel = "vpc.amazonaws.com/externalEniConfig"
+
 	// when "ENI_CONFIG_LABEL_DEF is defined, ENIConfigController will use that label key to
 	// search if is setting value for eniConfigLabelDef
 	// Example:
@@ -124,25 +128,23 @@ func GetNodeSpecificENIConfigName(ctx context.Context, k8sClient client.Client) 
 		return eniConfigName, err
 	}
 
-	//Derive ENIConfig Name from either Node Annotations or Labels
-	val, ok := node.GetAnnotations()[getEniConfigAnnotationDef()]
+	//Derive ENIConfig Name from either externally managed label, Node Annotations or Labels
+	val, ok := node.GetLabels()[externalEniConfigLabel]
 	if !ok {
-		val, ok = node.GetLabels()[getEniConfigLabelDef()]
+		val, ok = node.GetAnnotations()[getEniConfigAnnotationDef()]
 		if !ok {
-			val = eniConfigDefault
+			val, ok = node.GetLabels()[getEniConfigLabelDef()]
+			if !ok {
+				val = eniConfigDefault
+			}
 		}
 	}
 
 	eniConfigName = val
 	if val != eniConfigDefault {
 		labels := node.GetLabels()
-		if labels[eniConfigLabel] == "" {
-			//Only set if the label is not already set.
-			labels[eniConfigLabel] = eniConfigName
-			node.SetLabels(labels)
-		} else {
-			return labels[eniConfigLabel], nil
-		}
+		labels["vpc.amazonaws.com/eniConfig"] = eniConfigName
+		node.SetLabels(labels)
 	}
 
 	return eniConfigName, nil

--- a/pkg/eniconfig/eniconfig_test.go
+++ b/pkg/eniconfig/eniconfig_test.go
@@ -178,12 +178,12 @@ func TestMyENIConfig(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "Matching ENIConfig available - Using label",
+			name: "Matching ENIConfig available - Using external label",
 			env: env{
 				nodes:      []*corev1.Node{testNode},
 				eniconfigs: []*v1alpha1.ENIConfig{testENIConfigAZ1, testENIConfigCustom},
 				Labels: map[string]string{
-					"vpc.amazonaws.com/eniConfig":            "custom",
+					"vpc.amazonaws.com/externalEniConfig":    "custom",
 					"failure-domain.beta.kubernetes.io/zone": "az2",
 				},
 				eniConfigLabelKey: "failure-domain.beta.kubernetes.io/zone",


### PR DESCRIPTION
Closes #1593 
Signed-off-by: Jonah Back <jonah@jonahback.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
Bug
**Which issue does this PR fix**:
#1593 

**What does this PR do / Why do we need it**:
This PR makes the CNI respect existing eniConfig labels if they exist. This is useful for users who may want to setup custom ENIConfigurations, but want to manage it through node labels (which notably can be passed to kubelet at startup) instead of through the override annotation.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Manual testing on an EKS cluster to ensure that the CNI was properly choosing the right ENIConfig. 

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
It could be considered a breaking change if a user is currently setting these labels, since it would start using their specified ENIConfig instead of the one that the CNI chooses.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
