### PR TITLE
[ipamd] throw an error on configuration validation failure

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -397,7 +397,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	//Let's validate if the configured combination of env variables is supported before we
 	//proceed any further
 	if !c.isConfigValid() {
-		return nil, err
+		return nil, fmt.Errorf("ipamd: failed to validate configuration")
 	}
 
 	c.awsClient.InitCachedPrefixDelegation(c.enablePrefixDelegation)


### PR DESCRIPTION
**What type of PR is this?**: Bugfix

**Which issue does this PR fix:** N/A

**What does this PR do / Why do we need it:**:  Existing implementation panics in case of config validation error since returned error value is nil.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue:**
Launch ipamd with no ipv* env variables set:
```
{"level":"debug","ts":"2021-10-20T03:42:42.546Z","caller":"ipamd/ipamd.go:2164","msg":"Instance hypervisor family nitro"}
{"level":"error","ts":"2021-10-20T03:42:42.546Z","caller":"ipamd/ipamd.go:399","msg":"IPv4 and IPv6 are both disabled. One of them have to be enabled"}
{"level":"info","ts":"2021-10-20T03:42:42.546Z","caller":"aws-k8s-agent/main.go:73","msg":"Serving RPC Handler version  on 127.0.0.1:50051"}
{"level":"info","ts":"2021-10-20T03:42:42.546Z","caller":"runtime/asm_amd64.s:1371","msg":"Serving metrics on port 61678"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x39 pc=0x19d2a26]

goroutine 497 [running]:
github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd.(*IPAMContext).StartNodeIPPoolManager(0x0)
        go/src/github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/ipamd.go:633 +0x26
created by main._main
        go/src/github.com/aws/amazon-vpc-cni-k8s/cmd/aws-k8s-agent/main.go:64 +0x32c
```

**Testing done on this change:** Y

**Will this break upgrades or downgrades. Has updating a running cluster been tested?:** No. No.

**Does this change require updates to the CNI daemonset config files to work?:** No.

**Does this PR introduce any user-facing change?:** No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
