### PR TITLE
Updated aws-calico chart ClusterRole with endpointslices permissions

### DIFF
--- a/charts/aws-calico/Chart.yaml
+++ b/charts/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.8
+version: 0.3.10
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/charts/aws-calico/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/aws-calico/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -22,6 +22,14 @@ rules:
       - update
       - delete
       - watch
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch 
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
- bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
- Fix for error

```
2021-10-04 11:48:43.029 [INFO][7] watchercache.go 186: Failed to perform list of current data during resync ListRoot="/calico/resources/v3/projectcalico.org/kubernetesendpointslices" error=connection is unauthorized: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
```

**What does this PR do / Why do we need it**:
- Ref https://github.com/aws/eks-charts/pull/610
- Sync eks-charts/aws-calico with aws-vpc-cni-k8s
- Added permissions to endpointslices api endpoint
- updated chart.yaml to "0.3.10" (latest version for aws-calico chart from eks-charts repo)

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
$ kubectl get clusterroles calico-node -o yaml | grep -i endpoint
  - endpointslices
  - endpoints
  - hostendpoints

$ kubectl get clusterroles tigera-operator -o yaml | grep -i "endpointslices"
  - endpointslices

$ kubectl get pods -A | grep -i calico
calico-system     calico-kube-controllers-685b68c7c4-jzdrj    1/1     Running   0          13m
calico-system     calico-node-4gjcx                           1/1     Running   0          13m
calico-system     calico-node-ktmxt                           1/1     Running   0          13m
calico-system     calico-typha-6ff5856c45-5trdk               1/1     Running   0          13m
calico-system     calico-typha-6ff5856c45-fpccr               1/1     Running   0          13m

$ kubectl get pods -A | grep -i tigera
tigera-operator   tigera-operator-6fbb48778f-kzn2k            1/1     Running   0          14m
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
- n/a

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
- No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
