### PR TITLE
Support for no_manage=false

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -182,6 +182,9 @@ type APIs interface {
 
 	//Update cached prefix delegation flag
 	InitCachedPrefixDelegation(bool)
+
+	// GetInstanceID returns the instance ID
+	GetInstanceID() string
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -1651,6 +1654,11 @@ func (cache *EC2InstanceMetadataCache) GetPrimaryENImac() string {
 //SetUnmanagedENIs Set unmanaged ENI set
 func (cache *EC2InstanceMetadataCache) SetUnmanagedENIs(eniIDs []string) {
 	cache.unmanagedENIs.Set(eniIDs)
+}
+
+// GetInstanceID returns the instance ID
+func (cache *EC2InstanceMetadataCache) GetInstanceID() string {
+	return cache.instanceID
 }
 
 //IsUnmanagedENI returns if the eni is unmanaged

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -240,6 +240,20 @@ func (mr *MockAPIsMockRecorder) GetInstanceHypervisorFamily() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceHypervisorFamily", reflect.TypeOf((*MockAPIs)(nil).GetInstanceHypervisorFamily))
 }
 
+// GetInstanceID mocks base method
+func (m *MockAPIs) GetInstanceID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetInstanceID indicates an expected call of GetInstanceID
+func (mr *MockAPIsMockRecorder) GetInstanceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceID", reflect.TypeOf((*MockAPIs)(nil).GetInstanceID))
+}
+
 // GetInstanceType mocks base method
 func (m *MockAPIs) GetInstanceType() string {
 	m.ctrl.T.Helper()

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -240,7 +240,7 @@ func (c *IPAMContext) setUnmanagedENIs(tagMap map[string]awsutils.TagMap) {
 	// if "no_manage" tag is present and is true - ENI is unmanaged
 	// if "no_manage" tag is present and is "not true" - ENI is managed
 	// if "instance_id" tag is present and is set to instanceID - ENI is managed since this was created by IPAMD
-	// if "no_manage" or "instance_id" tag is not set, check if we are in Manage Untagged Mode, default is true.
+	// if "no_manage" tag is not present or not IPAMD created ENI, check if we are in Manage Untagged Mode, default is true.
 	// if enableManageUntaggedMode is false, then consider all untagged ENIs as unmanaged.
 	for eniID, tags := range tagMap {
 		if _, found := tags[eniNoManageTagKey]; found {
@@ -254,7 +254,7 @@ func (c *IPAMContext) setUnmanagedENIs(tagMap map[string]awsutils.TagMap) {
 		}
 
 		if eniID == c.awsClient.GetPrimaryENI() {
-			log.Debugf("Ignoring no_manage tag on primary ENI %s", eniID)
+			log.Debugf("Ignoring primary ENI %s since it is always managed", eniID)
 		} else {
 			log.Debugf("Marking ENI %s as being unmanaged", eniID)
 			unmanagedENIlist = append(unmanagedENIlist, eniID)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -135,6 +135,11 @@ const (
 	//envWarmPrefixTarget is used to keep a /28 prefix in warm pool.
 	envWarmPrefixTarget     = "WARM_PREFIX_TARGET"
 	defaultWarmPrefixTarget = 0
+
+	// envManageUntaggedENI is used to determine if untagged ENIs should be managed or unmanaged
+	envManageUntaggedENI = "MANAGE_UNTAGGED_ENI"
+
+	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
 )
 
 var log = logger.Get()
@@ -223,6 +228,7 @@ type IPAMContext struct {
 	enablePodENI               bool
 	myNodeName                 string
 	enableIpv4PrefixDelegation bool
+	enableManageUntaggedMode   bool
 }
 
 // setUnmanagedENIs will rebuild the set of ENI IDs for ENIs tagged as "no_manage"
@@ -231,14 +237,27 @@ func (c *IPAMContext) setUnmanagedENIs(tagMap map[string]awsutils.TagMap) {
 		return
 	}
 	var unmanagedENIlist []string
+	// if "no_manage" tag is present and is true - ENI is unmanaged
+	// if "no_manage" tag is present and is "not true" - ENI is managed
+	// if "instance_id" tag is present and is set to instanceID - ENI is managed since this was created by IPAMD
+	// if "no_manage" or "instance_id" tag is not set, check if we are in Manage Untagged Mode, default is true.
+	// if enableManageUntaggedMode is false, then consider all untagged ENIs as unmanaged.
 	for eniID, tags := range tagMap {
-		if tags[eniNoManageTagKey] == "true" {
-			if eniID == c.awsClient.GetPrimaryENI() {
-				log.Debugf("Ignoring no_manage tag on primary ENI %s", eniID)
-			} else {
-				log.Debugf("Marking ENI %s tagged with %s as being unmanaged", eniID, eniNoManageTagKey)
-				unmanagedENIlist = append(unmanagedENIlist, eniID)
+		if _, found := tags[eniNoManageTagKey]; found {
+			if tags[eniNoManageTagKey] != "true" {
+				continue
 			}
+		} else if _, found := tags[eniNodeTagKey]; found && tags[eniNodeTagKey] == c.awsClient.GetInstanceID() {
+			continue
+		} else if c.enableManageUntaggedMode {
+			continue
+		}
+
+		if eniID == c.awsClient.GetPrimaryENI() {
+			log.Debugf("Ignoring no_manage tag on primary ENI %s", eniID)
+		} else {
+			log.Debugf("Marking ENI %s as being unmanaged", eniID)
+			unmanagedENIlist = append(unmanagedENIlist, eniID)
 		}
 	}
 	c.awsClient.SetUnmanagedENIs(unmanagedENIlist)
@@ -319,6 +338,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.warmPrefixTarget = getWarmPrefixTarget()
 
 	c.enablePodENI = enablePodENI()
+	c.enableManageUntaggedMode = enableManageUntaggedMode()
 
 	hypervisorType, err := c.awsClient.GetInstanceHypervisorFamily()
 	if err != nil {
@@ -1512,6 +1532,10 @@ func enablePodENI() bool {
 
 func useIpv4PrefixDelegation() bool {
 	return getEnvBoolWithDefault(envEnableIpv4PrefixDelegation, false)
+}
+
+func enableManageUntaggedMode() bool {
+	return getEnvBoolWithDefault(envManageUntaggedENI, true)
 }
 
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Certain use cases need to use only specific ENIs for pod IPs similar to allow and deny list. Currently we support no_manage = true tag but certain use cases need no_manage=false.

**What does this PR do / Why do we need it**:
`no_manage=false` will take precedence and will be considered for pod IP allocation and If `MANAGE_UNTAGGED_ENI` = `false` is set then any untagged ENIs will be marked as unmanaged by IPAMD and will not be considered for pod IP allocation.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
yes. 
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Will update in a follow up PR.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
