### PR TITLE
Fix up default enconfig name

### DIFF
--- a/charts/aws-vpc-cni/templates/eniconfig.yaml
+++ b/charts/aws-vpc-cni/templates/eniconfig.yaml
@@ -3,7 +3,7 @@
 apiVersion: crd.k8s.amazonaws.com/v1alpha1
 kind: ENIConfig
 metadata:
-  name: {{ required ".Values.eniConfig.region must be specified" $.Values.eniConfig.region }}{{ $key }}
+  name: {{ $key }}
 spec:
   {{- if $value.securityGroups }}
   securityGroups:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #1917 

**What does this PR do / Why do we need it**:
Default eniconfig name recommended in EKS docs - https://aws.amazon.com/premiumsupport/knowledge-center/eks-multiple-cidr-ranges/ is AZ name but we used to build the name as region + key(az name) but not annotating the node. Instead we just default it to AZ name and the below label setting will automatically pick the nodes AZ -

```
kubectl set env daemonset aws-node \
    -n kube-system ENI_CONFIG_LABEL_DEF=topology.kubernetes.io/zone
```

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes

```
---
# Source: aws-vpc-cni/templates/eniconfig.yaml
apiVersion: crd.k8s.amazonaws.com/v1alpha1
kind: ENIConfig
metadata:
  name: us-west-2a
spec:
  securityGroups:
    - sg-123
  subnet: subnet-123
---
# Source: aws-vpc-cni/templates/eniconfig.yaml
apiVersion: crd.k8s.amazonaws.com/v1alpha1
kind: ENIConfig
metadata:
  name: us-west-2b
spec:
  securityGroups:
    - sg-456
  subnet: subnet-456
---
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
