### PR TITLE
Fix release branch with auto-cut PR

### DIFF
--- a/scripts/upload-resources-to-github.sh
+++ b/scripts/upload-resources-to-github.sh
@@ -59,7 +59,7 @@ RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
 
 RELEASE_BRANCH=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    https://api.github.com/repos/jayanthvn/amazon-vpc-cni-k8s/releases | \
+    https://api.github.com/repos/aws/amazon-vpc-cni-k8s/releases | \
     jq -r --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .target_commitish')
 
 ASSET_IDS_UPLOADED=()

--- a/scripts/upload-resources-to-github.sh
+++ b/scripts/upload-resources-to-github.sh
@@ -57,6 +57,11 @@ done
 RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
     https://api.github.com/repos/aws/amazon-vpc-cni-k8s/releases | \
     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
+
+RELEASE_BRANCH=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/jayanthvn/amazon-vpc-cni-k8s/releases | \
+    jq -r --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .target_commitish')
+
 ASSET_IDS_UPLOADED=()
 
 trap 'handle_errors_and_cleanup $?' EXIT
@@ -165,26 +170,26 @@ mkdir -p "${SYNC_DIR}"
 cd "${SYNC_DIR}"
 gh repo clone aws/amazon-vpc-cni-k8s
 DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\n')
-  CONFIG_DIR=amazon-vpc-cni-k8s/config/master
-  cd $CONFIG_DIR
-  REPO_NAME=$(echo ${REPO} | cut -d'/' -f2)
-  git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${REPO_NAME}".git
+CONFIG_DIR=amazon-vpc-cni-k8s/config/master
+cd $CONFIG_DIR
+REPO_NAME=$(echo ${REPO} | cut -d'/' -f2)
+git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${REPO_NAME}".git
 
-  git config user.name "eks-bot"
-  git config user.email "eks-bot@users.noreply.github.com"
+git config user.name "eks-bot"
+git config user.email "eks-bot@users.noreply.github.com"
 
-  FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
-  git checkout -b "${FORK_RELEASE_BRANCH}" origin
+FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
+git checkout -b "${FORK_RELEASE_BRANCH}" origin
 
-  COUNT=1
-  for asset in ${RESOURCES_TO_COPY[@]}; do
-          name=$(echo $asset | tr '/' '\n' | tail -1)
-          echo -e "\n  $((COUNT++)). $name"
-          cp "$asset" .
-  done
+COUNT=1
+for asset in ${RESOURCES_TO_COPY[@]}; do
+        name=$(echo $asset | tr '/' '\n' | tail -1)
+        echo -e "\n  $((COUNT++)). $name"
+        cp "$asset" .
+done
 
-  git add --all
-  git commit -m "${BINARY_BASE}: ${VERSION}"
+git add --all
+git commit -m "${BINARY_BASE}: ${VERSION}"
 
 PR_BODY=$(cat << EOM
 ## ${BINARY_BASE} ${VERSION} Automated manifest folder Sync! 🤖🤖
@@ -196,11 +201,11 @@ Updating all the generated release artifacts in master/config for master branch.
 EOM
 )
 
-  git push -u origin "${FORK_RELEASE_BRANCH}"
-  gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated manifest sync! 🥑" \
-      --body "${PR_BODY}" --repo ${REPO}
+git push -u origin "${FORK_RELEASE_BRANCH}"
+gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated manifest sync! 🥑" \
+    --body "${PR_BODY}" --repo ${REPO}
 
-  echo "✅ Manifest folder PR created for master"
+echo "✅ Manifest folder PR created for master"
 
 CLONE_DIR="${BUILD_DIR}/config-sync-release"
 SYNC_DIR="$CLONE_DIR"
@@ -209,28 +214,27 @@ rm -rf "${SYNC_DIR}"
 mkdir -p "${SYNC_DIR}"
 cd "${SYNC_DIR}"
 gh repo clone aws/amazon-vpc-cni-k8s
-RELEASE_BRANCH=$(git branch -a --contains $VERSION | grep "upstream" | cut -d '/' -f3)
 echo "Release branch $RELEASE_BRANCH"
-  CONFIG_DIR=amazon-vpc-cni-k8s/config/master
-  cd $CONFIG_DIR
-  REPO_NAME=$(echo ${REPO} | cut -d'/' -f2)
-  git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${REPO_NAME}".git
+CONFIG_DIR=amazon-vpc-cni-k8s/config/master
+cd $CONFIG_DIR
+REPO_NAME=$(echo ${REPO} | cut -d'/' -f2)
+git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${REPO_NAME}".git
 
-  git config user.name "eks-bot"
-  git config user.email "eks-bot@users.noreply.github.com"
+git config user.name "eks-bot"
+git config user.email "eks-bot@users.noreply.github.com"
 
-  FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
-  git checkout -b "${FORK_RELEASE_BRANCH}" origin/$RELEASE_BRANCH
+FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
+git checkout -b "${FORK_RELEASE_BRANCH}" origin/$RELEASE_BRANCH
 
-  COUNT=1
-  for asset in ${RESOURCES_TO_COPY[@]}; do
-          name=$(echo $asset | tr '/' '\n' | tail -1)
-          echo -e "\n  $((COUNT++)). $name"
-          cp "$asset" .
-  done
+COUNT=1
+for asset in ${RESOURCES_TO_COPY[@]}; do
+        name=$(echo $asset | tr '/' '\n' | tail -1)
+        echo -e "\n  $((COUNT++)). $name"
+        cp "$asset" .
+done
 
-  git add --all
-  git commit -m "${BINARY_BASE}: ${VERSION}"
+git add --all
+git commit -m "${BINARY_BASE}: ${VERSION}"
 
 PR_BODY=$(cat << EOM
 ## ${BINARY_BASE} ${VERSION} Automated manifest folder Sync! 🤖🤖
@@ -242,8 +246,8 @@ Updating all the generated release artifacts in master/config for $RELEASE_BRANC
 EOM
 )
 
-  git push -u origin "${FORK_RELEASE_BRANCH}":$RELEASE_BRANCH
-  gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated manifest sync! 🥑" \
-      --body "${PR_BODY}" --repo ${REPO} --base ${RELEASE_BRANCH}
+git push -u origin "${FORK_RELEASE_BRANCH}":$RELEASE_BRANCH
+gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated manifest sync! 🥑" \
+    --body "${PR_BODY}" --repo ${REPO} --base ${RELEASE_BRANCH}
 
-  echo "✅ Manifest folder PR created for $RELEASE_BRANCH"
+echo "✅ Manifest folder PR created for $RELEASE_BRANCH"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Release branch was wrongly determined

**What does this PR do / Why do we need it**:
Pick the correct release branch with curl

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
curl -s -H "Authorization: token $GITHUB_TOKEN"     https://api.github.com/repos/jayanthvn/amazon-vpc-cni-k8s/releases |     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .target_commitish' -r
varavaj-artifacts
```
Release artifacts - 
https://github.com/jayanthvn/amazon-vpc-cni-k8s/releases/tag/v1.22.3

EKS charts auto cut PR -
https://github.com/aws/eks-charts/pull/714

Config folder auto cut PR -
https://github.com/jayanthvn/amazon-vpc-cni-k8s/pull/37
https://github.com/jayanthvn/amazon-vpc-cni-k8s/pull/36

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
