### PR TITLE
Upgrade tigera operator for ARM support

### DIFF
--- a/charts/aws-calico/values.yaml
+++ b/charts/aws-calico/values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: calico
 
 tigeraOperator:
-  tag: "v1.20.1"
+  tag: "v1.22.4"
   image: quay.io/tigera/operator
 
 installation:

--- a/config/master/calico-operator.yaml
+++ b/config/master/calico-operator.yaml
@@ -4942,6 +4942,14 @@ rules:
       - update
       - delete
       - watch
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch 
+      - list
   - apiGroups:
       - ""
     resources:
@@ -5150,7 +5158,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tigera-operator
-          image: quay.io/tigera/operator:v1.20.1 
+          image: quay.io/tigera/operator:v1.22.4 
           imagePullPolicy: IfNotPresent
           command:
             - operator
@@ -5168,7 +5176,7 @@ spec:
             - name: OPERATOR_NAME
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
-              value: v1.20.1
+              value: v1.22.4
           envFrom:
             - configMapRef:
                 name: kubernetes-services-endpoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Upgrade tigera-operator
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #1708 

**What does this PR do / Why do we need it**:
1. 1.22.X onwards ARM support is added so upgrading tigera operator
2. Generated new manifests from helm - https://github.com/aws/amazon-vpc-cni-k8s/tree/master/charts/aws-calico

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1708 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Pending : <Will attach the testing logs>

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note
Upgrade tigera operator 1.22.4
```

/cc @tmjd @caseydavenport 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
