### PR TITLE
Fix go build failure with v6 networking suite.

### DIFF
--- a/test/integration/ipv6/pod_traffic_test_v6_PD_enabled.go
+++ b/test/integration/ipv6/pod_traffic_test_v6_PD_enabled.go
@@ -14,12 +14,15 @@
 package ipv6
 
 import (
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/agent"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var f *framework.Framework
 
 var _ = Describe("[CANARY] Test pod networking with prefix delegation enabled", func() {
 	var (

--- a/test/integration/ipv6/pod_v6_networking_suite_test.go
+++ b/test/integration/ipv6/pod_v6_networking_suite_test.go
@@ -28,7 +28,6 @@ import (
 
 const InstanceTypeNodeLabelKey = "beta.kubernetes.io/instance-type"
 
-var f *framework.Framework
 var primaryNode v1.Node
 
 func TestCNIv6PodNetworking(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

* bug
* cleanup

**Which issue does this PR fix**:

Before this change

```
[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipv6]$ go build .
# github.com/aws/amazon-vpc-cni-k8s/test/integration/ipv6
./pod_traffic_test_v6_PD_enabled.go:38:17: undefined: f
./pod_traffic_test_v6_PD_enabled.go:44:37: undefined: f
./pod_traffic_test_v6_PD_enabled.go:66:37: undefined: f
```

After this change.

[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipv6]$ go build .


**What does this PR do / Why do we need it**:

To exercise tests

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
