### PR TITLE
Add workflow to sync cni-metrics-helper helm chart to eks-charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ METRICS_IMAGE = amazon/cni-metrics-helper
 METRICS_IMAGE_NAME = $(METRICS_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
 METRICS_IMAGE_DIST = $(DESTDIR)/$(subst /,_,$(METRICS_IMAGE_NAME)).tar.gz
 REPO_FULL_NAME=aws/amazon-vpc-cni-k8s
-HELM_CHART_NAME ?= "aws-vpc-cni"
+HELM_CHART_NAMES ?= "aws-vpc-cni" "cni-metrics-helper"
 # TEST_IMAGE is the testing environment container image.
 TEST_IMAGE = amazon-k8s-cni-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
@@ -341,10 +341,14 @@ generate-limits:    ## Generate limit file go code
 	go run $(VENDOR_OVERRIDE_FLAG) scripts/gen_vpc_ip_limits.go
 
 ekscharts-sync:
-	${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b ${HELM_CHART_NAME} -r ${REPO_FULL_NAME}
+	for HELM_CHART_NAME in $(HELM_CHART_NAMES) ; do \
+		${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b $$HELM_CHART_NAME -r ${REPO_FULL_NAME} ; \
+	done
 
 ekscharts-sync-release:
-	${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b ${HELM_CHART_NAME} -r ${REPO_FULL_NAME} -n -y
+	for HELM_CHART_NAME in $(HELM_CHART_NAMES) ; do \
+		${MAKEFILE_PATH}/scripts/sync-to-eks-charts.sh -b $$HELM_CHART_NAME -r ${REPO_FULL_NAME} -n -y ; \
+	done
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
ORR task

**What does this PR do / Why do we need it**:
Currently, there are 3 args to run this command:

- `-b`, required, which is to assign binary basename
- `-r`, optional, which is the Github repot to sync to in the form of "org/name"
- `-n`, optional, which is to indicate whether to include the release note in the sync PR

This PR added a workflow to sync cni-metrics-helper helm chart to eks-charts repo, by using `-b` to choose which helm chart to sync. 

- The user can pass 2 values to `-b`: `aws-vpc-cni` or `cni-metrics-helper`. If invalid value is passed the script will quit.
- Sample command to sync aws-vpc-cni helm chart to eks-chart: `bash scripts/sync-to-eks-charts.sh -b aws-vpc-cni
`
- Sample command to sync cni-metrics-helper to eks-chart: `bash scripts/sync-to-eks-charts.sh -b cni-metrics-helper
`  
- Or use make command  `make ekscharts-sync-release` or `make ekscharts-sync`to sync both charts with/without  release note.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

- Tested sync from aws/amazon-vpc-cni-k8s to oliviassss/eks-charts repo

   - for aws-vpc-cni: [https://github.com/oliviassss/eks-charts/pull/9/](https://github.com/oliviassss/eks-charts/pull/9)
   - for cni-metrics-helper: [https://github.com/oliviassss/eks-charts/pull/10/](https://github.com/oliviassss/eks-charts/pull/10)

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
