### PR TITLE
Cherry-pick UTs for no_manage=false (#1612)

### DIFF
--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -48,23 +48,30 @@ import (
 const (
 	primaryENIid  = "eni-00000000"
 	secENIid      = "eni-00000001"
+	terENIid      = "eni-00000002"
 	primaryMAC    = "12:ef:2a:98:e5:5a"
 	secMAC        = "12:ef:2a:98:e5:5b"
+	terMAC        = "12:ef:2a:98:e5:5c"
 	primaryDevice = 0
 	secDevice     = 2
+	terDevice     = 3
 	primarySubnet = "10.10.10.0/24"
 	secSubnet     = "10.10.20.0/24"
+	terSubnet     = "10.10.30.0/24"
 	ipaddr01      = "10.10.10.11"
 	ipaddr02      = "10.10.10.12"
 	ipaddr03      = "10.10.10.13"
 	ipaddr11      = "10.10.20.11"
 	ipaddr12      = "10.10.20.12"
+	ipaddr21      = "10.10.30.11"
+	ipaddr22      = "10.10.30.12"
 	vpcCIDR       = "10.10.0.0/16"
 	myNodeName    = "testNodeName"
 	prefix01      = "10.10.30.0/28"
 	prefix02      = "10.10.40.0/28"
 	ipaddrPD01    = "10.10.30.0"
 	ipaddrPD02    = "10.10.40.0"
+	instanceID    = "i-0e1f3b9eb950e4980"
 )
 
 type testMocks struct {
@@ -120,7 +127,7 @@ func TestNodeInit(t *testing.T) {
 	}
 	mockContext.dataStore.CheckpointMigrationPhase = 2
 
-	eni1, eni2 := getDummyENIMetadata()
+	eni1, eni2, _ := getDummyENIMetadata()
 
 	var cidrs []string
 	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
@@ -255,13 +262,15 @@ func TestNodeInitwithPDenabled(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func getDummyENIMetadata() (awsutils.ENIMetadata, awsutils.ENIMetadata) {
+func getDummyENIMetadata() (awsutils.ENIMetadata, awsutils.ENIMetadata, awsutils.ENIMetadata) {
 	primary := true
 	notPrimary := false
 	testAddr1 := ipaddr01
 	testAddr2 := ipaddr02
 	testAddr11 := ipaddr11
 	testAddr12 := ipaddr12
+	testAddr21 := ipaddr21
+	testAddr22 := ipaddr22
 	eni1 := awsutils.ENIMetadata{
 		ENIID:          primaryENIid,
 		MAC:            primaryMAC,
@@ -291,7 +300,22 @@ func getDummyENIMetadata() (awsutils.ENIMetadata, awsutils.ENIMetadata) {
 			},
 		},
 	}
-	return eni1, eni2
+
+	eni3 := awsutils.ENIMetadata{
+		ENIID:          terENIid,
+		MAC:            terMAC,
+		DeviceNumber:   terDevice,
+		SubnetIPv4CIDR: terSubnet,
+		IPv4Addresses: []*ec2.NetworkInterfacePrivateIpAddress{
+			{
+				PrivateIpAddress: &testAddr21, Primary: &notPrimary,
+			},
+			{
+				PrivateIpAddress: &testAddr22, Primary: &notPrimary,
+			},
+		},
+	}
+	return eni1, eni2, eni3
 }
 
 func getDummyENIMetadataWithPrefix() (awsutils.ENIMetadata, awsutils.ENIMetadata) {
@@ -1146,14 +1170,27 @@ func datastoreWith3PodsFromPrefix() *datastore.DataStore {
 func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	eni1, eni2 := getDummyENIMetadata()
-	allENIs := []awsutils.ENIMetadata{eni1, eni2}
+	eni1, eni2, eni3 := getDummyENIMetadata()
+	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
 	primaryENIonly := []awsutils.ENIMetadata{eni1}
-	eni1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
-	eni2TagMap := map[string]awsutils.TagMap{eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
+	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3}
+	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
+	Test2TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
+	Test3TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
+	Test4TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
+	Test5TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
-	mockAWSUtils.EXPECT().GetPrimaryENI().Times(2).Return(eni1.ENIID)
+	mockAWSUtils.EXPECT().GetPrimaryENI().Times(6).Return(eni1.ENIID)
+	mockAWSUtils.EXPECT().GetInstanceID().Times(3).Return(instanceID)
 
 	tests := []struct {
 		name          string
@@ -1163,19 +1200,105 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 		unmanagedenis []string
 	}{
 		{"No tags at all", nil, allENIs, allENIs, nil},
-		{"Primary ENI unmanaged", eni1TagMap, allENIs, allENIs, nil},
-		{"Secondary ENI unmanaged", eni2TagMap, allENIs, primaryENIonly, []string{eni2.ENIID}},
+		{"Primary ENI unmanaged", Test1TagMap, allENIs, allENIs, nil},
+		{"Secondary/Tertiary ENI unmanaged", Test2TagMap, allENIs, primaryENIonly, []string{eni2.ENIID, eni3.ENIID}},
+		{"Secondary ENI unmanaged", Test3TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
+		{"Secondary ENI unmanaged and Tertiary ENI CNI created", Test4TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
+		{"Secondary ENI not CNI created and Tertiary ENI CNI created", Test5TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &IPAMContext{awsClient: mockAWSUtils}
+			c := &IPAMContext{
+				awsClient:                mockAWSUtils,
+				enableManageUntaggedMode: true}
 			mockAWSUtils.EXPECT().SetUnmanagedENIs(tt.unmanagedenis).AnyTimes()
 			c.setUnmanagedENIs(tt.tagMap)
 
 			mockAWSUtils.EXPECT().IsUnmanagedENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					if eni != eni1.ENIID {
-						if _, ok := tt.tagMap[eni]; ok {
+						tags := tt.tagMap[eni]
+						if _, ok := tags[eniNoManageTagKey]; ok {
+							if tags[eniNoManageTagKey] == "true" {
+								return true
+							}
+						} else if _, ok := tags[eniNodeTagKey]; ok && tags[eniNodeTagKey] != instanceID {
+							return true
+						}
+					}
+					return false
+
+				}).AnyTimes()
+
+			mockAWSUtils.EXPECT().IsCNIUnmanagedENI(gomock.Any()).DoAndReturn(
+				func(eni string) (unmanaged bool) {
+					return false
+
+				}).AnyTimes()
+
+			if got := c.filterUnmanagedENIs(tt.enis); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterUnmanagedENIs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	eni1, eni2, eni3 := getDummyENIMetadata()
+	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
+	primaryENIonly := []awsutils.ENIMetadata{eni1}
+	filteredENIonly := []awsutils.ENIMetadata{eni1, eni3}
+	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
+	Test2TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
+	Test3TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
+	Test4TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
+	Test5TagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
+
+	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
+	mockAWSUtils.EXPECT().GetPrimaryENI().Times(6).Return(eni1.ENIID)
+	mockAWSUtils.EXPECT().GetInstanceID().Times(3).Return(instanceID)
+
+	tests := []struct {
+		name          string
+		tagMap        map[string]awsutils.TagMap
+		enis          []awsutils.ENIMetadata
+		want          []awsutils.ENIMetadata
+		unmanagedenis []string
+	}{
+		{"No tags at all", nil, allENIs, allENIs, []string{eni2.ENIID, eni3.ENIID}},
+		{"Primary ENI unmanaged", Test1TagMap, allENIs, allENIs, nil},
+		{"Secondary/Tertiary ENI unmanaged", Test2TagMap, allENIs, primaryENIonly, []string{eni2.ENIID, eni3.ENIID}},
+		{"Secondary ENI unmanaged", Test3TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
+		{"Secondary ENI unmanaged and Tertiary ENI CNI created", Test4TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
+		{"Secondary ENI not CNI created and Tertiary ENI CNI created", Test5TagMap, allENIs, filteredENIonly, []string{eni2.ENIID}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &IPAMContext{
+				awsClient:                mockAWSUtils,
+				enableManageUntaggedMode: false}
+			mockAWSUtils.EXPECT().SetUnmanagedENIs(tt.unmanagedenis).AnyTimes()
+			c.setUnmanagedENIs(tt.tagMap)
+
+			mockAWSUtils.EXPECT().IsUnmanagedENI(gomock.Any()).DoAndReturn(
+				func(eni string) (unmanaged bool) {
+					if eni != eni1.ENIID {
+						tags := tt.tagMap[eni]
+						if _, ok := tags[eniNoManageTagKey]; ok {
+							if tags[eniNoManageTagKey] == "true" {
+								return true
+							}
+						} else if _, ok := tags[eniNodeTagKey]; ok && tags[eniNodeTagKey] != instanceID {
 							return true
 						}
 					}

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -17,7 +17,6 @@ RUN go get -u golang.org/x/tools/cmd/goimports
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .
-COPY vendor/ vendor/
 
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download


### PR DESCRIPTION
* UTs for no_manage=false

* make format

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Cherry pick to release 1.9

**What does this PR do / Why do we need it**:
n/a

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
