### PR TITLE
add script for IPv6 Canary testing

### DIFF
--- a/scripts/lib/add-on.sh
+++ b/scripts/lib/add-on.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Helper script for performing operations on vpc-cni addons
+
+function load_addon_details() {
+  echo "loading $VPC_CNI_ADDON_NAME addon details"
+  DESCRIBE_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name $VPC_CNI_ADDON_NAME --kubernetes-version "$K8S_VERSION")
+
+  LATEST_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq '.addons[0].addonVersions[0].addonVersion' -r)
+  DEFAULT_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq -r '.addons[].addonVersions[] | select(.compatibilities[0].defaultVersion == true) | .addonVersion')
+}
+
+function wait_for_addon_status() {
+  local expected_status=$1
+  local retry_attempt=0
+  if [ "$expected_status" =  "DELETED" ]; then
+    while $(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION"); do
+      if [ $retry_attempt -ge 20 ]; then
+        echo "failed to delete addon, qutting after too many attempts"
+        exit 1
+      fi
+      echo "addon is still not deleted"
+      sleep 5
+      ((retry_attempt=retry_attempt+1))
+    done
+    echo "addon deleted"
+    return
+  fi
+
+  retry_attempt=0
+  while true
+  do
+    STATUS=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION" | jq -r '.addon.status')
+    if [ "$STATUS" = "$expected_status" ]; then
+      echo "addon status matches expected status"
+      return
+    fi
+    # We have seen the canary test get stuck, we don't know what causes this but most likely suspect is
+    # the addon update/delete attempts. So adding limited retries.
+    if [ $retry_attempt -ge 30 ]; then
+      echo "failed to get desired add-on status: $STATUS, qutting after too many attempts"
+      exit 1
+    fi
+    echo "addon status is not equal to $expected_status"
+    sleep 5
+    ((retry_attempt=retry_attempt+1))
+  done
+}
+
+function patch_aws_node_maxunavialable() {
+   # Patch the aws-node, so any update in aws-node happens parallely for faster overall test execution
+   kubectl patch ds -n kube-system aws-node -p '{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable": "100%"}}}}'
+}
+
+function install_add_on() {
+  local new_addon_version=$1
+
+  if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION"); then
+    local current_addon_version=$(echo "$DESCRIBE_ADDON" | jq '.addon.addonVersion' -r)
+    if [ "$new_addon_version" != "$current_addon_version" ]; then
+      echo "deleting the $current_addon_version to install $new_addon_version"
+      aws eks delete-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name "$VPC_CNI_ADDON_NAME" --region "$REGION"
+      wait_for_addon_status "DELETED"
+    else
+      echo "addon version $current_addon_version already installed"
+      patch_aws_node_maxunavialable
+      return
+    fi
+  fi
+
+  echo "installing addon $new_addon_version"
+  aws eks create-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --resolve-conflicts OVERWRITE --addon-version $new_addon_version --region "$REGION"
+  patch_aws_node_maxunavialable
+  wait_for_addon_status "ACTIVE"
+}

--- a/scripts/lib/canary.sh
+++ b/scripts/lib/canary.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Helper script used for running canary test for CNI IPv4 and IPv6
+
+SECONDS=0
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+INTEGRATION_TEST_DIR="$SCRIPT_DIR/../../test/integration-new"
+VPC_CNI_ADDON_NAME="vpc-cni"
+
+echo "Running Canary tests for amazon-vpc-cni-k8s with the following variables
+KUBE_CONFIG_PATH:  $KUBE_CONFIG_PATH
+CLUSTER_NAME: $CLUSTER_NAME
+REGION: $REGION
+ENDPOINT: $ENDPOINT"
+
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
+
+# Request timesout in China Regions with default proxy
+if [[ $REGION == "cn-north-1" || $REGION == "cn-northwest-1" ]]; then
+  go env -w GOPROXY=https://goproxy.cn,direct
+  go env -w GOSUMDB=sum.golang.google.cn
+fi

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+function load_cluster_details() {
+  echo "loading cluster details $CLUSTER_NAME"
+  DESCRIBE_CLUSTER_OP=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" $ENDPOINT_FLAG)
+  VPC_ID=$(echo "$DESCRIBE_CLUSTER_OP" | jq -r '.cluster.resourcesVpcConfig.vpcId')
+  K8S_VERSION=$(echo "$DESCRIBE_CLUSTER_OP" | jq .cluster.version -r)
+}
+
 function down-test-cluster() {
     if [[ -n "${CIRCLE_JOB:-}" || -n "${DISABLE_PROMPT:-}" ]]; then
         $TESTER_PATH eks delete cluster --enable-prompt=false --path $CLUSTER_CONFIG || (echo "failed!" && exit 1)

--- a/scripts/run-canary-test.sh
+++ b/scripts/run-canary-test.sh
@@ -5,105 +5,9 @@
 
 set -e
 
-SECONDS=0
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration-new"
-VPC_CNI_ADDON_NAME="vpc-cni"
-
-echo "Running Canary tests for amazon-vpc-cni-k8s with the following variables
-KUBE_CONFIG_PATH:  $KUBE_CONFIG_PATH
-CLUSTER_NAME: $CLUSTER_NAME
-REGION: $REGION
-ENDPOINT: $ENDPOINT"
-
-if [[ -n "${ENDPOINT}" ]]; then
-  ENDPOINT_FLAG="--endpoint $ENDPOINT"
-fi
-
-# Request timesout in China Regions with default proxy
-if [[ $REGION == "cn-north-1" || $REGION == "cn-northwest-1" ]]; then
-  go env -w GOPROXY=https://goproxy.cn,direct
-  go env -w GOSUMDB=sum.golang.google.cn
-fi
-
-function load_cluster_details() {
-  echo "loading cluster details $CLUSTER_NAME"
-  DESCRIBE_CLUSTER_OP=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" $ENDPOINT_FLAG)
-  VPC_ID=$(echo "$DESCRIBE_CLUSTER_OP" | jq -r '.cluster.resourcesVpcConfig.vpcId')
-  K8S_VERSION=$(echo "$DESCRIBE_CLUSTER_OP" | jq .cluster.version -r)
-}
-
-function load_addon_details() {
-  echo "loading $VPC_CNI_ADDON_NAME addon details"
-  DESCRIBE_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name $VPC_CNI_ADDON_NAME --kubernetes-version "$K8S_VERSION")
-
-  LATEST_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq '.addons[0].addonVersions[0].addonVersion' -r)
-  DEFAULT_ADDON_VERSION=$(echo "$DESCRIBE_ADDON_VERSIONS" | jq -r '.addons[].addonVersions[] | select(.compatibilities[0].defaultVersion == true) | .addonVersion')
-}
-
-function wait_for_addon_status() {
-  local expected_status=$1
-  local retry_attempt=0
-  if [ "$expected_status" =  "DELETED" ]; then
-    while $(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION"); do
-      if [ $retry_attempt -ge 20 ]; then
-        echo "failed to delete addon, qutting after too many attempts"
-        exit 1
-      fi
-      echo "addon is still not deleted"
-      sleep 5
-      ((retry_attempt=retry_attempt+1))
-    done
-    echo "addon deleted"
-    return
-  fi
-
-  retry_attempt=0
-  while true
-  do
-    STATUS=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION" | jq -r '.addon.status')
-    if [ "$STATUS" = "$expected_status" ]; then
-      echo "addon status matches expected status"
-      return
-    fi
-    # We have seen the canary test get stuck, we don't know what causes this but most likely suspect is
-    # the addon update/delete attempts. So adding limited retries.
-    if [ $retry_attempt -ge 30 ]; then
-      echo "failed to get desired add-on status: $STATUS, qutting after too many attempts"
-      exit 1
-    fi
-    echo "addon status is not equal to $expected_status"
-    sleep 5
-    ((retry_attempt=retry_attempt+1))
-  done
-}
-
-function install_add_on() {
-  local new_addon_version=$1
-
-  if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region "$REGION"); then
-    local current_addon_version=$(echo "$DESCRIBE_ADDON" | jq '.addon.addonVersion' -r)
-    if [ "$new_addon_version" != "$current_addon_version" ]; then
-      echo "deleting the $current_addon_version to install $new_addon_version"
-      aws eks delete-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name "$VPC_CNI_ADDON_NAME" --region "$REGION"
-      wait_for_addon_status "DELETED"
-    else
-      echo "addon version $current_addon_version already installed"
-      patch_aws_node_maxunavialable
-      return
-    fi
-  fi
-
-  echo "installing addon $new_addon_version"
-  aws eks create-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --resolve-conflicts OVERWRITE --addon-version $new_addon_version --region "$REGION"
-  patch_aws_node_maxunavialable
-  wait_for_addon_status "ACTIVE"
-}
-
-function patch_aws_node_maxunavialable() {
-   # Patch the aws-node, so any update in aws-node happens parallely for faster overall test execution
-   kubectl patch ds -n kube-system aws-node -p '{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable": "100%"}}}}'
-}
+source lib/add-on.sh
+source lib/cluster.sh
+source lib/canary.sh
 
 function run_ginkgo_test() {
   local focus=$1
@@ -136,6 +40,5 @@ load_addon_details
 echo "Running Canary tests on the latest addon version"
 install_add_on "$LATEST_ADDON_VERSION"
 run_ginkgo_test "CANARY"
-
 
 echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/scripts/run-ipv6-canary-test.sh
+++ b/scripts/run-ipv6-canary-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# The script runs amazon-vpc-cni Canary tests on the default
+# addon version and then runs smoke test on the latest addon version.
+
+set -e
+
+source lib/add-on.sh
+source lib/cluster.sh
+source lib/canary.sh
+
+function run_ginkgo_test() {
+  local focus=$1
+  echo "Running ginkgo tests with focus: $focus"
+  (cd "$INTEGRATION_TEST_DIR/ipv6" && CGO_ENABLED=0 ginkgo --focus="$focus" -v --timeout 15m --failOnPending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux")
+}
+
+load_cluster_details
+load_addon_details
+
+echo "Running IPv6 Canary tests on the latest addon version"
+
+install_add_on "$LATEST_ADDON_VERSION"
+run_ginkgo_test "CANARY"
+
+echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/test/integration-new/ipv6/ipv6_host_networking_test.go
+++ b/test/integration-new/ipv6/ipv6_host_networking_test.go
@@ -47,7 +47,7 @@ const (
 	DEFAULT_VETH_PREFIX        = "eni"
 )
 
-var _ = Describe("test ipv6 host netns setup", func() {
+var _ = Describe("[CANARY] test ipv6 host netns setup", func() {
 	var err error
 	var podLabelKey = "app"
 	var podLabelVal = "host-networking-test"

--- a/test/integration-new/ipv6/ipv6_service_connectivity_test.go
+++ b/test/integration-new/ipv6/ipv6_service_connectivity_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Verifies connectivity to deployment behind different service types
-var _ = Describe("test service connectivity", func() {
+var _ = Describe("[CANARY] test service connectivity", func() {
 	var err error
 
 	// Deployment running the http server

--- a/test/integration-new/ipv6/pod_traffic_test_v6_PD_enabled.go
+++ b/test/integration-new/ipv6/pod_traffic_test_v6_PD_enabled.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Test pod networking with prefix delegation enabled", func() {
+var _ = Describe("[CANARY] Test pod networking with prefix delegation enabled", func() {
 	var (
 		// The Pod labels for client and server in order to retrieve the
 		// client and server Pods belonging to a Deployment/Jobs


### PR DESCRIPTION
**What type of PR is this?**
Testing

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Add IPv6 Canary Script. 

I think we should migrate to non shell script way for writing these canary/integration testing utilities. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
