### PR TITLE
cleanup info logs in event recorder and test script (#2043)

### DIFF
--- a/pkg/utils/eventrecorder/eventrecorder.go
+++ b/pkg/utils/eventrecorder/eventrecorder.go
@@ -64,7 +64,6 @@ func InitEventRecorder(k8sClient client.Client) error {
 	})
 	recorder.k8sClient = k8sClient
 	eventRecorder = recorder
-	log.Infof("eventrecoder set:", eventRecorder.recorder)
 	return nil
 }
 

--- a/scripts/update-cni-images.sh
+++ b/scripts/update-cni-images.sh
@@ -14,7 +14,7 @@ AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni.yaml"
 MANIFEST_IMG_VERSION=`grep "image:" $AWS_K8S_CNI_MANIFEST | cut -d ":" -f3 | cut -d "\"" -f1 | head -1`
 
 # Replace the images in aws-k8s-cni.yaml with the tester images
-echo "Replacing images in aws-k8s-cni manifest with \$AMAZON_K8S_CNI and \$AMAZON_K8S_CNI_INIT"
+echo "Replacing images in aws-k8s-cni manifest with $AMAZON_K8S_CNI and $AMAZON_K8S_CNI_INIT"
 sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI," "$AWS_K8S_CNI_MANIFEST"
 sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI_INIT," "$AWS_K8S_CNI_MANIFEST"
 


### PR DESCRIPTION
**What type of PR is this?**
Cleanup- Cherry-pick commit 35eac2d187d29d77e4850f524c58f3aac5ae6bf2 from master to release-1.11 branch

**Which issue does this PR fix**:
**What does this PR do / Why do we need it**:
**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
**Testing done on this change**:<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
**Automation added to e2e**:<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
**Will this PR introduce any new dependencies?**:<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
**Does this change require updates to the CNI daemonset config files to work?**:<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
**Does this PR introduce any user-facing change?**:<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A, PR to clean up info logs only. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
