### PR TITLE
Use IMDSv2 for cni e2e tests

### DIFF
--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -155,6 +155,10 @@ func CreateAndWaitTillSelfManagedNGReady(f *framework.Framework, properties Node
 			ParameterKey:   aws.String("KeyName"),
 			ParameterValue: aws.String(properties.KeyPairName),
 		},
+		{
+			ParameterKey:   aws.String("DisableIMDSv1"),
+			ParameterValue: aws.String("true"),
+		},
 	}
 
 	describeStackOutput, err := f.CloudServices.CloudFormation().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1728 

**What does this PR do / Why do we need it**:
It enforces usage for IMDSv2 for e2e test nodes

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran custom-networking, pod-eni and snat e2e tests and validated that all are passing 

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
