### PR TITLE
fix canary scripts when running from repo root

### DIFF
--- a/scripts/lib/canary.sh
+++ b/scripts/lib/canary.sh
@@ -3,7 +3,6 @@
 # Helper script used for running canary test for CNI IPv4 and IPv6
 
 SECONDS=0
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 INTEGRATION_TEST_DIR="$SCRIPT_DIR/../../test/integration-new"
 VPC_CNI_ADDON_NAME="vpc-cni"
 

--- a/scripts/run-canary-test.sh
+++ b/scripts/run-canary-test.sh
@@ -5,9 +5,11 @@
 
 set -e
 
-source lib/add-on.sh
-source lib/cluster.sh
-source lib/canary.sh
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$SCRIPT_DIR"/lib/add-on.sh
+source "$SCRIPT_DIR"/lib/cluster.sh
+source "$SCRIPT_DIR"/lib/canary.sh
 
 function run_ginkgo_test() {
   local focus=$1

--- a/scripts/run-ipv6-canary-test.sh
+++ b/scripts/run-ipv6-canary-test.sh
@@ -5,9 +5,11 @@
 
 set -e
 
-source lib/add-on.sh
-source lib/cluster.sh
-source lib/canary.sh
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$SCRIPT_DIR"/lib/add-on.sh
+source "$SCRIPT_DIR"/lib/cluster.sh
+source "$SCRIPT_DIR"/lib/canary.sh
 
 function run_ginkgo_test() {
   local focus=$1


### PR DESCRIPTION
**What type of PR is this?**
Test Issue Fix

**Which issue does this PR fix**:
Fixes issue with the canary script.

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
