### PR TITLE
Add automation script for running e2e test

### DIFF
--- a/scripts/test/run-e2e-tests.sh
+++ b/scripts/test/run-e2e-tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -eo pipefail
+
+pushd ./test/e2e
+
+echo "Running e2e test with the following configuration:
+KUBECONFIG: $KUBECONFIG
+CLUSTER_NAME: $CLUSTER_NAME
+AWS_REGION: $AWS_REGION"
+
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
+
+while getopts "f:" arg; do
+  case $arg in
+    f) FOCUS=$OPTARG;
+    echo "FOCUS: $FOCUS";
+  esac
+done
+
+CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $AWS_REGION  $ENDPOINT_FLAG)
+
+VPC_ID=$(echo $CLUSTER_INFO | jq -r '.cluster.resourcesVpcConfig.vpcId')
+SERVICE_ROLE_ARN=$(echo $CLUSTER_INFO | jq -r '.cluster.roleArn')
+ROLE_NAME=${SERVICE_ROLE_ARN##*/}
+TEST_FAILED=false
+
+START=$SECONDS
+
+for dir in */
+do
+
+    cd "${dir%*/}"
+    if [ -n "$FOCUS" ]; then
+        ( ginkgo --focus="$FOCUS" -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID ) || TEST_FAILED=true
+    else
+        ( ginkgo -v -r -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID ) || TEST_FAILED=true
+    fi
+    cd ..
+
+done
+
+DEFAULT_E2E_DURATION=$((SECONDS - START))
+echo "TIMELINE: e2e tests took $DEFAULT_E2E_DURATION seconds."
+
+popd
+
+# If any of the test failed, exit with non zero exit code
+if [ $TEST_FAILED = true ]; then
+  exit 1
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature
**Which issue does this PR fix**:
Automates running of e2e in the test/e2e folder

**What does this PR do / Why do we need it**:

   - Iterates and runs tests in test/e2e folder having sub-folders
   - Takes an optional flag -f in order to provide FOCUS as a parameter to run selective tests
   -  Uses a set of ENV variables and derives other variables needed to run tests


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
 % ./scripts/test/run-e2e-tests.sh
~/workplace/go/src/github.com/amazon-vpc-cni-k8s/test/e2e ~/workplace/go/src/github.com/amazon-vpc-cni-k8s
Running e2e test with the following configuration:
KUBECONFIG: /Users/xxx/.kube/eksctl/clusters/yyy
CLUSTER_NAME: yyy
AWS_REGION: us-west-2
Running Suite: CNI Custom Networking e2e Test Suite
===================================================
Random Seed: 1642617093
Will run 3 of 3 specs

STEP: creating test namespace
STEP: getting the cluster VPC Config
STEP: creating ec2 key-pair for the new node group
...
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
