### PR TITLE
Ipv6 init changes

### DIFF
--- a/cmd/cni-metrics-helper/metrics/cni_metrics.go
+++ b/cmd/cni-metrics-helper/metrics/cni_metrics.go
@@ -46,7 +46,7 @@ var InterestingCNIMetrics = map[string]metricsConvert{
 				matchFunc:  matchAny,
 				actionFunc: metricsAdd,
 				data:       &dataPoints{}}}},
-	"awscni_assigned_ip_per_ipv4cidr": {
+	"awscni_assigned_ip_per_cidr": {
 		actions: []metricsAction{
 			{cwMetricName: "totalAssignedIPv4sPerCidr",
 				matchFunc:  matchAny,

--- a/cmd/cni-metrics-helper/metrics/cni_test2.data
+++ b/cmd/cni-metrics-helper/metrics/cni_test2.data
@@ -7,9 +7,9 @@ awscni_assigned_ip_addresses 1
 # HELP awscni_total_ipv4_prefixes The total number of IPv4 prefixes
 # TYPE awscni_total_ipv4_prefixes gauge
 awscni_total_ipv4_prefixes 1
-# HELP awscni_assigned_ip_per_ipv4cidr The total number of IP addresses assigned per cidr
-# TYPE awscni_assigned_ip_per_ipv4cidr gauge
-awscni_assigned_ip_per_ipv4cidr 1
+# HELP awscni_assigned_ip_per_cidr The total number of IP addresses assigned per cidr
+# TYPE awscni_assigned_ip_per_cidr gauge
+awscni_assigned_ip_per_cidr{cidr="192.168.20.0/28"} 1
 # HELP awscni_aws_api_error_count The number of times AWS API returns an error
 # TYPE awscni_aws_api_error_count counter
 awscni_aws_api_error_count{api="DeleteNetworkInterface",error="InvalidParameterValue"} 14

--- a/cmd/cni-metrics-helper/metrics/metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/metrics_test.go
@@ -113,7 +113,7 @@ func TestAPIServerMetricwithPDenabled(t *testing.T) {
 	// verify awscni_total_ipv4_prefixes value
 	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
 
-	actions = InterestingCNIMetrics["awscni_assigned_ip_per_ipv4cidr"].actions
-	// verify awscni_assigned_ip_per_ipv4cidr value
+	actions = InterestingCNIMetrics["awscni_assigned_ip_per_cidr"].actions
+	// verify awscni_assigned_ip_per_cidr value
 	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
 }

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -217,6 +217,8 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
+        - "name": "ENABLE_IPv6"
+          "value": "false"
         "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "resources":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -217,6 +217,8 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
+        - "name": "ENABLE_IPv6"
+          "value": "false"
         "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "resources":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -217,6 +217,8 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
+        - "name": "ENABLE_IPv6"
+          "value": "false"
         "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "resources":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -217,6 +217,8 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
+        - "name": "ENABLE_IPv6"
+          "value": "false"
         "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.1"
         "name": "aws-vpc-cni-init"
         "resources":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "aws-node"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -255,10 +261,4 @@
     "rollingUpdate":
       "maxUnavailable": "10%"
     "type": "RollingUpdate"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -1,4 +1,10 @@
 ---
+"apiVersion": "v1"
+"kind": "ServiceAccount"
+"metadata":
+  "name": "cni-metrics-helper"
+  "namespace": "kube-system"
+---
 "apiVersion": "rbac.authorization.k8s.io/v1"
 "kind": "ClusterRoleBinding"
 "metadata":
@@ -90,10 +96,4 @@
         "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.9.1"
         "name": "cni-metrics-helper"
       "serviceAccountName": "cni-metrics-helper"
----
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "cni-metrics-helper"
-  "namespace": "kube-system"
 ...

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -231,11 +231,14 @@ local awsnode = {
               name: "aws-vpc-cni-init",
               image: "%s/amazon-k8s-cni-init:%s" % [$.ecrRepo, $.version],
               securityContext: {privileged: true},
+              env_:: {
+                DISABLE_TCP_EARLY_DEMUX: "false",
+                ENABLE_IPv6: "false",
+              },
               env: [
-                {
-                  name: "DISABLE_TCP_EARLY_DEMUX", value: "false",
-                },
-              ],
+                {name: kv[0]} + if std.isObject(kv[1]) then kv[1] else {value: kv[1]}
+                for kv in objectItems(self.env_)
+               ],
               resources: {
                 requests: {cpu: "10m", memory: "32Mi"},
                 limits: {cpu: "50m", memory: "64Mi"},

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -56,7 +56,7 @@ local awsnode = {
     ],
   },
 
-  serviceAccount: {
+  account: {
     apiVersion: "v1",
     kind: "ServiceAccount",
     metadata: {
@@ -77,9 +77,9 @@ local awsnode = {
       name: $.clusterRole.metadata.name,
     },
     subjects: [{
-      kind: $.serviceAccount.kind,
-      name: $.serviceAccount.metadata.name,
-      namespace: $.serviceAccount.metadata.namespace,
+      kind: $.account.kind,
+      name: $.account.metadata.name,
+      namespace: $.account.metadata.namespace,
     }],
   },
 
@@ -138,7 +138,7 @@ local awsnode = {
               },
             },
           },
-          serviceAccountName: $.serviceAccount.metadata.name,
+          serviceAccountName: $.account.metadata.name,
           hostNetwork: true,
           tolerations: [{operator: "Exists"}],
           containers_:: {
@@ -327,7 +327,7 @@ local metricsHelper = {
     ],
   },
 
-  serviceAccount: {
+  account: {
     apiVersion: "v1",
     kind: "ServiceAccount",
     metadata: {
@@ -348,9 +348,9 @@ local metricsHelper = {
       name: $.clusterRole.metadata.name,
     },
     subjects: [{
-      kind: $.serviceAccount.kind,
-      name: $.serviceAccount.metadata.name,
-      namespace: $.serviceAccount.metadata.namespace,
+      kind: $.account.kind,
+      name: $.account.metadata.name,
+      namespace: $.account.metadata.namespace,
     }],
   },
 
@@ -376,7 +376,7 @@ local metricsHelper = {
           },
         },
         spec: {
-          serviceAccountName: $.serviceAccount.metadata.name,
+          serviceAccountName: $.account.metadata.name,
           containers_:: {
             metricshelper: {
               image: "%s/cni-metrics-helper:%s" % [$.ecrRepo, $.version],

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -120,7 +120,7 @@ var (
 	)
 	ipsPerCidr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "awscni_assigned_ip_per_ipv4cidr",
+			Name: "awscni_assigned_ip_per_cidr",
 			Help: "The total number of IP addresses assigned per cidr",
 		},
 		[]string{"cidr"},

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -226,27 +226,6 @@ func findPrimaryInterfaceName(primaryMAC string) (string, error) {
 }
 
 func (n *linuxNetwork) enableIPv6() (err error) {
-	//Make sure IPv6 is enabled on host interfaces
-	if err = n.procSys.Set(fmt.Sprintf("net/ipv6/conf/all/disable_ipv6"), "0"); err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "setupVeth network: failed to enable IPv6 on hostVeth interface")
-		}
-	}
-	//Make sure IPv6 forwarding is enabled on all host interfaces
-	if err = n.procSys.Set(fmt.Sprintf("net/ipv6/conf/all/forwarding"), "1"); err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "setupVeth network: failed to enable IPv6 forwarding on all host interfaces")
-		}
-	}
-
-	//Set accept_ra to '2' for eth0. Allows us to overrule forwarding behaviour for the Node's Primary interface and
-	//will allow eth0 to accept Router Advertisements even though forwarding is enabled on *all* interfaces on the host netns.
-	if err = n.procSys.Set(fmt.Sprintf("net/ipv6/conf/eth0/accept_ra"), "2"); err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "setupVeth network: failed to set accept_ra to 2 for eth0")
-		}
-	}
-
 	if err = n.setupRuleToBlockNodeLocalV4Access(); err != nil {
 		return errors.Wrapf(err, "setupVeth network: failed to setup route to block pod access via IPv4 address")
 	}

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -750,9 +750,6 @@ func TestSetupHostNetworkWithIPv6Enabled(t *testing.T) {
 	}
 
 	setupNetLinkMocks(ctrl, mockNetLink)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/all/disable_ipv6", "0").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/all/forwarding", "1").Return(nil)
-	mockProcSys.EXPECT().Set("net/ipv6/conf/eth0/accept_ra", "2").Return(nil)
 
 	var vpcCIDRs []string
 	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false, false, true)

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -58,4 +58,15 @@ else
     sysctl -e -w "net.ipv4.tcp_early_demux=1"
 fi
 
+# If IPv6 is enabled,set `disable_ipv6` to `0` and ipv6 `forwarding` to `1`
+# We also set `accept_ra` to `2` on primary interface to allow it to honor RA packets.
+if [ "${ENABLE_IPv6:-false}" == "true" ]; then
+    sysctl -w "net.ipv6.conf.all.disable_ipv6=0"
+    sysctl -w "net.ipv6.conf.all.forwarding=1"
+    sysctl -w "net.ipv6.conf.$PRIMARY_IF.accept_ra=2"
+    cat "/proc/sys/net/ipv6/conf/all/disable_ipv6"
+    cat "/proc/sys/net/ipv6/conf/all/forwarding"
+    cat "/proc/sys/net/ipv6/conf/$PRIMARY_IF/accept_ra"
+fi
+
 echo "CNI init container done"


### PR DESCRIPTION
What type of PR is this?
bug/cleanup

Which issue does this PR fix:
aws-node pod is running in to permission issues with certain AMIs while trying to configure IPv6 settings with NET_ADMIN permissions. We had to enable privileged mode to get around that. However, we don't want to enable privileged mode for aws-node.aws-vpc-cni-init container currently operates in privileged mode, so moving the corresponding IPv6 config settings over to init container.

Also, modified a metric name to make it generic to both IPv4 and IPv6 CIDRs.

Testing done on this change:
Validated that aws-node no longer runs in to permission issues during boot-up and also validated basic traffic flows in IPv6 mode.

Does this change require updates to the CNI daemonset config files to work?:
Yes, aws-vpc-cni-init container will now have a new env variable exposed - ENABLE_IPv6. Variable has to be set to true in IPv6 mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.