### PR TITLE
Calico integration Tests

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -84,6 +84,7 @@ jobs:
           ROLE_ARN: ${{ secrets.ROLE_ARN }}
           MNG_ROLE_ARN: ${{ secrets.MNG_ROLE_ARN }}
           RUN_CALICO_TEST: true
+          RUN_LATEST_CALICO_VERSION: true
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           RUN_TESTER_LB_ADDONS: true
           S3_BUCKET_CREATE: false

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -242,6 +242,9 @@ TEST_PASS=$?
 popd
 CURRENT_IMAGE_INTEGRATION_DURATION=$((SECONDS - START))
 echo "TIMELINE: Current image integration tests took $CURRENT_IMAGE_INTEGRATION_DURATION seconds."
+if [[ $TEST_PASS -eq 0 ]]; then
+  emit_cloudwatch_metric "integration_test_status" "1"
+fi
 
 if [[ $RUN_CALICO_TEST == true ]]; then
   echo "Starting Helm installing Tigera operator and running Calico STAR tests"
@@ -268,26 +271,10 @@ if [[ $RUN_CALICO_TEST == true ]]; then
       echo "Waiting 15 minutes for new nodes being ready"
       sleep 900
   fi
+
+  emit_cloudwatch_metric "calico_test_status" "1"
 fi
 
-<<<<<<< HEAD
-echo "*******************************************************************************"
-echo "Running integration tests on current image:"
-echo ""
-START=$SECONDS
-pushd ./test/integration
-GO111MODULE=on go test -v -timeout 0 ./... --kubeconfig=$KUBECONFIG --ginkgo.focus="\[cni-integration\]" --ginkgo.skip="\[Disruptive\]" \
-    --assets=./assets
-TEST_PASS=$?
-popd
-CURRENT_IMAGE_INTEGRATION_DURATION=$((SECONDS - START))
-echo "TIMELINE: Current image integration tests took $CURRENT_IMAGE_INTEGRATION_DURATION seconds."
-if [[ $TEST_PASS -eq 0 ]]; then
-  emit_cloudwatch_metric "integration_test_status" "1"
-fi
-
-=======
->>>>>>> we should run new image CNI test and then calico tests
 if [[ $TEST_PASS -eq 0 && "$RUN_CONFORMANCE" == true ]]; then
   echo "Running conformance tests against cluster."
   START=$SECONDS

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -238,8 +238,12 @@ if [[ $RUN_CALICO_TEST == true ]]; then
   # we can automatically use latest version in Calico repo, or use the known highest version (currently v3.22.0)
   calico_version=$CALICO_VERSION
   if [[ $RUN_LATEST_CALICO_VERSION == true ]]; then
-    version_tag=$(curl -i https://api.github.com/repos/projectcalico/calico/releases/latest | grep "tag_name")
-    calico_version=$(echo $version_tag | cut -d ":" -f 2 | cut -d '"' -f 2 )
+    version_tag=$(curl -i https://api.github.com/repos/projectcalico/calico/releases/latest | grep "tag_name") || true
+    if [[ -n $version_tag ]]; then
+      calico_version=$(echo $version_tag | cut -d ":" -f 2 | cut -d '"' -f 2 )
+    else
+      echo "Getting Calico latest version failed, will fall back to default/set version $calico_version instead"
+    fi
   fi
   echo "Using Calico version $calico_version to test"
   ginkgo -v e2e/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version

--- a/test/e2e/calico/calico_suite_test.go
+++ b/test/e2e/calico/calico_suite_test.go
@@ -13,19 +13,22 @@ import (
 )
 
 var (
-	f               *framework.Framework
-	err             error
-	uiNamespace     = "management-ui"
-	clientNamespace = "client"
-	starsNamespace  = "stars"
-	uiLabel         = map[string]string{"role": "management-ui"}
-	clientLabel     = map[string]string{"role": "client"}
-	feLabel         = map[string]string{"role": "frontend"}
-	beLabel         = map[string]string{"role": "backend"}
-	uiPod           v1.Pod
-	clientPod       v1.Pod
-	fePod           v1.Pod
-	bePod           v1.Pod
+	f                *framework.Framework
+	err              error
+	uiNamespace      = "management-ui"
+	clientNamespace  = "client"
+	starsNamespace   = "stars"
+	uiLabel          = map[string]string{"role": "management-ui"}
+	clientLabel      = map[string]string{"role": "client"}
+	feLabel          = map[string]string{"role": "frontend"}
+	beLabel          = map[string]string{"role": "backend"}
+	nodeArchKey      = "kubernetes.io/arch"
+	nodeArchARMValue = "arm64"
+	nodeArchAMDValue = "amd64"
+	uiPod            v1.Pod
+	clientPod        v1.Pod
+	fePod            v1.Pod
+	bePod            v1.Pod
 )
 
 func TestCalicoPoliciesWithVPCCNI(t *testing.T) {
@@ -42,7 +45,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Patching ARM64 node unschedulable")
-	err = updateNodesSchedulability("beta.kubernetes.io/arch", "arm64", true)
+	err = updateNodesSchedulability(nodeArchKey, nodeArchARMValue, true)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("installing Calico Start Policy Tests Resources")
@@ -65,7 +68,7 @@ var _ = BeforeSuite(func() {
 		Container(uiContainer).
 		Replicas(1).
 		PodLabel("role", "management-ui").
-		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		NodeSelector(nodeArchKey, nodeArchAMDValue).
 		Labels(map[string]string{"role": "management-ui"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(uiDeployment, utils.DefaultDeploymentReadyTimeout)
@@ -84,7 +87,7 @@ var _ = BeforeSuite(func() {
 		Container(clientContainer).
 		Replicas(1).
 		PodLabel("role", "client").
-		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		NodeSelector(nodeArchKey, nodeArchAMDValue).
 		Labels(map[string]string{"role": "client"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(clientDeployment, utils.DefaultDeploymentReadyTimeout)
@@ -107,7 +110,7 @@ var _ = BeforeSuite(func() {
 		Container(feContainer).
 		Replicas(1).
 		PodLabel("role", "frontend").
-		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		NodeSelector(nodeArchKey, nodeArchAMDValue).
 		Labels(map[string]string{"role": "frontend"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(feDeployment, utils.DefaultDeploymentReadyTimeout)
@@ -130,7 +133,7 @@ var _ = BeforeSuite(func() {
 		Container(beContainer).
 		Replicas(1).
 		PodLabel("role", "backend").
-		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		NodeSelector(nodeArchKey, nodeArchAMDValue).
 		Labels(map[string]string{"role": "backend"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(beDeployment, utils.DefaultDeploymentReadyTimeout)
@@ -216,7 +219,7 @@ var _ = AfterSuite(func() {
 	f.InstallationManager.UninstallTigeraOperator()
 
 	By("Restore ARM64 Nodes Schedulability")
-	updateNodesSchedulability("beta.kubernetes.io/arch", "arm64", false)
+	updateNodesSchedulability(nodeArchKey, nodeArchARMValue, false)
 })
 
 func installNetcatToolInContainer(name string, namespace string) error {

--- a/test/e2e/calico/calico_suite_test.go
+++ b/test/e2e/calico/calico_suite_test.go
@@ -54,10 +54,14 @@ var _ = BeforeSuite(func() {
 		ImagePullPolicy(v1.PullAlways).
 		Port(v1.ContainerPort{ContainerPort: 9001}).
 		Build()
-	uiDeployment := manifest.NewCalicoStarDeploymentBuilder(uiNamespace, "management-ui", map[string]string{"role": "management-ui"}).
+	uiDeployment := manifest.NewCalicoStarDeploymentBuilder().
+		Namespace(uiNamespace).
+		Name("management-ui").
 		Container(uiContainer).
 		Replicas(1).
 		PodLabel("role", "management-ui").
+		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		Labels(map[string]string{"role": "management-ui"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(uiDeployment, utils.DefaultDeploymentReadyTimeout)
 	Expect(err).ToNot(HaveOccurred())
@@ -69,10 +73,14 @@ var _ = BeforeSuite(func() {
 		Command([]string{"probe", "--urls=http://frontend.stars:80/status,http://backend.stars:6379/status"}).
 		Port(v1.ContainerPort{ContainerPort: 9000}).
 		Build()
-	clientDeployment := manifest.NewCalicoStarDeploymentBuilder(clientNamespace, "client", map[string]string{"role": "client"}).
+	clientDeployment := manifest.NewCalicoStarDeploymentBuilder().
+		Namespace(clientNamespace).
+		Name("client").
 		Container(clientContainer).
 		Replicas(1).
 		PodLabel("role", "client").
+		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		Labels(map[string]string{"role": "client"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(clientDeployment, utils.DefaultDeploymentReadyTimeout)
 	Expect(err).ToNot(HaveOccurred())
@@ -88,10 +96,14 @@ var _ = BeforeSuite(func() {
 		}).
 		Port(v1.ContainerPort{ContainerPort: 80}).
 		Build()
-	feDeployment := manifest.NewCalicoStarDeploymentBuilder(starsNamespace, "frontend", map[string]string{"role": "frontend"}).
+	feDeployment := manifest.NewCalicoStarDeploymentBuilder().
+		Namespace(starsNamespace).
+		Name("frontend").
 		Container(feContainer).
 		Replicas(1).
 		PodLabel("role", "frontend").
+		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		Labels(map[string]string{"role": "frontend"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(feDeployment, utils.DefaultDeploymentReadyTimeout)
 	Expect(err).ToNot(HaveOccurred())
@@ -107,10 +119,14 @@ var _ = BeforeSuite(func() {
 		}).
 		Port(v1.ContainerPort{ContainerPort: 6379}).
 		Build()
-	beDeployment := manifest.NewCalicoStarDeploymentBuilder(starsNamespace, "backend", map[string]string{"role": "backend"}).
+	beDeployment := manifest.NewCalicoStarDeploymentBuilder().
+		Namespace(starsNamespace).
+		Name("backend").
 		Container(beContainer).
 		Replicas(1).
 		PodLabel("role", "backend").
+		NodeSelector("beta.kubernetes.io/arch", "amd64").
+		Labels(map[string]string{"role": "backend"}).
 		Build()
 	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(beDeployment, utils.DefaultDeploymentReadyTimeout)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/calico/calico_suite_test.go
+++ b/test/e2e/calico/calico_suite_test.go
@@ -1,0 +1,228 @@
+package calico
+
+import (
+	"context"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+var (
+	f               *framework.Framework
+	err             error
+	uiNamespace     = "management-ui"
+	clientNamespace = "client"
+	starsNamespace  = "stars"
+	uiLabel         = map[string]string{"role": "management-ui"}
+	clientLabel     = map[string]string{"role": "client"}
+	feLabel         = map[string]string{"role": "frontend"}
+	beLabel         = map[string]string{"role": "backend"}
+	uiPod           v1.Pod
+	clientPod       v1.Pod
+	fePod           v1.Pod
+	bePod           v1.Pod
+)
+
+func TestCalicoPoliciesWithVPCCNI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Calico with VPC CNI e2e Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	f = framework.New(framework.GlobalOptions)
+	By("installing Calico operator")
+
+	tigeraVersion := f.Options.CalicoVersion
+	err := f.InstallationManager.InstallTigeraOperator(tigeraVersion)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("installing Calico Start Policy Tests Resources")
+	err = f.K8sResourceManagers.NamespaceManager().CreateNamespaceWithLabels(uiNamespace, map[string]string{"role": "management-ui"})
+	Expect(err).ToNot(HaveOccurred())
+	err = f.K8sResourceManagers.NamespaceManager().CreateNamespaceWithLabels(clientNamespace, map[string]string{"role": "client"})
+	Expect(err).ToNot(HaveOccurred())
+	err = f.K8sResourceManagers.NamespaceManager().CreateNamespace(starsNamespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	uiContainer := manifest.NewBaseContainer().
+		Name("management-ui").
+		Image("calico/star-collect:v0.1.0").
+		ImagePullPolicy(v1.PullAlways).
+		Port(v1.ContainerPort{ContainerPort: 9001}).
+		Build()
+	uiDeployment := manifest.NewCalicoStarDeploymentBuilder(uiNamespace, "management-ui", map[string]string{"role": "management-ui"}).
+		Container(uiContainer).
+		Replicas(1).
+		PodLabel("role", "management-ui").
+		Build()
+	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(uiDeployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	clientContainer := manifest.NewBaseContainer().
+		Name("client").
+		Image("calico/star-probe:v0.1.0").
+		ImagePullPolicy(v1.PullAlways).
+		Command([]string{"probe", "--urls=http://frontend.stars:80/status,http://backend.stars:6379/status"}).
+		Port(v1.ContainerPort{ContainerPort: 9000}).
+		Build()
+	clientDeployment := manifest.NewCalicoStarDeploymentBuilder(clientNamespace, "client", map[string]string{"role": "client"}).
+		Container(clientContainer).
+		Replicas(1).
+		PodLabel("role", "client").
+		Build()
+	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(clientDeployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	feContainer := manifest.NewBaseContainer().
+		Name("frontend").
+		Image("calico/star-probe:v0.1.0").
+		ImagePullPolicy(v1.PullAlways).
+		Command([]string{
+			"probe",
+			"--http-port=80",
+			"--urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status",
+		}).
+		Port(v1.ContainerPort{ContainerPort: 80}).
+		Build()
+	feDeployment := manifest.NewCalicoStarDeploymentBuilder(starsNamespace, "frontend", map[string]string{"role": "frontend"}).
+		Container(feContainer).
+		Replicas(1).
+		PodLabel("role", "frontend").
+		Build()
+	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(feDeployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	beContainer := manifest.NewBaseContainer().
+		Name("backend").
+		Image("calico/star-probe:v0.1.0").
+		ImagePullPolicy(v1.PullAlways).
+		Command([]string{
+			"probe",
+			"--http-port=6379",
+			"--urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status",
+		}).
+		Port(v1.ContainerPort{ContainerPort: 6379}).
+		Build()
+	beDeployment := manifest.NewCalicoStarDeploymentBuilder(starsNamespace, "backend", map[string]string{"role": "backend"}).
+		Container(beContainer).
+		Replicas(1).
+		PodLabel("role", "backend").
+		Build()
+	_, err = f.K8sResourceManagers.DeploymentManager().CreateAndWaitTillDeploymentIsReady(beDeployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	ui := manifest.NewHTTPService().
+		Name("management-ui").
+		Namespace("management-ui").
+		ServiceType(v1.ServiceTypeNodePort).
+		NodePort(30002).
+		Port(9001).
+		Selector("role", "management-ui").
+		Build()
+	_, err = f.K8sResourceManagers.ServiceManager().CreateService(context.Background(), ui)
+	Expect(err).NotTo(HaveOccurred())
+
+	client := manifest.NewHTTPService().
+		Name("client").
+		Namespace("client").
+		Port(9000).
+		Selector("role", "client").
+		Build()
+	_, err = f.K8sResourceManagers.ServiceManager().CreateService(context.Background(), client)
+	Expect(err).NotTo(HaveOccurred())
+
+	frontend := manifest.NewHTTPService().
+		Name("frontend").
+		Namespace("stars").
+		Port(80).
+		Selector("role", "frontend").
+		Build()
+	_, err = f.K8sResourceManagers.ServiceManager().CreateService(context.Background(), frontend)
+	Expect(err).NotTo(HaveOccurred())
+
+	backend := manifest.NewHTTPService().
+		Name("backend").
+		Namespace("stars").
+		Port(6379).
+		Selector("role", "backend").
+		Build()
+	_, err = f.K8sResourceManagers.ServiceManager().CreateService(context.Background(), backend)
+	Expect(err).NotTo(HaveOccurred())
+
+	uiPods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelectorMap(uiLabel)
+	Expect(err).ToNot(HaveOccurred())
+	clientPods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelectorMap(clientLabel)
+	Expect(err).ToNot(HaveOccurred())
+	fePods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelectorMap(feLabel)
+	Expect(err).NotTo(HaveOccurred())
+	bePods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelectorMap(beLabel)
+	Expect(err).NotTo(HaveOccurred())
+	uiPod = uiPods.Items[0]
+	clientPod = clientPods.Items[0]
+	fePod = fePods.Items[0]
+	bePod = bePods.Items[0]
+
+	By("Installing netcat in all STAR containers for connectivity tests")
+	err = installNetcatToolInContainer(uiPod.Name, uiPod.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+	err = installNetcatToolInContainer(clientPod.Name, clientPod.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+	err = installNetcatToolInContainer(fePod.Name, fePod.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+	err = installNetcatToolInContainer(bePod.Name, bePod.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	assignPodsMetadataForTests()
+})
+
+var _ = AfterSuite(func() {
+	By("Remove All Star Resources")
+	f.K8sResourceManagers.NamespaceManager().DeleteAndWaitTillNamespaceDeleted(uiNamespace)
+	f.K8sResourceManagers.NamespaceManager().DeleteAndWaitTillNamespaceDeleted(clientNamespace)
+	f.K8sResourceManagers.NamespaceManager().DeleteAndWaitTillNamespaceDeleted(starsNamespace)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyDenyStars)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyDenyClient)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyAllowUIStars)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyAllowUIClient)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyAllowFE)
+	f.K8sResourceManagers.NetworkPolicyManager().DeleteNetworkPolicy(&networkPolicyAllowClient)
+
+	By("Helm Uninstall Calico Installation")
+	f.InstallationManager.UninstallTigeraOperator()
+})
+
+func installNetcatToolInContainer(name string, namespace string) error {
+	_, _, err := f.K8sResourceManagers.PodManager().PodExec(
+		namespace,
+		name,
+		[]string{"apt-get", "update"})
+
+	_, _, err = f.K8sResourceManagers.PodManager().PodExec(
+		namespace,
+		name,
+		[]string{"apt-get", "install", "netcat", "-y"})
+	return err
+}
+
+func assignPodsMetadataForTests() {
+	uiPodName = uiPod.Name
+	clientPodName = clientPod.Name
+	fePodName = fePod.Name
+	bePodName = bePod.Name
+
+	uiPodNamespace = uiPod.Namespace
+	clientPodNamespace = clientPod.Namespace
+	fePodNamespace = fePod.Namespace
+	bePodNamespace = bePod.Namespace
+
+	clientIP = clientPod.Status.PodIP
+	clientPort = int(clientPod.Spec.Containers[0].Ports[0].ContainerPort)
+	feIP = fePod.Status.PodIP
+	fePort = int(fePod.Spec.Containers[0].Ports[0].ContainerPort)
+	beIP = bePod.Status.PodIP
+	bePort = int(bePod.Spec.Containers[0].Ports[0].ContainerPort)
+}

--- a/test/e2e/calico/calico_test.go
+++ b/test/e2e/calico/calico_test.go
@@ -1,13 +1,14 @@
 package calico
 
 import (
+	"strconv"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strconv"
-	"time"
 )
 
 var (

--- a/test/e2e/calico/calico_test.go
+++ b/test/e2e/calico/calico_test.go
@@ -1,0 +1,365 @@
+package calico
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"strconv"
+	"time"
+)
+
+var (
+	retries       = 3
+	interval      = 3
+	testTimeOut   = 15.0
+	netcatTimeOut = "1"
+
+	uiPodName     string
+	clientPodName string
+	fePodName     string
+	bePodName     string
+
+	uiPodNamespace     string
+	clientPodNamespace string
+	fePodNamespace     string
+	bePodNamespace     string
+
+	clientIP   string
+	clientPort int
+	feIP       string
+	fePort     int
+	beIP       string
+	bePort     int
+
+	networkPolicyAllowFE = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-policy",
+			Namespace: starsNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "backend"}},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"role": "frontend"},
+							},
+						},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{IntVal: 6379},
+						},
+					},
+				},
+			},
+		},
+	}
+	networkPolicyAllowClient = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend-policy",
+			Namespace: starsNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "frontend"}},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"role": "client"},
+							},
+						},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{IntVal: 80},
+						},
+					},
+				},
+			},
+		},
+	}
+	networkPolicyDenyStars = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-deny",
+			Namespace: starsNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			},
+		},
+	}
+	networkPolicyDenyClient = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-deny",
+			Namespace: clientNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			},
+		},
+	}
+	networkPolicyAllowUIStars = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-ui",
+			Namespace: starsNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"role": "management-ui"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	networkPolicyAllowUIClient = netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-ui",
+			Namespace: clientNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"role": "management-ui"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+var _ = Describe("Calico Star Network Policy Tests", func() {
+	Context("Test All Allowed Network Policy", func() {
+		It("Allow Mode: Test UI connecting to client pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, clientIP, strconv.Itoa(clientPort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test UI connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test UI connecting to backend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test Client connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				clientPodNamespace,
+				clientPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test frontend connecting to backend pod", func() {
+			err := retryPodExecTest(
+				fePodNamespace,
+				fePodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+	})
+
+	Context("Test All Denied Network Policy", func() {
+		It("Applying ALL DENY network policy to the cluster", func() {
+			err := f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyDenyStars)
+			Expect(err).NotTo(HaveOccurred())
+			err = f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyDenyClient)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test UI connecting to client pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, clientIP, strconv.Itoa(clientPort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test UI connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test UI connecting to backend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test client connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				clientPodNamespace,
+				clientPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test frontend connecting to backend pod", func() {
+			err := retryPodExecTest(
+				fePodNamespace,
+				fePodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+	})
+
+	Context("Test allowing UI connecting to client", func() {
+		It("Applying network policy to allow UI connecting to client", func() {
+
+			err := f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyAllowUIStars)
+			Expect(err).NotTo(HaveOccurred())
+			err = f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyAllowUIClient)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+		It("Allow Mode: Test UI connecting to client pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, clientIP, strconv.Itoa(clientPort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test UI connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test UI connecting to backend pod", func() {
+			err := retryPodExecTest(
+				uiPodNamespace,
+				uiPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Deny Mode: Test client connecting to frontend pod", func() {
+			err := retryPodExecTest(
+				clientPodNamespace,
+				clientPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+	})
+
+	Context("Allow traffic from frontend to backend", func() {
+		It("Deny Mode: Test frontend shouldn't connect to backend pod before updating policy", func() {
+			err := retryPodExecTest(
+				fePodNamespace,
+				fePodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Applying network policy to allow frontend connecting to backend", func() {
+			err := f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyAllowFE)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Allow Mode: Test frontend should connect to backend pod after updating policy", func() {
+			err := retryPodExecTest(
+				fePodNamespace,
+				fePodName,
+				[]string{"nc", "-zv", beIP, strconv.Itoa(bePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+	})
+
+	Context("Allow traffic from client to frontend", func() {
+		It("Deny Mode: Test client shouldn't connect to frontend pod before updating policy", func() {
+			err := retryPodExecTest(
+				clientPodNamespace,
+				clientPodName,
+				[]string{"nc", "-zv", "-w", netcatTimeOut, feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).To(HaveOccurred())
+		}, testTimeOut)
+
+		It("Applying network policy to allow client connecting to frontend", func() {
+			err := f.K8sResourceManagers.NetworkPolicyManager().CreateNetworkPolicy(&networkPolicyAllowClient)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+
+		It("Allow Mode: Test client should connect to frontend pod after updating policy", func() {
+			err := retryPodExecTest(
+				clientPodNamespace,
+				clientPodName,
+				[]string{"nc", "-zv", feIP, strconv.Itoa(fePort)},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, testTimeOut)
+	})
+})
+
+func retryPodExecTest(namespace string, name string, cmd []string) error {
+	count := retries
+	for {
+		_, _, err := f.K8sResourceManagers.PodManager().PodExec(namespace, name, cmd)
+		if err == nil || count == 0 {
+			return err
+		}
+		count--
+		wait := interval * (retries - count)
+		time.Sleep(time.Second * time.Duration(wait))
+	}
+}

--- a/test/framework/controller/constant.go
+++ b/test/framework/controller/constant.go
@@ -17,4 +17,7 @@ const (
 	CNIMetricsHelperChartDir    = "/test/helm/charts/cni-metrics-helper"
 	CNIMetricsHelperReleaseName = "cni-metrics-helper"
 	CNIMetricHelperNamespace    = "kube-system"
+	TigeraOperatorReleaseName   = "calico"
+	TigeraOperatorHelmRepo      = "https://docs.projectcalico.org/charts"
+	TigeraOperatorHelmCharts    = "projectcalico/tigera-operator"
 )

--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -24,6 +24,9 @@ import (
 type InstallationManager interface {
 	InstallCNIMetricsHelper(image string, tag string) error
 	UnInstallCNIMetricsHelper() error
+	InstallTigeraOperator(version string) error
+	UninstallTigeraOperator() error
+	//AddAndUpdateRepository(entry repo.Entry)
 }
 
 func NewDefaultInstallationManager(manager helm.ReleaseManager) InstallationManager {
@@ -52,5 +55,16 @@ func (d *defaultInstallationManager) InstallCNIMetricsHelper(image string, tag s
 
 func (d *defaultInstallationManager) UnInstallCNIMetricsHelper() error {
 	_, err := d.releaseManager.UninstallRelease(CNIMetricHelperNamespace, CNIMetricsHelperReleaseName)
+	return err
+}
+
+func (d *defaultInstallationManager) InstallTigeraOperator(version string) error {
+	// helm SDK doesn't allow empty namepace during creation, we have to use "default" as placeholder
+	_, err := d.releaseManager.InstallPackagedRelease(TigeraOperatorHelmCharts, TigeraOperatorReleaseName, version, "default", map[string]interface{}{})
+	return err
+}
+
+func (d *defaultInstallationManager) UninstallTigeraOperator() error {
+	_, err := d.releaseManager.UninstallRelease("default", TigeraOperatorReleaseName)
 	return err
 }

--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -26,7 +26,6 @@ type InstallationManager interface {
 	UnInstallCNIMetricsHelper() error
 	InstallTigeraOperator(version string) error
 	UninstallTigeraOperator() error
-	//AddAndUpdateRepository(entry repo.Entry)
 }
 
 func NewDefaultInstallationManager(manager helm.ReleaseManager) InstallationManager {

--- a/test/framework/helm/release_manager.go
+++ b/test/framework/helm/release_manager.go
@@ -15,12 +15,14 @@ package helm
 
 import (
 	"fmt"
-
 	"github.com/prometheus/common/log"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/helmpath"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -28,6 +30,8 @@ type ReleaseManager interface {
 	InstallUnPackagedRelease(chart string, releaseName string, namespace string,
 		values map[string]interface{}) (*release.Release, error)
 	UninstallRelease(namespace string, releaseName string) (*release.UninstallReleaseResponse, error)
+	InstallPackagedRelease(chart string, releaseName string, version string, namespace string,
+		values map[string]interface{}) (*release.Release, error)
 }
 
 type defaultReleaseManager struct {
@@ -47,6 +51,37 @@ func (d *defaultReleaseManager) InstallUnPackagedRelease(chart string, releaseNa
 	installAction.Wait = true
 	installAction.ReleaseName = releaseName
 
+	return installCharts(installAction, chart, values)
+}
+
+func (d *defaultReleaseManager) InstallPackagedRelease(chart string, releaseName string, version string, namespace string,
+	values map[string]interface{}) (*release.Release, error) {
+	entry := &repo.Entry{
+		Name:                  "projectcalico",
+		URL:                   "https://projectcalico.docs.tigera.io/charts",
+		InsecureSkipTLSverify: true,
+	}
+	setting := cli.New()
+	r, err := repo.NewChartRepository(entry, getter.All(setting))
+	_, err = r.DownloadIndexFile()
+
+	file := repo.NewFile()
+	file.Update(entry)
+
+	err = file.WriteFile(helmpath.ConfigPath("repositories.yaml"), 0644)
+
+	actionConfig := d.obtainActionConfig(namespace)
+	client := action.NewInstall(actionConfig)
+	client.Version = version
+	client.ReleaseName = releaseName
+	client.Namespace = namespace
+	cp, err := client.ChartPathOptions.LocateChart(chart, setting)
+	chartReq, err := loader.Load(cp)
+	release, err := client.Run(chartReq, values)
+	return release, err
+}
+
+func installCharts(installAction *action.Install, chart string, values map[string]interface{}) (*release.Release, error) {
 	cp, err := installAction.ChartPathOptions.LocateChart(chart, cli.New())
 	if err != nil {
 		return nil, err

--- a/test/framework/helm/release_manager.go
+++ b/test/framework/helm/release_manager.go
@@ -15,6 +15,7 @@ package helm
 
 import (
 	"fmt"
+
 	"github.com/prometheus/common/log"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	NgNameLabelKey string
 	NgNameLabelVal string
 	EKSEndpoint    string
+	CalicoVersion  string
 }
 
 func (options *Options) BindFlags() {
@@ -44,6 +45,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.NgNameLabelKey, "ng-name-label-key", "eks.amazonaws.com/nodegroup", "label key used to identify nodegroup name")
 	flag.StringVar(&options.NgNameLabelVal, "ng-name-label-val", "", "label value with the nodegroup name")
 	flag.StringVar(&options.EKSEndpoint, "eks-endpoint", "", "optional eks api server endpoint")
+	flag.StringVar(&options.CalicoVersion, "calico-version", "3.22.0", "calico version to be tested")
 }
 
 func (options *Options) Validate() error {

--- a/test/framework/resources/k8s/manager.go
+++ b/test/framework/resources/k8s/manager.go
@@ -31,6 +31,7 @@ type ResourceManagers interface {
 	PodManager() resources.PodManager
 	DaemonSetManager() resources.DaemonSetManager
 	ConfigMapManager() resources.ConfigMapManager
+	NetworkPolicyManager() resources.NetworkPolicyManager
 }
 
 type defaultManager struct {
@@ -43,6 +44,7 @@ type defaultManager struct {
 	podManager            resources.PodManager
 	daemonSetManager      resources.DaemonSetManager
 	configMapManager      resources.ConfigMapManager
+	networkPolicyManager  resources.NetworkPolicyManager
 }
 
 func NewResourceManager(k8sClient client.DelegatingClient,
@@ -57,6 +59,7 @@ func NewResourceManager(k8sClient client.DelegatingClient,
 		podManager:            resources.NewDefaultPodManager(k8sClient, scheme, config),
 		daemonSetManager:      resources.NewDefaultDaemonSetManager(k8sClient),
 		configMapManager:      resources.NewConfigMapManager(k8sClient),
+		networkPolicyManager:  resources.NewNetworkPolicyManager(k8sClient),
 	}
 }
 
@@ -94,4 +97,8 @@ func (m *defaultManager) DaemonSetManager() resources.DaemonSetManager {
 
 func (m *defaultManager) ConfigMapManager() resources.ConfigMapManager {
 	return m.configMapManager
+}
+
+func (m *defaultManager) NetworkPolicyManager() resources.NetworkPolicyManager {
+	return m.networkPolicyManager
 }

--- a/test/framework/resources/k8s/manifest/container.go
+++ b/test/framework/resources/k8s/manifest/container.go
@@ -65,6 +65,10 @@ func NewNetCatAlpineContainer() *Container {
 	}
 }
 
+func NewBaseContainer() *Container {
+	return &Container{}
+}
+
 func (w *Container) CapabilitiesForSecurityContext(add []v1.Capability, drop []v1.Capability) *Container {
 	w.securityContext = &v1.SecurityContext{
 		Capabilities: &v1.Capabilities{

--- a/test/framework/resources/k8s/manifest/deployment.go
+++ b/test/framework/resources/k8s/manifest/deployment.go
@@ -57,6 +57,14 @@ func NewDefaultDeploymentBuilder() *DeploymentBuilder {
 	}
 }
 
+func NewCalicoStarDeploymentBuilder(namespace string, name string, labels map[string]string) *DeploymentBuilder {
+	return &DeploymentBuilder{
+		namespace: namespace,
+		name:      name,
+		labels:    labels,
+	}
+}
+
 func (d *DeploymentBuilder) NodeSelector(labelKey string, labelVal string) *DeploymentBuilder {
 	d.nodeSelector[labelKey] = labelVal
 	return d

--- a/test/framework/resources/k8s/manifest/deployment.go
+++ b/test/framework/resources/k8s/manifest/deployment.go
@@ -57,12 +57,16 @@ func NewDefaultDeploymentBuilder() *DeploymentBuilder {
 	}
 }
 
-func NewCalicoStarDeploymentBuilder(namespace string, name string, labels map[string]string) *DeploymentBuilder {
+func NewCalicoStarDeploymentBuilder() *DeploymentBuilder {
 	return &DeploymentBuilder{
-		namespace: namespace,
-		name:      name,
-		labels:    labels,
+		labels:       map[string]string{},
+		nodeSelector: map[string]string{},
 	}
+}
+
+func (d *DeploymentBuilder) Labels(labels map[string]string) *DeploymentBuilder {
+	d.labels = labels
+	return d
 }
 
 func (d *DeploymentBuilder) NodeSelector(labelKey string, labelVal string) *DeploymentBuilder {

--- a/test/framework/resources/k8s/resources/namespace.go
+++ b/test/framework/resources/k8s/resources/namespace.go
@@ -27,6 +27,7 @@ import (
 
 type NamespaceManager interface {
 	CreateNamespace(namespace string) error
+	CreateNamespaceWithLabels(namespace string, labels map[string]string) error
 	DeleteAndWaitTillNamespaceDeleted(namespace string) error
 }
 
@@ -44,6 +45,13 @@ func (m *defaultNamespaceManager) CreateNamespace(namespace string) error {
 	}
 	ctx := context.Background()
 	return m.k8sClient.Create(ctx, &v1.Namespace{ObjectMeta: metaV1.ObjectMeta{Name: namespace}})
+}
+
+func (m *defaultNamespaceManager) CreateNamespaceWithLabels(namespace string, labels map[string]string) error {
+	if namespace == "" || namespace == "default" {
+		return nil
+	}
+	return m.k8sClient.Create(context.Background(), &v1.Namespace{ObjectMeta: metaV1.ObjectMeta{Name: namespace, Labels: labels}})
 }
 
 func (m *defaultNamespaceManager) DeleteAndWaitTillNamespaceDeleted(namespace string) error {

--- a/test/framework/resources/k8s/resources/networkpolicy.go
+++ b/test/framework/resources/k8s/resources/networkpolicy.go
@@ -1,0 +1,28 @@
+package resources
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NetworkPolicyManager interface {
+	CreateNetworkPolicy(networkPolicy runtime.Object) error
+	DeleteNetworkPolicy(networkPolicy runtime.Object) error
+}
+
+type defaultNetworkPolicyManager struct {
+	networkPolicyClient client.DelegatingClient
+}
+
+func NewNetworkPolicyManager(client client.DelegatingClient) NetworkPolicyManager {
+	return &defaultNetworkPolicyManager{client}
+}
+
+func (d *defaultNetworkPolicyManager) CreateNetworkPolicy(networkPolicy runtime.Object) error {
+	return d.networkPolicyClient.Create(context.Background(), networkPolicy)
+}
+
+func (d *defaultNetworkPolicyManager) DeleteNetworkPolicy(networkPolicy runtime.Object) error {
+	return d.networkPolicyClient.Delete(context.Background(), networkPolicy)
+}

--- a/test/framework/resources/k8s/resources/networkpolicy.go
+++ b/test/framework/resources/k8s/resources/networkpolicy.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/test/framework/resources/k8s/resources/pod.go
+++ b/test/framework/resources/k8s/resources/pod.go
@@ -38,6 +38,7 @@ type PodManager interface {
 	PodExec(namespace string, name string, command []string) (string, string, error)
 	PodLogs(namespace string, name string) (string, error)
 	GetPodsWithLabelSelector(labelKey string, labelVal string) (v1.PodList, error)
+	GetPodsWithLabelSelectorMap(labels map[string]string) (v1.PodList, error)
 	GetPod(podNamespace string, podName string) (*v1.Pod, error)
 	CreatAndWaitTillRunning(pod *v1.Pod) (*v1.Pod, error)
 	CreateAndWaitTillPodCompleted(pod *v1.Pod) (*v1.Pod, error)
@@ -195,6 +196,13 @@ func (d *defaultPodManager) GetPodsWithLabelSelector(labelKey string, labelVal s
 	err := d.k8sClient.List(ctx, &podList, client.MatchingLabels{
 		labelKey: labelVal,
 	})
+	return podList, err
+}
+
+func (d *defaultPodManager) GetPodsWithLabelSelectorMap(labels map[string]string) (v1.PodList, error) {
+	ctx := context.Background()
+	podList := v1.PodList{}
+	err := d.k8sClient.List(ctx, &podList, client.MatchingLabels(labels))
 	return podList, err
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
This PR is fixing a failing weekly Calico integration tests and replacing it with helm installation with demoed STAR network policy tests suite. 
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug
**Which issue does this PR fix**:
Fixes #1874 

**What does this PR do / Why do we need it**:
We have deprecated support of Calico charts in this repo, but we need do routine integration tests with certain/latest calico version with our VPC CNI. This PR contains the following changes/additions:

1. Helm installation of Calico operator with a given version of Calico
2. STAR tests with various network policy settings
3. Calico tests are no longer using bash scripts. Ginkgo suite is used to implement the tests
4. New ENVs to config tests: RUN_LATEST_CALICO_VERSION (boolean) that indicates if fetching Calico repo to use the latest Calico released version; CALICO_VERSION (boolean) that sets Calico version to test if the `RUN_LATEST_CALICO_VERSION == false`
5. If `DEPROVISION == false`, EC2 instances will be terminated to avoid impact for future tests in the cluster
6. Reorganized VPC CNI tests on current image with Calico tests to avoid interference 
7. Due to installing AMD arch based Calico images and STAR resources, during the tests ARM arch nodes will be unschedulable. They will be restored to schedulable state after Calico tests are finished
9. To utilize the recently added metrics infra, Calico tests also add a new metrics `calico_test_status`
10. If the ENV `RUN_CALICO_TEST_WITH_PD` NOT set, the script will also run PD with Calico by default

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Using specified Calico version:
```
$ RUN_CALICO_TEST=true CALICO_VERSION=3.21.0 ./scripts/run-integration-tests.sh
...
2022-03-04 07:49:42 [✔]  EKS cluster "cni-test-16533" in "us-west-2" region is ready
ok.
TIMELINE: Upping test cluster took 1079 seconds.
...
=== RUN   TestIntegration
Mar  4 07:49:44.618: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: Amazon VPC CNI Integration Tests
...
Ran 2 of 2 Specs in 31.384 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (31.38s)
...
TIMELINE: Current image integration tests took 21 seconds.
Starting Helm installing Tigera operator and running Calico STAR tests
~/environment/go/src/amazon-vpc-cni-k8s/test ~/environment/go/src/amazon-vpc-cni-k8s
Using Calico version 3.21.0 to test   <-----
Running Suite: Calico with VPC CNI e2e Test Suite
=================================================
Random Seed: 1646380248
Will run 22 of 22 specs
...
STEP: Restore ARM64 Nodes Schedulability
 
Ran 22 of 22 Specs in 379.131 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
 
Ginkgo ran 1 suite in 6m24.072209201s
Test Suite Passed
~/environment/go/src/amazon-vpc-cni-k8s
Deleting cluster  (this may take ~10 mins) ... ok.
TIMELINE: Down processes took 420 seconds.
```

Using latest Calico released version (Automatically fetching from Calico)
```
% RUN_CALICO_TEST=true RUN_LATEST_CALICO_VERSION=true ./scripts/run-integration-tests.sh
...
TIMELINE: Current image integration tests took 39 seconds.
Starting Helm installing Tigera operator and running Calico STAR tests
~/go/src/amazon-vpc-cni-k8s/test ~/go/src/amazon-vpc-cni-k8s
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19996    0 19996    0     0  43094      0 --:--:-- --:--:-- --:--:-- 43094
Using Calico version v3.22.1 to test   <-----
Running Suite: Calico with VPC CNI e2e Test Suite
=================================================
Random Seed: 1646377066
Will run 22 of 22 specs

...
STEP: Restore ARM64 Nodes Schedulability
 
Ran 22 of 22 Specs in 373.879 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
 
Ginkgo ran 1 suite in 6m24.177285169s
Test Suite Passed
~/go/src/amazon-vpc-cni-k8s
Deleting cluster  (this may take ~10 mins) ... ok.
TIMELINE: Down processes took 442 seconds.
```
Prefix Delegation tests
```
STEP: Restore ARM64 Nodes Schedulability

Ran 22 of 22 Specs in 378.191 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6m24.845380702s
Test Suite Passed
~/go/src/amazon-vpc-cni-k8s
Run Calico tests with Prefix Delegation enabled
daemonset.apps/aws-node env updated
{
    "TerminatingInstances": [
        {
            "CurrentState": {
                "Code": 32,
                "Name": "shutting-down"
            },
            "InstanceId": "i-0341454b54c510205",
            "PreviousState": {
                "Code": 16,
                "Name": "running"
            }
        }
    ]
}
Waiting 15 minutes for new nodes being ready

Starting Helm installing Tigera operator and running Calico STAR tests
~/go/src/amazon-vpc-cni-k8s/test ~/go/src/amazon-vpc-cni-k8s
Using Calico version 3.22.0 to test
Running Suite: Calico with VPC CNI e2e Test Suite
=================================================
Random Seed: 1646727202
Will run 22 of 22 specs
...
STEP: Restore ARM64 Nodes Schedulability

Ran 22 of 22 Specs in 370.725 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6m18.087117999s
Test Suite Passed

```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
yes
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
