### PR TITLE
Upgrade kops version to 1.22.3

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 20 * * 3"  # every Wednesday
+    - cron: "0 18 * * 4"  # every Thursday
 
 permissions:
   contents: read

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -69,7 +69,7 @@ function up-kops-cluster {
     KOPS_S3_BUCKET=kops-cni-test-eks-$AWS_ACCOUNT_ID
     echo "Using $KOPS_S3_BUCKET as kops state store"
     aws s3api create-bucket --bucket $KOPS_S3_BUCKET --region $AWS_DEFAULT_REGION --create-bucket-configuration LocationConstraint=$AWS_DEFAULT_REGION
-    kops_version="v$K8S_VERSION"
+    kops_version="v1.22.3"
     echo "Using kops version $kops_version"
     curl -LO https://github.com/kubernetes/kops/releases/download/$kops_version/kops-linux-amd64
     chmod +x kops-linux-amd64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Upgrade kops version to 1.22.3 as the previous version encountered error of `Error: unknown flag: --admin` during export of kubeconfig.

**What does this PR do / Why do we need it**:
Upgrade kops version to 1.22.3 as the previous version encountered error of `Error: unknown flag: --admin` during export of kubeconfig.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1842

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
