### PR TITLE
Fix go build for cni test package.

### DIFF
--- a/test/integration/cni/pod_networking_suite_test.go
+++ b/test/integration/cni/pod_networking_suite_test.go
@@ -28,7 +28,6 @@ import (
 
 const InstanceTypeNodeLabelKey = "beta.kubernetes.io/instance-type"
 
-var f *framework.Framework
 var maxIPPerInterface int
 var primaryNode v1.Node
 var secondaryNode v1.Node

--- a/test/integration/cni/pod_traffic_test_PD_enabled.go
+++ b/test/integration/cni/pod_traffic_test_PD_enabled.go
@@ -14,6 +14,7 @@
 package cni
 
 import (
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
@@ -21,6 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 )
+
+var f *framework.Framework
 
 var _ = Describe("Test pod networking with prefix delegation enabled", func() {
 	var (


### PR DESCRIPTION
**What type of PR is this?**

* bug
* cleanup

**Which issue does this PR fix**:

Go build for cni test package.

**What does this PR do / Why do we need it**:

Ability to run test from IDEs.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Before this change**
```
[senthilx@88665a371033:~/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni]$ go build .
# github.com/aws/amazon-vpc-cni-k8s/test/integration/cni
./pod_traffic_test_PD_enabled.go:36:17: undefined: f
./pod_traffic_test_PD_enabled.go:39:51: undefined: f
./pod_traffic_test_PD_enabled.go:45:51: undefined: f
./pod_traffic_test_PD_enabled.go:58:27: undefined: f
./pod_traffic_test_PD_enabled.go:70:27: undefined: f
./pod_traffic_test_PD_toggle.go:48:18: undefined: f
./pod_traffic_test_PD_toggle.go:52:51: undefined: f
./pod_traffic_test_PD_toggle.go:60:52: undefined: f
./pod_traffic_test_PD_toggle.go:77:37: undefined: f
./pod_traffic_test_PD_toggle.go:106:37: undefined: f
./pod_traffic_test_PD_toggle.go:106:37: too many errors
```

**After this change**

```
$ go build .
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
