### PR TITLE
Ad-hoc ENI when IP address is required and WARM_ENI_TARGET is 0

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -307,6 +307,7 @@ type DataStore struct {
 	backingStore             Checkpointer
 	cri                      cri.APIs
 	isPDEnabled              bool
+	ipStarved                bool
 }
 
 // ENIInfos contains ENI IP information
@@ -803,6 +804,7 @@ func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey) (ipv4address string, 
 	}
 
 	ds.log.Errorf("DataStore has no available IP/Prefix addresses")
+	ds.ipStarved = true
 	return "", -1, errors.New("assignPodIPv4AddressUnsafe: no available IP/Prefix addresses")
 }
 
@@ -1506,4 +1508,18 @@ func (ds *DataStore) CheckFreeableENIexists() bool {
 		return true
 	}
 	return false
+}
+
+func (ds *DataStore) IsIPStarvedInDS() bool {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	ds.log.Debugf("Data Store is starved on IP addresses? %v", ds.ipStarved)
+	return ds.ipStarved
+}
+
+func (ds *DataStore) SetIPStarvedInDS(starved bool) {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	ds.log.Debugf("Data Store IP starvation is set to %v", starved)
+	ds.ipStarved = starved
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1118,7 +1118,8 @@ func TestIPAMContext_nodeIPPoolTooLow(t *testing.T) {
 		{"Test 1 used, 1 warm ENI", fields{3, 1, 0, datastoreWith1Pod1()}, true},
 		{"Test 1 used, 0 warm ENI", fields{3, 0, 0, datastoreWith1Pod1()}, false},
 		{"Test 3 used, 1 warm ENI", fields{3, 1, 0, datastoreWith3Pods()}, true},
-		{"Test 3 used, 0 warm ENI", fields{3, 0, 0, datastoreWith3Pods()}, true},
+		{"Test 3 used, 0 warm ENI", fields{3, 0, 0, datastoreWith3Pods()}, false},
+		{"Test no free IPs, 0 warm ENI", fields{3, 0, 0, datastoreWith0FreeIPsWithIPStarved()}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1206,6 +1207,13 @@ func datastoreWith3FreeIPs() *datastore.DataStore {
 	ipv4Addr = net.IPNet{IP: net.ParseIP(ipaddr03), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = datastoreWith3FreeIPs.AddIPv4CidrToStore(primaryENIid, ipv4Addr, false)
 	return datastoreWith3FreeIPs
+}
+
+func datastoreWith0FreeIPsWithIPStarved() *datastore.DataStore {
+	ds := testDatastore()
+	ds.AddENI("eni-1", 1, true, false, false)
+	ds.AssignPodIPv4Address(datastore.IPAMKey{NetworkName: "net1", ContainerID: "sandbox1", IfName: "eth0"})
+	return ds
 }
 
 func datastoreWith1Pod1() *datastore.DataStore {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1775 
#1451 

**What does this PR do / Why do we need it**:
When the env WARM_ENI_TARGET is set as 0 and none of existing ENIs has available IP address, ipamd will try to add and remove a new ENI infinitely since it always thinks IP availability is low (adding) but no warm ENI is set (deleting). This behavior could dramatically increase call volume to EC2 API. In some case (large clusters), the account could be throttled.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Non custom networking cluster:

1. assigned all IPs of primary ENI or the secondary ENI (t3 and c5 instance types) and checked no looping behavior(add/delete) occurring
2. soaking tests for 5 hours. Every 5 minutes, adding a request for IP into a fully assigned ENI, or removing an IP from an ENI in which only one IP was in use. Result showed new ENI can always been added and IP was successfully assigned from the ENI.
3. automation tests for WARM ENI in integration tests.

Custom networking enabled cluster:

1. no ENI was added if WARM_ENI_TARGET is 0 and no pod was created in the node.
2. new ENI and IP was added and assigned when creating a new pod.
3. ipamd won't add new ENI even if existing ENIs are full assigned for IP addresses.

Also confirmed when WARM_ENI_TARGET is not 0, all behavior stay same as before.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Unite tests were added. We should also add test cases in integration tests.
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
