### PR TITLE
Update MNG for single node perf test

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -14,7 +14,7 @@ function down-test-cluster() {
 function up-test-cluster() {
     MNGS=""
     if [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
-        MNGS='{"GetRef.Name-single-node-mng":{"name":"GetRef.Name-single-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1,"instance-types":["m5.16xlarge"],"volume-size":40}, "cni-test-multi-node-mng":{"name":"cni-test-multi-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":100,"asg-desired-capacity":99,"instance-types":["m5.xlarge"],"volume-size":40,"cluster-autoscaler":{"enable":true}}}'
+        MNGS='{"cni-test-single-node-mng":{"name":"cni-test-single-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1,"instance-types":["m5.16xlarge"],"volume-size":40}, "cni-test-multi-node-mng":{"name":"cni-test-multi-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":100,"asg-desired-capacity":99,"instance-types":["m5.xlarge"],"volume-size":40,"cluster-autoscaler":{"enable":true}}}'
         export RUN_CONFORMANCE="false"
         : "${PERFORMANCE_TEST_S3_BUCKET_NAME:=""}"
     else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Update the single node MNG to map https://github.com/aws/amazon-vpc-cni-k8s/blob/master/testdata/deploy-730-pods.yaml#L25

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
Times to scale up:
259
442
315

Times to scale down:
526 seconds
706 seconds
580 seconds

pod-5000-Test-9258-10-10-2021-20:00:24-v1.9.0.csv
Date, "slot1", "slot2"
2021-10-10-20:00:24, 259, 526
2021-10-10-20:00:24, 442, 706
2021-10-10-20:00:24, 315, 580

Times to scale up:
1057
599
589

Times to scale down:
1529 seconds
1097 seconds
1072 seconds

pod-730-Test-9258-10-10-2021-19:30:09-v1.9.0.csv
Date, "slot1", "slot2"
2021-10-10-19:30:09, 1057, 1529
2021-10-10-19:30:09, 599, 1097
2021-10-10-19:30:09, 589, 1072

Times to scale up:
41
33
52

Times to scale down:
63 seconds
55 seconds
70 seconds

pod-130-Test-9258-10-10-2021-18:28:28-v1.9.0.csv
Date, "slot1", "slot2"
2021-10-10-18:28:28, 41, 63
2021-10-10-18:28:28, 33, 55
2021-10-10-18:28:28, 52, 70
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
