### PR TITLE
Prevent allocate/free ENIs when node is marked noSchedule

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -690,7 +690,7 @@ func (c *IPAMContext) decreaseDatastorePool(interval time.Duration) {
 
 // tryFreeENI always tries to free one ENI
 func (c *IPAMContext) tryFreeENI() {
-	if c.isTerminating() {
+	if c.isTerminating() || c.isNodeNonSchedulable() {
 		log.Debug("AWS CNI is terminating, not detaching any ENIs")
 		return
 	}
@@ -779,7 +779,7 @@ func (c *IPAMContext) increaseDatastorePool(ctx context.Context) {
 		}
 	}
 
-	if c.isTerminating() {
+	if c.isTerminating() || c.isNodeNonSchedulable() {
 		log.Debug("AWS CNI is terminating, will not try to attach any new IPs or ENIs right now")
 		return
 	}
@@ -1803,6 +1803,34 @@ func (c *IPAMContext) setTerminating() {
 
 func (c *IPAMContext) isTerminating() bool {
 	return atomic.LoadInt32(&c.terminating) > 0
+}
+
+func (c *IPAMContext) isNodeNonSchedulable() bool {
+	ctx := context.TODO()
+
+	request := types.NamespacedName{
+		Name: c.myNodeName,
+	}
+
+	node := &corev1.Node{}
+	// Find my node
+	err := c.cachedK8SClient.Get(ctx, request, node)
+	if err != nil {
+		log.Errorf("Failed to get node while determining schedulability: %v", err)
+		return false
+	}
+	log.Debugf("Node found %q - no of taints - %d", node.Name, len(node.Spec.Taints))
+	taintToMatch := &corev1.Taint{
+		Key:    "node.kubernetes.io/unschedulable",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.MatchTaint(taintToMatch) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetConfigForDebug returns the active values of the configuration env vars (for debugging purposes).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Leaked ENIs

**What does this PR do / Why do we need it**:
Detach and FreeENI has few seconds delay and during this time if node is freed i.e, after detach then ENI will stay in Cx account but won't be deleted causing a leak.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#1223

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
{"level":"debug","ts":"2022-03-15T00:51:28.889Z","caller":"ipamd/ipamd.go:693","msg":"Node found \"ip-192-168-15-251.us-west-2.compute.internal\" - no of taints - 1"}
{"level":"debug","ts":"2022-03-15T00:51:28.889Z","caller":"ipamd/ipamd.go:693","msg":"FOUND taint - node.kubernetes.io/unschedulable:NoSchedule and match to node.kubernetes.io/unschedulable:NoSchedule"}
{"level":"debug","ts":"2022-03-15T00:51:28.889Z","caller":"ipamd/ipamd.go:665","msg":"AWS CNI is terminating, not detaching any ENIs"}
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
