### PR TITLE
Integration test helper

### DIFF
--- a/test/integration-new/run.sh
+++ b/test/integration-new/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # This script runs integration tests on the EKS Amazon VPC CNI K8s
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Running VPC CNI K8s integration test with the following variables
@@ -33,7 +34,8 @@ kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
 #Start the test
 echo "Starting the ginkgo test suite" 
 
-(cd $SCRIPT_DIR/cni && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -r -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+# CGO_ENABLED=0 GOOS=$OS_OVERRIDE
+(cd $SCRIPT_DIR && ginkgo -v -r -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
 
 echo "Successfully finished the test suite"
 

--- a/test/integration-new/run.sh
+++ b/test/integration-new/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script runs integration tests on the EKS Amazon VPC CNI K8s
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "Running VPC CNI K8s integration test with the following variables
+KUBE CONFIG: $KUBE_CONFIG_PATH
+CLUSTER_NAME: $CLUSTER_NAME
+REGION: $REGION
+OS_OVERRIDE: $OS_OVERRIDE"
+
+if [[ -z "${OS_OVERRIDE}" ]]; then
+  OS_OVERRIDE=linux
+fi
+
+CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $REGION)
+
+VPC_ID=$(echo $CLUSTER_INFO | jq -r '.cluster.resourcesVpcConfig.vpcId')
+SERVICE_ROLE_ARN=$(echo $CLUSTER_INFO | jq -r '.cluster.roleArn')
+ROLE_NAME=${SERVICE_ROLE_ARN##*/}
+ 
+echo "VPC ID: $VPC_ID, Service Role ARN: $SERVICE_ROLE_ARN, Role Name: $ROLE_NAME"
+
+# Set up local resources
+echo "Attaching IAM Policy to Cluster Service Role"
+aws iam attach-role-policy \
+    --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
+    --role-name "$ROLE_NAME" > /dev/null
+
+echo "Enabling Pod ENI on aws-node"
+kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
+
+#Start the test
+echo "Starting the ginkgo test suite" 
+
+(cd $SCRIPT_DIR/cni && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+(cd $SCRIPT_DIR/ipamd && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+(cd $SCRIPT_DIR/metrics-helper && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+
+echo "Successfully finished the test suite"
+
+#Tear down local resources
+echo "Detaching the IAM Policy from Cluster Service Role"
+aws iam detach-role-policy \
+    --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
+    --role-name $ROLE_NAME > /dev/null
+
+echo "Disabling Pod ENI on aws-node"
+kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=false

--- a/test/integration-new/run.sh
+++ b/test/integration-new/run.sh
@@ -33,9 +33,7 @@ kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
 #Start the test
 echo "Starting the ginkgo test suite" 
 
-(cd $SCRIPT_DIR/cni && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
-(cd $SCRIPT_DIR/ipamd && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
-(cd $SCRIPT_DIR/metrics-helper && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+(cd $SCRIPT_DIR/cni && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -r -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
 
 echo "Successfully finished the test suite"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Helper script to trigger integration tests

**What does this PR do / Why do we need it**:
Script is needed to execute tests on prow 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
For testing ran 1 spec
```
sh test/integration-new/run.sh
Running VPC CNI K8s integration test with the following variables
KUBE CONFIG: /Users/cgadgil/.kube/config
CLUSTER_NAME: cni-test
REGION: us-west-2
OS_OVERRIDE: 
VPC ID: vpc-04683af7a0b023b43, Service Role ARN: arn:aws:iam::567109707621:role/eksctl-cni-test-cluster-ServiceRole-XTX42SDQ5QXZ, Role Name: eksctl-cni-test-cluster-ServiceRole-XTX42SDQ5QXZ
Attaching IAM Policy to Cluster Service Role
Enabling Pod ENI on aws-node
Starting the ginkgo test suite
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1632461938
Will run 1 of 14 specs

STEP: creating test namespace
STEP: getting the node with the node label key eks.amazonaws.com/nodegroup and value 
STEP: verifying more than 1 nodes are present for the test
STEP: getting the instance type from node label beta.kubernetes.io/instance-type
STEP: getting the network interface details from ec2
STEP: describing the VPC to get the VPC CIDRs
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
SSSSSSSSS

```

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
