### PR TITLE
Delayed unused IP address cleanup.

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -247,9 +247,10 @@ func (cidr *CidrInfo) AssignedIPAddressesInCidr() int {
 	}
 	return count
 }
+
 type CidrStats struct {
-	AssignedIPs int
-	CooldownIPs int
+	AssignedIPs       int
+	CooldownIPs       int
 	DelayedReleaseIPs int
 }
 

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -35,9 +35,6 @@ const (
 	// in addressCoolingPeriod
 	addressCoolingPeriod = 30 * time.Second
 
-	// addressDelayedReleasePeriod is used to release unused IP after a period of inactivity.
-	addressDelayedReleasePeriod = 10 * time.Minute
-
 	// DuplicatedENIError is an error when caller tries to add an duplicate ENI to data store
 	DuplicatedENIError = "data store: duplicate ENI"
 
@@ -134,6 +131,8 @@ var (
 		[]string{"cidr"},
 	)
 	prometheusRegistered = false
+
+	log = logger.Get()
 )
 
 // IPAMKey is the IPAM primary key.  Quoting CNI spec:
@@ -286,7 +285,7 @@ func (addr AddressInfo) inCoolingPeriod() bool {
 
 // InDelayedRelease checks whether an addr is in addressDelayedReleasePeriod
 func (addr AddressInfo) inDelayedReleasePeriod() bool {
-	return time.Since(addr.UnassignedTime) <= addressDelayedReleasePeriod
+	return time.Since(addr.UnassignedTime) <= getDelayedReleaseTimeout()
 }
 
 // ENIPool is a collection of ENI, keyed by ENI ID

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -35,6 +35,11 @@ const (
 	// in addressCoolingPeriod
 	addressCoolingPeriod = 30 * time.Second
 
+	// envDelayedReleaseTimeout configures default delayed IP release timeout.
+	// IPs in delayed release state are available for allocation by other Pods after addressCoolingPeriod.
+	envDelayedReleaseTimeout     = "AWS_VPC_K8S_CNI_DELAYED_RELEASE_TIMEOUT_SECONDS"
+	defaultDelayedReleaseTimeout = 60 * time.Second
+
 	// DuplicatedENIError is an error when caller tries to add an duplicate ENI to data store
 	DuplicatedENIError = "data store: duplicate ENI"
 
@@ -52,10 +57,6 @@ const (
 
 	// UnknownENIError is an error when caller tries to access an ENI which is unknown to datastore
 	UnknownENIError = "datastore: unknown ENI"
-
-	// envDelayedReleaseTimeout configures default delayed IP release timeout, defaults to defaultDelayedReleaseTimeout
-	envDelayedReleaseTimeout     = "AWS_VPC_K8S_CNI_DELAYED_RELEASE_TIMEOUT_SECONDS"
-	defaultDelayedReleaseTimeout = 60 * time.Second
 )
 
 // We need to know which IPs are already allocated across

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -55,7 +55,7 @@ const (
 
 	// envDelayedReleaseTimeout configures default delayed IP release timeout, defaults to defaultDelayedReleaseTimeout
 	envDelayedReleaseTimeout     = "AWS_VPC_K8S_CNI_DELAYED_RELEASE_TIMEOUT_SECONDS"
-	defaultDelayedReleaseTimeout = 10 * time.Second
+	defaultDelayedReleaseTimeout = 60 * time.Second
 )
 
 // We need to know which IPs are already allocated across

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -483,9 +483,9 @@ func TestGetIPStatsV4(t *testing.T) {
 
 	assert.Equal(t,
 		DataStoreStats{
-			TotalIPs:    2,
-			AssignedIPs: 1,
-			CooldownIPs: 0,
+			TotalIPs:          2,
+			AssignedIPs:       1,
+			CooldownIPs:       0,
 			DelayedReleaseIPs: 1,
 		},
 		*ds.GetIPStats("4"),

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -486,6 +486,7 @@ func TestGetIPStatsV4(t *testing.T) {
 			TotalIPs:    2,
 			AssignedIPs: 1,
 			CooldownIPs: 0,
+			DelayedReleaseIPs: 1,
 		},
 		*ds.GetIPStats("4"),
 	)

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -402,7 +402,7 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, ds.assigned, 2)
 	assert.Equal(t, deviceNum, pod1Ns2Device)
 	assert.Equal(t, len(ds.eniPool["eni-2"].AvailableIPv4Cidrs), 1)
-	assert.Equal(t, ds.eniPool["eni-2"].AssignedIPv4Addresses(), 0)
+	assert.Equal(t, ds.eniPool["eni-2"].AssignedIPv4Addresses(), 1)
 	expectedCheckpointData = &CheckpointData{
 		Version: CheckpointFormatVersion,
 		Allocations: []CheckpointEntry{

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -490,6 +490,18 @@ func TestGetIPStatsV4(t *testing.T) {
 		},
 		*ds.GetIPStats("4"),
 	)
+
+	// wait additional 30s (delayed release period)
+	time.Sleep(30 * time.Second)
+	assert.Equal(t,
+		DataStoreStats{
+			TotalIPs:          2,
+			AssignedIPs:       1,
+			CooldownIPs:       0,
+			DelayedReleaseIPs: 0,
+		},
+		*ds.GetIPStats("4"),
+	)
 }
 
 func TestGetIPStatsV6(t *testing.T) {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -710,7 +710,7 @@ func (c *IPAMContext) tryFreeENI() {
 	}
 }
 
-// tryUnassignIPsorPrefixesFromAll determines if there are IPs to free when we have extra IPs beyond the target and warmIPTargetDefined
+// tryUnassignCidrsFromAll determines if there are IPs to free when we have extra IPs beyond the target and warmIPTargetDefined
 // is enabled, deallocate extra IP addresses
 func (c *IPAMContext) tryUnassignCidrsFromAll() {
 


### PR DESCRIPTION
**What type of PR is this?**: feature
**Which issue does this PR fix**: https://github.com/aws/amazon-vpc-cni-k8s/issues/1700
**What does this PR do / Why do we need it**: TODO
**Testing done on this change**: Y
**Automation added to e2e**: No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No/No
**Does this change require updates to the CNI daemonset config files to work?**: No
**Does this PR introduce any user-facing change?**: N
```release-note
Free IP addresses are released with a 10-minute delay to avoid unnecessary churn on loaded nodes.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
