### PR TITLE
Switch to public ECR for AL2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v
 # provide an alternate suffix or to omit.
 IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(ARCH),arm64))
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE = golang:1.16-stretch
+GOLANG_IMAGE = public.ecr.aws/docker/library/golang:1.16-stretch
 # For the requested build, these are the set of Go specific build environment variables.
 export GOARCH ?= $(ARCH)
 export GOOS = linux

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ HELM_CHART_NAME ?= "aws-vpc-cni"
 # TEST_IMAGE is the testing environment container image.
 TEST_IMAGE = amazon-k8s-cni-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
-# These values derive ARCH and DOCKER_ARCH which are needed by dependencies in
+# These values derive ARCH  which is needed by dependencies in
 # image build defaulting to system's architecture when not specified.
 #
 # UNAME_ARCH is the runtime architecture of the building host.
@@ -52,9 +52,6 @@ UNAME_ARCH = $(shell uname -m)
 #
 # These are pairs of input_arch to derived_arch separated by colons:
 ARCH = $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
-# DOCKER_ARCH is the docker specific architecture specifier used for building on
-# multiarch container images.
-DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v8)))
 # IMAGE_ARCH_SUFFIX is the `-arch` suffix included in the container image name.
 #
 # This is only applied to the arm64 container image by default. Override to
@@ -96,8 +93,7 @@ DOCKER_RUN_FLAGS = --rm -ti $(DOCKER_ARGS)
 # DOCKER_BUILD_FLAGS is the set of flags passed during container image builds
 # based on the requested build.
 DOCKER_BUILD_FLAGS = --build-arg GOARCH="$(ARCH)" \
-					  --build-arg docker_arch="$(DOCKER_ARCH)" \
-					  --build-arg golang_image="$(GOLANG_IMAGE)" \
+c					  --build-arg golang_image="$(GOLANG_IMAGE)" \
 					  --network=host \
 	  		          $(DOCKER_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ DOCKER_RUN_FLAGS = --rm -ti $(DOCKER_ARGS)
 # DOCKER_BUILD_FLAGS is the set of flags passed during container image builds
 # based on the requested build.
 DOCKER_BUILD_FLAGS = --build-arg GOARCH="$(ARCH)" \
-c					  --build-arg golang_image="$(GOLANG_IMAGE)" \
+					  --build-arg golang_image="$(GOLANG_IMAGE)" \
 					  --network=host \
 	  		          $(DOCKER_ARGS)
 

--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -1,4 +1,3 @@
-ARG docker_arch
 ARG golang_image
 
 FROM $golang_image as builder
@@ -14,7 +13,7 @@ RUN make plugins && make debug-script
 COPY . ./
 
 # Build the architecture specific container image:
-FROM $docker_arch/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y && \
     yum install -y iproute procps-ng && \
     yum clean all

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -1,4 +1,3 @@
-ARG docker_arch
 ARG golang_image
 
 FROM $golang_image as builder
@@ -16,7 +15,7 @@ RUN go mod download
 COPY . ./
 RUN make build-metrics
 
-FROM $docker_arch/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y && \
 	yum clean all
 

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,4 +1,3 @@
-ARG docker_arch
 ARG golang_image
 
 FROM $golang_image as builder
@@ -19,7 +18,7 @@ COPY . ./
 RUN make build-linux
 
 # Build the architecture specific container image:
-FROM $docker_arch/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y && \
     yum install -y iptables iproute jq && \
     yum clean all
@@ -39,3 +38,4 @@ COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/entrypoint.sh /app/
 
 ENTRYPOINT ["/app/entrypoint.sh"]
+cd

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -38,4 +38,3 @@ COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/entrypoint.sh /app/
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-cd

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -1,4 +1,3 @@
-ARG docker_arch
 ARG golang_image
 FROM $golang_image
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Switch to public ECR image of AL2

**What does this PR do / Why do we need it**:
Switch to public ECR image of AL2

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No
**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
