### PR TITLE
cleanup test cluster config

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -35,13 +35,7 @@ function up-test-cluster() {
         echo "Copying test cluster config to $CLUSTER_CONFIG"
         cp $CLUSTER_TEMPLATE_PATH/test-cluster.yaml $CLUSTER_CONFIG
         sed -i'.bak' "s,K8S_VERSION_PLACEHOLDER,$EKS_CLUSTER_VERSION," $CLUSTER_CONFIG
-        AMI_ID=`aws ssm get-parameter --name /aws/service/eks/optimized-ami/${EKS_CLUSTER_VERSION}/amazon-linux-2/recommended/image_id --region us-west-2 --query "Parameter.Value" --output text`
-        ARM_AMI_ID=`aws ssm get-parameter --name /aws/service/eks/optimized-ami/${EKS_CLUSTER_VERSION}/amazon-linux-2-arm64/recommended/image_id --region us-west-2 --query "Parameter.Value" --output text`
-        sed -i'.bak' "s,X86_AMI_ID_PLACEHOLDER,$AMI_ID," $CLUSTER_CONFIG
-        sed -i'.bak' "s,ARM_AMI_ID_PLACEHOLDER,$ARM_AMI_ID," $CLUSTER_CONFIG
         grep -r -q $EKS_CLUSTER_VERSION $CLUSTER_CONFIG
-        grep -r -q $AMI_ID $CLUSTER_CONFIG
-        grep -r -q $ARM_AMI_ID $CLUSTER_CONFIG
         : "${ROLE_ARN:=""}"
         sed -i'.bak' "s,ROLE_ARN_PLACEHOLDER,$ROLE_ARN," $CLUSTER_CONFIG
     fi

--- a/scripts/test/config/test-cluster.yaml
+++ b/scripts/test/config/test-cluster.yaml
@@ -13,10 +13,6 @@ iam:
 managedNodeGroups:
   - name: cni-test-arm64-mng
     instanceType: c6g.xlarge
-    ami: ARM_AMI_ID_PLACEHOLDER
-    overrideBootstrapCommand: |
-      #!/bin/bash
-      /etc/eks/bootstrap.sh CLUSTER_NAME_PLACEHOLDER
     desiredCapacity: 3
     minSize: 3
     maxSize: 3
@@ -27,10 +23,6 @@ managedNodeGroups:
 
   - name: cni-test-x86-mng
     instanceType: c5.xlarge
-    ami: X86_AMI_ID_PLACEHOLDER
-    overrideBootstrapCommand: |
-      #!/bin/bash
-      /etc/eks/bootstrap.sh CLUSTER_NAME_PLACEHOLDER
     desiredCapacity: 3
     minSize: 3
     maxSize: 3


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Clean up test cluster config to remove AMI ID placeholder & overrideBootstrapCommand. 
Background: This was included with #1899 as cluster creation failed with "not authorized for images [ami]" during testing. This error is not reproducible always, and not likely to occur in github workflows.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
Run ./scripts/run-integration-tests.sh

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
