### PR TITLE
Add scripts for cluster creation and deletion using eksctl & kops

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echoerr() { echo -e "$@" 1>&2; }
+
 check_is_installed() {
     local __name="$1"
     if ! is_installed "$__name"; then

--- a/scripts/test/create-cluster.sh
+++ b/scripts/test/create-cluster.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+TEST_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
+TEMPLATE_FILE="$TEST_DIR/template/eksctl/eks-cluster.yaml"
+
+source "$PWD/scripts/lib/common.sh"
+
+USAGE=$(cat << 'EOM'
+Usage: create-cluster.sh -n [cluster-name]
+Creates an EKS Cluster with Nodegroups. The Cluster is
+created using eksctl with a pre-defined eksctl template.
+ Required:
+ -n   Name of the EKS cluster
+ Optional:
+ -v   K8s Version. Defaults to 1.20
+ -r   Region of the EKS Cluster. Defaults to us-west-2
+ -c   eksctl Cluster config path. Defaults to build/eks-cluster.yaml
+ -t   Type of cluster. Defaults to eksctl cluster. Can be set to "kops" or "eksctl"
+EOM
+)
+
+
+
+while getopts "n:v:r:c:t:" o; do
+  case "${o}" in
+    n) # Name of the EKS Cluster
+      CLUSTER_NAME=${OPTARG}
+      ;;
+    v) # K8s Version of the EKS Cluster
+      K8S_VERSION=${OPTARG}
+      ;;
+    r) # Region where EKS Cluster will be created
+      AWS_REGION=${OPTARG}
+      ;;
+    c) # eksctl cluster config file path
+      CLUSTER_CONFIG_PATH=${OPTARG}
+      ;;
+    t) # Type of cluster to be created
+      CLUSTER_TYPE=${OPTARG}
+      ;;
+    *)
+      echoerr "${USAGE}"
+      exit 1
+      ;;
+  esac
+done
+
+
+
+shift $((OPTIND-1))
+
+if [[ -z "$CLUSTER_NAME" ]]; then
+ echoerr "${USAGE}\n\nmissing: -n is a required flag\n"
+ exit 1
+fi
+
+if [[ -z "$K8S_VERSION" ]]; then
+  K8S_VERSION="1.20"
+  echo "no k8s version defined, will fallback to default version $K8S_VERSION"
+fi
+
+if [[ -z "$AWS_REGION" ]]; then
+  AWS_REGION="us-west-2"
+  echo "no regions defined, will fallback to default region $AWS_REGION"
+fi
+
+if [[ -z "$CLUSTER_CONFIG_PATH" ]]; then
+  CLUSTER_CONFIG_DIR="$TEST_DIR/build"
+  CLUSTER_CONFIG_PATH="$CLUSTER_CONFIG_DIR/eks-cluster.yaml"
+
+  echo "cluster config path not defined, will generate it at default path $CLUSTER_CONFIG_PATH"
+
+  mkdir -p "$CLUSTER_CONFIG_DIR"
+fi
+
+
+function create_eksctl_cluster() {
+  check_is_installed eksctl
+  echo "creating a $K8S_VERSION cluster named $CLUSTER_NAME using eksctl"
+
+  # Using a static Instance Role Name so IAM Policies
+  # can be attached to it later without having to retrieve
+  # the auto generated eksctl name.
+  sed "s/CLUSTER_NAME/$CLUSTER_NAME/g;
+  s/CLUSTER_REGION/$AWS_REGION/g;
+  s/K8S_VERSION/$K8S_VERSION/g;
+  s/INSTANCE_ROLE_NAME/$INSTANCE_ROLE_NAME/g" \
+  "$TEMPLATE_FILE" > "$CLUSTER_CONFIG_PATH"
+
+  eksctl create cluster -f "$CLUSTER_CONFIG_PATH"
+}
+
+
+
+function create_kops_cluster {
+    aws s3api create-bucket --bucket kops-cni-test-temp --region $AWS_REGION --create-bucket-configuration LocationConstraint=$AWS_REGION
+    curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
+    chmod +x kops-linux-amd64
+    sudo mv kops-linux-amd64 /usr/local/bin/kops
+    CLUSTER_NAME=kops-cni-test-cluster-${CLUSTER_NAME}.k8s.local
+    export KOPS_STATE_STORE=s3://kops-cni-test-temp
+
+    SSH_KEYS=~/.ssh/devopsinuse
+    if [ ! -f "$SSH_KEYS" ]
+    then
+        echo -e "\nCreating SSH keys ..."
+        ssh-keygen -t rsa -N '' -f ~/.ssh/devopsinuse
+    else
+        echo -e "\nSSH keys are already in place!"
+    fi
+
+    kops create cluster \
+    --zones ${AWS_REGION}a,${AWS_REGION}b \
+    --networking amazon-vpc-routed-eni \
+    --node-count 2 \
+    --ssh-public-key=~/.ssh/devopsinuse.pub \
+    --kubernetes-version ${K8S_VERSION} \
+    ${CLUSTER_NAME}
+    kops update cluster --name ${CLUSTER_NAME} --yes
+    sleep 100
+    while [[ ! $(kops validate cluster | grep "is ready") ]]
+    do
+        sleep 5
+        echo "Waiting for cluster validation"
+    done
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/cni-metrics-helper.yaml
+}
+
+
+
+if [[ -z "$CLUSTER_TYPE" ]]; then  
+    create_eksctl_cluster 
+elif [[ $CLUSTER_TYPE == "kops" ]];then
+    create_kops_cluster
+elif [[ $CLUSTER_TYPE == "eksctl" ]];then
+    create_eksctl_cluster   
+else 
+   echoerr "${USAGE}\n -t optional type flag can be eksctl or kops \n"
+   exit 1
+fi

--- a/scripts/test/delete-cluster.sh
+++ b/scripts/test/delete-cluster.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+
+set -eo pipefail
+
+USAGE=$(cat << 'EOM'
+Usage: delete-cluster.sh -c [cluster-config]
+Deletes an EKS Cluster along with the Nodegroups. Takes in
+the cluster config as an optional argument. If no arugment is
+provided then it will use the cluster config in the default
+path i.e /build/eks-cluster.yaml
+ Optional:
+ -c   eksctl Cluster config path. Defaults to build/eks-cluster.yaml
+ -k   Creation of kOps Cluster. No flag defaults to false.
+ -t   Type of cluster. Defaults to eksctl cluster. Can be set to "kops" or "eksctl"
+EOM
+)
+
+TEST_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
+CLUSTER_CONFIG_DIR="$TEST_DIR/build"
+CLUSTER_CONFIG_PATH="$CLUSTER_CONFIG_DIR/eks-cluster.yaml"
+
+source "$PWD/scripts/lib/common.sh"
+
+
+check_is_installed eksctl
+
+while getopts "c:t:" o; do
+  case "${o}" in
+    c) # eksctl cluster config file path
+      CLUSTER_CONFIG_PATH=${OPTARG}
+      ;;
+    t) # Type of cluster to be deleted
+      CLUSTER_TYPE=${OPTARG}
+      ;;
+    *)
+      echoerr "${USAGE}"
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+function delete_eksctl_cluster {
+    eksctl delete cluster -f "$CLUSTER_CONFIG_PATH" --wait
+}
+
+function delete_kops_cluster {
+    kops delete cluster --name ${CLUSTER_NAME} --yes
+    aws s3 rm ${KOPS_STATE_STORE} --recursive
+    aws s3 rb ${KOPS_STATE_STORE} --region us-west-2
+}
+
+
+if [[ -z "$CLUSTER_TYPE" ]]; then  
+    delete_eksctl_cluster 
+elif [[ $CLUSTER_TYPE == "kops" ]];then
+    delete_kops_cluster
+elif [[ $CLUSTER_TYPE == "eksctl" ]];then
+    delete_eksctl_cluster   
+else 
+   echoerr "${USAGE}\n -t optional type flag can be eksctl or kops \n"
+   exit 1
+fi

--- a/scripts/test/template/eksctl/eks-cluster.yaml
+++ b/scripts/test/template/eksctl/eks-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: CLUSTER_NAME
+  region: CLUSTER_REGION
+  version: "K8S_VERSION"
+nodeGroups:
+  - name: linux-instance
+    instanceType: c5.large  # For SGP Tests, this must be a Nitro-based Instance
+    desiredCapacity: 3
+    iam:
+      instanceRoleName: INSTANCE_ROLE_NAME # Static IAM Role Name for easily adding IAM Policies after creation
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
- Added scripts for cluster creation/deletion using eksctl/kops instead of the existing k8s tester.
- Parameterized scripts for various input including cluster type - kops/eksctl 
- Added ```arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy``` to cluster config as per-requisite to  use Fluent Bit as a DaemonSet to send logs to CloudWatch Logs 


**What does this PR do / Why do we need it**:
- Refactoring of existing cluster creation/deletion scripts

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
% ./scripts/test/create-cluster.sh -n test-cluster-create-type-eksctl
no k8s version defined, will fallback to default version 1.20
no regions defined, will fallback to default region us-west-2
cluster config path not defined, will generate it at default path /Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s/scripts/test/build/eks-cluster.yaml
creating a 1.20 cluster named test-cluster-create-type-eksctl using eksctl
2021-11-23 20:38:11 [ℹ]  eksctl version 0.54.0
2021-11-23 20:38:11 [ℹ]  using region us-west-2
2021-11-23 20:38:12 [ℹ]  setting availability zones to [us-west-2d us-west-2a us-west-2c]
2021-11-23 20:38:12 [ℹ]  subnets for us-west-2d - public:192.168.0.0/19 private:192.168.96.0/19
2021-11-23 20:38:12 [ℹ]  subnets for us-west-2a - public:192.168.32.0/19 private:192.168.128.0/19
2021-11-23 20:38:12 [ℹ]  subnets for us-west-2c - public:192.168.64.0/19 private:192.168.160.0/19
2021-11-23 20:38:13 [ℹ]  nodegroup "linux-instance" will use "ami-0b0493e1b9d3ceb08" [AmazonLinux2/1.20]
2021-11-23 20:38:13 [ℹ]  using Kubernetes version 1.20
2021-11-23 20:38:13 [ℹ]  creating EKS cluster "test-cluster-create-type-eksctl" in "us-west-2" region with un-managed nodes
2021-11-23 20:38:13 [ℹ]  1 nodegroup (linux-instance) was included (based on the include/exclude rules)
2021-11-23 20:38:13 [ℹ]  will create a CloudFormation stack for cluster itself and 1 nodegroup stack(s)
2021-11-23 20:38:13 [ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
2021-11-23 20:38:13 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=test-cluster-create-type-eksctl'
2021-11-23 20:38:13 [ℹ]  CloudWatch logging will not be enabled for cluster "test-cluster-create-type-eksctl" in "us-west-2"
2021-11-23 20:38:13 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=test-cluster-create-type-eksctl'
2021-11-23 20:38:13 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-cluster-create-type-eksctl" in "us-west-2"
2021-11-23 20:38:13 [ℹ]  2 sequential tasks: { create cluster control plane "test-cluster-create-type-eksctl", 3 sequential sub-tasks: { wait for control plane to become ready, 1 task: { create addons }, create nodegroup "linux-instance" } }
2021-11-23 20:38:13 [ℹ]  building cluster stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:38:15 [ℹ]  deploying stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:38:45 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:39:16 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:40:18 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:41:19 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:42:20 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:43:22 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:44:23 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:45:24 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:46:25 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:47:27 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:48:28 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:49:29 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:50:30 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 20:54:38 [ℹ]  building nodegroup stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:54:38 [ℹ]  --nodes-min=3 was set automatically for nodegroup linux-instance
2021-11-23 20:54:38 [ℹ]  --nodes-max=3 was set automatically for nodegroup linux-instance
2021-11-23 20:54:39 [ℹ]  deploying stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:54:39 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:54:56 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:55:14 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:55:35 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:55:53 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:56:14 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:56:35 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:56:55 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:57:13 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:57:32 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:57:50 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:58:07 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:58:27 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 20:58:28 [ℹ]  waiting for the control plane availability...
2021-11-23 20:58:28 [✔]  saved kubeconfig as "/Users/shrenaik/.kube/config"
2021-11-23 20:58:28 [ℹ]  no tasks
2021-11-23 20:58:28 [✔]  all EKS cluster resources for "test-cluster-create-type-eksctl" have been created
2021-11-23 20:58:29 [ℹ]  adding identity "arn:aws:iam::621232764788:role/eksctl-test-cluster-create-type-e-NodeInstanceRole-1WIHIQB33MC7F" to auth ConfigMap
2021-11-23 20:58:29 [ℹ]  nodegroup "linux-instance" has 0 node(s)
2021-11-23 20:58:29 [ℹ]  waiting for at least 3 node(s) to become ready in "linux-instance"
2021-11-23 20:58:57 [ℹ]  nodegroup "linux-instance" has 3 node(s)
2021-11-23 20:58:57 [ℹ]  node "ip-192-168-13-231.us-west-2.compute.internal" is ready
2021-11-23 20:58:57 [ℹ]  node "ip-192-168-60-244.us-west-2.compute.internal" is ready
2021-11-23 20:58:57 [ℹ]  node "ip-192-168-73-135.us-west-2.compute.internal" is ready
2021-11-23 21:01:05 [ℹ]  kubectl command should work with "/Users/shrenaik/.kube/config", try 'kubectl get nodes'
2021-11-23 21:01:05 [✔]  EKS cluster "test-cluster-create-type-eksctl" in "us-west-2" region is ready
```

```
% ./scripts/test/delete-cluster.sh                                    
2021-11-23 22:01:20 [ℹ]  eksctl version 0.54.0
2021-11-23 22:01:20 [ℹ]  using region us-west-2
2021-11-23 22:01:20 [ℹ]  deleting EKS cluster "test-cluster-create-type-eksctl"
2021-11-23 22:01:23 [ℹ]  deleted 0 Fargate profile(s)
2021-11-23 22:01:25 [✔]  kubeconfig has been updated
2021-11-23 22:01:25 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
2021-11-23 22:01:29 [ℹ]  2 sequential tasks: { delete nodegroup "linux-instance", delete cluster control plane "test-cluster-create-type-eksctl" }
2021-11-23 22:01:29 [ℹ]  will delete stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:01:29 [ℹ]  waiting for stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance" to get deleted
2021-11-23 22:01:29 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:01:46 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:02:04 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:02:25 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:02:42 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:03:03 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:03:24 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:03:44 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:04:02 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:04:21 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-nodegroup-linux-instance"
2021-11-23 22:04:22 [ℹ]  will delete stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:04:22 [ℹ]  waiting for stack "eksctl-test-cluster-create-type-eksctl-cluster" to get deleted
2021-11-23 22:04:22 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:04:41 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:04:58 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:05:19 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:05:36 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:05:54 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:06:13 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:06:33 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:06:52 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:07:10 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:07:29 [ℹ]  waiting for CloudFormation stack "eksctl-test-cluster-create-type-eksctl-cluster"
2021-11-23 22:07:31 [✔]  all cluster resources were deleted
```

Couldn't test using kops. Faced error below:
```
% ./scripts/test/create-cluster.sh -n test-cluster-create-type-kops -t kops
no k8s version defined, will fallback to default version 1.20
no regions defined, will fallback to default region us-west-2
cluster config path not defined, will generate it at default path /Volumes/workplace/go/src/github.com/amazon-vpc-cni-k8s/scripts/test/build/eks-cluster.yaml

An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.
```



**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
