### PR TITLE
Re-use logger instance (#2029)

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -29,11 +29,7 @@ func main() {
 
 func _main() int {
 	//Do not add anything before initializing logger
-	logConfig := logger.Configuration{
-		LogLevel:    logger.GetLogLevel(),
-		LogLocation: logger.GetLogLocation(),
-	}
-	log := logger.New(&logConfig)
+	log := logger.Get()
 
 	log.Infof("Starting L-IPAMD %s  ...", version.Version)
 	version.RegisterMetric()

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -47,22 +47,17 @@ type Logger interface {
 
 // Get returns an default instance of the zap logger
 func Get() Logger {
-	var logf = &structuredLogger{}
-	if logf.isEmpty() {
+	if log == nil {
 		logConfig := LoadLogConfig()
 		log = New(logConfig)
-		return log
+		log.Info("Initialized new logger as an existing instance was not found")
 	}
-	log = logf
 	return log
-}
-
-func (logf *structuredLogger) isEmpty() bool {
-	return logf.zapLogger == nil
 }
 
 //New logger initializes logger
 func New(inputLogConfig *Configuration) Logger {
 	log = inputLogConfig.newZapLogger()
+	log.Info("Constructed new logger instance")
 	return log
 }

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -30,6 +30,21 @@ func TestEnvLogFilePath(t *testing.T) {
 	assert.Equal(t, path, GetLogLocation())
 }
 
+func TestLoggerGetSameInstance(t *testing.T) {
+	log1 := Get()
+	log2 := Get()
+
+	assert.True(t, log1 == log2)
+}
+
+func TestLoggerNewAndGetSameInstance(t *testing.T) {
+	logConfig := LoadLogConfig()
+	log1 := New(logConfig)
+	log2 := Get()
+
+	assert.True(t, log1 == log2)
+}
+
 func TestGetLogFileLocationReturnsDefaultPath(t *testing.T) {
 	defaultPath := "/host/var/log/aws-routed-eni/ipamd.log"
 	assert.Equal(t, defaultPath, GetLogLocation())


### PR DESCRIPTION
* Re-use logger instance

- Existing logger initialization constructed different logger
  instances upon call to Get() method.
- Fixed the initialization logic to re-use the logger instance.

* Added unit tests for logger initialization fix
* 
Cherry-pick of PR #2029 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
