### PR TITLE
Fix ipamd integ test

### DIFF
--- a/test/integration-new/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration-new/ipamd/warm_target_test_PD_enabled.go
@@ -202,14 +202,6 @@ var _ = Describe("test warm target variables", func() {
 
 			It("should have 2 free prefixes", func() {})
 		})
-
-		Context("when WARM_PREFIX_TARGET = 0", func() {
-			BeforeEach(func() {
-				warmPrefixTarget = 0
-			})
-
-			It("should have no free prefixes", func() {})
-		})
 	})
 
 	Context("when warm prefix, warm IP and min IP target is set with PD enabled", func() {
@@ -326,27 +318,6 @@ var _ = Describe("test warm target variables", func() {
 		})
 	})
 })
-
-func Max(x, y int) int {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-// MinIgnoreZero returns smaller of two number, if any number is zero returns the other number
-func MinIgnoreZero(x, y int) int {
-	if x == 0 {
-		return y
-	}
-	if y == 0 {
-		return x
-	}
-	if x < y {
-		return x
-	}
-	return y
-}
 
 func ceil(x, y int) int {
 	return (x + y - 1) / y


### PR DESCRIPTION
- Removed duplicate function definition in the package
- Removed invalid test case of warm_target_prefix = 0 with PD enabled

(cherry picked from commit d166406ffd0e855bafd1ba174da80415198e0999)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes invalid tests in ipamd test package

**What does this PR do / Why do we need it**:
To fix ipamd test package.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Executed ipamd tests

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
