### PR TITLE
Pod startup latency with Calico and EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Type: Boolean as a String
 
 Default: `false`
 
-Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will allow IPAMD to add an annotation `cni.projectcalico.org/podIPs` to the pod with pod IP.
+Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will allow IPAMD to add an annotation `vpc.amazonaws.com/pod-ips` to the pod with pod IP.
 
 There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,18 @@ Setting `ENABLE_BANDWIDTH_PLUGIN` to `true` will update `10-aws.conflist` to inc
 
 ---
 
+#### `ENABLE_CALICO_OPTIMIZATION` (v1.10.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will allow IPAMD to add an annotation `cni.projectcalico.org/podIPs` to the pod with pod IP.
+
+There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
+
+---
+
 ### ENI tags related to Allocation
 
 This plugin interacts with the following tags on ENIs:

--- a/README.md
+++ b/README.md
@@ -515,15 +515,15 @@ Setting `ENABLE_BANDWIDTH_PLUGIN` to `true` will update `10-aws.conflist` to inc
 
 ---
 
-#### `ENABLE_CALICO_OPTIMIZATION` (v1.10.0+)
+#### `ANNOTATE_POD_IP` (v1.10.0+)
 
 Type: Boolean as a String
 
 Default: `false`
 
-Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will allow IPAMD to add an annotation `vpc.amazonaws.com/pod-ips` to the pod with pod IP.
+Setting `ANNOTATE_POD_IP` to `true` will allow IPAMD to add an annotation `vpc.amazonaws.com/pod-ips` to the pod with pod IP.
 
-There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ENABLE_CALICO_OPTIMIZATION` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
+There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ANNOTATE_POD_IP` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
 
 ---
 

--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -12,9 +12,12 @@ rules:
     verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
-      - pods
       - namespaces
     verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get", "patch"]
   - apiGroups: [""]
     resources:
       - nodes

--- a/cmd/egress-v4-cni-plugin/cni.go
+++ b/cmd/egress-v4-cni-plugin/cni.go
@@ -16,10 +16,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"net"
 	"os"
 	"runtime"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -19,6 +19,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -26,10 +31,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"net"
-	"os"
-	"runtime"
-	"strings"
 
 	"github.com/aws/amazon-vpc-cni-k8s/cmd/routed-eni-cni-plugin/driver"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/grpcwrapper"

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -28,12 +28,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -61,16 +69,16 @@
     "kind": "ENIConfig"
     "plural": "eniconfigs"
     "singular": "eniconfig"
-  "scope": "Cluster"
   "preserveUnknownFields": false
+  "scope": "Cluster"
   "versions":
-    - "name": "v1alpha1"
-      "served": true
-      "storage": true
-      "schema":
-        "openAPIV3Schema":
-          "type": object
-          "x-kubernetes-preserve-unknown-fields": true
+  - "name": "v1alpha1"
+    "schema":
+      "openAPIV3Schema":
+        "type": "object"
+        "x-kubernetes-preserve-unknown-fields": true
+    "served": true
+    "storage": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -28,12 +28,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -61,16 +69,16 @@
     "kind": "ENIConfig"
     "plural": "eniconfigs"
     "singular": "eniconfig"
-  "scope": "Cluster"
   "preserveUnknownFields": false
+  "scope": "Cluster"
   "versions":
-    - "name": "v1alpha1"
-      "served": true
-      "storage": true
-      "schema":
-        "openAPIV3Schema":
-          "type": object
-          "x-kubernetes-preserve-unknown-fields": true
+  - "name": "v1alpha1"
+    "schema":
+      "openAPIV3Schema":
+        "type": "object"
+        "x-kubernetes-preserve-unknown-fields": true
+    "served": true
+    "storage": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -28,12 +28,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -61,16 +69,16 @@
     "kind": "ENIConfig"
     "plural": "eniconfigs"
     "singular": "eniconfig"
-  "scope": "Cluster"
   "preserveUnknownFields": false
+  "scope": "Cluster"
   "versions":
-    - "name": "v1alpha1"
-      "served": true
-      "storage": true
-      "schema":
-        "openAPIV3Schema":
-          "type": object
-          "x-kubernetes-preserve-unknown-fields": true
+  - "name": "v1alpha1"
+    "schema":
+      "openAPIV3Schema":
+        "type": "object"
+        "x-kubernetes-preserve-unknown-fields": true
+    "served": true
+    "storage": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -28,12 +28,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -61,16 +69,16 @@
     "kind": "ENIConfig"
     "plural": "eniconfigs"
     "singular": "eniconfig"
-  "scope": "Cluster"
   "preserveUnknownFields": false
+  "scope": "Cluster"
   "versions":
-    - "name": "v1alpha1"
-      "served": true
-      "storage": true
-      "schema":
-        "openAPIV3Schema":
-          "type": object
-          "x-kubernetes-preserve-unknown-fields": true
+  - "name": "v1alpha1"
+    "schema":
+      "openAPIV3Schema":
+        "type": "object"
+        "x-kubernetes-preserve-unknown-fields": true
+    "served": true
+    "storage": true
 ---
 "apiVersion": "apps/v1"
 "kind": "DaemonSet"

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -40,8 +40,13 @@ local awsnode = {
       },
       {
         apiGroups: [""],
-        resources: ["pods", "namespaces"],
+        resources: ["namespaces"],
         verbs: ["list", "watch", "get"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["pods"],
+        verbs: ["list", "watch", "get", "patch"],
       },
       {
         apiGroups: [""],

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -19,11 +19,12 @@
 package mock_awsutils
 
 import (
+	net "net"
+	reflect "reflect"
+
 	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
-	net "net"
-	reflect "reflect"
 )
 
 // MockAPIs is a mock of APIs interface

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -158,13 +158,13 @@ const (
 
 	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
 
-	// envEnableCalicoOptimization is used to annotate[vpc.amazonaws.com/pod-ips] pod's with IPs
+	// envAnnotatePodIP is used to annotate[vpc.amazonaws.com/pod-ips] pod's with IPs
 	// Ref : https://github.com/projectcalico/calico/issues/3530
 	// not present; in which case we fall back to the k8s podIP
 	// Present and set to an IP; in which case we use it
 	// Present and set to the empty string, which we use to mean "CNI DEL had occurred; networking has been removed from this pod"
 	// The empty string one helps close a trace at pod shutdown where it looks like the pod still has its IP when the IP has been released
-	envEnableCalicoOptimization = "ENABLE_CALICO_OPTIMIZATION"
+	envAnnotatePodIP = "ANNOTATE_POD_IP"
 )
 
 var log = logger.Get()
@@ -257,7 +257,7 @@ type IPAMContext struct {
 	enablePrefixDelegation    bool
 	lastInsufficientCidrError time.Time
 	enableManageUntaggedMode  bool
-	enableCalicoOptimization  bool
+	enablePodIPAnnotation     bool
 }
 
 // setUnmanagedENIs will rebuild the set of ENI IDs for ENIs tagged as "no_manage"
@@ -386,7 +386,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 
 	c.enablePodENI = enablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
-	c.enableCalicoOptimization = enableCalicoOptimization()
+	c.enablePodIPAnnotation = enablePodIPAnnotation()
 
 	err = c.awsClient.FetchInstanceTypeLimits()
 	if err != nil {
@@ -1698,8 +1698,8 @@ func enableManageUntaggedMode() bool {
 	return getEnvBoolWithDefault(envManageUntaggedENI, true)
 }
 
-func enableCalicoOptimization() bool {
-	return getEnvBoolWithDefault(envEnableCalicoOptimization, false)
+func enablePodIPAnnotation() bool {
+	return getEnvBoolWithDefault(envAnnotatePodIP, false)
 }
 
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -158,7 +158,7 @@ const (
 
 	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
 
-	// envEnableCalicoOptimization is used to annotate[cni.projectcalico.org/podIPs] pod's with IPs
+	// envEnableCalicoOptimization is used to annotate[vpc.amazonaws.com/pod-ips] pod's with IPs
 	// Ref : https://github.com/projectcalico/calico/issues/3530
 	// not present; in which case we fall back to the k8s podIP
 	// Present and set to an IP; in which case we use it

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -159,7 +159,7 @@ const (
 	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
 
 	// envEnableCalicoOptimization is used to annotate[cni.projectcalico.org/podIPs] pod's with IPs
-	// Ref : https://github.com/projectcalico/calico/issues/3530  
+	// Ref : https://github.com/projectcalico/calico/issues/3530
 	// not present; in which case we fall back to the k8s podIP
 	// Present and set to an IP; in which case we use it
 	// Present and set to the empty string, which we use to mean "CNI DEL had occurred; networking has been removed from this pod"
@@ -1916,7 +1916,7 @@ func (c *IPAMContext) AnnotatePod(podNamespace, podName, key, val string) error 
 		if pod, err = c.GetPod(podNamespace, podName); err != nil {
 			return err
 		}
-		
+
 		newPod := pod.DeepCopy()
 		newPod.Annotations[key] = val
 		if err = c.rawK8SClient.Patch(ctx, newPod, client.MergeFrom(pod)); err != nil {
@@ -1929,7 +1929,6 @@ func (c *IPAMContext) AnnotatePod(podNamespace, podName, key, val string) error 
 
 	return err
 }
-
 
 func (c *IPAMContext) tryUnassignIPsFromENIs() {
 	log.Debugf("In tryUnassignIPsFromENIs")

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/eniconfig"
@@ -156,6 +157,14 @@ const (
 	envManageUntaggedENI = "MANAGE_UNTAGGED_ENI"
 
 	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
+
+	// envEnableCalicoOptimization is used to annotate[cni.projectcalico.org/podIPs] pod's with IPs
+	// Ref : https://github.com/projectcalico/calico/issues/3530  
+	// not present; in which case we fall back to the k8s podIP
+	// Present and set to an IP; in which case we use it
+	// Present and set to the empty string, which we use to mean "CNI DEL had occurred; networking has been removed from this pod"
+	// The empty string one helps close a trace at pod shutdown where it looks like the pod still has its IP when the IP has been released
+	envEnableCalicoOptimization = "ENABLE_CALICO_OPTIMIZATION"
 )
 
 var log = logger.Get()
@@ -248,6 +257,7 @@ type IPAMContext struct {
 	enablePrefixDelegation    bool
 	lastInsufficientCidrError time.Time
 	enableManageUntaggedMode  bool
+	enableCalicoOptimization  bool
 }
 
 // setUnmanagedENIs will rebuild the set of ENI IDs for ENIs tagged as "no_manage"
@@ -376,6 +386,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 
 	c.enablePodENI = enablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
+	c.enableCalicoOptimization = enableCalicoOptimization()
 
 	err = c.awsClient.FetchInstanceTypeLimits()
 	if err != nil {
@@ -1687,6 +1698,10 @@ func enableManageUntaggedMode() bool {
 	return getEnvBoolWithDefault(envManageUntaggedENI, true)
 }
 
+func enableCalicoOptimization() bool {
+	return getEnvBoolWithDefault(envEnableCalicoOptimization, false)
+}
+
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag
 func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutils.ENIMetadata {
 	numFiltered := 0
@@ -1890,6 +1905,31 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 	}
 	return &pod, nil
 }
+
+// AnnotatePod annotates the pod with the provided key and value
+func (c *IPAMContext) AnnotatePod(podNamespace, podName, key, val string) error {
+	ctx := context.TODO()
+	var pod *corev1.Pod
+	var err error
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if pod, err = c.GetPod(podNamespace, podName); err != nil {
+			return err
+		}
+		
+		newPod := pod.DeepCopy()
+		newPod.Annotations[key] = val
+		if err = c.rawK8SClient.Patch(ctx, newPod, client.MergeFrom(pod)); err != nil {
+			log.Errorf("Failed to annotate %s the pod with %s, error %v", key, val, err)
+			return err
+		}
+		log.Debugf("Annotates pod %s with %s: %s", podName, key, val)
+		return nil
+	})
+
+	return err
+}
+
 
 func (c *IPAMContext) tryUnassignIPsFromENIs() {
 	log.Debugf("In tryUnassignIPsFromENIs")

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -41,7 +41,7 @@ const (
 	ipamdgRPCaddress      = "127.0.0.1:50051"
 	grpcHealthServiceName = "grpc.health.v1.aws-node"
 
-	calicoPodIPKey = "cni.projectcalico.org/podIPs"
+	vpccniPodIPKey = "vpc.amazonaws.com/pod-ips"
 )
 
 // server controls RPC service responses.
@@ -173,7 +173,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enableCalicoOptimization {
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, calicoPodIPKey, ipv4Addr)
+		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr)
 	}
 	resp := rpc.AddNetworkReply{
 		Success:         err == nil,
@@ -267,7 +267,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enableCalicoOptimization {
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, calicoPodIPKey, "")
+		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "")
 	}
 
 	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -172,7 +172,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		}
 	}
 
-	if s.ipamContext.enableCalicoOptimization {
+	if s.ipamContext.enablePodIPAnnotation {
 		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr)
 	}
 	resp := rpc.AddNetworkReply{
@@ -266,7 +266,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 		}
 	}
 
-	if s.ipamContext.enableCalicoOptimization {
+	if s.ipamContext.enablePodIPAnnotation {
 		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "")
 	}
 

--- a/rpc/mocks/rpc_mocks.go
+++ b/rpc/mocks/rpc_mocks.go
@@ -20,10 +20,11 @@ package mock_rpc
 
 import (
 	context "context"
+	reflect "reflect"
+
 	rpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
 	gomock "github.com/golang/mock/gomock"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockCNIBackendClient is a mock of CNIBackendClient interface


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Network connection latency on installing calico on EKS clusters with aws-vpc-cni plugin.

**What does this PR do / Why do we need it**:
Calico CNI plugin writes the IP address back to the pod as an annotation with `Key : vpc.amazonaws.com/pod-ips`  `Value : podIP` to mitigate the delay with kubelet updating the `Pod.Status.PodIP`. This PR leverages the same annotation for aws-vpc-cni and it can be enabled with ANNOTATE_POD_IP knob on need basis. Ref: https://github.com/projectcalico/calico/issues/3530 and upstream issue for kubelet delay - https://github.com/kubernetes/kubernetes/issues/39113

ClusterRole needs to be updated to provide patch capabilities to aws-node for pods.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Fixes #493 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

Knob disabled -

```
Ping Failed 1 times
Ping Failed 2 times
Ping Failed 3 times
Ping Failed 4 times
Ping Failed 5 times
Ping Failed 6 times
Ping Failed 7 times
Ping Failed 8 times
PING 192.168.73.105 (192.168.73.105) 56(84) bytes of data.
64 bytes from 192.168.73.105: icmp_seq=1 ttl=255 time=0.073 ms

--- 192.168.73.105 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
```

Knob enabled -
```
PING 192.168.73.105 (192.168.73.105) 56(84) bytes of data.
64 bytes from 192.168.73.105: icmp_seq=1 ttl=255 time=0.072 ms

--- 192.168.73.105 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Yes.

To use this feature -

Add clusterRole with "patch" capabilities to pods.
Knob to enable - ANNOTATE_POD_IP

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
