### PR TITLE
Switch cluster management to eksctl for perf tests

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 16 * * 1"  # every Monday
+    - cron: "0 16 * * 5"  # every Friday
 
 permissions:
   contents: read

--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 16 * * 5"  # every Friday
+    - cron: "0 16 * * 1"  # every Monday
 
 permissions:
   contents: read

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -5,12 +5,9 @@ function down-test-cluster() {
         $TESTER_PATH eks delete cluster --enable-prompt=false --path $CLUSTER_CONFIG || (echo "failed!" && exit 1)
     else
         echo -n "Deleting cluster $CLUSTER_NAME (this may take ~10 mins) ... "
-        if [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
-          eksctl delete cluster --name $CLUSTER_NAME
-        else
-          $TESTER_PATH eks delete cluster --enable-prompt=false --path $CLUSTER_CONFIG >>$CLUSTER_MANAGE_LOG_PATH 2>&1 ||
-              (echo "failed. Check $CLUSTER_MANAGE_LOG_PATH." && exit 1)
-          echo "ok."
+        $TESTER_PATH eks delete cluster --enable-prompt=false --path $CLUSTER_CONFIG >>$CLUSTER_MANAGE_LOG_PATH 2>&1 ||
+            (echo "failed. Check $CLUSTER_MANAGE_LOG_PATH." && exit 1)
+        echo "ok."
     fi
 }
 

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -13,45 +13,25 @@ function down-test-cluster() {
 
 function up-test-cluster() {
     MNGS=""
+    DIR=$(cd "$(dirname "$0")"; pwd)
     if [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
-        MNGS='{"cni-test-single-node-mng":{"name":"cni-test-single-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":1,"asg-desired-capacity":1,"instance-types":["m5.16xlarge"],"volume-size":40}, "cni-test-multi-node-mng":{"name":"cni-test-multi-node-mng","remote-access-user-name":"ec2-user","tags":{"group":"amazon-vpc-cni-k8s"},"release-version":"","ami-type":"AL2_x86_64","asg-min-size":1,"asg-max-size":100,"asg-desired-capacity":99,"instance-types":["m5.xlarge"],"volume-size":40,"cluster-autoscaler":{"enable":true}}}'
+        PERF_CLUSTER_CONFIG_PATH=$DIR/test/config/perf-cluster.yml
+        let AMI_ID=`aws ssm get-parameter --name /aws/service/eks/optimized-ami/${EKS_CLUSTER_VERSION}/amazon-linux-2/recommended/image_id --region region-code --query "Parameter.Value" --output text`
+        echo "Obtained ami_id as $ami_id"
+        sed -i'.bak' "s,AMI_ID_PLACEHOLDER,$AMI_ID," "$PERF_CLUSTER_CONFIG_PATH"
+        grep -r -q $AMI_ID $DIR/test/config/perf-cluster.yml
+        sed -i'.bak' "s,CLUSTER_NAME_PLACEHOLDER,$CLUSTER_NAME," "$PERF_CLUSTER_CONFIG_PATH"
+        grep -r -q $CLUSTER_NAME $DIR/test/config/perf-cluster.yml
         export RUN_CONFORMANCE="false"
         : "${PERFORMANCE_TEST_S3_BUCKET_NAME:=""}"
+        eksctl create cluster -f $PERF_CLUSTER_CONFIG_PATH
+        kubectl create -f $DIR/test/config/cluster-autoscaler-autodiscover.yml
+
     else
-        DIR=$(cd "$(dirname "$0")"; pwd)
         mng_multi_arch_config=`cat $DIR/test/config/multi-arch-mngs-config.json`
         MNGS=$mng_multi_arch_config
     fi
 
-    echo -n "Configuring cluster $CLUSTER_NAME"
-    AWS_K8S_TESTER_EKS_NAME=$CLUSTER_NAME \
-        AWS_K8S_TESTER_EKS_LOG_COLOR=false \
-        AWS_K8S_TESTER_EKS_LOG_COLOR_OVERRIDE=true \
-        AWS_K8S_TESTER_EKS_KUBECONFIG_PATH=$KUBECONFIG_PATH \
-        AWS_K8S_TESTER_EKS_KUBECTL_PATH=$KUBECTL_PATH \
-        AWS_K8S_TESTER_EKS_S3_BUCKET_NAME=$S3_BUCKET_NAME \
-        AWS_K8S_TESTER_EKS_S3_BUCKET_CREATE=$S3_BUCKET_CREATE \
-        AWS_K8S_TESTER_EKS_VERSION=${EKS_CLUSTER_VERSION} \
-        AWS_K8S_TESTER_EKS_PARAMETERS_ENCRYPTION_CMK_CREATE=false \
-        AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_CREATE=$ROLE_CREATE \
-        AWS_K8S_TESTER_EKS_PARAMETERS_ROLE_ARN=$ROLE_ARN \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ENABLE=true \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_CREATE=$ROLE_CREATE \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_ROLE_ARN=$MNG_ROLE_ARN \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_MNGS=$MNGS \
-        AWS_K8S_TESTER_EKS_ADD_ON_MANAGED_NODE_GROUPS_FETCH_LOGS=true \
-        AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE=$RUN_TESTER_LB_ADDONS \
-        AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE=$RUN_TESTER_LB_ADDONS \
-        $TESTER_PATH eks create config --path $CLUSTER_CONFIG 1>&2
-
-    if [[ -n "${CIRCLE_JOB:-}" || -n "${DISABLE_PROMPT:-}" ]]; then
-        $TESTER_PATH eks create cluster --enable-prompt=false --path $CLUSTER_CONFIG || (echo "failed!" && exit 1)
-    else
-        echo -n "Creating cluster $CLUSTER_NAME (this may take ~20 mins. details: tail -f $CLUSTER_MANAGE_LOG_PATH)... "
-        $TESTER_PATH eks create cluster --path $CLUSTER_CONFIG >>$CLUSTER_MANAGE_LOG_PATH 1>&2 ||
-            (echo "failed. Check $CLUSTER_MANAGE_LOG_PATH." && exit 1)
-        echo "ok."
-    fi
 }
 
 function up-kops-cluster {

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -74,7 +74,7 @@ CLUSTER_MANAGE_LOG_PATH=$TEST_CLUSTER_DIR/cluster-manage.log
 # shared binaries
 : "${TESTER_DIR:=${DIR}/aws-k8s-tester}"
 : "${TESTER_PATH:=$TESTER_DIR/aws-k8s-tester}"
-: "${KUBECTL_PATH:=$TESTER_DIR/kubectl}"
+: "${KUBECTL_PATH:=kubectl}"
 export PATH=${PATH}:$TESTER_DIR
 
 LOCAL_GIT_VERSION=$(git rev-parse HEAD)
@@ -197,8 +197,7 @@ sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init
 grep -r -q $INIT_IMAGE_NAME $TEST_CONFIG_PATH
 
 
-if [[ $RUN_KOPS_TEST == true || $RUN_BOTTLEROCKET_TEST == true ]]; then
-    KUBECTL_PATH=kubectl
+if [[ $RUN_KOPS_TEST == true || $RUN_BOTTLEROCKET_TEST == true || $RUN_PERFORMANCE_TESTS == true ]]; then
     export KUBECONFIG=~/.kube/config
 else
     export KUBECONFIG=$KUBECONFIG_PATH

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -46,6 +46,8 @@ on_error() {
                 down-kops-cluster
             elif [[ $RUN_BOTTLEROCKET_TEST == true ]]; then
                 eksctl delete cluster bottlerocket
+            elif [[ $RUN_PERFORMANCE_TESTS == true ]]; then
+                eksctl delete cluster $CLUSTER_NAME
             else
                 down-test-cluster
             fi
@@ -307,6 +309,8 @@ if [[ "$DEPROVISION" == true ]]; then
         down-kops-cluster
     elif [[ "$RUN_BOTTLEROCKET_TEST" == true ]]; then
         eksctl delete cluster bottlerocket
+    elif [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
+        eksctl delete cluster $CLUSTER_NAME
     else
         down-test-cluster
     fi

--- a/scripts/test/config/cluster-autoscaler-autodiscover.yml
+++ b/scripts/test/config/cluster-autoscaler-autodiscover.yml
@@ -1,0 +1,168 @@
+#Cluster autoscaler deployment used in performance tests
+#Based on https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.21.2/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
+    spec:
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 600Mi
+            requests:
+              cpu: 100m
+              memory: 600Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt #/etc/ssl/certs/ca-bundle.crt for Amazon Linux Worker Nodes
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"

--- a/scripts/test/config/perf-cluster.yml
+++ b/scripts/test/config/perf-cluster.yml
@@ -12,11 +12,16 @@ managedNodeGroups:
     ami: AMI_ID_PLACEHOLDER
     instanceType: m5.16xlarge
     desiredCapacity: 1
+    minSize: 1
+    maxSize: 1
     volumeSize: 100
     volumeName: /dev/xvda
+    iam:
+      withAddonPolicies:
+        autoScaler: true
     overrideBootstrapCommand: |
       #!/bin/bash
-      /etc/eks/bootstrap.sh latest-mixed-cluster --kubelet-extra-args '--max-pods=740'
+      /etc/eks/bootstrap.sh CLUSTER_NAME_PLACEHOLDER --kubelet-extra-args '--max-pods=740'
 
   - name: cni-test-multi-node-mng
     instanceType: m5.xlarge

--- a/scripts/test/config/perf-cluster.yml
+++ b/scripts/test/config/perf-cluster.yml
@@ -1,0 +1,30 @@
+# A cluster with two managed nodegroups.
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: CLUSTER_NAME_PLACEHOLDER
+  region: us-west-2
+
+managedNodeGroups:
+  - name: cni-test-single-node-mng
+    ami: AMI_ID_PLACEHOLDER
+    instanceType: m5.16xlarge
+    desiredCapacity: 1
+    volumeSize: 100
+    volumeName: /dev/xvda
+    overrideBootstrapCommand: |
+      #!/bin/bash
+      /etc/eks/bootstrap.sh latest-mixed-cluster --kubelet-extra-args '--max-pods=740'
+
+  - name: cni-test-multi-node-mng
+    instanceType: m5.xlarge
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 100
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+    volumeSize: 100
+    volumeName: /dev/xvda

--- a/testdata/bottlerocket.yaml
+++ b/testdata/bottlerocket.yaml
@@ -5,7 +5,6 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.15'
 
 nodeGroups:
   - name: ng-bottlerocket


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug_fix
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1842 

**What does this PR do / Why do we need it**:
Switches perf test cluster creation and deletion to eksctl as the previous config with k8s-tester was non-functional.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran ./scripts/integration-tests.sh with `RUN_PERFORMANCE_TESTS` set to `true` and verified that the test passed and the cluster got deleted.
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
