### PR TITLE
Add "ip rule add" command to cni-proposal.md

### DIFF
--- a/docs/cni-proposal.md
+++ b/docs/cni-proposal.md
@@ -149,11 +149,19 @@ Here are the wiring steps to enable pod to pod communication:
 	ip netns exec ns1 arp -i veth-1c -s 169.254.1.1 <veth-1's mac> /* add static ARP entry for default gateway */
 	```
 
-* On host side, add host route so that incoming Pod's traffic can be routed to Pod.
+* On host side, add host route and routing rule so that incoming Pod's traffic can be routed to Pod.
 
 	```
 	/* Pod's IP address is 20.0.49.215 */
 	ip route add 20.0.49.215/32 dev veth-1 /* add host route */
+	ip rule add from all to 20.0.49.215/32 table main prio 512 /* add routing rule */
+	```
+	Note:
+
+	When Pod's ip address is associated with the secondary ENI, the from-pod rule is also added.
+	For example, if the ip address "20.0.49.215" is associated with eth1, add the following rule.
+	```
+	ip rule add from 20.0.49.215/32 table 2 prio 1536  /* add from-pod rule */
 	```
 
 #### Life of a Pod to Pod Ping Packet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Update cni-proposal.md document.

**What does this PR do / Why do we need it**:

Currently, [cni-proposal.md](https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.10.1/docs/cni-proposal.md) indicates the example of the routing rules.
```
# ip rule list
0:	from all lookup local 
512:	from all to 10.0.97.30 lookup main <---------- to Pod's traffic
1025:	not from all to 10.0.0.0/16 lookup main 
1536:	from 10.0.97.30 lookup eni-1 <-------------- from Pod's traffic
```
However, there is no "ip rule add" command in the section of ["CNI Plugin Sequence"](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/cni-proposal.md#cni-plugin-sequence).

I think this command (ip rule add) should be described in this section for introducing the work of amazon-vpc-cni-k8s in more detail.

[Note]
This cni plugin adds routing rules for launched pods.
The 1536 priority rule is not always added. So I think it's OK to describe just the rule of "to Pod's traffic" (512 priority rule) in this example.

https://github.com/aws/amazon-vpc-cni-k8s/blob/104354c45bb210c444bb3317e4199b696cfbb2f9/cmd/routed-eni-cni-plugin/driver/driver.go#L501-L527

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.