### PR TITLE
Switch golang image to public ECR image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v
 # provide an alternate suffix or to omit.
 IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(ARCH),arm64))
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE = golang:1.16-stretch
+GOLANG_IMAGE = public.ecr.aws/bitnami/golang:1.16
 # For the requested build, these are the set of Go specific build environment variables.
 export GOARCH ?= $(ARCH)
 export GOOS = linux
@@ -168,7 +168,7 @@ build-docker-test:     ## Build the unit test driver container image.
 		.
 
 # Run unit tests inside of the testing container image.
-docker-unit-test: build-docker-test     ## Run unit tests inside of the testing container image.
+docker-unit-tests: build-docker-test     ## Run unit tests inside of the testing container image.
 	docker run $(DOCKER_RUN_ARGS) \
 		$(TEST_IMAGE_NAME) \
 		make unit-test

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Alternatively there is also a [Helm](https://helm.sh/) chart: [eks/aws-vpc-cni](
 * `make` defaults to `make build-linux` that builds the Linux binaries.
 * `unit-test`, `format`,`lint` and `vet` provide ways to run the respective tests/tools and should be run before submitting a PR.
 * `make docker` will create a docker container using the docker-build with the finished binaries, with a tag of `amazon/amazon-k8s-cni:latest`
-* `make docker-build` uses a docker container (golang:1.14) to build the binaries.
-* `make docker-unit-tests` uses a docker container (golang:1.14) to run all unit tests.
+* `make docker-build` uses a docker container (golang:1.16) to build the binaries.
+* `make docker-unit-tests` uses a docker container (golang:1.16) to run all unit tests.
 
 ## Components
 


### PR DESCRIPTION
- Switch golang image to public ECR image
- Corrected readme and make file target for docker unit-tests

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Switch golang image to public ECR image

**What does this PR do / Why do we need it**:
Switch golang image to public ECR image

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Executed make docker-unit-tests and verified that they passed.
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
