### PR TITLE
Readiness and Liveness Timeout/readme update for rel 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,24 @@ Default: `false`
 
 Setting `ANNOTATE_POD_IP` to `true` will allow IPAMD to add an annotation `vpc.amazonaws.com/pod-ips` to the pod with pod IP.
 
-There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ANNOTATE_POD_IP` to `true` will enable AWS VPC CNI similar to the optimization added in Calico CNI plugin to write the IP address back to the pod as an annotation to close this race condition. 
+There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ANNOTATE_POD_IP` to `true` will enable AWS VPC CNI plugin to add Pod IP as an annotation to the pod spec to address this race condition.
+
+To annotate the pod with pod IP, you will have to add "patch" permission for pods resource in aws-node clusterrole. You can use the below command - 
+
+```
+ cat << EOF > append.yaml
+ - apiGroups:
+   - ""
+   resources:
+   - pods
+   verbs:
+   - patch
+ EOF
+ ```
+
+ ```
+ kubectl apply -f <(cat <(kubectl get clusterrole aws-node -o yaml) append.yaml)
+ ```
 
 ---
 

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -47,7 +47,6 @@
   - "list"
   - "watch"
   - "get"
-  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -179,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -189,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -47,7 +47,6 @@
   - "list"
   - "watch"
   - "get"
-  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -179,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -189,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -47,7 +47,6 @@
   - "list"
   - "watch"
   - "get"
-  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -179,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -189,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -47,7 +47,6 @@
   - "list"
   - "watch"
   - "get"
-  - "patch"
 - "apiGroups":
   - ""
   "resources":
@@ -179,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -189,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -46,7 +46,7 @@ local awsnode = {
       {
         apiGroups: [""],
         resources: ["pods"],
-        verbs: ["list", "watch", "get", "patch"],
+        verbs: ["list", "watch", "get"],
       },
       {
         apiGroups: [""],
@@ -156,12 +156,13 @@ local awsnode = {
               name: "aws-node",
               readinessProbe: {
                 exec: {
-                  command: ["/app/grpc-health-probe", "-addr=:50051"],
+                  command: ["/app/grpc-health-probe", "-addr=:50051", "-connect-timeout=2s", "-rpc-timeout=2s"],
                 },
                 initialDelaySeconds: 1,
               },
               livenessProbe: self.readinessProbe + {
                 initialDelaySeconds: 60,
+                timeoutSeconds: 5,
               },
               env_:: {
                 ADDITIONAL_ENI_TAGS: "{}",

--- a/config/v1.9/aws-k8s-cni-cn.yaml
+++ b/config/v1.9/aws-k8s-cni-cn.yaml
@@ -34,8 +34,15 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
   "verbs":
   - "list"
   - "watch"
@@ -171,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -181,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/v1.9/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/v1.9/aws-k8s-cni-us-gov-east-1.yaml
@@ -34,8 +34,15 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
   "verbs":
   - "list"
   - "watch"
@@ -171,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -181,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/v1.9/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/v1.9/aws-k8s-cni-us-gov-west-1.yaml
@@ -34,8 +34,15 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
   "verbs":
   - "list"
   - "watch"
@@ -171,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -181,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":

--- a/config/v1.9/aws-k8s-cni.yaml
+++ b/config/v1.9/aws-k8s-cni.yaml
@@ -34,8 +34,15 @@
 - "apiGroups":
   - ""
   "resources":
-  - "pods"
   - "namespaces"
+  "verbs":
+  - "list"
+  - "watch"
+  - "get"
+- "apiGroups":
+  - ""
+  "resources":
+  - "pods"
   "verbs":
   - "list"
   - "watch"
@@ -171,7 +178,10 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 60
+          "timeoutSeconds": 5
         "name": "aws-node"
         "ports":
         - "containerPort": 61678
@@ -181,6 +191,8 @@
             "command":
             - "/app/grpc-health-probe"
             - "-addr=:50051"
+            - "-connect-timeout=2s"
+            - "-rpc-timeout=2s"
           "initialDelaySeconds": 1
         "resources":
           "requests":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
NA

**What does this PR do / Why do we need it**:
1. Add timeout for readiness and liveness 
2. Update readme for patch permission for pod resources

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
