### PR TITLE
Remove deprecated beta.kubernetes.io/os and beta.kubernetes.io/arch labels

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -121,20 +121,6 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: "beta.kubernetes.io/os"
-              operator: In
-              values:
-                - linux
-            - key: "beta.kubernetes.io/arch"
-              operator: In
-              values:
-                - amd64
-                - arm64
-            - key: "eks.amazonaws.com/compute-type"
-              operator: NotIn
-              values:
-                - fargate
-        - matchExpressions:
             - key: "kubernetes.io/os"
               operator: In
               values:

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -93,20 +93,6 @@
           "requiredDuringSchedulingIgnoredDuringExecution":
             "nodeSelectorTerms":
             - "matchExpressions":
-              - "key": "beta.kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "beta.kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-            - "matchExpressions":
               - "key": "kubernetes.io/os"
                 "operator": "In"
                 "values":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -93,20 +93,6 @@
           "requiredDuringSchedulingIgnoredDuringExecution":
             "nodeSelectorTerms":
             - "matchExpressions":
-              - "key": "beta.kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "beta.kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-            - "matchExpressions":
               - "key": "kubernetes.io/os"
                 "operator": "In"
                 "values":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -93,20 +93,6 @@
           "requiredDuringSchedulingIgnoredDuringExecution":
             "nodeSelectorTerms":
             - "matchExpressions":
-              - "key": "beta.kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "beta.kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-            - "matchExpressions":
               - "key": "kubernetes.io/os"
                 "operator": "In"
                 "values":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -93,20 +93,6 @@
           "requiredDuringSchedulingIgnoredDuringExecution":
             "nodeSelectorTerms":
             - "matchExpressions":
-              - "key": "beta.kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "beta.kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-            - "matchExpressions":
               - "key": "kubernetes.io/os"
                 "operator": "In"
                 "values":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -114,27 +114,25 @@ local awsnode = {
           affinity: {
             nodeAffinity: {
               requiredDuringSchedulingIgnoredDuringExecution: {
-                nodeSelectorTerms: [
-                  {
-                    matchExpressions: [
-                      {
-                        key: prefix + "kubernetes.io/os",
-                        operator: "In",
-                        values: ["linux"],
-                      },
-                      {
-                        key: prefix + "kubernetes.io/arch",
-                        operator: "In",
-                        values: ["amd64", "arm64"],
-                      },
-                      {
-                        key: "eks.amazonaws.com/compute-type",
-                        operator: "NotIn",
-                        values: ["fargate"],
-                      },
-                    ],
-                  } for prefix in ["beta.", ""]
-                ],
+                nodeSelectorTerms: [{ 
+                  matchExpressions: [
+                    {
+                      key: "kubernetes.io/os",
+                      operator: "In",
+                      values: ["linux"],
+                    },
+                    {
+                      key: "kubernetes.io/arch",
+                      operator: "In",
+                      values: ["amd64", "arm64"],
+                    },
+                    {
+                      key: "eks.amazonaws.com/compute-type",
+                      operator: "NotIn",
+                      values: ["fargate"],
+                    },
+                  ],
+                }],
               },
             },
           },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #1581 

**What does this PR do / Why do we need it**:
Cleanup deprecated beta.kubernetes.io/os and beta.kubernetes.io/arch labels. 

OS and Arch information is now recorded in kubernetes.io/os and kubernetes.io/arch labels on Node objects. The previous labels (beta.kubernetes.io/os and beta.kubernetes.io/arch) are still recorded, but are deprecated and targeted for removal in v1.18. [Ref : https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md]

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
