### PR TITLE
add canary test entrypoint script

### DIFF
--- a/scripts/run-canary-test.sh
+++ b/scripts/run-canary-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# The script runs amazon-vpc-cni integration tests on the supplied add-on version.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration-new"
+VPC_CNI_ADDON_NAME="vpc-cni"
+
+echo "Running Canary tests for amazon-vpc-cni-k8s with the following varialbes
+KUBE_CONFIG_PATH:  $KUBE_CONFIG_PATH
+CLUSTER_NAME: $CLUSTER_NAME
+REGION: $REGION
+ENDPOINT: $ENDPOINT"
+
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
+
+function load_cluster_details() {
+  echo "loading cluster details $CLUSTER_NAME"
+  DESCRIBE_CLUSTER_OP=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" $ENDPOINT_FLAG)
+  VPC_ID=$(echo "$DESCRIBE_CLUSTER_OP" | jq -r '.cluster.resourcesVpcConfig.vpcId')
+  K8S_VERSION=$(echo "$DESCRIBE_CLUSTER_OP" | jq .cluster.version -r)
+}
+
+function load_addon_details() {
+  echo "loading $VPC_CNI_ADDON_NAME addon details"
+  DESCRIBE_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name $VPC_CNI_ADDON_NAME --kubernetes-version "$K8S_VERSION")
+
+  LATEST_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq '.addons[0].addonVersions[0].addonVersion' -r)
+  DEFAULT_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq -r '.addons[].addonVersions[] | select(.compatibilities[0].defaultVersion == true) | .addonVersion')
+}
+
+function wait_for_addon_status() {
+  local expected_status=$1
+
+  if [ "$expected_status" =  "DELETED" ]; then
+    while $(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME); do
+      echo "addon is still not deleted"
+      sleep 5
+    done
+    echo "addon deleted"
+    return
+  fi
+
+  while true
+  do
+    STATUS=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME | jq -r '.addon.status')
+    if [ "$STATUS" = "$expected_status" ]; then
+      echo "addon status matches expected status"
+      return
+    fi
+    echo "addon status is not euqal to $expected_status"
+    sleep 5
+  done
+}
+
+function install_add_on() {
+  local new_addon_version=$1
+
+  if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME); then
+    local current_addon_version=$(echo "$DESCRIBE_ADDON" | jq '.addon.addonVersion' -r)
+    if [ "$new_addon_version" != "$current_addon_version" ]; then
+      echo "deleting the $current_addon_version to install $new_addon_version"
+      aws eks delete-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name "$VPC_CNI_ADDON_NAME"
+      wait_for_addon_status "DELETED"
+    else
+      echo "addon version $current_addon_version already installed"
+      return
+    fi
+  fi
+
+  echo "installing addon $new_addon_version"
+  aws eks create-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --resolve-conflicts OVERWRITE --addon-version $new_addon_version
+  wait_for_addon_status "ACTIVE"
+}
+
+function run_ginkgo_test() {
+  local focus=$1
+  echo "Running ginkgo tests with focus: $focus"
+  (cd "$INTEGRATION_TEST_DIR/cni" && ginkgo --focus="$focus" -v --timeout 20m --failOnPending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID")
+  (cd "$INTEGRATION_TEST_DIR/ipamd" && ginkgo --focus="$focus" -v --timeout 10m --failOnPending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID")
+}
+
+load_cluster_details
+load_addon_details
+
+# Run more comprehensive test on the default addon version. CANARY focused tests
+# tests basic functionlity plus test that could detect issues with dependencies
+# early on.
+echo "Running Canary tests on the default addon version"
+install_add_on "$DEFAULT_ADDON_VERSION"
+run_ginkgo_test "CANARY"
+
+# Run smoke test on the latest addon version. Smoke tests contains a subset of test
+# used in Canary tests.
+echo "Running Smoke tests on the latest addon version"
+install_add_on "$LATEST_ADDON_VERSION"
+run_ginkgo_test "SMOKE"

--- a/scripts/run-canary-test.sh
+++ b/scripts/run-canary-test.sh
@@ -96,17 +96,27 @@ function run_ginkgo_test() {
 load_cluster_details
 load_addon_details
 
+# TODO: v1.7.5 restarts continiously if IMDS goes out of sync, the issue is mitigated
+# from v.1.8.0 onwards, once the default addon is updated to v1.8.0+ we should uncomment
+# the following code. See: https://github.com/aws/amazon-vpc-cni-k8s/issues/1340
+
 # Run more comprehensive test on the default addon version. CANARY focused tests
 # tests basic functionlity plus test that could detect issues with dependencies
 # early on.
-echo "Running Canary tests on the default addon version"
-install_add_on "$DEFAULT_ADDON_VERSION"
-run_ginkgo_test "CANARY"
+#echo "Running Canary tests on the default addon version"
+#install_add_on "$DEFAULT_ADDON_VERSION"
+#run_ginkgo_test "CANARY"
 
 # Run smoke test on the latest addon version. Smoke tests contains a subset of test
 # used in Canary tests.
-echo "Running Smoke tests on the latest addon version"
+#echo "Running Smoke tests on the latest addon version"
+#install_add_on "$LATEST_ADDON_VERSION"
+#run_ginkgo_test "SMOKE"
+
+# TODO: Remove the following code once the v1.8.0+ is made the default addon version
+echo "Running Canary tests on the latest addon version"
 install_add_on "$LATEST_ADDON_VERSION"
-run_ginkgo_test "SMOKE"
+run_ginkgo_test "CANARY"
+
 
 echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/scripts/run-canary-test.sh
+++ b/scripts/run-canary-test.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration-new"
 VPC_CNI_ADDON_NAME="vpc-cni"
 
-echo "Running Canary tests for amazon-vpc-cni-k8s with the following varialbes
+echo "Running Canary tests for amazon-vpc-cni-k8s with the following variables
 KUBE_CONFIG_PATH:  $KUBE_CONFIG_PATH
 CLUSTER_NAME: $CLUSTER_NAME
 REGION: $REGION
@@ -54,7 +54,7 @@ function wait_for_addon_status() {
       echo "addon status matches expected status"
       return
     fi
-    echo "addon status is not euqal to $expected_status"
+    echo "addon status is not equal to $expected_status"
     sleep 5
   done
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,26 @@
-## Available Ginkgo Focuses
+## amazon-vpc-cni-k8s Test Framework
+The test framework consists of integration and e2e tests using the Ginkgo framework invoked manually and using collection of bash scripts using GitHub Workflow and Prow(not publicly available).
 
-### [CANARY]
-Canary focused tests run periodically on live production environment. The tests do basic sanity testing along with testing other dependencies like service created using NLB/CLB giving us early indication of dependency failures.
+### Types of Tests
 
-### [SMOKE]
-Smoke test do basic sanity testing and can be used as a pre-requisite for the running the much longer Integration tests.
+#### Pull Request Tests
+Runs on each Pull Request, verifies the new code changes don't introduce any regression. Given the entire test suite may span for long duration, run only the integration tests.
 
+#### Nightly Integration Tests
+Runs the entire test suite every night using the current GitHub build to catch regression.
+
+#### Canary Tests
+Canary tests run frequently, multiple times in a day on live production environment. Given all integration tests run spans for hours we can only run a limited set of tests of most important features along with tests that have dependencies like Load Balancer Service Creation. These test runs are not publicly accessible at this moment.
+
+Ginkgo Focus: [CANARY]
+
+### Smoke Tests
+Smoke test provide fail early mechanism by failing the test if basic functionality doesn't work. This can be used as a pre-requisite for the running the much longer Integration tests.
+
+Ginkgo Focus: [SMOKE]
+
+
+#### Work In Progress
+- Run Upstream Conformance tests as part of Nightly Integration tests.
+- Run All Integration/e2e tests as part of Nightly Integration tests.
+- Run all Integration tests on each Pull Request.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,8 @@
+## Available Ginkgo Focuses
+
+### [CANARY]
+Canary focused tests run periodically on live production environment. The tests do basic sanity testing along with testing other dependencies like service created using NLB/CLB giving us early indication of dependency failures.
+
+### [SMOKE]
+Smoke test do basic sanity testing and can be used as a pre-requisite for the running the much longer Integration tests.
+

--- a/test/framework/resources/k8s/manifest/deployment.go
+++ b/test/framework/resources/k8s/manifest/deployment.go
@@ -43,7 +43,7 @@ func NewBusyBoxDeploymentBuilder() *DeploymentBuilder {
 		replicas:               10,
 		container:              NewBusyBoxContainerBuilder().Build(),
 		labels:                 map[string]string{"role": "test"},
-		nodeSelector:           map[string]string{},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
 		terminationGracePeriod: 0,
 	}
 }
@@ -53,7 +53,7 @@ func NewDefaultDeploymentBuilder() *DeploymentBuilder {
 		namespace:              utils.DefaultTestNamespace,
 		terminationGracePeriod: 0,
 		labels:                 map[string]string{"role": "test"},
-		nodeSelector:           map[string]string{},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
 	}
 }
 

--- a/test/framework/resources/k8s/manifest/job.go
+++ b/test/framework/resources/k8s/manifest/job.go
@@ -49,7 +49,7 @@ func (j *JobBuilder) Name(name string) *JobBuilder {
 	return j
 }
 
-func(j *JobBuilder) NodeSelector(selectorKey string, selectorVal string) *JobBuilder {
+func (j *JobBuilder) NodeSelector(selectorKey string, selectorVal string) *JobBuilder {
 	j.nodeSelector[selectorKey] = selectorVal
 	return j
 }

--- a/test/framework/resources/k8s/manifest/job.go
+++ b/test/framework/resources/k8s/manifest/job.go
@@ -30,6 +30,7 @@ type JobBuilder struct {
 	terminationGracePeriod int
 	nodeName               string
 	hostNetwork            bool
+	nodeSelector           map[string]string
 }
 
 func NewDefaultJobBuilder() *JobBuilder {
@@ -39,11 +40,17 @@ func NewDefaultJobBuilder() *JobBuilder {
 		parallelism:            1,
 		terminationGracePeriod: 0,
 		labels:                 map[string]string{},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
 	}
 }
 
 func (j *JobBuilder) Name(name string) *JobBuilder {
 	j.name = name
+	return j
+}
+
+func(j *JobBuilder) NodeSelector(selectorKey string, selectorVal string) *JobBuilder {
+	j.nodeSelector[selectorKey] = selectorVal
 	return j
 }
 
@@ -100,6 +107,7 @@ func (j *JobBuilder) Build() *batchV1.Job {
 					TerminationGracePeriodSeconds: aws.Int64(int64(j.terminationGracePeriod)),
 					RestartPolicy:                 v1.RestartPolicyNever,
 					NodeName:                      j.nodeName,
+					NodeSelector:                  j.nodeSelector,
 				},
 			},
 		},

--- a/test/framework/resources/k8s/manifest/pod.go
+++ b/test/framework/resources/k8s/manifest/pod.go
@@ -40,7 +40,7 @@ func NewDefaultPodBuilder() *PodBuilder {
 		labels:                 map[string]string{},
 		terminationGracePeriod: 0,
 		restartPolicy:          v1.RestartPolicyNever,
-		nodeSelector:           map[string]string{},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
 	}
 }
 

--- a/test/integration-new/cni/pod_traffic_test.go
+++ b/test/integration-new/cni/pod_traffic_test.go
@@ -187,7 +187,7 @@ var _ = Describe("test pod networking", func() {
 		})
 	})
 
-	Context("when establishing UDP connection from tester to server", func() {
+	Context("[CANARY][SMOKE] when establishing UDP connection from tester to server", func() {
 		BeforeEach(func() {
 			serverPort = 2273
 			protocol = ec2.ProtocolUdp
@@ -225,7 +225,7 @@ var _ = Describe("test pod networking", func() {
 		})
 	})
 
-	Context("when establishing TCP connection from tester to server", func() {
+	Context("[CANARY][SMOKE] when establishing TCP connection from tester to server", func() {
 
 		BeforeEach(func() {
 			serverPort = 2273

--- a/test/integration-new/cni/service_connectivity_test.go
+++ b/test/integration-new/cni/service_connectivity_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Verifies connectivity to deployment behind different service types
-var _ = Describe("test service connectivity", func() {
+var _ = Describe("[CANARY] test service connectivity", func() {
 	var err error
 
 	// Deployment running the http server

--- a/test/integration-new/ipamd/eni_ip_leak_test.go
+++ b/test/integration-new/ipamd/eni_ip_leak_test.go
@@ -17,7 +17,7 @@ const (
 	HOST_POD_LABEL_VAL = "host"
 )
 
-var _ = Describe("ENI/IP Leak Test", func() {
+var _ = Describe("[CANARY] ENI/IP Leak Test", func() {
 	Context("ENI/IP Released on Pod Deletion", func() {
 		BeforeEach(func() {
 			By("creating test namespace")


### PR DESCRIPTION
**What type of PR is this?**
Script for adding Canary tests entrypoint script. The script does the following
- Installs default addon and runs canary tests.
- installs the latest addon and runs the smoke tests.

Currently the total time for the entire canary script executions is around 25minutes.


**Testing done on this change**:
Results from test execution.
```
loading cluster details networking-prow-test
loading vpc-cni addon details
Running Canary tests on the default addon version
deleting the v1.9.1-eksbuild.1 to install v1.7.5-eksbuild.2
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "networking-prow-test",
        "status": "DELETING",
        "addonVersion": "v1.9.1-eksbuild.1",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:REDACTED:addon/networking-prow-test/vpc-cni/0cbe66e5-9fe6-4ce1-739d-c2d721308465",
        "createdAt": 1635540222.059,
        "modifiedAt": 1635542632.955,
        "tags": {}
    }
}

An error occurred (ResourceNotFoundException) when calling the DescribeAddon operation: No addon: vpc-cni found in cluster: networking-prow-test
addon deleted
installing addon v1.7.5-eksbuild.2
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "networking-prow-test",
        "status": "CREATING",
        "addonVersion": "v1.7.5-eksbuild.2",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:REDACTED:addon/networking-prow-test/vpc-cni/24be66f8-09ae-45b4-e367-5d32167ad40d",
        "createdAt": 1635542635.609,
        "modifiedAt": 1635542635.629,
        "tags": {}
    }
}
daemonset.apps/aws-node patched
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status matches expected status
Running ginkgo tests with focus: CANARY
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1635542669
Will run 6 of 14 specs

STEP: creating test namespace
STEP: getting the node with the node label key kubernetes.io/os and value linux
STEP: verifying more than 1 nodes are present for the test
STEP: getting the instance type from node label beta.kubernetes.io/instance-type
STEP: getting the network interface details from ec2
STEP: describing the VPC to get the VPC CIDRs
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists
S
------------------------------
test pod networking [CANARY][SMOKE] when establishing UDP connection from tester to server 
  connection should be established
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:216
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-6cd96cb97d-vz7hb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.238.211 to pod primary-node-server-6cd96cb97d-6bc8v on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.167.97
stdout:  and stderr: Connection to 10.2.167.97 2273 port [udp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-vz7hb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.238.211 to pod primary-node-server-6cd96cb97d-x9fv6 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.106.226
stdout:  and stderr: Connection to 10.2.106.226 2273 port [udp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-x9fv6 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.106.226 to pod primary-node-server-6cd96cb97d-p8vbd on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.2.32
stdout:  and stderr: Connection to 10.2.2.32 2273 port [udp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-6cd96cb97d-vz7hb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.238.211 to pod secondary-node-server-dcdfb59b4-mlw4q on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.67.240
stdout:  and stderr: Connection to 10.1.67.240 2273 port [udp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-vz7hb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.238.211 to pod secondary-node-server-dcdfb59b4-dhjdl on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.153.41
stdout:  and stderr: Connection to 10.1.153.41 2273 port [udp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-x9fv6 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.106.226 to pod secondary-node-server-dcdfb59b4-dhjdl on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.153.41
stdout:  and stderr: Connection to 10.1.153.41 2273 port [udp/*] succeeded!

STEP: verifying connection fails for unreachable port
verifying connectivity fails from pod primary-node-server-6cd96cb97d-vz7hb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.238.211 to pod primary-node-server-6cd96cb97d-6bc8v on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.167.97
STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:68.808 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:35
  [CANARY][SMOKE] when establishing UDP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:190
    connection should be established
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:216
------------------------------
test pod networking [CANARY][SMOKE] when establishing TCP connection from tester to server 
  should allow connection across nodes and across interface types
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:255
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-55478b7978-vncv7 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.201.195 to pod primary-node-server-55478b7978-5kzdr on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.46.4
stdout:  and stderr: Connection to 10.2.46.4 2273 port [tcp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-55478b7978-vncv7 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.201.195 to pod primary-node-server-55478b7978-bwnwj on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.2.32
stdout:  and stderr: Connection to 10.2.2.32 2273 port [tcp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-55478b7978-bwnwj on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.2.32 to pod primary-node-server-55478b7978-5v94n on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.115.102
stdout:  and stderr: Connection to 10.2.115.102 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-55478b7978-vncv7 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.201.195 to pod secondary-node-server-787dc9cfdd-lc4rg on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.252.195
stdout:  and stderr: Connection to 10.1.252.195 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-55478b7978-vncv7 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.201.195 to pod secondary-node-server-787dc9cfdd-ddb6k on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.253.219
stdout:  and stderr: Connection to 10.1.253.219 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-55478b7978-bwnwj on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.2.32 to pod secondary-node-server-787dc9cfdd-ddb6k on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.253.219
stdout:  and stderr: Connection to 10.1.253.219 2273 port [tcp/*] succeeded!

STEP: verifying connection fails for unreachable port
verifying connectivity fails from pod primary-node-server-55478b7978-vncv7 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.201.195 to pod primary-node-server-55478b7978-5kzdr on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.46.4
STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:75.793 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:35
  [CANARY][SMOKE] when establishing TCP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:228
    should allow connection across nodes and across interface types
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:255
------------------------------
SSSSSSS
------------------------------
[CANARY] test service connectivity when a deployment behind clb service is created 
  clb service pod should be reachable
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:147
STEP: creating and waiting for deployment to be ready
STEP: creating the service of type LoadBalancer
created service
: {LoadBalancer:{Ingress:[]}}
STEP: sleeping for some time to allow service to become ready
STEP: creating jobs to verify service connectivity
STEP: creating negative jobs to verify service connectivity fails for unreachable port

• [SLOW TEST:105.482 seconds]
[CANARY] test service connectivity
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:37
  when a deployment behind clb service is created
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:142
    clb service pod should be reachable
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:147
------------------------------
[CANARY] test service connectivity when a deployment behind nlb service is created 
  nlb service pod should be reachable
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:157
STEP: creating and waiting for deployment to be ready
STEP: creating the service of type LoadBalancer
created service
: {LoadBalancer:{Ingress:[]}}
STEP: sleeping for some time to allow service to become ready
STEP: creating jobs to verify service connectivity
STEP: creating negative jobs to verify service connectivity fails for unreachable port

• [SLOW TEST:132.826 seconds]
[CANARY] test service connectivity
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:37
  when a deployment behind nlb service is created
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:150
    nlb service pod should be reachable
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:157
------------------------------
[CANARY] test service connectivity when a deployment behind cluster IP is created 
  clusterIP service pod should be reachable
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:165
STEP: creating and waiting for deployment to be ready
STEP: creating the service of type ClusterIP
created service
: {LoadBalancer:{Ingress:[]}}
STEP: sleeping for some time to allow service to become ready
STEP: creating jobs to verify service connectivity
STEP: creating negative jobs to verify service connectivity fails for unreachable port

• [SLOW TEST:134.843 seconds]
[CANARY] test service connectivity
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:37
  when a deployment behind cluster IP is created
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:160
    clusterIP service pod should be reachable
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:165
------------------------------
[CANARY] test service connectivity when a deployment behind node port is created 
  node port service pod should be reachable
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:173
STEP: creating and waiting for deployment to be ready
STEP: creating the service of type NodePort
created service
: {LoadBalancer:{Ingress:[]}}
STEP: sleeping for some time to allow service to become ready
STEP: creating jobs to verify service connectivity
STEP: creating negative jobs to verify service connectivity fails for unreachable port

• [SLOW TEST:134.904 seconds]
[CANARY] test service connectivity
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:37
  when a deployment behind node port is created
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:168
    node port service pod should be reachable
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/service_connectivity_test.go:173
------------------------------
STEP: deleting test namespace
STEP: update environment variables map[AWS_VPC_ENI_MTU:9001 AWS_VPC_K8S_CNI_VETHPREFIX:eni], remove map[WARM_ENI_TARGET:{} WARM_IP_TARGET:{}]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists

Ran 6 of 14 Specs in 734.695 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 8 Skipped
PASS

Ginkgo ran 1 suite in 12m25.749202272s
Test Suite Passed
Running Suite: VPC IPAMD Test Suite
===================================
Random Seed: 1635543414
Will run 1 of 26 specs

STEP: Delete coredns addon if it exists
SSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[CANARY] ENI/IP Leak Test ENI/IP Released on Pod Deletion 
  Verify that on Pod Deletion, ENI/IP State is restored
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/eni_ip_leak_test.go:28
STEP: creating test namespace
STEP: Setting WARM_ENI_TARGET to 0
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists
STEP: Recording the initial count of IP before new deployment
STEP: Deploying a max number of Busybox pods
STEP: Deleting the deployment
STEP: Validating that count of ENI/IP is same as before
STEP: deleting test namespace
STEP: Restoring WARM ENI Target value
STEP: removing the environment variables from the ds map[WARM_ENI_TARGET:{} WARM_IP_TARGET:{}]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists

• [SLOW TEST:257.230 seconds]
[CANARY] ENI/IP Leak Test
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/eni_ip_leak_test.go:20
  ENI/IP Released on Pod Deletion
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/eni_ip_leak_test.go:21
    Verify that on Pod Deletion, ENI/IP State is restored
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd/eni_ip_leak_test.go:28
------------------------------

Ran 1 of 26 Specs in 261.096 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 25 Skipped
PASS

Ginkgo ran 1 suite in 4m30.218992238s
Test Suite Passed
Running Smoke tests on the latest addon version
deleting the v1.7.5-eksbuild.2 to install v1.9.1-eksbuild.1
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "networking-prow-test",
        "status": "DELETING",
        "addonVersion": "v1.7.5-eksbuild.2",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:REDACTED:addon/networking-prow-test/vpc-cni/24be66f8-09ae-45b4-e367-5d32167ad40d",
        "createdAt": 1635542635.609,
        "modifiedAt": 1635543687.535,
        "tags": {}
    }
}

An error occurred (ResourceNotFoundException) when calling the DescribeAddon operation: No addon: vpc-cni found in cluster: networking-prow-test
addon deleted
installing addon v1.9.1-eksbuild.1
{
    "addon": {
        "addonName": "vpc-cni",
        "clusterName": "networking-prow-test",
        "status": "CREATING",
        "addonVersion": "v1.9.1-eksbuild.1",
        "health": {
            "issues": []
        },
        "addonArn": "arn:aws:eks:us-west-2:REDACTED:addon/networking-prow-test/vpc-cni/c4be6700-1528-7436-0393-efe087b818e3",
        "createdAt": 1635543689.965,
        "modifiedAt": 1635543689.984,
        "tags": {}
    }
}
daemonset.apps/aws-node patched
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status is not euqal to ACTIVE
addon status matches expected status
Running ginkgo tests with focus: SMOKE
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1635543751
Will run 2 of 14 specs

STEP: creating test namespace
STEP: getting the node with the node label key kubernetes.io/os and value linux
STEP: verifying more than 1 nodes are present for the test
STEP: getting the instance type from node label beta.kubernetes.io/instance-type
STEP: getting the network interface details from ec2
STEP: describing the VPC to get the VPC CIDRs
STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists
SSSSSSS
------------------------------
test pod networking [CANARY][SMOKE] when establishing UDP connection from tester to server 
  connection should be established
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:216
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-6cd96cb97d-wnws8 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.80.4 to pod primary-node-server-6cd96cb97d-mh49j on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165
stdout:  and stderr: Connection to 10.2.94.165 2273 port [udp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-wnws8 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.80.4 to pod primary-node-server-6cd96cb97d-w26jq on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.172.230
stdout:  and stderr: Connection to 10.2.172.230 2273 port [udp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-w26jq on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.172.230 to pod primary-node-server-6cd96cb97d-7ptzb on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.67.23
stdout:  and stderr: Connection to 10.2.67.23 2273 port [udp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-6cd96cb97d-wnws8 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.80.4 to pod secondary-node-server-dcdfb59b4-pbz9r on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.10.67
stdout:  and stderr: Connection to 10.1.10.67 2273 port [udp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-wnws8 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.80.4 to pod secondary-node-server-dcdfb59b4-mdtct on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.213.180
stdout:  and stderr: Connection to 10.1.213.180 2273 port [udp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-6cd96cb97d-w26jq on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.172.230 to pod secondary-node-server-dcdfb59b4-mdtct on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.213.180
stdout:  and stderr: Connection to 10.1.213.180 2273 port [udp/*] succeeded!

STEP: verifying connection fails for unreachable port
verifying connectivity fails from pod primary-node-server-6cd96cb97d-wnws8 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.80.4 to pod primary-node-server-6cd96cb97d-mh49j on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165
STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:120.364 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:35
  [CANARY][SMOKE] when establishing UDP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:190
    connection should be established
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:216
------------------------------
test pod networking [CANARY][SMOKE] when establishing TCP connection from tester to server 
  should allow connection across nodes and across interface types
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:255
STEP: authorizing security group ingress on instance security group
STEP: authorizing security group egress on instance security group
STEP: creating server deployment on the primary node
STEP: creating server deployment on secondary node
STEP: checking connection on same node, primary to primary
verifying connectivity from pod primary-node-server-55478b7978-mn5vk on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165 to pod primary-node-server-55478b7978-qhvp2 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.144.216
stdout:  and stderr: Connection to 10.2.144.216 2273 port [tcp/*] succeeded!

STEP: checking connection on same node, primary to secondary
verifying connectivity from pod primary-node-server-55478b7978-mn5vk on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165 to pod primary-node-server-55478b7978-j2wp2 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.117.83
stdout:  and stderr: Connection to 10.2.117.83 2273 port [tcp/*] succeeded!

STEP: checking connection on same node, secondary to secondary
verifying connectivity from pod primary-node-server-55478b7978-j2wp2 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.117.83 to pod primary-node-server-55478b7978-cjb5b on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.51.129
stdout:  and stderr: Connection to 10.2.51.129 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to primary
verifying connectivity from pod primary-node-server-55478b7978-mn5vk on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165 to pod secondary-node-server-787dc9cfdd-rfvjl on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.150.51
stdout:  and stderr: Connection to 10.1.150.51 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, primary to secondary
verifying connectivity from pod primary-node-server-55478b7978-mn5vk on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165 to pod secondary-node-server-787dc9cfdd-xhptj on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.91.155
stdout:  and stderr: Connection to 10.1.91.155 2273 port [tcp/*] succeeded!

STEP: checking connection on different node, secondary to secondary
verifying connectivity from pod primary-node-server-55478b7978-j2wp2 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.117.83 to pod secondary-node-server-787dc9cfdd-xhptj on node ip-10-1-119-98.us-west-2.compute.internal with IP 10.1.91.155
stdout:  and stderr: Connection to 10.1.91.155 2273 port [tcp/*] succeeded!

STEP: verifying connection fails for unreachable port
verifying connectivity fails from pod primary-node-server-55478b7978-mn5vk on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.94.165 to pod primary-node-server-55478b7978-qhvp2 on node ip-10-2-176-108.us-west-2.compute.internal with IP 10.2.144.216
STEP: revoking security group ingress on instance security group
STEP: revoking security group egress on instance security group
STEP: deleting the primary node server deployment
STEP: deleting the secondary node server deployment

• [SLOW TEST:124.517 seconds]
test pod networking
/Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:35
  [CANARY][SMOKE] when establishing TCP connection from tester to server
  /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:228
    should allow connection across nodes and across interface types
    /Users/abhipth/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni/pod_traffic_test.go:255
------------------------------
SSSSSSTEP: deleting test namespace
STEP: update environment variables map[AWS_VPC_ENI_MTU:9001 AWS_VPC_K8S_CNI_VETHPREFIX:eni], remove map[WARM_ENI_TARGET:{} WARM_IP_TARGET:{}]
STEP: getting the aws-node daemon set in namesapce kube-system
STEP: updating the daemon set with new environment variable
STEP: Restarting Multus daemonset if it exists

Ran 2 of 14 Specs in 321.148 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS

Ginkgo ran 1 suite in 5m29.733108522s
Test Suite Passed
Running Suite: VPC IPAMD Test Suite
===================================
Random Seed: 1635544081
Will run 0 of 26 specs

STEP: Delete coredns addon if it exists
SSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 0 of 26 Specs in 3.878 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 26 Skipped
PASS

Ginkgo ran 1 suite in 10.965499193s
Test Suite Passed
all tests ran successfully in 24 minutes and 25 seconds
```


**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
