### PR TITLE
fix ipamd integration failures and cleanup

### DIFF
--- a/test/framework/resources/aws/services/iam.go
+++ b/test/framework/resources/aws/services/iam.go
@@ -37,6 +37,7 @@ type IAM interface {
 	CreatePolicy(policyName string, policyDocument string) (*iam.CreatePolicyOutput, error)
 	DeletePolicy(policyARN string) error
 	GetInstanceProfile(instanceProfileName string) (*iam.GetInstanceProfileOutput, error)
+	ListPolicies(scope string) (*iam.ListPoliciesOutput, error)
 }
 
 type defaultIAM struct {
@@ -82,6 +83,13 @@ func (d *defaultIAM) GetInstanceProfile(instanceProfileName string) (*iam.GetIns
 		InstanceProfileName: aws.String(instanceProfileName),
 	}
 	return d.IAMAPI.GetInstanceProfile(getInstanceProfileInput)
+}
+
+func (d *defaultIAM) ListPolicies(scope string) (*iam.ListPoliciesOutput, error) {
+	listPolicyInput := &iam.ListPoliciesInput{
+		Scope: aws.String(scope),
+	}
+	return d.IAMAPI.ListPolicies(listPolicyInput)
 }
 
 func NewIAM(session *session.Session) IAM {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -38,6 +38,26 @@ ginkgo -v --failOnPending -- \
 ```
 
 ### cni-metrics-helper
+
+> #### Prerequisites: 
+>
+> This test expects CNIMetricsHelperPolicy to be present in the test account. Create the policy with below permissions:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricData"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
 The CNI Metrics Helper Integration test uses helm to install the cni-metrics-helper. The helm charts are present in local test directory and if needed can be published to a repository.
 
 In order to test a custom image you need pass the following tags along with the tags discussed above.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -41,7 +41,7 @@ ginkgo -v --failOnPending -- \
 
 > #### Prerequisites: 
 >
-> This test expects CNIMetricsHelperPolicy to be present in the test account. Create the policy with below permissions:
+> This test expects CNIMetricsHelperPolicy to be present in the test account. Create the policy with below permissions in the test account:
 
 ```
 {

--- a/test/integration/ipamd/eni_ip_leak_test.go
+++ b/test/integration/ipamd/eni_ip_leak_test.go
@@ -22,11 +22,6 @@ var numOfNodes int
 
 var _ = Describe("[CANARY] ENI/IP Leak Test", func() {
 	Context("ENI/IP Released on Pod Deletion", func() {
-		BeforeEach(func() {
-			By("creating test namespace")
-			f.K8sResourceManagers.NamespaceManager().
-				CreateNamespace(utils.DefaultTestNamespace)
-		})
 
 		It("Verify that on Pod Deletion, ENI/IP State is restored", func() {
 			// Set the WARM_ENI_TARGET to 0 to prevent all pods being scheduled on secondary ENI
@@ -72,9 +67,6 @@ var _ = Describe("[CANARY] ENI/IP Leak Test", func() {
 		})
 
 		AfterEach(func() {
-			By("deleting test namespace")
-			f.K8sResourceManagers.NamespaceManager().
-				DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 
 			By("Restoring WARM ENI Target value")
 			k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",

--- a/test/integration/ipamd/eni_tag_test.go
+++ b/test/integration/ipamd/eni_tag_test.go
@@ -39,9 +39,6 @@ var _ = Describe("test tags are created on Secondary ENI", func() {
 	// sets the desired environment variables and gets the list of new ENIs created after setting
 	// the environment variables
 	JustBeforeEach(func() {
-		By("creating test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			CreateNamespace(utils.DefaultTestNamespace)
 
 		// To re-initialize for each test case
 		newENIs = []string{}
@@ -84,9 +81,6 @@ var _ = Describe("test tags are created on Secondary ENI", func() {
 	})
 
 	JustAfterEach(func() {
-		By("deleting test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 
 		envVarToRemove := map[string]struct{}{}
 		for key, _ := range environmentVariables {

--- a/test/integration/ipamd/introspection_test.go
+++ b/test/integration/ipamd/introspection_test.go
@@ -34,9 +34,6 @@ var _ = Describe("test Environment Variables for IPAMD Introspection ", func() {
 	var curlJob *v1.Job
 
 	JustBeforeEach(func() {
-		By("creating test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			CreateNamespace(utils.DefaultTestNamespace)
 
 		// Initially the host networking job pod should succeed
 		curlContainer = manifest.NewCurlContainer().
@@ -65,12 +62,6 @@ var _ = Describe("test Environment Variables for IPAMD Introspection ", func() {
 		err = f.K8sResourceManagers.JobManager().
 			DeleteAndWaitTillJobIsDeleted(curlJob)
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	JustAfterEach(func() {
-		By("deleting test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 	})
 
 	Context("when disabling introspection by setting DISABLE_INTROSPECTION to true", func() {

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -15,9 +15,11 @@ package ipamd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -29,6 +31,10 @@ func TestIPAMD(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	f = framework.New(framework.GlobalOptions)
+
+	By("creating test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		CreateNamespace(utils.DefaultTestNamespace)
 
 	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey,
 		f.Options.NgNameLabelVal)
@@ -43,4 +49,17 @@ var _ = BeforeSuite(func() {
 	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
+
+	// Remove WARM_ENI_TARGET, WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET before running IPAMD tests
+	k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",
+		"aws-node", map[string]struct{}{"WARM_ENI_TARGET": {}, "WARM_IP_TARGET": {}, "MINIMUM_IP_TARGET": {}, "WARM_PREFIX_TARGET": {}})
+
+	// Allow reconciler to free up ENIs if any
+	time.Sleep(utils.PollIntervalLong)
+})
+
+var _ = AfterSuite(func() {
+	By("deleting test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 })

--- a/test/integration/ipamd/metrics_test.go
+++ b/test/integration/ipamd/metrics_test.go
@@ -32,18 +32,6 @@ var _ = Describe("test IPAMD metric environment variable", func() {
 	// Job's output determines if the API is reachable or not
 	var curlJob *v1.Job
 
-	JustBeforeEach(func() {
-		By("creating test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			CreateNamespace(utils.DefaultTestNamespace)
-	})
-
-	JustAfterEach(func() {
-		By("deleting test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
-	})
-
 	Context("when metrics is disabled", func() {
 		metricAddr := "127.0.0.1:61678/metrics"
 		It("should not be accessible anymore", func() {

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -73,7 +73,6 @@ var _ = Describe("test warm target variables", func() {
 					*primaryInstance.PrivateDnsName, pod.Status.PodIP, pod.Spec.NodeName))
 				if pod.Spec.NodeName == *primaryInstance.PrivateDnsName {
 					assigned++
-					break
 				}
 			}
 

--- a/test/integration/metrics-helper/metric_helper_test.go
+++ b/test/integration/metrics-helper/metric_helper_test.go
@@ -28,18 +28,6 @@ import (
 
 var _ = Describe("test cni-metrics-helper publishes metrics", func() {
 
-	JustBeforeEach(func() {
-		By("creating test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			CreateNamespace(utils.DefaultTestNamespace)
-	})
-
-	JustAfterEach(func() {
-		By("deleting test namespace")
-		f.K8sResourceManagers.NamespaceManager().
-			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
-	})
-
 	Context("when a metric is updated", func() {
 		It("the updated metric is published to CW", func() {
 


### PR DESCRIPTION
**What type of PR is this?**
bug, cleanup

**What does this PR do / Why do we need it**:
1. Fix ipamd integration test failures: Remove WARM_ENI_TARGET, WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET before running IPAMD warm target tests
2. Remove CNIMetricsHelperPolicy creation in test suite
3. Cleanup: Move test namespace creation and deletion to before suite & after suite respectively to avoid doing for each test case

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
```
ginkgo -v -timeout 100m --fail-on-pending -- \
 --cluster-kubeconfig=$KUBECONFIG \
 --cluster-name=$CLUSTER_NAME \
 --aws-region=$AWS_REGION \
 --aws-vpc-id=$VPC_ID \
 --ng-name-label-key=$NG_NAME_LABEL_KEY \
 --ng-name-label-val=$NG_NAME_LABEL_VAL
Running Suite: VPC IPAMD Test Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd
=====================================================================================================================
Random Seed: 1658486649

Will run 26 of 26 specs
<REDACTED FOR VERBOSITY>

Ran 26 of 26 Specs in 5244.027 seconds
FAIL! -- 25 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestIPAMD (5244.03s)
FAIL

Ginkgo ran 1 suite in 1h27m45.209972174s

Test Suite Failed
```

The one failed test above is testing unauthorized event on aws-node pod when VPC_CNI policy is missing. This test is not applicable to current release and can be ignored for now.

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.