### PR TITLE
Update AWS Calico charts version and add missed endpointslice

### DIFF
--- a/charts/aws-calico/Chart.yaml
+++ b/charts/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.10
+version: 0.3.11
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/config/master/calico-operator.yaml
+++ b/config/master/calico-operator.yaml
@@ -4942,14 +4942,6 @@ rules:
       - update
       - delete
       - watch
-  # EndpointSlices are used for Service-based network policy rule
-  # enforcement.
-  - apiGroups: ["discovery.k8s.io"]
-    resources:
-      - endpointslices
-    verbs:
-      - watch 
-      - list
   - apiGroups:
       - ""
     resources:

--- a/config/master/calico-operator.yaml
+++ b/config/master/calico-operator.yaml
@@ -4942,6 +4942,14 @@ rules:
       - update
       - delete
       - watch
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch 
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
We want to upgrade the aws-calico charts version to 0.3.11 to be synced with eks-charts.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup
**Which issue does this PR fix**:
aws-calico charts version and adding endpointslice into cluster role which was missed in config file.

**What does this PR do / Why do we need it**:

1. We will have a version parity between two repositories.
2. We need add endpointslice 

Tests done:
```
NAMESPACE         NAME                                       READY   STATUS    RESTARTS   AGE
calico-system     calico-kube-controllers-685b68c7c4-xkbds   1/1     Running   0          81s
calico-system     calico-node-42r8c                          1/1     Running   0          81s
calico-system     calico-node-4dv9m                          1/1     Running   0          80s
calico-system     calico-node-bcfvs                          1/1     Running   0          80s
calico-system     calico-node-rffdv                          1/1     Running   0          81s
calico-system     calico-node-t7rm5                          1/1     Running   0          81s
calico-system     calico-typha-6667d47744-5dwxn              1/1     Running   0          73s
calico-system     calico-typha-6667d47744-776jw              1/1     Running   0          73s
calico-system     calico-typha-6667d47744-d699c              1/1     Running   0          81s
kube-system       aws-node-2qblk                             1/1     Running   0          21h
kube-system       aws-node-9qqdk                             1/1     Running   0          21h
kube-system       aws-node-jgbqn                             1/1     Running   0          21h
kube-system       aws-node-kwrqg                             1/1     Running   0          21h
kube-system       aws-node-lhxtk                             1/1     Running   0          21h
kube-system       coredns-85d5b4454c-9mszt                   1/1     Running   0          21h
kube-system       coredns-85d5b4454c-jgwxw                   1/1     Running   0          21h
kube-system       kube-proxy-7rcks                           1/1     Running   0          21h
kube-system       kube-proxy-d7d9s                           1/1     Running   0          21h
kube-system       kube-proxy-jksrr                           1/1     Running   0          21h
kube-system       kube-proxy-llj4n                           1/1     Running   0          21h
kube-system       kube-proxy-mqsp5                           1/1     Running   0          21h
tigera-operator   tigera-operator-6fbb48778f-fss5h           1/1     Running   0          85s
```
```
kubectl get clusterrole tigera-operator -oyaml | grep -e "- discovery.k8s.io" -A5
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - watch
  - list
```
Star Policy Demo was tested and passed.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
yes
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
no
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
