### PR TITLE
Fallback for get hypervisor type and eni ipv4 limits

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -148,10 +148,10 @@ type APIs interface {
 	GetPrimaryENI() string
 
 	// GetENIIPv4Limit return IP address limit per ENI based on EC2 instance type
-	GetENIIPv4Limit() (int, error)
+	GetENIIPv4Limit() int
 
 	// GetENILimit returns the number of ENIs that can be attached to an instance
-	GetENILimit() (int, error)
+	GetENILimit() int
 
 	// GetPrimaryENImac returns the mac address of the primary ENI
 	GetPrimaryENImac() string
@@ -175,7 +175,7 @@ type APIs interface {
 	RefreshSGIDs(mac string) error
 
 	//GetInstanceHypervisorFamily returns the hypervisor family for the instance
-	GetInstanceHypervisorFamily() (string, error)
+	GetInstanceHypervisorFamily() string
 
 	//GetInstanceType returns the EC2 instance type
 	GetInstanceType() string
@@ -185,6 +185,9 @@ type APIs interface {
 
 	// GetInstanceID returns the instance ID
 	GetInstanceID() string
+
+	// Verify if the InstanceNetworkingLimits has the ENI limits else make EC2 call to fill cache.
+	VerifyElseFetchLimitsFromEC2() error
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -1249,14 +1252,19 @@ func (cache *EC2InstanceMetadataCache) AllocIPAddress(eniID string) error {
 	return nil
 }
 
-func (cache *EC2InstanceMetadataCache) fetchLimitsFromEC2() (InstanceTypeLimits, error) {
+func (cache *EC2InstanceMetadataCache) VerifyElseFetchLimitsFromEC2() error {
+	_, ok := InstanceNetworkingLimits[cache.instanceType]
+	if ok {
+		return nil
+	}
+
 	log.Debugf("Instance type limits are missing from vpc_ip_limits.go hence making an EC2 call to fetch the limits")
 	var eniLimits InstanceTypeLimits
 	describeInstanceTypesInput := &ec2.DescribeInstanceTypesInput{InstanceTypes: []*string{aws.String(cache.instanceType)}}
 	output, err := cache.ec2SVC.DescribeInstanceTypesWithContext(context.Background(), describeInstanceTypesInput)
 	if err != nil || len(output.InstanceTypes) != 1 {
 		log.Errorf("", err)
-		return InstanceTypeLimits{}, errors.New(fmt.Sprintf("Failed calling DescribeInstanceTypes for `%s`: %v", cache.instanceType, err))
+		return errors.New(fmt.Sprintf("Failed calling DescribeInstanceTypes for `%s`: %v", cache.instanceType, err))
 	}
 	info := output.InstanceTypes[0]
 	// Ignore any missing values
@@ -1273,55 +1281,29 @@ func (cache *EC2InstanceMetadataCache) fetchLimitsFromEC2() (InstanceTypeLimits,
 		}
 		InstanceNetworkingLimits[instanceType] = eniLimits
 	} else {
-		return InstanceTypeLimits{}, errors.New(fmt.Sprintf("%s: %s", UnknownInstanceType, cache.instanceType))
+		return errors.New(fmt.Sprintf("%s: %s", UnknownInstanceType, cache.instanceType))
 	}
-	return eniLimits, nil
+	return nil
 }
 
 // GetENIIPv4Limit return IP address limit per ENI based on EC2 instance type
-func (cache *EC2InstanceMetadataCache) GetENIIPv4Limit() (int, error) {
-	eniLimits, ok := InstanceNetworkingLimits[cache.instanceType]
-	if !ok {
-		// Fetch from EC2 API
-		var err error
-		eniLimits, err = cache.fetchLimitsFromEC2()
-		if err != nil {
-			log.Errorf("Failed to get ENI IP limit due to unknown instance type %s", cache.instanceType)
-			return 0, err
-		}
-	}
+func (cache *EC2InstanceMetadataCache) GetENIIPv4Limit() int {
+	eniLimits, _ := InstanceNetworkingLimits[cache.instanceType]
 	// Subtract one from the IPv4Limit since we don't use the primary IP on each ENI for pods.
-	return eniLimits.IPv4Limit - 1, nil
+	return eniLimits.IPv4Limit - 1
 }
 
 // GetENILimit returns the number of ENIs can be attached to an instance
-func (cache *EC2InstanceMetadataCache) GetENILimit() (int, error) {
-	eniLimits, ok := InstanceNetworkingLimits[cache.instanceType]
-	if !ok {
-		// Fetch from EC2 API
-		var err error
-		eniLimits, err = cache.fetchLimitsFromEC2()
-		if err != nil {
-			return 0, err
-		}
-	}
-	return eniLimits.ENILimit, nil
+func (cache *EC2InstanceMetadataCache) GetENILimit() int {
+	eniLimits, _ := InstanceNetworkingLimits[cache.instanceType]
+	return eniLimits.ENILimit
 }
 
 // GetInstanceHypervisorFamily return hypervior of EC2 instance type
-func (cache *EC2InstanceMetadataCache) GetInstanceHypervisorFamily() (string, error) {
-	eniLimits, ok := InstanceNetworkingLimits[cache.instanceType]
-	if !ok {
-		// Fetch from EC2 API
-		var err error
-		eniLimits, err = cache.fetchLimitsFromEC2()
-		if err != nil {
-			log.Errorf("Failed to get hypervisor info due to unknown instance type %s", cache.instanceType)
-			return "", err
-		}
-	}
+func (cache *EC2InstanceMetadataCache) GetInstanceHypervisorFamily() string {
+	eniLimits, _ := InstanceNetworkingLimits[cache.instanceType]
 	log.Debugf("Instance hypervisor family %s", eniLimits.HypervisorType)
-	return eniLimits.HypervisorType, nil
+	return eniLimits.HypervisorType
 }
 
 // GetInstanceType return EC2 instance type
@@ -1333,11 +1315,7 @@ func (cache *EC2InstanceMetadataCache) GetInstanceType() string {
 func (cache *EC2InstanceMetadataCache) AllocIPAddresses(eniID string, numIPs int) error {
 	var needIPs = numIPs
 
-	ipLimit, err := cache.GetENIIPv4Limit()
-	if err != nil {
-		awsUtilsErrInc("UnknownInstanceType", err)
-		return err
-	}
+	ipLimit := cache.GetENIIPv4Limit()
 
 	if ipLimit < needIPs {
 		needIPs = ipLimit

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -186,8 +186,8 @@ type APIs interface {
 	// GetInstanceID returns the instance ID
 	GetInstanceID() string
 
-	// Verify if the InstanceNetworkingLimits has the ENI limits else make EC2 call to fill cache.
-	VerifyElseFetchLimitsFromEC2() error
+	// FetchInstanceTypeLimits Verify if the InstanceNetworkingLimits has the ENI limits else make EC2 call to fill cache.
+	FetchInstanceTypeLimits() error
 }
 
 // EC2InstanceMetadataCache caches instance metadata
@@ -1252,7 +1252,7 @@ func (cache *EC2InstanceMetadataCache) AllocIPAddress(eniID string) error {
 	return nil
 }
 
-func (cache *EC2InstanceMetadataCache) VerifyElseFetchLimitsFromEC2() error {
+func (cache *EC2InstanceMetadataCache) FetchInstanceTypeLimits() error {
 	_, ok := InstanceNetworkingLimits[cache.instanceType]
 	if ok {
 		return nil
@@ -1263,7 +1263,6 @@ func (cache *EC2InstanceMetadataCache) VerifyElseFetchLimitsFromEC2() error {
 	describeInstanceTypesInput := &ec2.DescribeInstanceTypesInput{InstanceTypes: []*string{aws.String(cache.instanceType)}}
 	output, err := cache.ec2SVC.DescribeInstanceTypesWithContext(context.Background(), describeInstanceTypesInput)
 	if err != nil || len(output.InstanceTypes) != 1 {
-		log.Errorf("", err)
 		return errors.New(fmt.Sprintf("Failed calling DescribeInstanceTypes for `%s`: %v", cache.instanceType, err))
 	}
 	info := output.InstanceTypes[0]

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -537,11 +537,11 @@ func TestDescribeInstanceTypes(t *testing.T) {
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
 	ins.instanceType = "not-there"
-	value, err := ins.GetENILimit()
+	err := ins.FetchInstanceTypeLimits()
 	assert.NoError(t, err)
+	value := ins.GetENILimit()
 	assert.Equal(t, 9, value)
-	pv4Limit, err := ins.GetENIIPv4Limit()
-	assert.NoError(t, err)
+	pv4Limit := ins.GetENIIPv4Limit()
 	assert.Equal(t, 98, pv4Limit)
 }
 

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -136,6 +136,20 @@ func (mr *MockAPIsMockRecorder) DescribeAllENIs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAllENIs", reflect.TypeOf((*MockAPIs)(nil).DescribeAllENIs))
 }
 
+// FetchInstanceTypeLimits mocks base method
+func (m *MockAPIs) FetchInstanceTypeLimits() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchInstanceTypeLimits")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FetchInstanceTypeLimits indicates an expected call of FetchInstanceTypeLimits
+func (mr *MockAPIsMockRecorder) FetchInstanceTypeLimits() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchInstanceTypeLimits", reflect.TypeOf((*MockAPIs)(nil).FetchInstanceTypeLimits))
+}
+
 // FreeENI mocks base method
 func (m *MockAPIs) FreeENI(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -166,12 +180,11 @@ func (mr *MockAPIsMockRecorder) GetAttachedENIs() *gomock.Call {
 }
 
 // GetENIIPv4Limit mocks base method
-func (m *MockAPIs) GetENIIPv4Limit() (int, error) {
+func (m *MockAPIs) GetENIIPv4Limit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENIIPv4Limit")
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetENIIPv4Limit indicates an expected call of GetENIIPv4Limit
@@ -181,12 +194,11 @@ func (mr *MockAPIsMockRecorder) GetENIIPv4Limit() *gomock.Call {
 }
 
 // GetENILimit mocks base method
-func (m *MockAPIs) GetENILimit() (int, error) {
+func (m *MockAPIs) GetENILimit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENILimit")
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetENILimit indicates an expected call of GetENILimit
@@ -226,12 +238,11 @@ func (mr *MockAPIsMockRecorder) GetIPv4sFromEC2(arg0 interface{}) *gomock.Call {
 }
 
 // GetInstanceHypervisorFamily mocks base method
-func (m *MockAPIs) GetInstanceHypervisorFamily() (string, error) {
+func (m *MockAPIs) GetInstanceHypervisorFamily() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceHypervisorFamily")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetInstanceHypervisorFamily indicates an expected call of GetInstanceHypervisorFamily

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -362,7 +362,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.enablePodENI = enablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
 
-	err = c.awsClient.VerifyElseFetchLimitsFromEC2()
+	err = c.awsClient.FetchInstanceTypeLimits()
 	if err != nil {
 		log.Errorf("Failed to get ENI limits from file:vpc_ip_limits or EC2 for %s", c.awsClient.GetInstanceType())
 		return nil, err

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1587,7 +1587,7 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 	for _, eni := range enis {
 		// If we have unmanaged ENIs, filter them out
 		if c.awsClient.IsUnmanagedENI(eni.ENIID) {
-			log.Debugf("Skipping ENI %s: tagged with %s", eni.ENIID, eniNoManageTagKey)
+			log.Debugf("Skipping ENI %s: since it is unmanaged", eni.ENIID)
 			numFiltered++
 			continue
 		} else if c.awsClient.IsCNIUnmanagedENI(eni.ENIID) {

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -123,8 +123,8 @@ func TestNodeInit(t *testing.T) {
 	eni1, eni2 := getDummyENIMetadata()
 
 	var cidrs []string
-	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
-	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14, nil)
+	m.awsutils.EXPECT().GetENILimit().Return(4)
+	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Addresses, nil)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Addresses, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
@@ -207,8 +207,8 @@ func TestNodeInitwithPDenabled(t *testing.T) {
 	eni1, eni2 := getDummyENIMetadataWithPrefix()
 
 	var cidrs []string
-	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
-	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14, nil)
+	m.awsutils.EXPECT().GetENILimit().Return(4)
+	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Prefixes, nil)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Prefixes, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
For new instances get hypervisor type and get eni ipv4 limit will fail

**What does this PR do / Why do we need it**:
Fallback for get instance type

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
{"level":"debug","ts":"2021-09-13T21:19:38.935Z","caller":"awsutils/awsutils.go:1317","msg":"Instance type limits are missing from vpc_ip_limits.go hence making an EC2 call to fetch the limits"}
{"level":"debug","ts":"2021-09-13T21:19:39.902Z","caller":"ipamd/ipamd.go:365","msg":"Instance hypervisor family nitro"}
{"level":"info","ts":"2021-09-13T21:19:39.902Z","caller":"ipamd/ipamd.go:374","msg":"Prefix Delegation enabled false"}
{"level":"debug","ts":"2021-09-13T21:19:39.902Z","caller":"ipamd/ipamd.go:379","msg":"Start node init"}
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
