### PR TITLE
Cherry-pick - Make error count granular (#1651)

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -363,7 +363,6 @@ func (i instrumentedIMDS) GetMetadataWithContext(ctx context.Context, p string) 
 	awsAPILatency.WithLabelValues("GetMetadata", fmt.Sprint(err != nil), awsReqStatus(err)).Observe(duration)
 
 	if err != nil {
-		awsAPIErrInc("GetMetadata", err)
 		return "", newIMDSRequestError(p, err)
 	}
 
@@ -429,6 +428,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve availability-zone
 	cache.availabilityZone, err = cache.imds.GetAZ(ctx)
 	if err != nil {
+		awsAPIErrInc("GetAZ", err)
 		return err
 	}
 	log.Debugf("Found availability zone: %s ", cache.availabilityZone)
@@ -436,6 +436,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve eth0 local-ipv4
 	cache.localIPv4, err = cache.imds.GetLocalIPv4(ctx)
 	if err != nil {
+		awsAPIErrInc("GetLocalIPv4", err)
 		return err
 	}
 	log.Debugf("Discovered the instance primary IPv4 address: %s", cache.localIPv4)
@@ -443,6 +444,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve instance-id
 	cache.instanceID, err = cache.imds.GetInstanceID(ctx)
 	if err != nil {
+		awsAPIErrInc("GetInstanceID", err)
 		return err
 	}
 	log.Debugf("Found instance-id: %s ", cache.instanceID)
@@ -450,6 +452,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve instance-type
 	cache.instanceType, err = cache.imds.GetInstanceType(ctx)
 	if err != nil {
+		awsAPIErrInc("GetInstanceType", err)
 		return err
 	}
 	log.Debugf("Found instance-type: %s ", cache.instanceType)
@@ -457,6 +460,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve primary interface's mac
 	mac, err := cache.imds.GetMAC(ctx)
 	if err != nil {
+		awsAPIErrInc("GetMAC", err)
 		return err
 	}
 	cache.primaryENImac = mac
@@ -464,6 +468,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 
 	cache.primaryENI, err = cache.imds.GetInterfaceID(ctx, mac)
 	if err != nil {
+		awsAPIErrInc("GetInterfaceID", err)
 		return errors.Wrap(err, "get instance metadata: failed to find primary ENI")
 	}
 	log.Debugf("%s is the primary ENI of this instance", cache.primaryENI)
@@ -471,6 +476,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	// retrieve sub-id
 	cache.subnetID, err = cache.imds.GetSubnetID(ctx, mac)
 	if err != nil {
+		awsAPIErrInc("GetSubnetID", err)
 		return err
 	}
 	log.Debugf("Found subnet-id: %s ", cache.subnetID)
@@ -490,6 +496,7 @@ func (cache *EC2InstanceMetadataCache) RefreshSGIDs(mac string) error {
 
 	sgIDs, err := cache.imds.GetSecurityGroupIDs(ctx, mac)
 	if err != nil {
+		awsAPIErrInc("GetSecurityGroupIDs", err)
 		return err
 	}
 
@@ -563,6 +570,7 @@ func (cache *EC2InstanceMetadataCache) GetAttachedENIs() (eniList []ENIMetadata,
 	// retrieve number of interfaces
 	macs, err := cache.imds.GetMACs(ctx)
 	if err != nil {
+		awsAPIErrInc("GetMACs", err)
 		return nil, err
 	}
 	log.Debugf("Total number of interfaces found: %d ", len(macs))
@@ -587,16 +595,19 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 
 	eniID, err := cache.imds.GetInterfaceID(ctx, eniMAC)
 	if err != nil {
+		awsAPIErrInc("GetInterfaceID", err)
 		return ENIMetadata{}, err
 	}
 
 	deviceNum, err = cache.imds.GetDeviceNumber(ctx, eniMAC)
 	if err != nil {
+		awsAPIErrInc("GetDeviceNumber", err)
 		return ENIMetadata{}, err
 	}
 
 	primaryMAC, err := cache.imds.GetMAC(ctx)
 	if err != nil {
+		awsAPIErrInc("GetMAC", err)
 		return ENIMetadata{}, err
 	}
 	if eniMAC == primaryMAC && deviceNum != 0 {
@@ -609,11 +620,13 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 
 	cidr, err := cache.imds.GetSubnetIPv4CIDRBlock(ctx, eniMAC)
 	if err != nil {
+		awsAPIErrInc("GetSubnetIPv4CIDRBlock", err)
 		return ENIMetadata{}, err
 	}
 
 	imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
 	if err != nil {
+		awsAPIErrInc("GetLocalIPv4s", err)
 		return ENIMetadata{}, err
 	}
 
@@ -633,6 +646,7 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 	if cache.v6Enabled {
 		imdsIPv6Prefixes, err := cache.imds.GetIPv6Prefixes(ctx, eniMAC)
 		if err != nil {
+			awsAPIErrInc("GetIPv6Prefixes", err)
 			return ENIMetadata{}, err
 		}
 		for _, ipv6prefix := range imdsIPv6Prefixes {
@@ -647,6 +661,7 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 		// primary ENI.
 		imdsIPv4Prefixes, err := cache.imds.GetIPv4Prefixes(ctx, eniMAC)
 		if err != nil {
+			awsAPIErrInc("GetIPv4Prefixes", err)
 			return ENIMetadata{}, err
 		}
 		for _, ipv4prefix := range imdsIPv4Prefixes {
@@ -1716,6 +1731,7 @@ func (cache *EC2InstanceMetadataCache) GetVPCIPv4CIDRs() ([]string, error) {
 
 	ipnets, err := cache.imds.GetVPCIPv4CIDRBlocks(ctx, cache.primaryENImac)
 	if err != nil {
+		awsAPIErrInc("GetVPCIPv4CIDRBlocks", err)
 		return nil, err
 	}
 
@@ -1739,6 +1755,7 @@ func (cache *EC2InstanceMetadataCache) GetVPCIPv6CIDRs() ([]string, error) {
 
 	ipnets, err := cache.imds.GetVPCIPv6CIDRBlocks(ctx, cache.primaryENImac)
 	if err != nil {
+		awsAPIErrInc("GetVPCIPv6CIDRBlocks", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
* Make error count granular

* minor nit

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1651 

**What does this PR do / Why do we need it**:
Cherry-pick to release-1.10

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/a

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/a

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
