### PR TITLE
Cherry pick test agent image change to 1.10 branch

### DIFF
--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -22,7 +22,7 @@ const (
 	AWSInitContainerName = "aws-vpc-cni-init"
 
 	// See https://gallery.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper
-	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:66180f40"
+	TestAgentImage = "public.ecr.aws/r3i6j7b0/aws-vpc-cni-test-helper:5c99fc7b"
 )
 
 const (

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/apparentlymart/go-cidr v1.0.1
 	github.com/aws/amazon-vpc-cni-k8s v1.7.10
-	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2
+	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20211007200130-5c99fc7bd508
 	github.com/aws/amazon-vpc-resource-controller-k8s v1.0.7
 	github.com/aws/aws-sdk-go v1.40.6
 	github.com/onsi/ginkgo v1.12.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -73,6 +73,8 @@ github.com/aws/amazon-vpc-cni-k8s v1.7.10/go.mod h1:DvKcToLCSKRXnnoIE5u1Bphq97bd
 github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210504235351-07ac754880d8/go.mod h1:S9uWML/tLwNzmgjeeRJC1gncEa/4z2xIxWvLdEt1GlQ=
 github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2 h1:g3zjwqtsPu8ufcwB3itAXZPEwg5ymrQNXpq5DHT/zCk=
 github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20210519174950-4d1931b480a2/go.mod h1:rVKUK/i11rmmbRY40+vRjAGF74qjkZ+eHuceB8NPg+s=
+github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20211007200130-5c99fc7bd508 h1:mZRvkOMoMXchAsgZ01QzWxSCYQuPGy/xm2pZO43X5fo=
+github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20211007200130-5c99fc7bd508/go.mod h1:QBpwHZBwf6mRICQxl25bFTvxZHaNXbXmKbs1AbUuTho=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.0.7 h1:F2/ilyN24aDrgwMVXjZoQM9Q0JsZUGrR5BxTOOVi7Iw=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.0.7/go.mod h1:iObLR7LsAf1BUb9+5rGpHHXQ1nwkX8On6BFp+dk4VVk=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix:**
Updates test image used by integration test suite..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.