### PR TITLE
Fix flaky unit test of TestIPAMContext_filterUnmanagedENIs_disableMan…

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 22 * * 1"  # every Monday
+    - cron: "0 22 * * 2"  # every Tuesday
 
 permissions:
   contents: read

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1386,7 +1387,16 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 			c := &IPAMContext{
 				awsClient:                mockAWSUtils,
 				enableManageUntaggedMode: false}
-			mockAWSUtils.EXPECT().SetUnmanagedENIs(tt.unmanagedenis).AnyTimes()
+
+			mockAWSUtils.
+				EXPECT().
+				SetUnmanagedENIs(gomock.Any()).
+				Do(func(args []string) {
+					sort.Strings(tt.unmanagedenis)
+					sort.Strings(args)
+					assert.Equal(t, tt.unmanagedenis, args)
+				})
+
 			c.setUnmanagedENIs(tt.tagMap)
 
 			mockAWSUtils.EXPECT().IsUnmanagedENI(gomock.Any()).DoAndReturn(

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -69,7 +69,7 @@ function up-kops-cluster {
     KOPS_S3_BUCKET=kops-cni-test-eks-$AWS_ACCOUNT_ID
     echo "Using $KOPS_S3_BUCKET as kops state store"
     aws s3api create-bucket --bucket $KOPS_S3_BUCKET --region $AWS_DEFAULT_REGION --create-bucket-configuration LocationConstraint=$AWS_DEFAULT_REGION
-    kops_version=$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)
+    kops_version='v$K8S_VERSION'
     echo "Using kops version $kops_version"
     curl -LO https://github.com/kubernetes/kops/releases/download/$kops_version/kops-linux-amd64
     chmod +x kops-linux-amd64


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup
**Which issue does this PR fix**:

- 'TestIPAMContext_filterUnmanagedENIs' unit test relied on particular iteration order of the input map
  in order for the match to succeed.
- Changed it to capture the argument passed to the function, sort the
  slices and then check for equality.

**What does this PR do / Why do we need it**:

- `TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode` unit test relied on particular iteration order of the input map
  in order for the match to succeed.
- Changed it to capture the argument passed to the function, sort the
  slices and then check for equality.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1821

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Executed unit test which was modified and verified that it passed continually.

```
while true; do go clean -testcache; /usr/local/go/bin/go test -timeout 30s -run ^TestIPAMContext_nodeIPPoolTooLow$ github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd; done
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.016s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd     0.015s
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No
**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
