### PR TITLE
Fallback for get hypervisor type and eni ipv4 limits (#1616)

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -537,11 +537,11 @@ func TestDescribeInstanceTypes(t *testing.T) {
 
 	ins := &EC2InstanceMetadataCache{ec2SVC: mockEC2}
 	ins.instanceType = "not-there"
-	value, err := ins.GetENILimit()
+	err := ins.FetchInstanceTypeLimits()
 	assert.NoError(t, err)
+	value := ins.GetENILimit()
 	assert.Equal(t, 9, value)
-	pv4Limit, err := ins.GetENIIPv4Limit()
-	assert.NoError(t, err)
+	pv4Limit := ins.GetENIIPv4Limit()
 	assert.Equal(t, 98, pv4Limit)
 }
 

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -136,6 +136,20 @@ func (mr *MockAPIsMockRecorder) DescribeAllENIs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAllENIs", reflect.TypeOf((*MockAPIs)(nil).DescribeAllENIs))
 }
 
+// FetchInstanceTypeLimits mocks base method
+func (m *MockAPIs) FetchInstanceTypeLimits() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchInstanceTypeLimits")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FetchInstanceTypeLimits indicates an expected call of FetchInstanceTypeLimits
+func (mr *MockAPIsMockRecorder) FetchInstanceTypeLimits() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchInstanceTypeLimits", reflect.TypeOf((*MockAPIs)(nil).FetchInstanceTypeLimits))
+}
+
 // FreeENI mocks base method
 func (m *MockAPIs) FreeENI(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -166,12 +180,11 @@ func (mr *MockAPIsMockRecorder) GetAttachedENIs() *gomock.Call {
 }
 
 // GetENIIPv4Limit mocks base method
-func (m *MockAPIs) GetENIIPv4Limit() (int, error) {
+func (m *MockAPIs) GetENIIPv4Limit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENIIPv4Limit")
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetENIIPv4Limit indicates an expected call of GetENIIPv4Limit
@@ -181,12 +194,11 @@ func (mr *MockAPIsMockRecorder) GetENIIPv4Limit() *gomock.Call {
 }
 
 // GetENILimit mocks base method
-func (m *MockAPIs) GetENILimit() (int, error) {
+func (m *MockAPIs) GetENILimit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENILimit")
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetENILimit indicates an expected call of GetENILimit
@@ -226,12 +238,11 @@ func (mr *MockAPIsMockRecorder) GetIPv4sFromEC2(arg0 interface{}) *gomock.Call {
 }
 
 // GetInstanceHypervisorFamily mocks base method
-func (m *MockAPIs) GetInstanceHypervisorFamily() (string, error) {
+func (m *MockAPIs) GetInstanceHypervisorFamily() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceHypervisorFamily")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetInstanceHypervisorFamily indicates an expected call of GetInstanceHypervisorFamily

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -362,11 +362,14 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.enablePodENI = enablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
 
-	hypervisorType, err := c.awsClient.GetInstanceHypervisorFamily()
+	err = c.awsClient.FetchInstanceTypeLimits()
 	if err != nil {
-		log.Error("Failed to get hypervisor type")
+		log.Errorf("Failed to get ENI limits from file:vpc_ip_limits or EC2 for %s", c.awsClient.GetInstanceType())
 		return nil, err
 	}
+
+	hypervisorType := c.awsClient.GetInstanceHypervisorFamily()
+
 	if hypervisorType != "nitro" && c.enableIpv4PrefixDelegation {
 		log.Warnf("Prefix delegation is not supported on non-nitro instance %s hence falling back to default (secondary IP) mode", c.awsClient.GetInstanceType())
 		c.enableIpv4PrefixDelegation = false
@@ -1019,10 +1022,8 @@ func (c *IPAMContext) addENIprefixesToDataStore(ec2PrefixAddrs []*ec2.Ipv4Prefix
 // the limit for the instance type and the value configured via the MAX_ENI environment variable. If the value of
 // the environment variable is 0 or less, it will be ignored and the maximum for the instance is returned.
 func (c *IPAMContext) getMaxENI() (int, error) {
-	instanceMaxENI, err := c.awsClient.GetENILimit()
-	if err != nil {
-		return 0, err
-	}
+	instanceMaxENI := c.awsClient.GetENILimit()
+
 	inputStr, found := os.LookupEnv(envMaxENI)
 	envMax := defaultMaxENI
 	if found {
@@ -1587,7 +1588,7 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 	for _, eni := range enis {
 		// If we have unmanaged ENIs, filter them out
 		if c.awsClient.IsUnmanagedENI(eni.ENIID) {
-			log.Debugf("Skipping ENI %s: tagged with %s", eni.ENIID, eniNoManageTagKey)
+			log.Debugf("Skipping ENI %s: since it is unmanaged", eni.ENIID)
 			numFiltered++
 			continue
 		} else if c.awsClient.IsCNIUnmanagedENI(eni.ENIID) {
@@ -1868,21 +1869,14 @@ func (c *IPAMContext) GetENIResourcesToAllocate() int {
 
 func (c *IPAMContext) GetIPv4Limit() (int, int, error) {
 	var maxIPsPerENI, maxPrefixesPerENI, maxIpsPerPrefix int
-	var err error
 	if !c.enableIpv4PrefixDelegation {
-		maxIPsPerENI, err = c.awsClient.GetENIIPv4Limit()
+		maxIPsPerENI = c.awsClient.GetENIIPv4Limit()
 		maxPrefixesPerENI = 0
-		if err != nil {
-			return 0, 0, err
-		}
 	} else if c.enableIpv4PrefixDelegation {
 		//Single PD - allocate one prefix per ENI and new add will be new ENI + prefix
 		//Multi - allocate one prefix per ENI and new add will be new prefix or new ENI + prefix
 		_, maxIpsPerPrefix, _ = datastore.GetPrefixDelegationDefaults()
-		maxPrefixesPerENI, err = c.awsClient.GetENIIPv4Limit()
-		if err != nil {
-			return 0, 0, err
-		}
+		maxPrefixesPerENI = c.awsClient.GetENIIPv4Limit()
 		maxIPsPerENI = maxPrefixesPerENI * maxIpsPerPrefix
 		log.Debugf("max prefix %d max ips %d", maxPrefixesPerENI, maxIPsPerENI)
 	}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -123,8 +123,8 @@ func TestNodeInit(t *testing.T) {
 	eni1, eni2 := getDummyENIMetadata()
 
 	var cidrs []string
-	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
-	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14, nil)
+	m.awsutils.EXPECT().GetENILimit().Return(4)
+	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Addresses, nil)
 	m.awsutils.EXPECT().GetIPv4sFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Addresses, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
@@ -207,8 +207,8 @@ func TestNodeInitwithPDenabled(t *testing.T) {
 	eni1, eni2 := getDummyENIMetadataWithPrefix()
 
 	var cidrs []string
-	m.awsutils.EXPECT().GetENILimit().Return(4, nil)
-	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14, nil)
+	m.awsutils.EXPECT().GetENILimit().Return(4)
+	m.awsutils.EXPECT().GetENIIPv4Limit().Return(14)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(eni1.ENIID).AnyTimes().Return(eni1.IPv4Prefixes, nil)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(eni2.ENIID).AnyTimes().Return(eni2.IPv4Prefixes, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()


### PR DESCRIPTION
* Fallback for hypervisor type and ipv4enilimit for new instances

* Update a debug

* Move fetch to common location

* Updated Uts

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fallback for get hypervisor type and eni ipv4 limits (#1616)

**What does this PR do / Why do we need it**:
n/a

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
