### PR TITLE
Do not silently fail in k8s agent initialization

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -39,17 +39,20 @@ func _main() int {
 	version.RegisterMetric()
 
 	//Check API Server Connectivity
-	if k8sapi.CheckAPIServerConnectivity() != nil {
+	if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
+		log.Errorf("Failed to connect to the API server: %v", err)
 		return 1
 	}
 
 	rawK8SClient, err := k8sapi.CreateKubeClient()
 	if err != nil {
+		log.Errorf("Failed to create the Kubernetes client: %v", err)
 		return 1
 	}
 
 	cacheK8SClient, err := k8sapi.CreateCachedKubeClient(rawK8SClient)
 	if err != nil {
+		log.Errorf("Failed to create the cached Kubernetes client: %v", err)
 		return 1
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

bug/cleanup

**What does this PR do / Why do we need it**:

It logs aws-k8s-agent initialisation error. Currently, aws-k8s-agent may fail without any error message in the log file, for example if the API server cannot be found.

*Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No.

**Does this change require updates to the CNI daemonset config files to work?**:

No.

**Does this PR introduce any user-facing change?**:

Not a change that deserve inclusion in the release notes IMHO.
