### PR TITLE
Cherry-pick Pod startup latency with Calico and EKS (#1629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,18 @@ Setting `DISABLE_NETWORK_RESOURCE_PROVISIONING` to `true` will make IPAMD to dep
 
 ---
 
+#### `ANNOTATE_POD_IP` (v1.9.3+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Setting `ANNOTATE_POD_IP` to `true` will allow IPAMD to add an annotation `vpc.amazonaws.com/pod-ips` to the pod with pod IP.
+
+There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ANNOTATE_POD_IP` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
+
+---
+
 ### ENI tags related to Allocation
 
 This plugin interacts with the following tags on ENIs:

--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -12,9 +12,12 @@ rules:
     verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
-      - pods
       - namespaces
     verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get", "patch"]
   - apiGroups: [""]
     resources:
       - nodes

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -34,12 +34,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -34,12 +34,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -34,12 +34,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -34,12 +34,20 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
   "verbs":
   - "list"
   - "watch"
   - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+  - "patch"
 - "apiGroups":
   - ""
   "resources":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -40,8 +40,13 @@ local awsnode = {
       },
       {
         apiGroups: [""],
-        resources: ["pods", "namespaces"],
+        resources: ["namespaces"],
         verbs: ["list", "watch", "get"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["pods"],
+        verbs: ["list", "watch", "get", "patch"],
       },
       {
         apiGroups: [""],

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/eniconfig"
@@ -147,6 +148,14 @@ const (
 	envManageUntaggedENI = "MANAGE_UNTAGGED_ENI"
 
 	eniNodeTagKey = "node.k8s.amazonaws.com/instance_id"
+
+	// envAnnotatePodIP is used to annotate[vpc.amazonaws.com/pod-ips] pod's with IPs
+	// Ref : https://github.com/projectcalico/calico/issues/3530
+	// not present; in which case we fall back to the k8s podIP
+	// Present and set to an IP; in which case we use it
+	// Present and set to the empty string, which we use to mean "CNI DEL had occurred; networking has been removed from this pod"
+	// The empty string one helps close a trace at pod shutdown where it looks like the pod still has its IP when the IP has been released
+	envAnnotatePodIP = "ANNOTATE_POD_IP"
 )
 
 var log = logger.Get()
@@ -229,14 +238,15 @@ type IPAMContext struct {
 	lastDecreaseIPPool   time.Time
 	// reconcileCooldownCache keeps timestamps of the last time an IP address was unassigned from an ENI,
 	// so that we don't reconcile and add it back too quickly if IMDS lags behind reality.
-	reconcileCooldownCache     ReconcileCooldownCache
-	terminating                int32 // Flag to warn that the pod is about to shut down.
-	disableENIProvisioning     bool
-	enablePodENI               bool
-	myNodeName                 string
-	enableIpv4PrefixDelegation bool
-	lastInsufficientCidrError  time.Time
-	enableManageUntaggedMode   bool
+	reconcileCooldownCache    ReconcileCooldownCache
+	terminating               int32 // Flag to warn that the pod is about to shut down.
+	disableENIProvisioning    bool
+	enablePodENI              bool
+	myNodeName                string
+	enablePrefixDelegation    bool
+	lastInsufficientCidrError time.Time
+	enableManageUntaggedMode  bool
+	enablePodIPAnnotation     bool
 }
 
 // setUnmanagedENIs will rebuild the set of ENI IDs for ENIs tagged as "no_manage"
@@ -361,6 +371,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 
 	c.enablePodENI = enablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
+	c.enablePodIPAnnotation = enablePodIPAnnotation()
 
 	err = c.awsClient.FetchInstanceTypeLimits()
 	if err != nil {
@@ -1581,6 +1592,10 @@ func enableManageUntaggedMode() bool {
 	return getEnvBoolWithDefault(envManageUntaggedENI, true)
 }
 
+func enablePodIPAnnotation() bool {
+	return getEnvBoolWithDefault(envAnnotatePodIP, false)
+}
+
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag
 func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutils.ENIMetadata {
 	numFiltered := 0
@@ -1777,6 +1792,30 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("Error while trying to retrieve Pod Info: %s", err)
 	}
 	return &pod, nil
+}
+
+// AnnotatePod annotates the pod with the provided key and value
+func (c *IPAMContext) AnnotatePod(podNamespace, podName, key, val string) error {
+	ctx := context.TODO()
+	var pod *corev1.Pod
+	var err error
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if pod, err = c.GetPod(podNamespace, podName); err != nil {
+			return err
+		}
+
+		newPod := pod.DeepCopy()
+		newPod.Annotations[key] = val
+		if err = c.rawK8SClient.Patch(ctx, newPod, client.MergeFrom(pod)); err != nil {
+			log.Errorf("Failed to annotate %s the pod with %s, error %v", key, val, err)
+			return err
+		}
+		log.Debugf("Annotates pod %s with %s: %s", podName, key, val)
+		return nil
+	})
+
+	return err
 }
 
 func (c *IPAMContext) tryUnassignIPsFromENIs() {


### PR DESCRIPTION
* Calico optimization

* make format because of older commits

* Update the annotation

* update env variable

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1629 

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
