### PR TITLE
UTs for no_manage=false

### DIFF
--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -48,13 +48,13 @@ import (
 const (
 	primaryENIid  = "eni-00000000"
 	secENIid      = "eni-00000001"
-	terENIid      = "eni-00000002" 
+	terENIid      = "eni-00000002"
 	primaryMAC    = "12:ef:2a:98:e5:5a"
 	secMAC        = "12:ef:2a:98:e5:5b"
 	terMAC        = "12:ef:2a:98:e5:5c"
 	primaryDevice = 0
 	secDevice     = 2
-	terDevice     = 3	
+	terDevice     = 3
 	primarySubnet = "10.10.10.0/24"
 	secSubnet     = "10.10.20.0/24"
 	terSubnet     = "10.10.30.0/24"
@@ -127,7 +127,7 @@ func TestNodeInit(t *testing.T) {
 	}
 	mockContext.dataStore.CheckpointMigrationPhase = 2
 
-	eni1, eni2, _:= getDummyENIMetadata()
+	eni1, eni2, _ := getDummyENIMetadata()
 
 	var cidrs []string
 	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
@@ -1170,10 +1170,10 @@ func datastoreWith3PodsFromPrefix() *datastore.DataStore {
 func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	eni1, eni2, eni3:= getDummyENIMetadata()
+	eni1, eni2, eni3 := getDummyENIMetadata()
 	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
 	primaryENIonly := []awsutils.ENIMetadata{eni1}
-	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3} 
+	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3}
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
@@ -1186,7 +1186,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}		
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
 	mockAWSUtils.EXPECT().GetPrimaryENI().Times(6).Return(eni1.ENIID)
@@ -1209,8 +1209,8 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &IPAMContext{
-				awsClient: mockAWSUtils,
-				enableManageUntaggedMode: true,}
+				awsClient:                mockAWSUtils,
+				enableManageUntaggedMode: true}
 			mockAWSUtils.EXPECT().SetUnmanagedENIs(tt.unmanagedenis).AnyTimes()
 			c.setUnmanagedENIs(tt.tagMap)
 
@@ -1246,10 +1246,10 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	eni1, eni2, eni3:= getDummyENIMetadata()
+	eni1, eni2, eni3 := getDummyENIMetadata()
 	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
 	primaryENIonly := []awsutils.ENIMetadata{eni1}
-	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3} 
+	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3}
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
@@ -1262,7 +1262,7 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}		
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
 	mockAWSUtils.EXPECT().GetPrimaryENI().Times(6).Return(eni1.ENIID)
@@ -1285,8 +1285,8 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &IPAMContext{
-				awsClient: mockAWSUtils,
-				enableManageUntaggedMode: false,}
+				awsClient:                mockAWSUtils,
+				enableManageUntaggedMode: false}
 			mockAWSUtils.EXPECT().SetUnmanagedENIs(tt.unmanagedenis).AnyTimes()
 			c.setUnmanagedENIs(tt.tagMap)
 

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -17,7 +17,6 @@ RUN go get -u golang.org/x/tools/cmd/goimports
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .
-COPY vendor/ vendor/
 
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Add UTs

**What does this PR do / Why do we need it**:
UTs for no manage false

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
PASS
coverage: 100.0% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/retry	0.003s	coverage: 100.0% of statements
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime/mocks	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/version	[no test files]
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/a
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
