### PR TITLE
update aws-node clusterrole permissions

### DIFF
--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.19
+version: 1.1.20
 appVersion: "v1.11.3"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -36,4 +36,4 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -73,7 +73,7 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -73,7 +73,7 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -73,7 +73,7 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -73,7 +73,7 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug, cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Updates aws-node clusterrole permissions to have the least required permissions

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Ran the relevant integration test:
```
[9/08/22 10:32:01] ➜  ipamd git:(eaca3fe5) ✗ ginkgo -v -timeout 10m --fail-on-pending -- \
 --cluster-kubeconfig=$KUBECONFIG \
 --cluster-name=$CLUSTER_NAME \
 --aws-region=$AWS_REGION \
 --aws-vpc-id=$VPC_ID \
 --ng-name-label-key=$NG_NAME_LABEL_KEY \
 --ng-name-label-val=$NG_NAME_LABEL_VAL
Running Suite: VPC IPAMD Test Suite - /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd
=====================================================================================================================
Random Seed: 1660066326

Will run 1 of 26 specs
------------------------------
[BeforeSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_suite_test.go:32
I0809 10:32:30.451424   48615 request.go:665] Waited for 1.001363345s due to client-side throttling, not priority and fairness, request: GET:https://1C30ABE12DEABC4CBA07E6115710E11D.yl4.us-west-2.eks.amazonaws.com/apis/coordination.k8s.io/v1?timeout=32s
STEP: creating test namespace 08/09/22 10:32:32.241
STEP: removing the environment variables from the ds map[MINIMUM_IP_TARGET:{} WARM_ENI_TARGET:{} WARM_IP_TARGET:{} WARM_PREFIX_TARGET:{}] 08/09/22 10:32:33.083
STEP: getting the aws-node daemon set in namesapce kube-system 08/09/22 10:32:33.083
STEP: updating the daemon set with new environment variable 08/09/22 10:32:33.284
------------------------------
[BeforeSuite] PASSED [25.348 seconds]
[BeforeSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_suite_test.go:32

  Begin Captured GinkgoWriter Output >>
    STEP: creating test namespace 08/09/22 10:32:32.241
    STEP: removing the environment variables from the ds map[MINIMUM_IP_TARGET:{} WARM_ENI_TARGET:{} WARM_IP_TARGET:{} WARM_PREFIX_TARGET:{}] 08/09/22 10:32:33.083
    STEP: getting the aws-node daemon set in namesapce kube-system 08/09/22 10:32:33.083
    STEP: updating the daemon set with new environment variable 08/09/22 10:32:33.284
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSS
------------------------------
[1.11.3] test aws-node pod event when iam role is missing VPC_CNI policy
  unauthorized event must be raised on aws-node pod
  /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_event_test.go:105
STEP: getting the iam role 08/09/22 10:32:53.513
STEP: detaching VPC_CNI policy and restart aws-node pods 08/09/22 10:32:53.814
STEP: checking aws-node pods not running 08/09/22 10:33:44.627
STEP: attaching VPC_CNI policy and restart aws-node pods 08/09/22 10:33:49.627
STEP: checking aws-node pods are running 08/09/22 10:34:28.062
------------------------------
• [SLOW TEST] [104.551 seconds]
[1.11.3] test aws-node pod event
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_event_test.go:33
  when iam role is missing VPC_CNI policy
  /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_event_test.go:36
    unauthorized event must be raised on aws-node pod
    /Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_event_test.go:105

  Begin Captured GinkgoWriter Output >>
    STEP: getting the iam role 08/09/22 10:32:53.513
    STEP: detaching VPC_CNI policy and restart aws-node pods 08/09/22 10:32:53.814
    STEP: checking aws-node pods not running 08/09/22 10:33:44.627
    STEP: attaching VPC_CNI policy and restart aws-node pods 08/09/22 10:33:49.627
    STEP: checking aws-node pods are running 08/09/22 10:34:28.062
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSSSSSSSS
------------------------------
[AfterSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_suite_test.go:61
STEP: deleting test namespace 08/09/22 10:34:38.073
------------------------------
[AfterSuite] PASSED [6.436 seconds]
[AfterSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_suite_test.go:61

  Begin Captured GinkgoWriter Output >>
    STEP: deleting test namespace 08/09/22 10:34:38.073
  << End Captured GinkgoWriter Output
------------------------------

Ran 1 of 26 Specs in 136.351 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 25 Skipped
PASS | FOCUSED
```
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A, test already present
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
No.
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, upgrade from 1.11.2 tested.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes, updated. 
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No.
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
