### PR TITLE
Fix Go build for ipamd test package.

### DIFF
--- a/test/integration/ipamd/eni_ip_leak_test.go
+++ b/test/integration/ipamd/eni_ip_leak_test.go
@@ -1,6 +1,7 @@
 package ipamd
 
 import (
+	"k8s.io/api/core/v1"
 	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
@@ -14,6 +15,9 @@ const (
 	HOST_POD_LABEL_KEY = "network"
 	HOST_POD_LABEL_VAL = "host"
 )
+
+var primaryNode v1.Node
+var numOfNodes int
 
 var _ = Describe("[CANARY] ENI/IP Leak Test", func() {
 	Context("ENI/IP Released on Pod Deletion", func() {

--- a/test/integration/ipamd/eni_ip_leak_test.go
+++ b/test/integration/ipamd/eni_ip_leak_test.go
@@ -1,8 +1,9 @@
 package ipamd
 
 import (
-	"k8s.io/api/core/v1"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -18,18 +18,9 @@ import (
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 )
-
-var err error
-var f *framework.Framework
-var primaryNode v1.Node
-var primaryInstance *ec2.Instance
-var numOfNodes int
-var addonDeleteError error
 
 func TestIPAMD(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/integration/ipamd/warm_target_test.go
+++ b/test/integration/ipamd/warm_target_test.go
@@ -171,24 +171,3 @@ var _ = Describe("test warm target variables", func() {
 		})
 	})
 })
-
-func Max(x, y int) int {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-// MinIgnoreZero returns smaller of two number, if any number is zero returns the other number
-func MinIgnoreZero(x, y int) int {
-	if x == 0 {
-		return y
-	}
-	if y == 0 {
-		return x
-	}
-	if x < y {
-		return x
-	}
-	return y
-}

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -15,10 +15,11 @@ package ipamd
 
 import (
 	"fmt"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"strconv"
 	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -15,6 +15,8 @@ package ipamd
 
 import (
 	"fmt"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"strconv"
 	"time"
 
@@ -24,6 +26,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var primaryInstance *ec2.Instance
+var f *framework.Framework
+var err error
 
 // IMPORTANT: THE NODEGROUP TO RUN THE TEST MUST NOT HAVE ANY POD
 // Ideally we should drain the node, but drain from go client is non trivial
@@ -321,4 +327,25 @@ var _ = Describe("test warm target variables", func() {
 
 func ceil(x, y int) int {
 	return (x + y - 1) / y
+}
+
+func Max(x, y int) int {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+// MinIgnoreZero returns smaller of two number, if any number is zero returns the other number
+func MinIgnoreZero(x, y int) int {
+	if x == 0 {
+		return y
+	}
+	if y == 0 {
+		return x
+	}
+	if x < y {
+		return x
+	}
+	return y
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug
cleanup

**Which issue does this PR fix**:

`go build .`  compilation in ipamd test package. These fixe the references to these tests and packages, when we are exercising through IDE.


**What does this PR do / Why do we need it**:

The _test.go files are compiled only when you run go test.
When a package is imported from another package any code from its _test.go files is not used.

https://stackoverflow.com/questions/36638149/undefined-variables-within-a-package-during-build


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:

Before this change.
```
[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd]$ go build .
# github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd
./warm_target_test_PD_enabled.go:42:52: undefined: f
./warm_target_test_PD_enabled.go:54:4: undefined: primaryInstance
./warm_target_test_PD_enabled.go:54:21: undefined: err
./warm_target_test_PD_enabled.go:54:27: undefined: f
./warm_target_test_PD_enabled.go:55:29: undefined: primaryInstance
./warm_target_test_PD_enabled.go:56:11: undefined: err
./warm_target_test_PD_enabled.go:59:21: undefined: f
./warm_target_test_PD_enabled.go:66:7: undefined: primaryInstance
./warm_target_test_PD_enabled.go:67:30: undefined: primaryInstance
./warm_target_test_PD_enabled.go:74:37: undefined: primaryInstance
./warm_target_test_PD_enabled.go:74:37: too many errors
```

After this change.

```
[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd]$ go build .
[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd]$

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
