### PR TITLE
revert to use update for node label update

### DIFF
--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update", "patch"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update", "patch"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update", "patch"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update", "patch"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update", "patch"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1881,7 +1881,7 @@ func (c *IPAMContext) SetNodeLabel(ctx context.Context, key, value string) error
 			delete(updateNode.Labels, key)
 		}
 
-		if err = c.cachedK8SClient.Patch(ctx, updateNode, client.StrategicMergeFrom(node)); err != nil {
+		if err = c.cachedK8SClient.Update(ctx, updateNode); err != nil {
 			log.Errorf("Failed to patch node %s with label %q: %q, error: %v", c.myNodeName, key, value, err)
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/pull/1892

**What does this PR do / Why do we need it**:
This PR reverts to use Update instead Patch for https://github.com/aws/amazon-vpc-cni-k8s/pull/1892 to avoid introduce additional RBAC permission

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually tested node label can be updated successfully

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Yes/No. (With this change, we no longer need to update the RBAC for next CNI version)

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
