### PR TITLE
Handle delays tied to V6 interfaces

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -43,6 +44,8 @@ const (
 	fromContainerRulePriority = 1536
 	// Main routing table number
 	mainRouteTable = unix.RT_TABLE_MAIN
+
+	WAIT_INTERVAL = 50 * time.Millisecond
 )
 
 // NetworkAPIs defines network API calls
@@ -208,12 +211,60 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 		return errors.Wrap(err, "setup NS network: failed to add static ARP")
 	}
 
+	if createVethContext.v6Addr != nil && createVethContext.v6Addr.IP.To16() != nil {
+			if err := WaitForAddressesToBeStable(createVethContext.contVethName, 10); err != nil {
+			return errors.Wrap(err, "setup NS network: failed while waiting for v6 addresses to be stable")
+		}
+	}
+
 	// Now that the everything has been successfully set up in the container, move the "host" end of the
 	// veth into the host namespace.
 	if err = createVethContext.netLink.LinkSetNsFd(hostVeth, int(hostNS.Fd())); err != nil {
 		return errors.Wrap(err, "setup NS network: failed to move veth to host netns")
 	}
 	return nil
+}
+
+// Implements `SettleAddresses` functionality of the `ip` package.
+// WaitForAddressesToBeStable waits for all addresses on a link to leave tentative state.
+// Will be particularly useful for ipv6, where all addresses need to do DAD.
+// If any addresses are still tentative after timeout seconds, then error.
+func WaitForAddressesToBeStable(ifName string, timeout int) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve link: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	for {
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return fmt.Errorf("could not list addresses: %v", err)
+		}
+
+		if len(addrs) == 0 {
+			return nil
+		}
+
+		ok := true
+		for _, addr := range addrs {
+			if addr.Flags&(syscall.IFA_F_TENTATIVE|syscall.IFA_F_DADFAILED) > 0 {
+				ok = false
+				break
+			}
+		}
+
+		if ok {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("link %s still has tentative addresses after %d seconds",
+				ifName,
+				timeout)
+		}
+
+		time.Sleep(WAIT_INTERVAL)
+	}
 }
 
 // SetupNS wires up linux networking for a pod's network

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -212,7 +212,7 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 	}
 
 	if createVethContext.v6Addr != nil && createVethContext.v6Addr.IP.To16() != nil {
-			if err := WaitForAddressesToBeStable(createVethContext.contVethName, 10); err != nil {
+		if err := WaitForAddressesToBeStable(createVethContext.contVethName, 10); err != nil {
 			return errors.Wrap(err, "setup NS network: failed while waiting for v6 addresses to be stable")
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
V6 addresses assigned to an interface might take a while before they transition from `tentative` state to `stable` state as all addresses need to go through Duplicate Address Detection (DAD). PR introduces a check to make sure the address is in `stable` state before CNI returns.

**Testing done on this change**:
Verified that there is no packet loss observed  right after pod boot-up due to the issue documented above.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
