### PR TITLE
fix flaky canary test

### DIFF
--- a/test/framework/resources/k8s/resources/service.go
+++ b/test/framework/resources/k8s/resources/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,7 +29,7 @@ import (
 type ServiceManager interface {
 	GetService(ctx context.Context, namespace string, name string) (*v1.Service, error)
 	CreateService(ctx context.Context, service *v1.Service) (*v1.Service, error)
-	DeleteService(ctx context.Context, service *v1.Service) error
+	DeleteAndWaitTillServiceDeleted(ctx context.Context, service *v1.Service) error
 }
 
 type defaultServiceManager struct {
@@ -69,11 +70,20 @@ func (s *defaultServiceManager) CreateService(ctx context.Context, service *v1.S
 	}, ctx.Done())
 }
 
-func (s *defaultServiceManager) DeleteService(ctx context.Context, service *v1.Service) error {
+func (s *defaultServiceManager) DeleteAndWaitTillServiceDeleted(ctx context.Context, service *v1.Service) error {
 	err := s.k8sClient.Delete(ctx, service)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	observed := &v1.Service{}
+	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := s.k8sClient.Get(ctx, utils.NamespacedName(service), observed); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}, ctx.Done())
 }

--- a/test/integration-new/cni/service_connectivity_test.go
+++ b/test/integration-new/cni/service_connectivity_test.go
@@ -62,7 +62,7 @@ var _ = Describe("[CANARY] test service connectivity", func() {
 			Command(nil).
 			Port(v1.ContainerPort{
 				ContainerPort: 80,
-				Protocol: "TCP",
+				Protocol:      "TCP",
 			}).Build()
 
 		deployment = manifest.NewDefaultDeploymentBuilder().

--- a/test/integration-new/ipv6/ipv6_service_connectivity_test.go
+++ b/test/integration-new/ipv6/ipv6_service_connectivity_test.go
@@ -136,7 +136,7 @@ var _ = Describe("test service connectivity", func() {
 		err = f.K8sResourceManagers.JobManager().DeleteAndWaitTillJobIsDeleted(negativeTesterJob)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = f.K8sResourceManagers.ServiceManager().DeleteService(context.Background(), service)
+		err = f.K8sResourceManagers.ServiceManager().DeleteAndWaitTillServiceDeleted(context.Background(), service)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** 
enhancement

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: 
Flaky canary tests.


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran Canary tests multiple times.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
