### PR TITLE
Disable LB addon tests

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -37,7 +37,7 @@ jobs:
           MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
           RUN_CONFORMANCE: true
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          RUN_TESTER_LB_ADDONS: true
+          RUN_TESTER_LB_ADDONS: false 
           S3_BUCKET_CREATE: false
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
         run: |

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -16,7 +16,7 @@ ensure_ecr_repo() {
 }
 
 ensure_aws_k8s_tester() {
-    TESTER_RELEASE=${TESTER_RELEASE:-v1.6.5}
+    TESTER_RELEASE=${TESTER_RELEASE:-v1.6.6}
     TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/$TESTER_RELEASE/aws-k8s-tester-$TESTER_RELEASE-$OS-$ARCH
 
     # Download aws-k8s-tester if not yet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Fix nightly E2E
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
With #1888 downgrading won't work since arm instances aren't supported with k8s tester 1.6.5 version. 

**What does this PR do / Why do we need it**:
Instead disabling LB addons test.

This a temp change and eventually we will be removing k8s tester completely and use eksctl.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
No

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
