### PR TITLE
record pod metadata and allocationTime in IP allocation state file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-iptables v0.4.5
 	github.com/golang/mock v1.4.1
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-cmp v0.5.2
 	github.com/google/go-jsonnet v0.16.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
@@ -41,7 +42,6 @@ require (
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.1 // indirect
@@ -66,6 +66,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.1.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1216,6 +1216,9 @@ func datastoreWith1Pod1() *datastore.DataStore {
 		NetworkName: "net0",
 		ContainerID: "sandbox-1",
 		IfName:      "eth0",
+	}, datastore.IPAMMetadata{
+		K8SPodNamespace: "default",
+		K8SPodName:      "sample-pod",
 	})
 	return datastoreWith1Pod1
 }
@@ -1229,7 +1232,10 @@ func datastoreWith3Pods() *datastore.DataStore {
 			ContainerID: fmt.Sprintf("sandbox-%d", i),
 			IfName:      "eth0",
 		}
-		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key)
+		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key, datastore.IPAMMetadata{
+			K8SPodNamespace: "default",
+			K8SPodName:      fmt.Sprintf("sample-pod-%d", i),
+		})
 	}
 	return datastoreWith3Pods
 }
@@ -1249,6 +1255,9 @@ func datastoreWith1Pod1FromPrefix() *datastore.DataStore {
 		NetworkName: "net0",
 		ContainerID: "sandbox-1",
 		IfName:      "eth0",
+	}, datastore.IPAMMetadata{
+		K8SPodNamespace: "default",
+		K8SPodName:      "sample-pod",
 	})
 	return datastoreWith1Pod1
 }
@@ -1262,7 +1271,11 @@ func datastoreWith3PodsFromPrefix() *datastore.DataStore {
 			ContainerID: fmt.Sprintf("sandbox-%d", i),
 			IfName:      "eth0",
 		}
-		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key)
+		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key,
+			datastore.IPAMMetadata{
+				K8SPodNamespace: "default",
+				K8SPodName:      fmt.Sprintf("sample-pod-%d", i),
+			})
 	}
 	return datastoreWith3Pods
 }

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -144,7 +144,11 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 			IfName:      in.IfName,
 			NetworkName: in.NetworkName,
 		}
-		ipv4Addr, ipv6Addr, deviceNumber, err = s.ipamContext.dataStore.AssignPodIPAddress(ipamKey, s.ipamContext.enableIPv4, s.ipamContext.enableIPv6)
+		ipamMetadata := datastore.IPAMMetadata{
+			K8SPodNamespace: in.K8S_POD_NAMESPACE,
+			K8SPodName:      in.K8S_POD_NAME,
+		}
+		ipv4Addr, ipv6Addr, deviceNumber, err = s.ipamContext.dataStore.AssignPodIPAddress(ipamKey, ipamMetadata, s.ipamContext.enableIPv4, s.ipamContext.enableIPv6)
 	}
 
 	var pbVPCV4cidrs, pbVPCV6cidrs []string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
/kind feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR records additional metadata(pod's namespace & name) and allocationTimestamp about IP allocations into the state file.
Which improves the debug experience, and allow CNI to know Pod's info after CRI socket is removed(which can be leveraged for things like state file drift detection)
```json
{
            "networkName": "_migrated-from-cri",
            "containerID": "69f891af2059cccc41678bae50d35e45cd31ef59dd59547d57d4754ff1a4511a",
            "ifName": "unknown",
            "ipv4": "192.168.5.118",
            "allocationTimestamp": 1647904840686935398,
            "metadata": {
                "k8sPodNamespace": "kube-system",
                "k8sPodName": "coredns-85d5b4454c-ml29q"
            }
},
```

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
* manually tested against dockershim & containerd:
    * ipam.json after recovery:
    ```
    {"version":"vpc-cni-ipam/1","allocations":[{"networkName":"_migrated-from-cri","containerID":"75ebe0da8b3f1e5ee3faab89e538fb32af7c038fd0cd0ebf39dee8e459d1788e","ifName":"unknown","ipv4":"192.168.12.15","allocationTimestamp":1647904840550836685,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-l9pwn"}},{"networkName":"_migrated-from-cri","containerID":"b26913f3b6009fc8e554ae62f6c43e27c8414af04cc6b708c1d8f416386f6bcc","ifName":"unknown","ipv4":"192.168.16.112","allocationTimestamp":1647904840496172364,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-fcn4m"}},{"networkName":"_migrated-from-cri","containerID":"bb54610652bf15bf8fe02f0411fce05e3c132419990d7e87a277dbca2b3058a0","ifName":"unknown","ipv4":"192.168.8.32","allocationTimestamp":1647904840619460226,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-tptns"}},{"networkName":"_migrated-from-cri","containerID":"69f891af2059cccc41678bae50d35e45cd31ef59dd59547d57d4754ff1a4511a","ifName":"unknown","ipv4":"192.168.5.118","allocationTimestamp":1647904840686935398,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-ml29q"}}]}
    ```
    * ipam.json after created 6 new pods:
    ```
    {"version":"vpc-cni-ipam/1","allocations":[{"networkName":"aws-cni","containerID":"86393b9f1df0e7685b5910f965e53189ca498677e70e25b0a9dcd2a2d4586d19","ifName":"eth0","ipv4":"192.168.23.207","allocationTimestamp":1649464716972801842,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-z9px5"}},{"networkName":"_migrated-from-cri","containerID":"75ebe0da8b3f1e5ee3faab89e538fb32af7c038fd0cd0ebf39dee8e459d1788e","ifName":"unknown","ipv4":"192.168.12.15","allocationTimestamp":1647904840550836685,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-l9pwn"}},{"networkName":"_migrated-from-cri","containerID":"b26913f3b6009fc8e554ae62f6c43e27c8414af04cc6b708c1d8f416386f6bcc","ifName":"unknown","ipv4":"192.168.16.112","allocationTimestamp":1647904840496172364,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-fcn4m"}},{"networkName":"aws-cni","containerID":"f01429a0aa8890cb5f3a23721367c02f0c71b5b8c5595df650f46f81a585faef","ifName":"eth0","ipv4":"192.168.6.38","allocationTimestamp":1649464717694547918,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-n4tx2"}},{"networkName":"aws-cni","containerID":"603f5869a39c0d79b09743e010c8d88efcbfa91ed65dfbfbf6b9c4b4295dddef","ifName":"eth0","ipv4":"192.168.23.87","allocationTimestamp":1649464716882459247,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-g4vcw"}},{"networkName":"_migrated-from-cri","containerID":"bb54610652bf15bf8fe02f0411fce05e3c132419990d7e87a277dbca2b3058a0","ifName":"unknown","ipv4":"192.168.8.32","allocationTimestamp":1647904840619460226,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-tptns"}},{"networkName":"aws-cni","containerID":"3d585e34ead299c28a1cedb6bb5c69db8795a815d56bcd91fbb30e17e41c6684","ifName":"eth0","ipv4":"192.168.15.30","allocationTimestamp":1649464717170318997,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-2z8wl"}},{"networkName":"aws-cni","containerID":"558dd4ec5db25456514f2488d9b8b644e15d2b2f8e8593f3bc395c03befa8945","ifName":"eth0","ipv4":"192.168.6.115","allocationTimestamp":1649464717347900310,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-gzg5b"}},{"networkName":"_migrated-from-cri","containerID":"69f891af2059cccc41678bae50d35e45cd31ef59dd59547d57d4754ff1a4511a","ifName":"unknown","ipv4":"192.168.5.118","allocationTimestamp":1647904840686935398,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-ml29q"}},{"networkName":"aws-cni","containerID":"f0b1fd965ae54742b3ee5c5f76441a262a4d286e8d6a4ebd82d5b3111f1bd3d1","ifName":"eth0","ipv4":"192.168.14.165","allocationTimestamp":1649464716814346224,"metadata":{"k8sPodNamespace":"game-2048","k8sPodName":"deployment-2048-9796d449-drgxw"}}]}
    ```
    * ipam.json after deleted 6 pods:
    ```
    {"version":"vpc-cni-ipam/1","allocations":[{"networkName":"_migrated-from-cri","containerID":"75ebe0da8b3f1e5ee3faab89e538fb32af7c038fd0cd0ebf39dee8e459d1788e","ifName":"unknown","ipv4":"192.168.12.15","allocationTimestamp":1647904840550836685,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-l9pwn"}},{"networkName":"_migrated-from-cri","containerID":"b26913f3b6009fc8e554ae62f6c43e27c8414af04cc6b708c1d8f416386f6bcc","ifName":"unknown","ipv4":"192.168.16.112","allocationTimestamp":1647904840496172364,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-fcn4m"}},{"networkName":"_migrated-from-cri","containerID":"bb54610652bf15bf8fe02f0411fce05e3c132419990d7e87a277dbca2b3058a0","ifName":"unknown","ipv4":"192.168.8.32","allocationTimestamp":1647904840619460226,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"aws-load-balancer-controller-588487d8fc-tptns"}},{"networkName":"_migrated-from-cri","containerID":"69f891af2059cccc41678bae50d35e45cd31ef59dd59547d57d4754ff1a4511a","ifName":"unknown","ipv4":"192.168.5.118","allocationTimestamp":1647904840686935398,"metadata":{"k8sPodNamespace":"kube-system","k8sPodName":"coredns-85d5b4454c-ml29q"}}]}
    ```
    * The `/v1/enis` API is also updated to contain `assignedTime` in str time format due to this change
    ```     
    "IPAddresses": {
        "192.168.12.15": {
            "Address": "192.168.12.15",
            "IPAMKey": {
                "networkName": "_migrated-from-cri",
                "containerID": "75ebe0da8b3f1e5ee3faab89e538fb32af7c038fd0cd0ebf39dee8e459d1788e",
                "ifName": "unknown"
            },
            "IPAMMetadata": {
                "k8sPodNamespace": "kube-system",
                "k8sPodName": "coredns-85d5b4454c-l9pwn"
            },
            "AssignedTime": "2022-03-21T23:20:40.550836685Z",
            "UnassignedTime": "0001-01-01T00:00:00Z"
        }
    },
    ```
* Benchmarked with 500 pod entries on m5.xlarge(Kubernetes only support at most 150 pods per node). Since even with 500 pods per nodes, it took only 0.35ms(vs 0.21ms before) to checkpoint with metadata and timestamp. The performance impact is unnoticeable in foreseeable future.
  ```
  without_meta_time                                     215092 ns/op
  with_meta_only                                           312026 ns/op
  with_meta_time(str time format)               762831 ns/op
  with_meta_timestamp(int time format)    353913 ns/op
  ```



**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Test covered by unit test

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This don't break upgrades/downgrades.
Tested with a running cluster.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes, the ipam.json file will now contain additional metadata(pod's namespace & name) and allocationTimestamp about IP allocations

```release-note
records additional metadata(pod's namespace & name) and allocationTime about IP allocations into IP pool state file.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
