### PR TITLE
fix image name during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,18 @@ HELM_CHART_NAME ?= "aws-vpc-cni"
 TEST_IMAGE = amazon-k8s-cni-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
 
+UNAME_ARCH = $(shell uname -m)
+ARCH = $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
+# This is only applied to the arm64 container image by default. Override to
+# provide an alternate suffix or to omit.
+IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(ARCH),arm64))
+
 # Mandate usage of docker buildkit as platform arguments are available only with buildkit
 # Refer to https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # and https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds
 export DOCKER_BUILDKIT=1
 GOARCH = $(TARGETARCH)
-# This is only applied to the arm64 container image by default. Override to
-# provide an alternate suffix or to omit.
-IMAGE_ARCH_SUFFIX = $(addprefix -,$(filter $(GOARCH),arm64))
+
 # GOLANG_IMAGE is the building golang container image used.
 GOLANG_IMAGE = public.ecr.aws/docker/library/golang:1.17-stretch
 # For the requested build, these are the set of Go specific build environment variables.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fix the image name for internal build process

**What does this PR do / Why do we need it**:
The internal build process requires the image name to have  `-arm64` for arm version. This was broken by https://github.com/aws/amazon-vpc-cni-k8s/pull/1824/files

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
