### PR TITLE
add nodeSelector to cni-metrics-helper deployment

### DIFF
--- a/test/helm/charts/cni-metrics-helper/values.yaml
+++ b/test/helm/charts/cni-metrics-helper/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper
   pullPolicy: Always
-  tag: "v1.7.10"
+  tag: "v1.11.2"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -56,7 +56,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: "linux"
 
 tolerations: []
 

--- a/test/integration/metrics-helper/metrics_helper_suite_test.go
+++ b/test/integration/metrics-helper/metrics_helper_suite_test.go
@@ -52,7 +52,7 @@ const (
 // Parse optional flags for setting the cni metrics helper image
 func init() {
 	flag.StringVar(&imageRepository, "cni-metrics-helper-image-repo", "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper", "CNI Metrics Helper Image Repository")
-	flag.StringVar(&imageTag, "cni-metrics-helper-image-tag", "v1.7.10", "CNI Metrics Helper Image Tag")
+	flag.StringVar(&imageTag, "cni-metrics-helper-image-tag", "v1.11.2", "CNI Metrics Helper Image Tag")
 
 	// Order in which we try fetch the keys and use it as CLUSTER_ID dimension
 	clusterIDKeys = []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**What does this PR do / Why do we need it**:
Add nodeSelector to cni-metrics-helper deployment in tests so pods get scheduled on Linux nodes only when a mix of Linux & Windows pod are present on the cluster. Without this field, pod may get scheduled on Windows node & fail to be ready as we do not enable Windows IPAM for vpc-cni tests.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran metrics-helper integration test & verified nodeSelector field in ```kubectl describe pod```
```
kubectl describe pod -n kube-system cni-metrics-helper-55996558b5-9dptm
Name:         cni-metrics-helper-55996558b5-9dptm
Namespace:    kube-system
Node-Selectors:              kubernetes.io/os=linux
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
None. 

**Will this PR introduce any new dependencies?**:<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No, only cni-metrics-helper deployment in test folder is updated. 

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
