### PR TITLE
Update CNI Plugins to v1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ multi-arch-cni-init-build-push:     ## Build VPC CNI plugin Init container image
 		--push \
 		.
 # Fetch the CNI plugins
-plugins: FETCH_VERSION=0.9.0
+plugins: FETCH_VERSION=1.1.1
 plugins: FETCH_URL=https://github.com/containernetworking/plugins/releases/download/v$(FETCH_VERSION)/cni-plugins-$(GOOS)-$(GOARCH)-v$(FETCH_VERSION).tgz
 plugins: VISIT_URL=https://github.com/containernetworking/plugins/tree/v$(FETCH_VERSION)/plugins/
 plugins:   ## Fetch the CNI plugins


### PR DESCRIPTION
**What type of PR is this?**

Improvement - Update CNI Plugins to v1.1.1

**Which issue does this PR fix**:

Upgrades the CNI plugins used by vpc-cni

**What does this PR do / Why do we need it**:

General Improvement.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note
Includes v1.1.1 of CNI Plugins `loopback` `portmap` `bandwidth` and `host-local`

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
