### PR TITLE
v1.9.1 config, charts and changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.9.1
+* Enhancement - [Support DISABLE_NETWORK_RESOURCE_PROVISIONING][https://github.com/aws/amazon-vpc-cni-k8s/pull/1586] (#1586, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Allow reconciler retry for InsufficientCIDR EC2 error][https://github.com/aws/amazon-vpc-cni-k8s/pull/1585] (#1585, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Support for setting no_manage=false][https://github.com/aws/amazon-vpc-cni-k8s/pull/1607] (#1607, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Support for m6i instances][https://github.com/aws/amazon-vpc-cni-k8s/pull/1601] (#1601, [@causton81](https://github.com/causton81))
+* Bug - [Fallback for get hypervisor type and eni ipv4 limits][https://github.com/aws/amazon-vpc-cni-k8s/pull/1616] (#1616, [@jayanthvn](https://github.com/jayanthvn))
+* Bug - [fix typo and regenerate limits file ][https://github.com/aws/amazon-vpc-cni-k8s/pull/1597] (#1597, [@jayanthvn](https://github.com/jayanthvn))
+* Testing - [UTs for no_manage=false][https://github.com/aws/amazon-vpc-cni-k8s/pull/1612] (#1612, [@jayanthvn](https://github.com/jayanthvn))
+* Testing - [Run integration test on release branch][https://github.com/aws/amazon-vpc-cni-k8s/pull/1615] (#1615, [@vikasmb](https://github.com/vikasmb))
+
 ## v1.9.0
 * Enhancement - [EC2 sdk model override][https://github.com/aws/amazon-vpc-cni-k8s/pull/1508] (#1508, [@jayanthvn](https://github.com/jayanthvn))
 * Enhancement - [Prefix Delegation feature support][https://github.com/aws/amazon-vpc-cni-k8s/pull/1516] (#1516, [@jayanthvn](https://github.com/jayanthvn))

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.8
-appVersion: "v1.9.0"
+version: 1.1.9
+appVersion: "v1.9.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.9.0
+    tag: v1.9.1
     region: us-west-2
     pullPolicy: Always
     # Set to use custom image
@@ -20,7 +20,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.9.0
+  tag: v1.9.1
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -159,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -201,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -159,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -201,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -159,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -201,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -159,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -201,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -3,7 +3,7 @@ local objectItems(obj) = [[k, obj[k]] for k in std.objectFields(obj)];
 
 local regions = {
   default: {
-    version:: "v1.9.0", // or eg "v1.6.2"
+    version:: "v1.9.1", // or eg "v1.6.2"
     ecrRegion:: "us-west-2",
     ecrAccount:: "602401143452",
     ecrDomain:: "amazonaws.com",

--- a/config/v1.9/aws-k8s-cni-cn.yaml
+++ b/config/v1.9/aws-k8s-cni-cn.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"
@@ -157,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -199,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.9/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.9/aws-k8s-cni-us-gov-east-1.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"
@@ -157,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -199,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.9/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.9/aws-k8s-cni-us-gov-west-1.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"
@@ -157,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -199,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.9/aws-k8s-cni.yaml
+++ b/config/v1.9/aws-k8s-cni.yaml
@@ -145,6 +145,8 @@
           "value": "false"
         - "name": "DISABLE_METRICS"
           "value": "false"
+        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
+          "value": "false"
         - "name": "ENABLE_POD_ENI"
           "value": "false"
         - "name": "ENABLE_PREFIX_DELEGATION"
@@ -157,7 +159,7 @@
           "value": "1"
         - "name": "WARM_PREFIX_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.1"
         "livenessProbe":
           "exec":
             "command":
@@ -199,7 +201,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "securityContext":
           "privileged": true

--- a/config/v1.9/cni-metrics-helper-cn.yaml
+++ b/config/v1.9/cni-metrics-helper-cn.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.0"
+        "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.9/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/v1.9/cni-metrics-helper-us-gov-east-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.9/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/v1.9/cni-metrics-helper-us-gov-west-1.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---

--- a/config/v1.9/cni-metrics-helper.yaml
+++ b/config/v1.9/cni-metrics-helper.yaml
@@ -87,7 +87,7 @@
       - "env":
         - "name": "USE_CLOUDWATCH"
           "value": "true"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.0"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
V1.9.1 release artifacts

**What does this PR do / Why do we need it**:
update image tag

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
n/a

```release-note
Please check CHANGELOG
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
