### PR TITLE
Remove extra decrement of totalIP count

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -1219,10 +1219,7 @@ func (ds *DataStore) UnassignPodIPAddress(ipamKey IPAMKey) (e *ENI, ip string, d
 		return nil, "", 0, err
 	}
 	addr.UnassignedTime = time.Now()
-	if ds.isPDEnabled && !availableCidr.IsPrefix {
-		ds.log.Infof("Prefix delegation is enabled and the IP is from secondary pool hence no need to update prefix pool")
-		ds.total--
-	}
+
 	//Update prometheus for ips per cidr
 	ipsPerCidr.With(prometheus.Labels{"cidr": availableCidr.Cidr.String()}).Dec()
 	ds.log.Infof("UnassignPodIPAddress: sandbox %s's ipAddr %s, DeviceNumber %d",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Wrong computation of totalIPs

**What does this PR do / Why do we need it**:
The issue is because we decrement the total here - https://github.com/aws/amazon-vpc-cni-k8s/blob/c7443ae30f40037adaa997c26b66fc5912737958/pkg/ipamd/datastore/data_store.go#L1224 and decrement again here https://github.com/aws/amazon-vpc-cni-k8s/blob/c7443ae30f40037adaa997c26b66fc5912737958/pkg/ipamd/datastore/data_store.go#L655 while we force delete the secondary IP because we are in PD mode and we don't need the IP/32 anymore attached to the instance.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
#2041 

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Repro'ed the issue and fix is holding up

Secondary IP mode and 1 pod running ->

```
"TotalIPs":10,"AssignedIPs":1
```

PD mode toggle ->

```
"TotalIPs":17,"AssignedIPs":1
```

Deleted the pod behind secondary IP ->

```
"TotalIPs":16,"AssignedIPs":0
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No, will add it up

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
