### PR TITLE
[WIP] refactor networkutils.NetworkAPI & remove legacy features

### DIFF
--- a/pkg/networkutils/iptables.go
+++ b/pkg/networkutils/iptables.go
@@ -1,0 +1,43 @@
+package networkutils
+
+import (
+	"github.com/coreos/go-iptables/iptables"
+	"strings"
+)
+
+// goIPTables directly wraps methods exposed by the "github.com/coreos/go-iptables/iptables" package
+type goIPTables interface {
+	Exists(table, chain string, rulespec ...string) (bool, error)
+	Insert(table, chain string, pos int, rulespec ...string) error
+	Append(table, chain string, rulespec ...string) error
+	Delete(table, chain string, rulespec ...string) error
+	List(table, chain string) ([]string, error)
+	NewChain(table, chain string) error
+	ClearChain(table, chain string) error
+	DeleteChain(table, chain string) error
+	ListChains(table string) ([]string, error)
+	HasRandomFully() bool
+}
+
+type IPTables interface {
+	goIPTables
+}
+
+var _ IPTables = &ipTables{}
+
+type ipTables struct {
+	*iptables.IPTables
+}
+
+// NewIPTablesWithProtocol creates a new ipTables object
+func NewIPTablesWithProtocol(proto iptables.Protocol) (IPTables, error) {
+	ipt, err := iptables.NewWithProtocol(proto)
+	if err != nil {
+		return nil, err
+	}
+	return &ipTables{IPTables: ipt}, nil
+}
+
+func IsChainExistErr(err error) bool {
+	return strings.Contains(err.Error(), "Chain already exists")
+}

--- a/pkg/networkutils/utils.go
+++ b/pkg/networkutils/utils.go
@@ -1,0 +1,23 @@
+package networkutils
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// IncrementIPv4Addr returns incremented IPv4 address
+func IncrementIPv4Addr(ip net.IP) (net.IP, error) {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("%q is not a valid IPv4 Address", ip)
+	}
+	intIP := binary.BigEndian.Uint32(ip4)
+	if intIP == (1<<32 - 1) {
+		return nil, fmt.Errorf("%q will be overflowed", ip)
+	}
+	intIP++
+	nextIPv4 := make(net.IP, 4)
+	binary.BigEndian.PutUint32(nextIPv4, intIP)
+	return nextIPv4, nil
+}


### PR DESCRIPTION
The purpose of this PR is to cleanup the networkutils.NetworkAPI
1. remove legacy features:
   * remove the AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER knob, since we already unconditionally configures the rpFilter through init container.
   * remove the AWS_VPC_CNI_NODE_PORT_SUPPORT knob, since 
     * the nodePort should always be enabled for kubernetes Conformence.
     * the mainENI route rule is needed for SNAT as well, not just nodePort.
   * remove configureIPRulesForPods since we already moved away from CIDR based from pod rule. And the only functionality of the code is backwards-compability(by aggregate multiple from pod rule into a single one). Removing this will require users to upgrade to CNI 1.10.x before upgrade to CNI 1.11
2. refactors:
   * make the interfaces more clear by move static configurations such as IPv4Enabled as member variable of NetworkAPI.
   * separate functionalities into smaller functions.
   * findPrimaryInterfaceName is replaced by link.Attrs().Name
   * move functionalities related to netlink into netlink wrapper 

[WIP]: Unit tests
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
