### PR TITLE
fix failures in weekly test

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 16 * * 5"  # every Friday
+    - cron: "0 16 * * 1"  # every Monday
 
 permissions:
   contents: read

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -52,7 +52,8 @@ function up-test-cluster() {
     eksctl create cluster -f $CLUSTER_CONFIG --kubeconfig $KUBECONFIG_PATH >>$CLUSTER_MANAGE_LOG_PATH 1>&2 ||
         (echo "failed. Check $CLUSTER_MANAGE_LOG_PATH." && exit 1)
     echo "ok."
-
+    export KUBECONFIG=$KUBECONFIG_PATH
+    
     if [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
         kubectl create -f $DIR/test/config/cluster-autoscaler-autodiscover.yml
     fi

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -194,8 +194,6 @@ grep -r -q $INIT_IMAGE_NAME $TEST_CONFIG_PATH
 
 if [[ $RUN_KOPS_TEST == true ]]; then
     export KUBECONFIG=~/.kube/config
-else
-    export KUBECONFIG=$KUBECONFIG_PATH
 fi
 
 if [[ $RUN_KOPS_TEST == true ]]; then
@@ -306,7 +304,7 @@ if [[ "$DEPROVISION" == true ]]; then
     if [[ "$RUN_KOPS_TEST" == true ]]; then
         down-kops-cluster
     elif [[ "$RUN_BOTTLEROCKET_TEST" == true ]]; then
-        eksctl delete cluster bottlerocket
+        eksctl delete cluster $CLUSTER_NAME
         emit_cloudwatch_metric "bottlerocket_test_status" "1"
     elif [[ "$RUN_PERFORMANCE_TESTS" == true ]]; then
         eksctl delete cluster $CLUSTER_NAME


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
Failures in weekly tests:
Error: unable to describe cluster control plane: ResourceNotFoundException: No cluster found for name: bottlerocket.

Cluster name incorrect in script.

**What does this PR do / Why do we need it**:
Fixes the above failures

**Testing done on this change**:
Bottlerocket tests in dev

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
