### PR TITLE
Fix formatting in changeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Changelog
 
+## v1.9.1
+* Enhancement - [Support DISABLE_NETWORK_RESOURCE_PROVISIONING](https://github.com/aws/amazon-vpc-cni-k8s/pull/1586) (#1586, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Allow reconciler retry for InsufficientCIDR EC2 error](https://github.com/aws/amazon-vpc-cni-k8s/pull/1585) (#1585, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Support for setting no_manage=false](https://github.com/aws/amazon-vpc-cni-k8s/pull/1607) (#1607, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Support for m6i instances](https://github.com/aws/amazon-vpc-cni-k8s/pull/1601) (#1601, [@causton81](https://github.com/causton81))
+* Bug - [Fallback for get hypervisor type and eni ipv4 limits](https://github.com/aws/amazon-vpc-cni-k8s/pull/1616) (#1616, [@jayanthvn](https://github.com/jayanthvn))
+* Bug - [fix typo and regenerate limits file ](https://github.com/aws/amazon-vpc-cni-k8s/pull/1597) (#1597, [@jayanthvn](https://github.com/jayanthvn))
+* Testing - [UTs for no_manage=false](https://github.com/aws/amazon-vpc-cni-k8s/pull/1612) (#1612, [@jayanthvn](https://github.com/jayanthvn))
+* Testing - [Run integration test on release branch](https://github.com/aws/amazon-vpc-cni-k8s/pull/1615) (#1615, [@vikasmb](https://github.com/vikasmb))
+
 ## v1.9.0
-* Enhancement - [EC2 sdk model override][https://github.com/aws/amazon-vpc-cni-k8s/pull/1508] (#1508, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [Prefix Delegation feature support][https://github.com/aws/amazon-vpc-cni-k8s/pull/1516] (#1516, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [Header formatting for env variable][https://github.com/aws/amazon-vpc-cni-k8s/pull/1522] (#1522, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [non-nitro instances init issues][https://github.com/aws/amazon-vpc-cni-k8s/pull/1527] (#1527, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [Add metrics for total prefix count and ips used per cidr][https://github.com/aws/amazon-vpc-cni-k8s/pull/1530] (#1530, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [Update documentation for PD][https://github.com/aws/amazon-vpc-cni-k8s/pull/1540] (#1540, [@jayanthvn](https://github.com/jayanthvn))
-* Enhancement - [Update SDK Go version][https://github.com/aws/amazon-vpc-cni-k8s/pull/1544] (#1544, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [EC2 sdk model override](https://github.com/aws/amazon-vpc-cni-k8s/pull/1508) (#1508, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Prefix Delegation feature support](https://github.com/aws/amazon-vpc-cni-k8s/pull/1516) (#1516, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Header formatting for env variable](https://github.com/aws/amazon-vpc-cni-k8s/pull/1522) (#1522, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [non-nitro instances init issues](https://github.com/aws/amazon-vpc-cni-k8s/pull/1527) (#1527, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Add metrics for total prefix count and ips used per cidr](https://github.com/aws/amazon-vpc-cni-k8s/pull/1530) (#1530, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Update documentation for PD](https://github.com/aws/amazon-vpc-cni-k8s/pull/1540) (#1540, [@jayanthvn](https://github.com/jayanthvn))
+* Enhancement - [Update SDK Go version](https://github.com/aws/amazon-vpc-cni-k8s/pull/1544) (#1544, [@jayanthvn](https://github.com/jayanthvn))
 
 ## v1.8.0
 * Bug - [Use symmetric return path for non-VPC traffic - alternate solution](https://github.com/aws/amazon-vpc-cni-k8s/pull/1475) (#1475, [@kishorj](https://github.com/kishorj))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Fix formatting

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
