### PR TITLE
Fix for the failing e2e test and warm_target_test 

### DIFF
--- a/test/e2e/pod-eni/securiy_group_per_pod_suite_test.go
+++ b/test/e2e/pod-eni/securiy_group_per_pod_suite_test.go
@@ -14,6 +14,8 @@
 package pod_eni
 
 import (
+	"net/url"
+	"path"
 	"strings"
 	"testing"
 
@@ -48,6 +50,8 @@ var (
 	nodeGroupProperties awsUtils.NodeGroupProperties
 	// Cluster Role name derived from cluster Role ARN, used to attach VPC Controller Policy
 	clusterRoleName string
+	// NodeSecurityGroupId for Node-Node communication
+	nodeSecurityGroupID string
 )
 
 func TestSecurityGroupForPods(t *testing.T) {
@@ -103,6 +107,40 @@ var _ = BeforeSuite(func() {
 	By("creating a new self managed node group")
 	err = awsUtils.CreateAndWaitTillSelfManagedNGReady(f, nodeGroupProperties)
 	Expect(err).ToNot(HaveOccurred())
+
+	By("Get Reference to any node from the self managed node group")
+	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(nodeGroupProperties.NgLabelKey,
+		nodeGroupProperties.NgLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(nodeList.Items)).Should(BeNumerically(">", 0))
+
+	// Get ref to any node from newly created nodegroup
+	By("Getting providerID of the node")
+	node := nodeList.Items[0]
+	providerID := node.Spec.ProviderID
+	Expect(len(providerID)).To(BeNumerically(">", 0))
+
+	By("Get InstanceID from the node")
+	awsUrl, err := url.Parse(providerID)
+	Expect(err).NotTo(HaveOccurred())
+
+	instanceID := path.Base(awsUrl.Path)
+	Expect(len(instanceID)).To(BeNumerically(">", 0))
+
+	By("Fetching Node Security GroupId")
+	instance, err := f.CloudServices.EC2().DescribeInstance(instanceID)
+	Expect(err).NotTo(HaveOccurred())
+
+	networkInterface := instance.NetworkInterfaces[0]
+	securityGroups := networkInterface.Groups
+	nodeSecurityGroupPrefix := nodeGroupProperties.NgLabelVal + "-NodeSecurityGroup"
+	for _, group := range securityGroups {
+		if strings.HasPrefix(*group.GroupName, nodeSecurityGroupPrefix) {
+			nodeSecurityGroupID = *group.GroupId
+			break
+		}
+	}
+	Expect(len(nodeSecurityGroupID)).To(BeNumerically(">", 0))
 
 	By("enabling pod eni on aws-node DaemonSet")
 	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName,

--- a/test/framework/resources/aws/services/eks.go
+++ b/test/framework/resources/aws/services/eks.go
@@ -22,6 +22,8 @@ import (
 
 type EKS interface {
 	DescribeCluster(clusterName string) (*eks.DescribeClusterOutput, error)
+	CreateAddon(addon string, clusterName string) (*eks.CreateAddonOutput, error)
+	DeleteAddon(addon string, clusterName string) (*eks.DeleteAddonOutput, error)
 }
 
 type defaultEKS struct {
@@ -35,6 +37,22 @@ func NewEKS(session *session.Session, endpoint string) EKS {
 			Region:   session.Config.Region,
 		}),
 	}
+}
+
+func (d defaultEKS) CreateAddon(addon string, clusterName string) (*eks.CreateAddonOutput, error) {
+	createAddonInput := &eks.CreateAddonInput{
+		AddonName:   aws.String(addon),
+		ClusterName: aws.String(clusterName),
+	}
+	return d.EKSAPI.CreateAddon(createAddonInput)
+}
+
+func (d defaultEKS) DeleteAddon(addon string, clusterName string) (*eks.DeleteAddonOutput, error) {
+	deleteAddonInput := &eks.DeleteAddonInput{
+		AddonName:   aws.String(addon),
+		ClusterName: aws.String(clusterName),
+	}
+	return d.EKSAPI.DeleteAddon(deleteAddonInput)
 }
 
 func (d defaultEKS) DescribeCluster(clusterName string) (*eks.DescribeClusterOutput, error) {

--- a/test/integration-new/ipamd/ipamd_suite_test.go
+++ b/test/integration-new/ipamd/ipamd_suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	if addonDeleteError == nil {
-		By("Restore coredns deployment")
+		By("Restore coredns addon")
 		_, err := f.CloudServices.EKS().CreateAddon("coredns", f.Options.ClusterName)
 		Expect(err).NotTo(HaveOccurred())
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
cleanup

**Which issue does this PR fix**:
- Fixes failing e2e tests which check for communication between server and client when both are behind branch ENI as the communication between client and metric pod wasn't happening. Had to update NodeSecuirtyGroup of metric pods to allow ingress from client pods ENI SG.
- Fixes the warm_target_test by uninstalling coredns addon before we run tests and restoring it back after the tests

**Testing done on this change**:
```
ginkgo -v -r -- --cluster-kubeconfig=/Users/cgadgil/.kube/config --cluster-name=cni-v6-test --aws-region=us-west-2 --aws-vpc-id=vpc-0cdd39f158ed97411


Running Suite: VPC IPAMD Test Suite
===================================
Random Seed: 1633502083
Will run 1 of 26 specs

STEP: Delete coredns addon if it exists
SSSS
------------------------------
test warm target variables when warm ENI target is used when WARM_ENI_TARGET = 2 and MAX_ENI = 1 
  instance should have only 2 ENIs
  /Users/cgadgil/Documents/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:66
STEP: setting the environment variables on the ds to map[MAX_ENI:1 WARM_ENI_TARGET:2]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: removing the environment variables from the ds map[MAX_ENI:{} WARM_ENI_TARGET:{}]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable

• [SLOW TEST:211.070 seconds]
test warm target variables
/Users/cgadgil/Documents/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:30
  when warm ENI target is used
  /Users/cgadgil/Documents/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:31
    when WARM_ENI_TARGET = 2 and MAX_ENI = 1
    /Users/cgadgil/Documents/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:60
      instance should have only 2 ENIs
      /Users/cgadgil/Documents/amazon-vpc-cni-k8s/test/integration-new/ipamd/warm_target_test.go:66
------------------------------
SSSSSSSSSSSSSSSSSSSSSSTEP: Restore coredns addon
```

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
