### PR TITLE
fix integration test script

### DIFF
--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -15,9 +15,8 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-TEST_DIR="$SCRIPT_DIR/../test"
-INTEGRATION_TEST_DIR="$TEST_DIR/integration"
-CALICO_TEST_DIR="$TEST_DIR/e2e/calico"
+INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration"
+CALICO_TEST_DIR="$SCRIPT_DIR/../test/e2e/calico"
 
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/integration.sh
@@ -28,11 +27,12 @@ function run_integration_test() {
   TEST_RESULT=success
   echo "Running cni integration tests"
   START=$SECONDS
-  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/cni --timeout 60m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
+  # skip tests for changes not released yet and are applicable in future releases only, for now skipping 1.11.3
+  cd $INTEGRATION_TEST_DIR/cni && CGO_ENABLED=0 ginkgo --skip="1.11.3" -v -timeout 60m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
   echo "cni test took $((SECONDS - START)) seconds."
   echo "Running ipamd integration tests"
   START=$SECONDS
-  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/ipamd --timeout 120m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
+  cd $INTEGRATION_TEST_DIR/ipamd && CGO_ENABLED=0 ginkgo --skip="1.11.3" -v -timeout 90m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
   echo "ipamd test took $((SECONDS - START)) seconds."
 
   : "${CNI_METRICS_HELPER:=602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.7.10}"
@@ -40,7 +40,7 @@ function run_integration_test() {
   TAG=$(echo $CNI_METRICS_HELPER | cut -d ":" -f 2)
   echo "Running cni-metrics-helper image($CNI_METRICS_HELPER) tests"
   START=$SECONDS
-  CGO_ENABLED=0 ginkgo -v $INTEGRATION_TEST_DIR/metrics-helper --timeout 120m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" --cni-metrics-helper-image-repo=$REPO_NAME --cni-metrics-helper-image-tag=$TAG || TEST_RESULT=fail
+  cd $INTEGRATION_TEST_DIR/metrics-helper && CGO_ENABLED=0 ginkgo --skip="1.11.3" -v -timeout 15m --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" --cni-metrics-helper-image-repo=$REPO_NAME --cni-metrics-helper-image-tag=$TAG || TEST_RESULT=fail
   echo "cni-metrics-helper test took $((SECONDS - START)) seconds."
   if [[ "$TEST_RESULT" == fail ]]; then
       echo "Integration test failed."
@@ -70,7 +70,6 @@ fi
 echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION"
 load_cluster_details
 START=$SECONDS
-cd $TEST_DIR
 run_integration_test
 run_calico_tests
 echo "Completed running all tests in $((SECONDS - START)) seconds."

--- a/test/integration/ipamd/ipamd_event_test.go
+++ b/test/integration/ipamd/ipamd_event_test.go
@@ -29,7 +29,8 @@ import (
 const EKSCNIPolicyARN = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
 const AwsNodeLabelKey = "k8s-app"
 
-var _ = Describe("test aws-node pod event", func() {
+// Changes tested in this case is not released yet, adding future release version label to identify
+var _ = Describe("[1.11.3] test aws-node pod event", func() {
 
 	// Verifies aws-node pod events works as expected
 	Context("when iam role is missing VPC_CNI policy", func() {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
1. Previously ginkgo timeout was not being honored for ipamd tests. After changing to run test in each folder separately, the issue has been fixed.
2. Add PENDING_RELEASE label to skip tests not included in any release yet.

**Testing done on this change**:
Before this change, test was timing out after 1h(default ginkgo timeout) even when test timeout was set to 120m:
```
FAIL! - Interrupted by Timeout
--- FAIL: TestIPAMD (3626.82s)

Ginkgo ran 1 suite in 1h0m30.041509644s
```
ipamd test is run for >1h now:
```
Ginkgo ran 1 suite in 1h19m15.127402222s
```

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
**Does this PR introduce any user-facing change?**:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.