### PR TITLE
Imdsv2 for entrypoint 

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -118,6 +118,7 @@ wait_for_ipam() {
         fi
         # We sleep for 1 second between each retry
         sleep 1
+	log_in_json info "Retrying waiting for IPAM-D"
     done
 }
 
@@ -125,12 +126,14 @@ wait_for_ipam() {
 get_node_primary_v4_address() {
     while :
     do
-        NODE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+	token=$(curl -Ss -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+        NODE_IP=$(curl -H "X-aws-ec2-metadata-token: $token" -Ss http://169.254.169.254/latest/meta-data/local-ipv4)
         if [[ "${NODE_IP}" != "" ]]; then
             return 0
         fi
         # We sleep for 1 second between each retry
         sleep 1
+	log_in_json info "Retrying fetching node-IP"
     done
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Porting PR #1727 from @chlunde 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
IMDSv1 disabled nodes will fail to be marked as ready because the conf file is not copied and entry point script is hung.

**What does this PR do / Why do we need it**:
Use tokens.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

Node is marked as not ready with v1.10.0 with IMDSV1 disabled -

```
ip-192-168-86-222.us-west-2.compute.internal   NotReady   <none>   7m15s   v1.17.17-eks-ac51f2   192.168.86.222   54.212.222.201   Amazon Linux 2   4.14.248-189.473.amzn2.x86_64   docker://20.10.7
```

Conf file is missing -

```
[root@ip-192-168-86-222 ec2-user]# cd /etc/cni/net.d/
[root@ip-192-168-86-222 net.d]# ls
[root@ip-192-168-86-222 net.d]# ls
```

With fix -

```
[root@ip-192-168-86-222 net.d]# ls
10-aws.conflist
```

Node is ready -

```
ip-192-168-86-222.us-west-2.compute.internal   Ready    <none>   21m   v1.17.17-eks-ac51f2   192.168.86.222   54.212.222.201   Amazon Linux 2   4.14.248-189.473.amzn2.x86_64   docker://20.10.7
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
