### PR TITLE
 Update release manifests for VPC CNI v1.11.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v1.11.2
+## v1.11.1
 
 * Improvement -  [Update golang to Go 1.18](https://github.com/aws/amazon-vpc-cni-k8s/pull/1991) (@orsenthil)
 
-## v1.11.1
+## v1.11.0
 
 * Feature - [Support new SGPP standard mode](https://github.com/aws/amazon-vpc-cni-k8s/pull/1907) (@M00nF1sh )
 * Feature - [IPv4 Randomize SNAT support for IPv6 pods](https://github.com/aws/amazon-vpc-cni-k8s/pull/1903) (@achevuru)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 # Changelog
+
+## v1.11.2
+
+* Improvement -  [Update golang to Go 1.18](https://github.com/aws/amazon-vpc-cni-k8s/pull/1991) (@orsenthil)
+
+## v1.11.1
+
+* Feature - [Support new SGPP standard mode](https://github.com/aws/amazon-vpc-cni-k8s/pull/1907) (@M00nF1sh )
+* Feature - [IPv4 Randomize SNAT support for IPv6 pods](https://github.com/aws/amazon-vpc-cni-k8s/pull/1903) (@achevuru)
+* Feature - [Respect existing ENIConfig label if set on node](https://github.com/aws/amazon-vpc-cni-k8s/pull/1596) (@backjo)
+* Improvement - [Timeout and reconcile when checking API server connectivity](https://github.com/aws/amazon-vpc-cni-k8s/pull/1943)
+(@prateekgogia)
+* Improvement - [Improve startup performance of IPAMD](https://github.com/aws/amazon-vpc-cni-k8s/pull/1855) (@backjo)
+* Improvement - [Record pod metadata and allocationTime in IP allocation state file](https://github.com/aws/amazon-vpc-cni-k8s/pull/1958) (@M00nF1sh )
+* Bug - [Fixes node label error handling](https://github.com/aws/amazon-vpc-cni-k8s/pull/1892) & [revert to use update for node label update](https://github.com/aws/amazon-vpc-cni-k8s/pull/1959) (@jayanthvn, @M00nF1sh )
+       (#1959)
+* Bug - [IPAMD throw an error on configuration validation failure](https://github.com/aws/amazon-vpc-cni-k8s/pull/1698) (@veshij)
+* Cleanup - [refactoring DataStore.GetStats to simplify adding new fields](https://github.com/aws/amazon-vpc-cni-k8s/pull/1704) (@veshij)
+
+## v1.10.3
+
+* Improvement - [Upgrade AWS SDK GO](https://github.com/aws/amazon-vpc-cni-k8s/pull/1944) (@jayanthvn)
+* Improvement - [C7g instances support](https://github.com/aws/amazon-vpc-cni-k8s/pull/1940) (@jayanthvn)
+* Improvement - [Enable Prefix Delegation on Bare metal instances](https://github.com/aws/amazon-vpc-cni-k8s/pull/1937) (@achevuru)
+* Bugfix - [Fix dependabot high sev issue caused by GoGo protobuf](https://github.com/aws/amazon-vpc-cni-k8s/pull/1942) (@jayanthvn)
+* Bugfix - [Fixed empty netns bug](https://github.com/aws/amazon-vpc-cni-k8s/pull/1941 ) (@cgchinmay)
+
+
 ## v1.10.2
 * Improvement - [Fetch Region and CLUSTER_ID information from cni-metrics-helper env](https://github.com/aws/amazon-vpc-cni-k8s/pull/1715) (@cgchinmay )
 * Improvement - [Add VlanId in the cmdAdd Result struct](https://github.com/aws/amazon-vpc-cni-k8s/pull/1705) (@cgchinmay )

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.16
+version: 1.1.17
 appVersion: "v1.11.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
 version: 1.1.16
-appVersion: "v1.11.0"
+appVersion: "v1.11.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.11.0
+    tag: v1.11.1
     region: us-west-2
     account: "602401143452"   
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.11.0
+  tag: v1.11.1
   account: "602401143452"   
   domain: "amazonaws.com"  
   pullPolicy: Always

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.11.0
+appVersion: v1.11.1

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.11.0
+  tag: v1.11.1
   account: "602401143452"
   domain: "amazonaws.com"   
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.11.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.11.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.11.0"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.11.1"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.11.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.11.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.11.0"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.11.1"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.11.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.11.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.11.0"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.11.1"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.0"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.1"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.11.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.11.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.11.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.11.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.11.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.11.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/version: "v1.11.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.11.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.11.1"
       serviceAccountName: cni-metrics-helper


### PR DESCRIPTION
Replaces https://github.com/aws/amazon-vpc-cni-k8s/pull/1994

What type of PR is this?

    Updated release manifest in Charts and config directory.
    Replaced v1.11.0 with v1.11.1 in those directories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
