### PR TITLE
Enable Calico on ARM64 and add configureable flags for Calico installation

### DIFF
--- a/scripts/lib/integration.sh
+++ b/scripts/lib/integration.sh
@@ -36,17 +36,30 @@ function run_calico_test() {
   echo "Starting Helm installing Tigera operator and running Calico STAR tests"
   pushd ./test
   VPC_ID=$(eksctl get cluster $CLUSTER_NAME -oyaml | grep vpc | cut -d ":" -f 2 | awk '{$1=$1};1')
-  # we can automatically use latest version in Calico repo, or use the known highest version (currently v3.22.0)
+
   calico_version=$CALICO_VERSION
-  if [[ $RUN_LATEST_CALICO_VERSION == true ]]; then
-    version_tag=$(curl -i https://api.github.com/repos/projectcalico/calico/releases/latest | grep "tag_name") || true
-    if [[ -n $version_tag ]]; then
-      calico_version=$(echo $version_tag | cut -d ":" -f 2 | cut -d '"' -f 2 )
-    else
-      echo "Getting Calico latest version failed, will fall back to default/set version $calico_version instead"
+  if [[ $1 == "true" ]]; then
+    # we can automatically use latest version in Calico repo, or use the known highest version (currently v3.23.0)
+    if [[ $RUN_LATEST_CALICO_VERSION == true ]]; then
+      version_tag=$(curl -i https://api.github.com/repos/projectcalico/calico/releases/latest | grep "tag_name") || true
+      if [[ -n $version_tag ]]; then
+        calico_version=$(echo $version_tag | cut -d ":" -f 2 | cut -d '"' -f 2 )
+      else
+        echo "Getting Calico latest version failed, will fall back to default/set version $calico_version instead"
+      fi
+    else echo "Using default Calico version"
     fi
+    echo "Using Calico version $calico_version to test"
+  else
+    version=$(kubectl describe ds -n calico-system calico-node | grep "calico/node:" | cut -d ':' -f3)
+    echo "Calico has been installed in testing cluster, keep using the version $version"
   fi
-  echo "Using Calico version $calico_version to test"
-  ginkgo -v e2e/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version
+
+  echo "Testing amd64"
+  instance_type="amd64"
+  ginkgo -v e2e/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version --instance-type=$instance_type --install-calico=$1
+  echo "Testing arm64"
+  instance_type="arm64"
+  ginkgo -v e2e/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version --instance-type=$instance_type --install-calico=false
   popd
 }

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -51,7 +51,7 @@ function run_integration_test() {
 
 function run_calico_tests(){
   # get version from run-integration-tests.sh
-  : "${CALICO_VERSION:=3.22.0}"
+  : "${CALICO_VERSION:=3.23.0}"
   echo "Running calico tests, version $CALICO_VERSION"
   START=$SECONDS
   TEST_RESULT=success

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -51,7 +51,7 @@ function run_integration_test() {
 
 function run_calico_tests(){
   # get version from run-integration-tests.sh
-  : "${CALICO_VERSION:=3.23.0}"
+  : "${CALICO_VERSION:=v3.23.0}"
   echo "Running calico tests, version $CALICO_VERSION"
   START=$SECONDS
   TEST_RESULT=success

--- a/test/e2e/calico/calico_suite_test.go
+++ b/test/e2e/calico/calico_suite_test.go
@@ -45,7 +45,7 @@ var _ = BeforeSuite(func() {
 		err := f.InstallationManager.InstallTigeraOperator(tigeraVersion)
 		// wait for Calico resources being provisioned and setup.
 		// we don't have control on Calico pods metadata thus we may not poll the pods for waiting wisely.
-		time.Sleep(utils.DefaultDeploymentReadyTimeout)
+		time.Sleep(utils.DefaultDeploymentReadyTimeout / 2)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	TargetAddon      string
 	InitialManifest  string
 	TargetManifest   string
+	InstallCalico    bool
 }
 
 func (options *Options) BindFlags() {
@@ -55,9 +56,10 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.TargetAddon, "target-addon-version", "", "Target CNI addon version after upgrade applied")
 	flag.StringVar(&options.InitialManifest, "initial-manifest-file", "", "Initial CNI manifest, can be local file path or remote Url")
 	flag.StringVar(&options.TargetManifest, "target-manifest-file", "", "Target CNI manifest, can be local file path or remote Url")
-	flag.StringVar(&options.CalicoVersion, "calico-version", "3.22.0", "calico version to be tested")
+	flag.StringVar(&options.CalicoVersion, "calico-version", "v3.23.0", "calico version to be tested")
 	flag.StringVar(&options.ContainerRuntime, "container-runtime", "", "Optionally can specify it as 'containerd' for the test nodes")
 	flag.StringVar(&options.InstanceType, "instance-type", "amd64", "Optionally specify instance type as arm64 for the test nodes")
+	flag.BoolVar(&options.InstallCalico, "install-calico", true, "Install Calico operator before running e2e tests")
 }
 
 func (options *Options) Validate() error {


### PR DESCRIPTION
Enable ARM for Calico integration tests on latest Calico version. Also fix a failing cause when running multiple times of the test on different settings.
- support ARM64 via Calico multi-arch image
- add flag InstallCalico 
- use instance-type flag to direct Calico tests

####Tests####
Tests were done and passed from dev cluster in us-west-2
- amd64
- arm64
- amd64 with prefix delegation
- arm64 with prefix delegation
```
Ran 22 of 22 Specs in 238.575 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 4m6.691385569s
Test Suite Passed
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
