### PR TITLE
Disable auto scale-in for the cluster autoscaler in perf tests

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 22 * * 3"  # every Wednesday
+    - cron: "0 16 * * 4"  # every Thursday
 
 permissions:
   contents: read

--- a/scripts/test/config/cluster-autoscaler-autodiscover.yml
+++ b/scripts/test/config/cluster-autoscaler-autodiscover.yml
@@ -156,6 +156,7 @@ spec:
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
+            - --scale-down-utilization-threshold=0
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled
           volumeMounts:
             - name: ssl-certs


### PR DESCRIPTION
- Disable auto scale-in as it led to longer execution times
  for 5000 pod test

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Disable auto scale-in of nodes as it led to longer execution times
  for 5000 pod test

**What does this PR do / Why do we need it**:
With auto scale-in, ASG capacity got lowered from initial value of 99 and re-scaling during 5000 pod takes longer time compared to previous test executions.
New config based on faq entry of https://github.com/kubernetes/autoscaler/blob/59f2eaa1d8fcb92bf7df97ec083fc02c6830205b/cluster-autoscaler/FAQ.md#how-can-i-prevent-cluster-autoscaler-from-scaling-down-non-empty-nodes


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No
**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
