### PR TITLE
cherry-pick Support DISABLE_NETWORK_RESOURCE_PROVISIONING (#1586)

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,18 @@ Default: None
 Specifies the number of free IPv4(/28) prefixes that the `ipamd` daemon should attempt to keep available for pod assignment on the node.
 This environment variable works when `ENABLE_PREFIX_DELEGATION` is set to `true` and is overriden when `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are configured.
 
+---
+
+#### `DISABLE_NETWORK_RESOURCE_PROVISIONING` (v1.9.1+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Setting `DISABLE_NETWORK_RESOURCE_PROVISIONING` to `true` will make IPAMD to depend only on IMDS to get attached ENIs and IPs/prefixes.
+
+---
+
 ### ENI tags related to Allocation
 
 This plugin interacts with the following tags on ENIs:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -46,6 +46,7 @@ env:
   ENABLE_PREFIX_DELEGATION: "false"
   WARM_ENI_TARGET: "1"
   WARM_PREFIX_TARGET: "1"
+  DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -175,6 +175,7 @@ local awsnode = {
                 DISABLE_METRICS: "false",
                 ENABLE_POD_ENI: "false",
                 ENABLE_PREFIX_DELEGATION: "false",
+                DISABLE_NETWORK_RESOURCE_PROVISIONING: "false",
                 MY_NODE_NAME: {
                   valueFrom: {
                     fieldRef: {fieldPath: "spec.nodeName"},

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -342,7 +342,7 @@ func (i instrumentedIMDS) GetMetadataWithContext(ctx context.Context, p string) 
 }
 
 // New creates an EC2InstanceMetadataCache
-func New(useCustomNetworking bool) (*EC2InstanceMetadataCache, error) {
+func New(useCustomNetworking, disableENIProvisioning bool) (*EC2InstanceMetadataCache, error) {
 	//ctx is passed to initWithEC2Metadata func to cancel spawned go-routines when tests are run
 	ctx := context.Background()
 
@@ -379,7 +379,9 @@ func New(useCustomNetworking bool) (*EC2InstanceMetadataCache, error) {
 	}
 
 	// Clean up leaked ENIs in the background
-	go wait.Forever(cache.cleanUpLeakedENIs, time.Hour)
+	if !disableENIProvisioning {
+		go wait.Forever(cache.cleanUpLeakedENIs, time.Hour)
+	}
 
 	return cache, nil
 }

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -303,8 +303,9 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.networkClient = networkutils.New()
 	c.useCustomNetworking = UseCustomNetworkCfg()
 	c.enableIpv4PrefixDelegation = useIpv4PrefixDelegation()
+	c.disableENIProvisioning = disablingENIProvisioning()
 
-	client, err := awsutils.New(c.useCustomNetworking)
+	client, err := awsutils.New(c.useCustomNetworking, c.disableENIProvisioning)
 	if err != nil {
 		return nil, errors.Wrap(err, "ipamd: can not initialize with AWS SDK interface")
 	}
@@ -317,7 +318,6 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.minimumIPTarget = getMinimumIPTarget()
 	c.warmPrefixTarget = getWarmPrefixTarget()
 
-	c.disableENIProvisioning = disablingENIProvisioning()
 	c.enablePodENI = enablePodENI()
 
 	hypervisorType, err := c.awsClient.GetInstanceHypervisorFamily()
@@ -341,15 +341,17 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 
 	mac := c.awsClient.GetPrimaryENImac()
 	// retrieve security groups
+	if !c.disableENIProvisioning {
+		err = c.awsClient.RefreshSGIDs(mac)
+		if err != nil {
+			return nil, err
+		}
 
-	err = c.awsClient.RefreshSGIDs(mac)
-	if err != nil {
-		return nil, err
+		// Refresh security groups and VPC CIDR blocks in the background
+		// Ignoring errors since we will retry in 30s
+		go wait.Forever(func() { _ = c.awsClient.RefreshSGIDs(mac) }, 30*time.Second)
 	}
 
-	// Refresh security groups and VPC CIDR blocks in the background
-	// Ignoring errors since we will retry in 30s
-	go wait.Forever(func() { _ = c.awsClient.RefreshSGIDs(mac) }, 30*time.Second)
 	return c, nil
 }
 
@@ -401,7 +403,7 @@ func (c *IPAMContext) nodeInit() error {
 
 		isTrunkENI := eni.ENIID == metadataResult.TrunkENI
 		isEFAENI := metadataResult.EFAENIs[eni.ENIID]
-		if !isTrunkENI {
+		if !isTrunkENI && !c.disableENIProvisioning {
 			if err := c.awsClient.TagENI(eni.ENIID, metadataResult.TagMap[eni.ENIID]); err != nil {
 				return errors.Wrapf(err, "ipamd init: failed to tag managed ENI %v", eni.ENIID)
 			}
@@ -489,12 +491,14 @@ func (c *IPAMContext) nodeInit() error {
 		c.askForTrunkENIIfNeeded(ctx)
 	}
 
-	// For a new node, attach Cidrs (secondary ips/prefixes)
-	increasedPool, err := c.tryAssignCidrs()
-	if err == nil && increasedPool {
-		c.updateLastNodeIPPoolAction()
-	} else if err != nil {
-		return err
+	if !c.disableENIProvisioning {
+		// For a new node, attach Cidrs (secondary ips/prefixes)
+		increasedPool, err := c.tryAssignCidrs()
+		if err == nil && increasedPool {
+			c.updateLastNodeIPPoolAction()
+		} else if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1177,7 +1181,7 @@ func (c *IPAMContext) nodeIPPoolReconcile(ctx context.Context, interval time.Dur
 
 		isTrunkENI := attachedENI.ENIID == trunkENI
 		isEFAENI := efaENIs[attachedENI.ENIID]
-		if !isTrunkENI {
+		if !isTrunkENI && !c.disableENIProvisioning {
 			if err := c.awsClient.TagENI(attachedENI.ENIID, eniTagMap[attachedENI.ENIID]); err != nil {
 				log.Errorf("IP pool reconcile: failed to tag managed ENI %v: %v", attachedENI.ENIID, err)
 				ipamdErrInc("eniReconcileAdd")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick #1586 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
N/A

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
