### PR TITLE
Use IMDSv2 token when fetching node ip in entrypoint

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -125,12 +125,14 @@ wait_for_ipam() {
 get_node_primary_v4_address() {
     while :
     do
-        NODE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+        token=$(curl -Ss -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+        NODE_IP=$(curl -H "X-aws-ec2-metadata-token: $token" -Ss http://169.254.169.254/latest/meta-data/local-ipv4)
         if [[ "${NODE_IP}" != "" ]]; then
             return 0
         fi
         # We sleep for 1 second between each retry
         sleep 1
+        log_in_json info "Retrying fetching node-IP"
     done
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

<!--
Add one of the following:
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
**What does this PR do / Why do we need it**:

Use IMDSv2/tokens.

This is required in hardened setups (as recommended by the AWS
documentation)

Without the change, the CNI driver did not become ready on the master
branch.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
**Testing done on this change**:

This has been tested on nodes with the following launch template
options:

  MetadataOptions.HttpTokens required
  MetadataOptions.HttpPutResponseHopLimit 1
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A, I can create an issue for this (switch e2e nodes to IMDSv2)

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No, it worked with 1.9.3
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
