### PR TITLE
Timeout and reconcile when checking API server connectivity

### DIFF
--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -2,10 +2,13 @@ package k8sapi
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -85,15 +88,25 @@ func CheckAPIServerConnectivity() error {
 	if err != nil {
 		return err
 	}
-	clientSet, _ := kubernetes.NewForConfig(restCfg)
-
-	log.Infof("Testing communication with server")
-	version, err := clientSet.Discovery().ServerVersion()
+	restCfg.Timeout = 5 * time.Second
+	clientSet, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
-		return fmt.Errorf("error communicating with apiserver: %v", err)
+		return fmt.Errorf("creating kube config, %w", err)
 	}
-	log.Infof("Successful communication with the Cluster! Cluster Version is: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
-		version.Major, version.Minor, version.GitVersion, version.GitTreeState, version.GitCommit, version.Platform)
-
-	return nil
+	log.Infof("Testing communication with server")
+	// Reconcile the API server query after waiting for a second, as the request
+	// times out in one second if it fails to connect to the server
+	return wait.PollInfinite(2*time.Second, func() (bool, error) {
+		version, err := clientSet.Discovery().ServerVersion()
+		if err != nil {
+			// When times out return no error, so the PollInfinite will retry with the given interval
+			if os.IsTimeout(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("error communicating with apiserver: %v", err)
+		}
+		log.Infof("Successful communication with the Cluster! Cluster Version is: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
+			version.Major, version.Minor, version.GitVersion, version.GitTreeState, version.GitCommit, version.Platform)
+		return true, nil
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Some of the instance take ~2 minutes to become ready while other can connect in <30 seconds.

**What does this PR do / Why do we need it**:
In the current implementation, request to the API server hangs if kube-proxy starts after aws-node pod, it doesn't time out. Container gets restarted after ~90-120 seconds and client reconnects again to the API server to check connectivity.
As part of this change kube client times out in 1 second if it fails to connect and will try to reconnect after 1 second. If its never able to connect to the API server container will be restarted like it does today.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
I have tested this change on my cluster by adding ~20 nodes with this fix and without this fix. 

The following graph shows the time a given node stays in not ready state.

Test with CNI image - `amazon-k8s-cni:v1.10.2`, shows some of the instances were not ready for ~2 minutes in the API server
![Screen Shot 2022-03-30 at 10 39 15 AM](https://user-images.githubusercontent.com/5033759/160876888-f816015c-bd6c-435a-bf30-5404a3535cd9.png)

Test image with this fix, shows all the nodes were ready in <30 seconds.
![Screen Shot 2022-03-30 at 10 40 06 AM](https://user-images.githubusercontent.com/5033759/160876970-aab16c01-952f-48e6-b065-c70abe2b407b.png)


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
