### PR TITLE
remove set -x from bash, add -Ss to curl

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 get_metadata()
 {
-    TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+    TOKEN=$(curl -Ss -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
     attempts=60
     false
     while [ "${?}" -gt 0 ]; do
@@ -12,7 +12,7 @@ get_metadata()
         echo "Failed to get metdata"
         exit 1
         fi
-        meta=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/${1})
+        meta=$(curl -Ss -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/${1})
         if [ "${?}" -gt 0 ]; then
             let attempts--
             sleep 0.5


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:
#1801 


**What does this PR do / Why do we need it**:
While not catastrophic, it's sub-optimal for the `init.sh` script to emit diagnostic data to stderr.  This PR removes the `-x` from the Bash `set` command.  `-x` is great for debugging and troubleshooting, but probably not necessary in the normal course of operations of this script.

I also added `-Ss` to the two `curl` calls in `init.sh`.  This suppresses the status output going to stderr, but will still emit errors in the event of actual errors.  This is consistent with other `curl` calls within this repo.

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
It ought not.  I have not tested this yet, as I don't currently have sufficient scaffolding to do so.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes, insofar as messages that had been emitted previously will no longer be emitted.  If someone was expecting / relying on those messages for some purpose, those expectations won't be satisfied.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
