### PR TITLE
Update README to highlight containerd.sock edge case with EKS AMI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,10 +620,10 @@ The mountPath should be changed to `/var/run/cri.sock` and hostPath should be po
 `/var/run/containerd/containerd.sock` for containerd. If using helm chart, the flag `--set cri.hostPath.path=/var/run/containerd/containerd.sock`
 can set the paths for you.
 
-*Note*: 
+*Note*:
 
-* When using other container runtime instead of dockershim, make sure also setting kubelet in instances.
-* If you are using EKS provided AMI, there is no need to containerd.sock to cri.sock, as EKS AMI [symlinks containerd.sock to dockershim.sock](https://github.com/awslabs/amazon-eks-ami/blob/2289937fe9fb3933d066b6ae72a4299b2624e154/files/bootstrap.sh#L470). In addition, if planning upgrade to containerd runtime while using EKS provided AMI, please follow the instructions in our documentation.
+* When using a different container runtime instead of dockershim in VPC CNI, make sure kubelet is also configured to use the same CRI.
+* If you want to enable containerd runtime with the support provided by Amazon AMI, please follow the instructions in our documentation, [Enable the containerd runtime bootstrap flag](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html#containerd-bootstrap)
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -620,7 +620,10 @@ The mountPath should be changed to `/var/run/cri.sock` and hostPath should be po
 `/var/run/containerd/containerd.sock` for containerd. If using helm chart, the flag `--set cri.hostPath.path=/var/run/containerd/containerd.sock`
 can set the paths for you.
 
-*Note*: When using other container runtime instead of dockershim, make sure also setting kubelet in instances.
+*Note*: 
+
+* When using other container runtime instead of dockershim, make sure also setting kubelet in instances.
+* If you are using EKS provided AMI, there is no need to containerd.sock to cri.sock, as EKS AMI [symlinks containerd.sock to dockershim.sock](https://github.com/awslabs/amazon-eks-ami/blob/2289937fe9fb3933d066b6ae72a4299b2624e154/files/bootstrap.sh#L470). In addition, if planning upgrade to containerd runtime while using EKS provided AMI, please follow the instructions in our documentation.
 
 ### Notes
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

Documention

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

Customer were using EKS AMI, and followed these instructions to point to containerd runtime. 
They also tried to upgrade, and ran into surprising issues. 

**What does this PR do / Why do we need it**:


* This clarifies, that while using EKS AMI, no need to point to containerd to cri.sock as AMI symlinks containerd.sock to dockershim.sock
* Also gives a link to upgrade documentation that customers can follow to upgrade customer to containerd runtime. As suggested by managed nodes group team.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
