### PR TITLE
Make error count granular

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -570,7 +570,7 @@ func (cache *EC2InstanceMetadataCache) GetAttachedENIs() (eniList []ENIMetadata,
 	// retrieve number of interfaces
 	macs, err := cache.imds.GetMACs(ctx)
 	if err != nil {
-		awsAPIErrInc("GetMACS", err)
+		awsAPIErrInc("GetMACs", err)
 		return nil, err
 	}
 	log.Debugf("Total number of interfaces found: %d ", len(macs))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #1636

**What does this PR do / Why do we need it**:
Currently we `awsAPIErrInc("GetMetadata", err)` in a common function which fetches from IMDS `GetMetadataWithContext`. We query for prefixes and secondary IPs but with secondary IP mode get prefixes will return 404 which is expected but the common functions logs the events as an error. Instead moving the logic to make the error count more granular. With this PR we will know the exact field in IMDS which is causing the error rather than just getMetaData which isnt sufficient for debugging.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

No errors incrementing.

<img width="1442" alt="Screen Shot 2021-10-01 at 3 27 35 PM" src="https://user-images.githubusercontent.com/1111446/135692497-c88d3622-7371-4530-9bb1-6ee322a9a131.png">

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
