### PR TITLE
Automation script for running IT 

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -42,3 +42,7 @@ jobs:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
         run: |
           ./scripts/run-integration-tests.sh
+
+      - name: Run new integration tests
+        run: |
+          ./scripts/test/run-integration-tests.sh 

--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -42,7 +42,3 @@ jobs:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
         run: |
           ./scripts/run-integration-tests.sh
-
-      - name: Run new integration tests
-        run: |
-          ./scripts/test/run-integration-tests.sh 

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-set -e
-OS_OVERRIDE=$(go env GOOS)
+set -eo pipefail
+
 pushd ./test/integration-new
 
 echo "Running integration test with the following configuration:
-KUBE CONFIG: $KUBECONFIG
+KUBECONFIG: $KUBECONFIG
 CLUSTER_NAME: $CLUSTER_NAME
-AWS_REGION: $AWS_REGION
-OS_OVERRIDE: $OS_OVERRIDE"
+AWS_REGION: $AWS_REGION"
+
+
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
 
 while getopts "f:" arg; do
   case $arg in
@@ -16,20 +20,14 @@ while getopts "f:" arg; do
     echo "FOCUS: $FOCUS";
   esac
 done
-    
 
-if [[ -z "${OS_OVERRIDE}" ]]; then
-    OS_OVERRIDE=linux
-fi
-
-CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $AWS_REGION)
+CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $AWS_REGION $ENDPOINT_FLAG)
 
 VPC_ID=$(echo $CLUSTER_INFO | jq -r '.cluster.resourcesVpcConfig.vpcId')
 SERVICE_ROLE_ARN=$(echo $CLUSTER_INFO | jq -r '.cluster.roleArn')
 ROLE_NAME=${SERVICE_ROLE_ARN##*/}
+TEST_FAILED=false
  
-
-
 START=$SECONDS
 
 for dir in */  
@@ -37,16 +35,20 @@ do
 
     cd "${dir%*/}"  
     if [ -n "$FOCUS" ]; then
-        ginkgo --focus="$FOCUS" -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+        ( ginkgo --focus="$FOCUS" -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID ) || TEST_FAILED=true
     else
-        ginkgo -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+        ( ginkgo -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID ) || TEST_FAILED=true
     fi
     cd ..    
      
 done
 
-
 DEFAULT_INTEGRATION_DURATION=$((SECONDS - START))
 echo "TIMELINE: Integration tests took $DEFAULT_INTEGRATION_DURATION seconds."
 
 popd
+
+# If any of the test failed, exit with non zero exit code
+if [ $TEST_FAILED = true ]; then
+  exit 1
+fi

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -37,9 +37,9 @@ do
 
     cd "${dir%*/}"  
     if [ -n "$FOCUS" ]; then
-        ginkgo --focus="$FOCUS" -v  -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+        ginkgo --focus="$FOCUS" -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
     else
-        ginkgo -v  -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+        ginkgo -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
     fi
     cd ..    
      

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+OS_OVERRIDE=$(go env GOOS)
+pushd ./test/integration-new
+
+echo "Running integration test with the following configuration:
+KUBE CONFIG: $KUBECONFIG
+CLUSTER_NAME: $CLUSTER_NAME
+AWS_REGION: $AWS_REGION
+OS_OVERRIDE: $OS_OVERRIDE"
+
+while getopts "f:" arg; do
+  case $arg in
+    f) FOCUS=$OPTARG;
+    echo "FOCUS: $FOCUS";
+  esac
+done
+    
+
+if [[ -z "${OS_OVERRIDE}" ]]; then
+    OS_OVERRIDE=linux
+fi
+
+CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $AWS_REGION)
+
+VPC_ID=$(echo $CLUSTER_INFO | jq -r '.cluster.resourcesVpcConfig.vpcId')
+SERVICE_ROLE_ARN=$(echo $CLUSTER_INFO | jq -r '.cluster.roleArn')
+ROLE_NAME=${SERVICE_ROLE_ARN##*/}
+ 
+
+
+START=$SECONDS
+
+for dir in */  
+do
+
+    cd "${dir%*/}"  
+    if [ -n "$FOCUS" ]; then
+        ginkgo --focus="$FOCUS" -v  -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+    else
+        ginkgo -v  -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID
+    fi
+    cd ..    
+     
+done
+
+
+DEFAULT_INTEGRATION_DURATION=$((SECONDS - START))
+echo "TIMELINE: Integration tests took $DEFAULT_INTEGRATION_DURATION seconds."
+
+popd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Automates running of integration tests in the integration-new folder.

**What does this PR do / Why do we need it**:
- Iterates and runs tests in new integration folder having sub-folders
- Takes an optional flag -f in order to provide FOCUS as a parameter to run selective tests
- Uses a set of ENV variables and derives other variables needed to run tests
- Created a new folder test inside script, all refactored test scripts will be added here in future.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Running script with focus flag as "CANARY"

```

% ./scripts/test/run-integration-tests.sh -f "CANARY"
/Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s/test/integration-new /Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s
Running integration test with the following configuration:
KUBE CONFIG: /Users/shrenaik/.kube/eksctl/clusters/test-cluster-ec2
CLUSTER_NAME: test-cluster-ec2
AWS_REGION: us-west-2
OS_OVERRIDE: darwin
FOCUS: CANARY
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1637357115
Will run 6 of 15 specs

STEP: creating test namespace
STEP: getting the node with the node label key eks.amazonaws.com/nodegroup and value 
```
Running script with no focus flag passed

```

% ./scripts/test/run-integration-tests.sh            
/Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s/test/integration-new /Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s
Running integration test with the following configuration:
KUBE CONFIG: /Users/shrenaik/.kube/eksctl/clusters/test-cluster-ec2
CLUSTER_NAME: test-cluster-ec2
AWS_REGION: us-west-2
OS_OVERRIDE: darwin
Running Suite: CNI Pod Networking Suite
=======================================
Random Seed: 1637357132
Will run 15 of 15 specs

STEP: creating test namespace
STEP: getting the node with the node label key eks.amazonaws.com/nodegroup and value 
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
