### PR TITLE
Use minimal base image for Docker Builds.

### DIFF
--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -12,11 +12,7 @@ RUN make plugins && make debug-script
 
 COPY . ./
 
-# Build the architecture specific container image:
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum update -y && \
-    yum install -y iproute procps-ng && \
-    yum clean all
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest.2022
 
 WORKDIR /init
 

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -14,9 +14,7 @@ RUN go mod download
 COPY . ./
 RUN make build-metrics
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum update -y && \
-	yum clean all
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest.2022
 
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -17,11 +17,7 @@ RUN make plugins && make debug-script
 COPY . ./
 RUN make build-linux
 
-# Build the architecture specific container image:
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum update -y && \
-    yum install -y iptables iproute jq && \
-    yum clean all
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest.2022
 
 WORKDIR /app
 


### PR DESCRIPTION
**What type of PR is this?**

* Use minimal base image
* The required packages are already included in the minimal base.

**Testing done on this change**:

$ make docker
$ make docker-unit-tests

Triggered Integration Tests - https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/2491111408 

were successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
