### PR TITLE
add cni release test script

### DIFF
--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# script to run integration and calico tests tests(no cluster creation & deletion/installing addons)
+# use case: run script after CNI images are updated to the image to be verified (see update-cni-images.sh)
+
+# CLUSTER_NAME: name of the cluster to run the test
+# VPC_ID: cluster VPC ID
+# REGION: default us-west-2
+# KUBE_CONFIG_PATH: path to the kubeconfig file, default ~/.kube/config
+# NG_LABEL_KEY: nodegroup label key, default "kubernetes.io/os"
+# NG_LABEL_VAL: nodegroup label val, default "linux"
+# CNI_METRICS_HELPER: cni metrics helper image tag, default "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.10"
+# CALICO_VERSION: calico version, default 3.22.0
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TEST_DIR="$SCRIPT_DIR/../test"
+INTEGRATION_TEST_DIR="$TEST_DIR/integration-new"
+CALICO_TEST_DIR="$TEST_DIR/e2e/calico"
+
+source "$SCRIPT_DIR"/lib/cluster.sh
+source "$SCRIPT_DIR"/lib/integration.sh
+
+function run_integration_test() {
+  : "${NG_LABEL_KEY:=kubernetes.io/os}"
+  : "${NG_LABEL_VAL:=linux}"
+  TEST_RESULT=success
+  echo "Running cni integration tests"
+  START=$SECONDS
+  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/cni --timeout 60m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
+  echo "cni test took $((SECONDS - START)) seconds."
+  echo "Running ipamd integration tests"
+  START=$SECONDS
+  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/ipamd --timeout 120m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
+  echo "ipamd test took $((SECONDS - START)) seconds."
+
+  : "${CNI_METRICS_HELPER:=602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.10}"
+  REPO_NAME=$(echo $CNI_METRICS_HELPER | cut -d ":" -f 1)
+  TAG=$(echo $CNI_METRICS_HELPER | cut -d ":" -f 2)
+  echo "Running cni-metrics-helper image($CNI_METRICS_HELPER) tests"
+  START=$SECONDS
+  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/metrics-helper --timeout 120m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" --cni-metrics-helper-image-repo=$REPO_NAME --cni-metrics-helper-image-tag=$TAG || TEST_RESULT=fail
+  echo "cni-metrics-helper test took $((SECONDS - START)) seconds."
+  if [[ "$TEST_RESULT" == fail ]]; then
+      echo "Integration test failed."
+      exit 1
+  fi
+  echo "Integration tests completed successfully!"
+}
+
+function run_calico_tests(){
+  # get version from run-integration-tests.sh
+  : "${CALICO_VERSION:=3.22.0}"
+  echo "Running calico tests, version $CALICO_VERSION"
+  START=$SECONDS
+  TEST_RESULT=success
+  ginkgo -v $CALICO_TEST_DIR -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID --calico-version=$CALICO_VERSION || TEST_RESULT=fail
+  if [[ "$TEST_RESULT" == fail ]]; then
+      echo "Calico tests failed."
+      exit 1
+  fi
+  echo "Calico tests completed successfully!"
+}
+
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
+
+echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION"
+load_cluster_details
+START=$SECONDS
+cd $TEST_DIR
+run_integration_test
+run_calico_tests
+echo "Completed running all tests in $((SECONDS - START)) seconds."

--- a/scripts/update-cni-images.sh
+++ b/scripts/update-cni-images.sh
@@ -25,4 +25,4 @@ grep -r -q $AMAZON_K8S_CNI_INIT $AWS_K8S_CNI_MANIFEST
 echo "Applying aws-k8s-cni.yaml manifest to aws-node daemonset"
 kubectl apply -f $AWS_K8S_CNI_MANIFEST
 
-check_ds_rollout "aws-node" "kube-system"
+check_ds_rollout "aws-node" "kube-system" "4m"

--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -40,6 +40,11 @@ func (d *defaultInstallationManager) InstallCNIMetricsHelper(image string, tag s
 	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 	projectRoot := strings.SplitAfter(dir, "amazon-vpc-cni-k8s")[0]
 
+	if dir == projectRoot {
+		// in prow tests, the repository name is "vpc-cni"
+		projectRoot = strings.SplitAfter(dir, "vpc-cni")[0]
+	}
+
 	values := map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": image,

--- a/test/framework/helm/release_manager.go
+++ b/test/framework/helm/release_manager.go
@@ -16,6 +16,7 @@ package helm
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -51,6 +52,7 @@ func (d *defaultReleaseManager) InstallUnPackagedRelease(chart string, releaseNa
 	installAction.Namespace = namespace
 	installAction.Wait = true
 	installAction.ReleaseName = releaseName
+	installAction.Timeout = time.Minute
 
 	return installCharts(installAction, chart, values)
 }

--- a/test/integration-new/README.md
+++ b/test/integration-new/README.md
@@ -54,6 +54,9 @@ In order to test a custom image you need pass the following tags along with the 
 
 *IMPORTANT*: Should use an IPv6 cluster with Prefix Delegation enabled. VPC CNI only supports IPv6 mode with Prefix Delegation.
 
+### Running release tests with scripts/run-cni-release-tests.sh
+`run-cni-release-tests.sh` will run cni, ipamd, and cni-metrics-helper (integration tests)[https://github.com/aws/amazon-vpc-cni-k8s/tree/master/test/integration-new] and (Calico tests)[https://github.com/aws/amazon-vpc-cni-k8s/tree/master/test/e2e/calico]. The script _does not_ create a test cluster, instead it will run the test on cluster specified via variables required in the script. The tests are run on the vpc-cni version installed on the cluster(it does not upgrade/install any specific vpc-cni version). See script `update-cni-images.sh` to update the test cluster with required cni version before running the tests. 
+
 ### Future Work
 Currently the package is named as `integration-new` because we already have `integration` directory with existing Ginkgo test cases with a separate `go.mod`. Once the older package is completely deprecated we will rename this package to `integration`.
 


### PR DESCRIPTION
**What type of PR is this?**
feature- test script

**Which issue does this PR fix**:
N/A. 

**What does this PR do / Why do we need it**:
Adding CNI release test script to run integration and calico tests

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
```
./scripts/run-pipeline-release-tests.sh 
Running release tests on cluster: dev-eks-test in region: us-west-2
loading cluster details dev-eks-test
Running cni integration tests
Running Suite: CNI Pod Networking Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/cni
===========================================================================================================================
..
cni test took 346 seconds.
Running ipamd integration tests
Running Suite: VPC IPAMD Test Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration-new/ipamd
=========================================================================================================================
...
ipamd test took 744 seconds.
Running calico tests, version 3.22.0
Running Suite: Calico with VPC CNI e2e Test Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/e2e/calico
============================================================================================================================
..
Test Suite Passed
Calico tests completed successfully!
Completed running all tests in 457 seconds.
```
**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.