### PR TITLE
ServiceAccount should precede DaemonSet in yaml aws

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -56,7 +56,7 @@ local awsnode = {
     ],
   },
 
-  serviceAccount: {
+  account: {
     apiVersion: "v1",
     kind: "ServiceAccount",
     metadata: {
@@ -77,9 +77,9 @@ local awsnode = {
       name: $.clusterRole.metadata.name,
     },
     subjects: [{
-      kind: $.serviceAccount.kind,
-      name: $.serviceAccount.metadata.name,
-      namespace: $.serviceAccount.metadata.namespace,
+      kind: $.account.kind,
+      name: $.account.metadata.name,
+      namespace: $.account.metadata.namespace,
     }],
   },
 
@@ -138,7 +138,7 @@ local awsnode = {
               },
             },
           },
-          serviceAccountName: $.serviceAccount.metadata.name,
+          serviceAccountName: $.account.metadata.name,
           hostNetwork: true,
           tolerations: [{operator: "Exists"}],
           containers_:: {
@@ -327,7 +327,7 @@ local metricsHelper = {
     ],
   },
 
-  serviceAccount: {
+  account: {
     apiVersion: "v1",
     kind: "ServiceAccount",
     metadata: {
@@ -348,9 +348,9 @@ local metricsHelper = {
       name: $.clusterRole.metadata.name,
     },
     subjects: [{
-      kind: $.serviceAccount.kind,
-      name: $.serviceAccount.metadata.name,
-      namespace: $.serviceAccount.metadata.namespace,
+      kind: $.account.kind,
+      name: $.account.metadata.name,
+      namespace: $.account.metadata.namespace,
     }],
   },
 
@@ -376,7 +376,7 @@ local metricsHelper = {
           },
         },
         spec: {
-          serviceAccountName: $.serviceAccount.metadata.name,
+          serviceAccountName: $.account.metadata.name,
           containers_:: {
             metricshelper: {
               image: "%s/cni-metrics-helper:%s" % [$.ecrRepo, $.version],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**: bug 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
fixes #1632 

**What does this PR do / Why do we need it**:
Ensure serviceAccount obj is created  before daemonSet creation to avoid race condition mentioned in #1632 

Alphabetic order of jsonet object name in manifest.jsonet file decides the order of k8s objects in
CNI yaml manifest. This fix ensures serviceAccount appears at top of CNI manifest for manual yaml generation work flow. 

Starting CNI 1.10 version, Github workflow will be added to
automatically generate CNI manifests (and Calico manifest) using helm and these
auto generated artifacts will be placed in CNI 1.10 release Dir. Github
workflow changes are already available in CNI master branch.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
1. Create a cluster with CNI 1.9.1 (MAO)
2. Delete VPC CNI addon - This step triggers deletion of ServiceAccount, DaemonSet..etc aws-node objects on cluster as verified by Kubectl
3. Apply the manually generated aws-vpc-cni.yaml (from manifest.jsnonet) that has service account at top
aws-node service account, DaemonSet..etc are recreated as listed in manually generated CNI yaml
4. Bring up worker nodes and confirm aws-node DS is healthy. 
5. Verify connectivity across nodes
6. Downgrade to 1.9.1 yaml that has service account at bottom of aws-node yaml 
7. Upgrade to master yaml that has service account listed at the top of aws-node yaml
```

**Automation added to e2e**: No
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: Yes

Rollback to 1.91 from master didnt have any impact
ramabad@88665a3712d6 cni-manifest-1.10 % kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.9.1/config/v1.9/aws-k8s-cni.yaml

clusterrolebinding.rbac.authorization.k8s.io/aws-node unchanged
clusterrole.rbac.authorization.k8s.io/aws-node unchanged
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/eniconfigs.crd.k8s.amazonaws.com configured
daemonset.apps/aws-node configured
serviceaccount/aws-node unchanged

Upgrade from 1.9.1 to manually generated manifest didnt have any issues

ramabad@88665a3712d6 cni-manifest-1.10 % k apply  -f aws-k8s-cni.yaml
serviceaccount/aws-node unchanged
clusterrolebinding.rbac.authorization.k8s.io/aws-node unchanged
clusterrole.rbac.authorization.k8s.io/aws-node unchanged
customresourcedefinition.apiextensions.k8s.io/eniconfigs.crd.k8s.amazonaws.com configured
daemonset.apps/aws-node configured


**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
