### PR TITLE
#1626: skip null string in security group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/tools v0.1.5 // indirect
 	google.golang.org/grpc v1.29.0
+	google.golang.org/protobuf v1.23.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
-golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -826,8 +826,11 @@ func (c *IPAMContext) tryAllocateENI(ctx context.Context) error {
 
 		log.Infof("ipamd: using custom network config: %v, %s", eniCfg.SecurityGroups, eniCfg.Subnet)
 		for _, sgID := range eniCfg.SecurityGroups {
-			log.Debugf("Found security-group id: %s", sgID)
-			securityGroups = append(securityGroups, aws.String(sgID))
+			// skip null string - issue 1626
+			if len(sgID) > 0 {
+				log.Debugf("Found security-group id: %s", sgID)
+				securityGroups = append(securityGroups, aws.String(sgID))
+			}
 		}
 		subnet = eniCfg.Subnet
 	}


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
[issue-1626](https://github.com/aws/amazon-vpc-cni-k8s/issues/1626)

**What does this PR do / Why do we need it**:
skips the blank entries in ENIConfig which cause POD creation to fail with unexplained errors

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:

Example ENIConfig used (note the blank security group specified):-

```
apiVersion: crd.k8s.amazonaws.com/v1alpha1
kind: ENIConfig
metadata: 
  name: us-east-1a
spec: 
  securityGroups: 
    - sg-4221946c
    - ""
  subnet: subnet-073637fac0e0b7e72
```

ipamd.log before change (PODs stuck in ContainerCreating):-

```
{"level":"info","ts":"2021-09-22T17:37:15.718Z","caller":"eniconfig/eniconfig.go:68","msg":"Get Node Info for: ip-172-31-27-153.ec2.internal"}
{"level":"debug","ts":"2021-09-22T17:37:15.718Z","caller":"eniconfig/eniconfig.go:129","msg":"Using ENI_CONFIG_LABEL_DEF failure-domain.beta.kubernetes.io/zone"}
{"level":"info","ts":"2021-09-22T17:37:15.718Z","caller":"ipamd/ipamd.go:731","msg":"Found ENI Config Name: us-east-1a"}
{"level":"info","ts":"2021-09-22T17:37:15.718Z","caller":"ipamd/ipamd.go:705","msg":"ipamd: using custom network config: [sg-4221946c ], subnet-073637fac0e0b7e72"}
{"level":"debug","ts":"2021-09-22T17:37:15.718Z","caller":"ipamd/ipamd.go:705","msg":"Found security-group id: sg-4221946c"}
{"level":"debug","ts":"2021-09-22T17:37:15.718Z","caller":"ipamd/ipamd.go:705","msg":"Found security-group id: "}
{"level":"info","ts":"2021-09-22T17:37:15.718Z","caller":"awsutils/awsutils.go:667","msg":"Using a custom network config for the new ENI"}
{"level":"info","ts":"2021-09-22T17:37:15.718Z","caller":"awsutils/awsutils.go:667","msg":"Creating ENI with security groups: [sg-4221946c ] in subnet: subnet-073637fac0e0b7e72"}
{"level":"info","ts":"2021-09-22T17:37:16.408Z","caller":"rpc/rpc.pb.go:519","msg":"Received DelNetwork for Sandbox feeaf77d76afa10de5f8657a24468c3ccf1428e22a5c03ba0a0d4f8f8e290df5"}
{"level":"debug","ts":"2021-09-22T17:37:16.408Z","caller":"rpc/rpc.pb.go:519","msg":"DelNetworkRequest: ClientVersion:\"v1.9.0\" K8S_POD_NAME:\"coredns-7d74b564bd-ztkvw\" K8S_POD_NAMESPACE:\"kube-system\" K8S_POD_INFRA_CONTAINER_ID:\"feeaf77d76afa10de5f8657a24468c3ccf1428e22a5c03ba0a0d4f8f8e290df5\" Reason:\"PodDeleted\" ContainerID:\"feeaf77d76afa10de5f8657a24468c3ccf1428e22a5c03ba0a0d4f8f8e290df5\" IfName:\"eth0\" NetworkName:\"aws-cni\" "}
{"level":"debug","ts":"2021-09-22T17:37:16.408Z","caller":"ipamd/rpc_handler.go:204","msg":"UnassignPodIPv4Address: IP address pool stats: total:0, assigned 0, sandbox aws-cni/feeaf77d76afa10de5f8657a24468c3ccf1428e22a5c03ba0a0d4f8f8e290df5/eth0"}
{"level":"debug","ts":"2021-09-22T17:37:16.408Z","caller":"ipamd/rpc_handler.go:204","msg":"UnassignPodIPv4Address: Failed to find IPAM entry under full key, trying CRI-migrated version"}
{"level":"warn","ts":"2021-09-22T17:37:16.408Z","caller":"ipamd/rpc_handler.go:204","msg":"UnassignPodIPv4Address: Failed to find sandbox _migrated-from-cri/feeaf77d76afa10de5f8657a24468c3ccf1428e22a5c03ba0a0d4f8f8e290df5/unknown"}
```


ipamd.log after change (PODs could be created):-

```

{"level":"info","ts":"2021-09-22T17:38:28.234Z","caller":"eniconfig/eniconfig.go:68","msg":"Get Node Info for: ip-172-31-27-153.ec2.internal"}
{"level":"debug","ts":"2021-09-22T17:38:28.234Z","caller":"eniconfig/eniconfig.go:129","msg":"Using ENI_CONFIG_LABEL_DEF failure-domain.beta.kubernetes.io/zone"}
{"level":"info","ts":"2021-09-22T17:38:28.234Z","caller":"ipamd/ipamd.go:731","msg":"Found ENI Config Name: us-east-1a"}
{"level":"info","ts":"2021-09-22T17:38:28.234Z","caller":"ipamd/ipamd.go:705","msg":"ipamd: using custom network config: [sg-4221946c ], subnet-073637fac0e0b7e72"}
{"level":"debug","ts":"2021-09-22T17:38:28.234Z","caller":"ipamd/ipamd.go:705","msg":"Found security-group id: sg-4221946c"}
{"level":"info","ts":"2021-09-22T17:38:28.234Z","caller":"awsutils/awsutils.go:667","msg":"Using a custom network config for the new ENI"}
{"level":"info","ts":"2021-09-22T17:38:28.234Z","caller":"awsutils/awsutils.go:667","msg":"Creating ENI with security groups: [sg-4221946c] in subnet: subnet-073637fac0e0b7e72"}
{"level":"info","ts":"2021-09-22T17:38:28.711Z","caller":"awsutils/awsutils.go:667","msg":"Created a new ENI: eni-0df735d090f710c72"}
```


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
