### PR TITLE
Emit test specific metric upon error in weekly tests

### DIFF
--- a/.github/workflows/weekly-cron-test.yml
+++ b/.github/workflows/weekly-cron-test.yml
@@ -2,7 +2,7 @@ name: Weekly CNI tests
 
 on:
   schedule:
-    - cron: "0 16 * * 1"  # every Monday
+    - cron: "0 16 * * 3"  # every Wednesday
 
 permissions:
   contents: read

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -39,6 +39,20 @@ __cluster_deprovisioned=0
 on_error() {
     echo "Error with exit code $1 occurred on line $2"
     emit_cloudwatch_metric "error_occurred" "1"
+
+    #Emit test specific error metric 
+    if [[ $RUN_KOPS_TEST == true ]]; then
+        emit_cloudwatch_metric "kops_test_status" "0"
+    fi
+    if [[ $RUN_CALICO_TEST == true ]]; then
+        emit_cloudwatch_metric "calico_test_status" "0"
+    fi
+    if [[ $RUN_BOTTLEROCKET_TEST == true ]]; then
+        emit_cloudwatch_metric "bottlerocket_test_status" "0"
+    fi
+    if [[ $RUN_PERFORMANCE_TESTS == true ]]; then
+        emit_cloudwatch_metric "performance_test_status" "0"
+    fi
     # Make sure we destroy any cluster that was created if we hit run into an
     # error when attempting to run tests against the 
     if [[ $RUNNING_PERFORMANCE == false ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Emit test specific metric upon error in weekly tests

**What does this PR do / Why do we need it**:
Emit test specific metric upon error in weekly tests

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
