### PR TITLE
Validate Security Groups before attempt to attach to ENI Config

### DIFF
--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -489,6 +489,20 @@ func (mr *MockAPIsMockRecorder) TagENI(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagENI", reflect.TypeOf((*MockAPIs)(nil).TagENI), arg0, arg1)
 }
 
+// ValidateSecurityGroups mocks base method
+func (m *MockAPIs) ValidateSecurityGroups(arg0 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateSecurityGroups", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateSecurityGroups indicates an expected call of ValidateSecurityGroups
+func (mr *MockAPIsMockRecorder) ValidateSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSecurityGroups", reflect.TypeOf((*MockAPIs)(nil).ValidateSecurityGroups), arg0)
+}
+
 // WaitForENIAndIPsAttached mocks base method
 func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENIMetadata, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ec2wrapper/client.go
+++ b/pkg/ec2wrapper/client.go
@@ -36,6 +36,7 @@ type EC2 interface {
 	ModifyNetworkInterfaceAttributeWithContext(ctx aws.Context, input *ec2svc.ModifyNetworkInterfaceAttributeInput, opts ...request.Option) (*ec2svc.ModifyNetworkInterfaceAttributeOutput, error)
 	CreateTagsWithContext(ctx aws.Context, input *ec2svc.CreateTagsInput, opts ...request.Option) (*ec2svc.CreateTagsOutput, error)
 	DescribeNetworkInterfacesPagesWithContext(ctx aws.Context, input *ec2svc.DescribeNetworkInterfacesInput, fn func(*ec2svc.DescribeNetworkInterfacesOutput, bool) bool, opts ...request.Option) error
+	DescribeSecurityGroups(input *ec2svc.DescribeSecurityGroupsInput) (*ec2svc.DescribeSecurityGroupsOutput, error)
 }
 
 // New creates a new EC2 wrapper

--- a/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
+++ b/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
@@ -249,6 +249,21 @@ func (mr *MockEC2MockRecorder) DescribeNetworkInterfacesWithContext(arg0, arg1 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeNetworkInterfacesWithContext), varargs...)
 }
 
+// DescribeSecurityGroups mocks base method
+func (m *MockEC2) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups
+func (mr *MockEC2MockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockEC2)(nil).DescribeSecurityGroups), arg0)
+}
+
 // DetachNetworkInterfaceWithContext mocks base method
 func (m *MockEC2) DetachNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.DetachNetworkInterfaceInput, arg2 ...request.Option) (*ec2.DetachNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

Bug, Cleanup.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

This tries to fix https://github.com/aws/amazon-vpc-cni-k8s/issues/1626

**What does this PR do / Why do we need it**:

This adds a method to call describe all the security groups, and if an error is returned in the describe, it will fail the operation (return the err) to the high level call and skip Eni creation.

1. Validate SG from enicfg during the node initialization phase,  when custom networking is enabled and cache the validation.

2. When node pool update is called, the uncached SG will be validated and cache will be kept to update.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
make unit-test

...

PASS
coverage: 100.0% of statements
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
No
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
