### PR TITLE
request NET_RAW capabilities in CNI manifests

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -63,8 +63,7 @@ The following table lists the configurable parameters for this chart and their d
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
 | `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
-| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" 
-- "NET_RAW"`  |
+| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"`  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -63,7 +63,8 @@ The following table lists the configurable parameters for this chart and their d
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
 | `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
-| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN"`  |
+| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" 
+- "NET_RAW"`  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -67,6 +67,7 @@ securityContext:
   capabilities:
     add:
     - "NET_ADMIN"
+    - "NET_RAW"
 
 crd:
   create: true

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -79,6 +79,7 @@ securityContext:
   capabilities:
     add:
     - "NET_ADMIN"
+    - "NET_RAW"
 
 crd:
   create: true

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -219,6 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
+	      - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -219,7 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-	      - NET_RAW
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -219,6 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
+	      - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -219,7 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-	      - NET_RAW
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -219,6 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
+	      - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -219,7 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-	      - NET_RAW
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -219,6 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
+	      - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -219,7 +219,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-	      - NET_RAW
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -199,7 +199,7 @@ local awsnode = {
                 requests: {cpu: "25m"},
               },
               securityContext: {
-                capabilities: {add: ["NET_ADMIN"]},
+                capabilities: {add: ["NET_ADMIN", "NET_RAW"]},
               },
               volumeMounts: [
                 {mountPath: "/host/opt/cni/bin", name: "cni-bin-dir"},

--- a/test/e2e/snat/snat_test.go
+++ b/test/e2e/snat/snat_test.go
@@ -141,6 +141,7 @@ func ValidateIPTableRules(randomizedSNATValue string, numOfCidrs int) {
 		Command([]string{"./snat-utils"}).
 		CapabilitiesForSecurityContext([]corev1.Capability{
 			"NET_ADMIN",
+			"NET_RAW",
 		}, nil).
 		Args(testerArgs).
 		Build()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2061

**What does this PR do / Why do we need it**:
This PR request NET_RAW Capabilities in CNI manifests. Linux NET_RAW capabilities let us use RAW and PACKET sockets; bind to any address for transparent proxying which is quite powerful. Our application request NET_RAW capabilities that calls
iptables, which opens up a SOCK_RAW netlink socket to configure
netfilter settings. It's likely the VPC CNI will continue needing NET_RAW in the future and to be used by other applications.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
--- PASS: TestSetupHostNetworkIgnoringRpFilterUpdate (0.00s)
=== RUN   TestSetupHostNetworkUpdateLocalRule
{"level":"info","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network_test.go:852","msg":"Setting up host network... "}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:280","msg":"Trying to find primary interface that has mac : "}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:280","msg":"Discovered interface: lo, mac: "}
{"level":"info","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:280","msg":"Discovered primary interface: lo"}
{"level":"info","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network_test.go:852","msg":"Skip updating RPF for primary interface: net/ipv4/conf/lo/rp_filter"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:307","msg":"Found the Link that uses mac address  and its index is 0 (attempt 1/5)"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:383","msg":"Trying to find primary interface that has mac : "}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:383","msg":"Discovered interface: lo, mac: "}
{"level":"info","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:383","msg":"Discovered primary interface: lo"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:403","msg":"Total CIDRs to program - 0"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:403","msg":"Setup Host Network: iptables -N AWS-SNAT-CHAIN-0 -t nat"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:403","msg":"Setup Host Network: iptables -A POSTROUTING -m comment --comment \"AWS SNAT CHAIN\" -j AWS-SNAT-CHAIN-0"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:714","msg":"Setup Host Network: loading existing iptables nat rules with chain prefix AWS-SNAT-CHAIN"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:509","msg":"Setup Host Network: computing stale iptables rules for %s table with chain prefix %s"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:403","msg":"iptableRules: [nat/POSTROUTING rule first SNAT rules for non-VPC outbound traffic shouldExist false rule [-m comment --comment AWS SNAT CHAIN -j AWS-SNAT-CHAIN-0] nat/AWS-SNAT-CHAIN-0 rule last SNAT rule for non-VPC outbound traffic shouldExist false rule [! -o vlan+ -m comment --comment AWS, SNAT -m addrtype ! --dst-type LOCAL -j SNAT --to-source 10.10.10.20] mangle/PREROUTING rule connmark for primary ENI shouldExist true rule [-m comment --comment AWS, primary ENI -i lo -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-mark 0x80/0x80] mangle/PREROUTING rule connmark restore for primary ENI shouldExist true rule [-m comment --comment AWS, primary ENI -i eni+ -j CONNMARK --restore-mark --mask 0x80] mangle/PREROUTING rule connmark restore for primary ENI from vlan shouldExist true rule [-m comment --comment AWS, primary ENI -i vlan+ -j CONNMARK --restore-mark --mask 0x80]]"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"execute iptable rule : first SNAT rules for non-VPC outbound traffic"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"rule nat/POSTROUTING rule first SNAT rules for non-VPC outbound traffic shouldExist false rule [-m comment --comment AWS SNAT CHAIN -j AWS-SNAT-CHAIN-0] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"execute iptable rule : last SNAT rule for non-VPC outbound traffic"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"rule nat/AWS-SNAT-CHAIN-0 rule last SNAT rule for non-VPC outbound traffic shouldExist false rule [! -o vlan+ -m comment --comment AWS, SNAT -m addrtype ! --dst-type LOCAL -j SNAT --to-source 10.10.10.20] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"execute iptable rule : connmark for primary ENI"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"rule mangle/PREROUTING rule connmark for primary ENI shouldExist true rule [-m comment --comment AWS, primary ENI -i lo -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-mark 0x80/0x80] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"execute iptable rule : connmark restore for primary ENI"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"rule mangle/PREROUTING rule connmark restore for primary ENI shouldExist true rule [-m comment --comment AWS, primary ENI -i eni+ -j CONNMARK --restore-mark --mask 0x80] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"execute iptable rule : connmark restore for primary ENI from vlan"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:407","msg":"rule mangle/PREROUTING rule connmark restore for primary ENI from vlan shouldExist true rule [-m comment --comment AWS, primary ENI -i vlan+ -j CONNMARK --restore-mark --mask 0x80] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:411","msg":"Total CIDRs to exempt from connmark rules - 0"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:411","msg":"Setup Host Network: iptables -N AWS-CONNMARK-CHAIN-0 -t nat"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:411","msg":"Setup Host Network: iptables -t nat -A PREROUTING -i eni+ -m comment --comment \"AWS, outbound connections\" -m state --state NEW -j AWS-CONNMARK-CHAIN-0"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:714","msg":"Setup Host Network: loading existing iptables nat rules with chain prefix AWS-CONNMARK-CHAIN"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:639","msg":"Setup Host Network: computing stale iptables rules for %s table with chain prefix %s"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:411","msg":"iptableRules: [nat/PREROUTING rule connmark rule for non-VPC outbound traffic shouldExist false rule [-i eni+ -m comment --comment AWS, outbound connections -m state --state NEW -j AWS-CONNMARK-CHAIN-0] nat/AWS-CONNMARK-CHAIN-0 rule connmark rule for external  outbound traffic shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --set-xmark 0x80/0x80] nat/PREROUTING rule connmark to fwmark copy shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --restore-mark --mask 0x80] nat/PREROUTING rule connmark to fwmark copy shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --restore-mark --mask 0x80]]"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"execute iptable rule : connmark rule for non-VPC outbound traffic"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"rule nat/PREROUTING rule connmark rule for non-VPC outbound traffic shouldExist false rule [-i eni+ -m comment --comment AWS, outbound connections -m state --state NEW -j AWS-CONNMARK-CHAIN-0] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"execute iptable rule : connmark rule for external  outbound traffic"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"rule nat/AWS-CONNMARK-CHAIN-0 rule connmark rule for external  outbound traffic shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --set-xmark 0x80/0x80] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"execute iptable rule : connmark to fwmark copy"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"rule nat/PREROUTING rule connmark to fwmark copy shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --restore-mark --mask 0x80] exists false, err <nil>"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"execute iptable rule : connmark to fwmark copy"}
{"level":"debug","ts":"2022-08-15T07:06:46.432Z","caller":"networkutils/network.go:415","msg":"rule nat/PREROUTING rule connmark to fwmark copy shouldExist false rule [-m comment --comment AWS, CONNMARK -j CONNMARK --restore-mark --mask 0x80] exists false, err <nil>"}
--- PASS: TestSetupHostNetworkUpdateLocalRule (0.00s)
PASS
coverage: 70.8% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils	0.025s	coverage: 70.8% of statements
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils/mocks	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper/mocks	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper/mocks	[no test files]
{"level":"info","ts":"2022-08-15T07:06:47.504Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-08-15T07:06:47.504Z","caller":"awssession/session.go:39","msg":"Initialized new logger as an existing instance was not found"}
=== RUN   TestCloudWatchPublisherWithNoIMDS
{"level":"info","ts":"2022-08-15T07:06:47.504Z","caller":"publisher/publisher_test.go:42","msg":"Constructed new logger instance"}
{"level":"warn","ts":"2022-08-15T07:06:47.504Z","caller":"awssession/session.go:64","msg":"HTTP_TIMEOUT env is not set or set to less than 10 seconds, defaulting to httpTimeout to 10sec"}
{"level":"info","ts":"2022-08-15T07:06:47.504Z","caller":"publisher/publisher_test.go:49","msg":"Using REGION=us-west-2 and CLUSTER_ID=TEST_CLUSTER_ID"}
--- PASS: TestCloudWatchPublisherWithNoIMDS (0.00s)
=== RUN   TestCloudWatchPublisherWithSingleDatum
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher_test.go:63","msg":"Fetching CloudWatch dimensions"}
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
--- PASS: TestCloudWatchPublisherWithSingleDatum (0.00s)
=== RUN   TestCloudWatchPublisherWithMultipleDatum
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher_test.go:86","msg":"Fetching CloudWatch dimensions"}
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
--- PASS: TestCloudWatchPublisherWithMultipleDatum (0.00s)
=== RUN   TestCloudWatchPublisherWithGreaterThanMaxDatapoints
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher_test.go:108","msg":"Fetching CloudWatch dimensions"}
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
--- PASS: TestCloudWatchPublisherWithGreaterThanMaxDatapoints (0.00s)
=== RUN   TestCloudWatchPublisherWithGreaterThanMaxDatapointsAndStop
{"level":"info","ts":"2022-08-15T07:06:47.505Z","caller":"publisher/publisher_test.go:129","msg":"Fetching CloudWatch dimensions"}
{"level":"info","ts":"2022-08-15T07:06:47.516Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.516Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.526Z","caller":"publisher/publisher.go:173","msg":"Missing data for publishing CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.536Z","caller":"publisher/publisher.go:173","msg":"Missing data for publishing CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.547Z","caller":"publisher/publisher.go:173","msg":"Missing data for publishing CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.556Z","caller":"publisher/publisher.go:173","msg":"Missing data for publishing CloudWatch metrics"}
{"level":"info","ts":"2022-08-15T07:06:47.556Z","caller":"publisher/publisher_test.go:136","msg":"Stopping monitor loop for CloudWatch publisher"}
{"level":"info","ts":"2022-08-15T07:06:47.556Z","caller":"publisher/publisher.go:220","msg":"Stopping monitor loop for CloudWatch publisher"}
--- PASS: TestCloudWatchPublisherWithGreaterThanMaxDatapointsAndStop (0.10s)
=== RUN   TestCloudWatchPublisherWithSingleDatumWithError
{"level":"info","ts":"2022-08-15T07:06:47.608Z","caller":"publisher/publisher_test.go:161","msg":"Fetching CloudWatch dimensions"}
{"level":"info","ts":"2022-08-15T07:06:47.608Z","caller":"publisher/publisher.go:191","msg":"Sending data to CloudWatch metrics"}
{"level":"warn","ts":"2022-08-15T07:06:47.608Z","caller":"publisher/publisher.go:173","msg":"Unable to publish CloudWatch metrics: test error"}
--- PASS: TestCloudWatchPublisherWithSingleDatumWithError (0.00s)
=== RUN   TestGetCloudWatchMetricNamespace
--- PASS: TestGetCloudWatchMetricNamespace (0.00s)
=== RUN   TestGetCloudWatchMetricDatumDimensions
--- PASS: TestGetCloudWatchMetricDatumDimensions (0.00s)
=== RUN   TestGetCloudWatchMetricDatumDimensionsWithMissingClusterID
--- PASS: TestGetCloudWatchMetricDatumDimensionsWithMissingClusterID (0.00s)
=== RUN   TestPublishWithNoData
{"level":"info","ts":"2022-08-15T07:06:47.608Z","caller":"publisher/publisher_test.go:209","msg":"Fetching CloudWatch dimensions"}
--- PASS: TestPublishWithNoData (0.00s)
=== RUN   TestPushWithMissingData
{"level":"info","ts":"2022-08-15T07:06:47.608Z","caller":"publisher/publisher_test.go:217","msg":"Missing data for publishing CloudWatch metrics"}
--- PASS: TestPushWithMissingData (0.00s)
=== RUN   TestMin
--- PASS: TestMin (0.00s)
PASS
coverage: 70.8% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/publisher	0.112s	coverage: 70.8% of statements
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/publisher/mock_publisher	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/rpcwrapper	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/rpcwrapper/mocks	[no test files]
=== RUN   TestBuildHostVethNamePrefix
=== RUN   TestBuildHostVethNamePrefix/standard_mode_should_use_configured_vethNamePrefix
=== RUN   TestBuildHostVethNamePrefix/strict_mode_should_use_vlan_vethNamePrefix
--- PASS: TestBuildHostVethNamePrefix (0.00s)
    --- PASS: TestBuildHostVethNamePrefix/standard_mode_should_use_configured_vethNamePrefix (0.00s)
    --- PASS: TestBuildHostVethNamePrefix/strict_mode_should_use_vlan_vethNamePrefix (0.00s)
=== RUN   TestLoadEnforcingModeFromEnv
=== RUN   TestLoadEnforcingModeFromEnv/use_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_set_to_strict
=== RUN   TestLoadEnforcingModeFromEnv/use_standard_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_set_to_standard
=== RUN   TestLoadEnforcingModeFromEnv/default_to_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_not_set
=== RUN   TestLoadEnforcingModeFromEnv/default_to_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_incorrectly_configured
--- PASS: TestLoadEnforcingModeFromEnv (0.00s)
    --- PASS: TestLoadEnforcingModeFromEnv/use_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_set_to_strict (0.00s)
    --- PASS: TestLoadEnforcingModeFromEnv/use_standard_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_set_to_standard (0.00s)
    --- PASS: TestLoadEnforcingModeFromEnv/default_to_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_not_set (0.00s)
    --- PASS: TestLoadEnforcingModeFromEnv/default_to_strict_mode_when_POD_SECURITY_GROUP_ENFORCING_MODE_incorrectly_configured (0.00s)
PASS
coverage: 88.9% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp	0.008s	coverage: 88.9% of statements
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/typeswrapper	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/typeswrapper/mocks	[no test files]
=== RUN   Test_FindInterfaceByName
=== RUN   Test_FindInterfaceByName/found_the_CNI_interface_at_index_0
=== RUN   Test_FindInterfaceByName/found_the_CNI_interface_at_index_1
=== RUN   Test_FindInterfaceByName/didn't_found_CNI_interface
--- PASS: Test_FindInterfaceByName (0.00s)
    --- PASS: Test_FindInterfaceByName/found_the_CNI_interface_at_index_0 (0.00s)
    --- PASS: Test_FindInterfaceByName/found_the_CNI_interface_at_index_1 (0.00s)
    --- PASS: Test_FindInterfaceByName/didn't_found_CNI_interface (0.00s)
=== RUN   Test_FindIPConfigsByIfaceIndex
=== RUN   Test_FindIPConfigsByIfaceIndex/single_matched_IPConfig
=== RUN   Test_FindIPConfigsByIfaceIndex/multiple_matched_IPConfig
=== RUN   Test_FindIPConfigsByIfaceIndex/none_matched_IPConfig
=== RUN   Test_FindIPConfigsByIfaceIndex/interface_is_not_set
--- PASS: Test_FindIPConfigsByIfaceIndex (0.00s)
    --- PASS: Test_FindIPConfigsByIfaceIndex/single_matched_IPConfig (0.00s)
    --- PASS: Test_FindIPConfigsByIfaceIndex/multiple_matched_IPConfig (0.00s)
    --- PASS: Test_FindIPConfigsByIfaceIndex/none_matched_IPConfig (0.00s)
    --- PASS: Test_FindIPConfigsByIfaceIndex/interface_is_not_set (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils	0.024s	coverage: 100.0% of statements
{"level":"info","ts":"2022-08-15T07:06:47.752Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-08-15T07:06:47.753Z","caller":"k8sapi/k8sutils.go:23","msg":"Initialized new logger as an existing instance was not found"}
=== RUN   TestBroadcastEvents
{"level":"debug","ts":"2022-08-15T07:06:47.763Z","caller":"eventrecorder/eventrecorder_test.go:99","msg":"Broadcasting event on pod mockPodWithLabelAndSpec"}
--- PASS: TestBroadcastEvents (0.01s)
PASS
coverage: 34.6% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/eventrecorder	0.035s	coverage: 34.6% of statements
=== RUN   TestEnvLogFilePath
--- PASS: TestEnvLogFilePath (0.00s)
=== RUN   TestLoggerGetSameInstance
--- PASS: TestLoggerGetSameInstance (0.00s)
=== RUN   TestLoggerNewAndGetSameInstance
--- PASS: TestLoggerNewAndGetSameInstance (0.00s)
=== RUN   TestGetLogFileLocationReturnsDefaultPath
--- PASS: TestGetLogFileLocationReturnsDefaultPath (0.00s)
=== RUN   TestLogLevelReturnsOverriddenLevel
--- PASS: TestLogLevelReturnsOverriddenLevel (0.00s)
=== RUN   TestLogLevelReturnsDefaultLevelWhenEnvNotSet
--- PASS: TestLogLevelReturnsDefaultLevelWhenEnvNotSet (0.00s)
=== RUN   TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue
--- PASS: TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue (0.00s)
=== RUN   TestGetPluginLogFilePathEmpty
--- PASS: TestGetPluginLogFilePathEmpty (0.00s)
=== RUN   TestGetPluginLogFilePathStdout
--- PASS: TestGetPluginLogFilePathStdout (0.00s)
=== RUN   TestGetPluginLogFilePath
--- PASS: TestGetPluginLogFilePath (0.00s)
PASS
coverage: 62.5% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger	0.008s	coverage: 62.5% of statements
=== RUN   TestSimpleBackoff
--- PASS: TestSimpleBackoff (0.00s)
=== RUN   TestJitter
--- PASS: TestJitter (0.00s)
=== RUN   TestRetryWithBackoff
=== RUN   TestRetryWithBackoff/retries
=== RUN   TestRetryWithBackoff/no_retries
--- PASS: TestRetryWithBackoff (0.00s)
    --- PASS: TestRetryWithBackoff/retries (0.00s)
    --- PASS: TestRetryWithBackoff/no_retries (0.00s)
=== RUN   TestRetryWithBackoffCtx
=== RUN   TestRetryWithBackoffCtx/retries
=== RUN   TestRetryWithBackoffCtx/no_retries
=== RUN   TestRetryWithBackoffCtx/cancel_context
--- PASS: TestRetryWithBackoffCtx (0.00s)
    --- PASS: TestRetryWithBackoffCtx/retries (0.00s)
    --- PASS: TestRetryWithBackoffCtx/no_retries (0.00s)
    --- PASS: TestRetryWithBackoffCtx/cancel_context (0.00s)
=== RUN   TestRetryNWithBackoff
=== RUN   TestRetryNWithBackoff/count_exceeded
=== RUN   TestRetryNWithBackoff/retry_succeeded
--- PASS: TestRetryNWithBackoff (0.00s)
    --- PASS: TestRetryNWithBackoff/count_exceeded (0.00s)
    --- PASS: TestRetryNWithBackoff/retry_succeeded (0.00s)
=== RUN   TestRetryNWithBackoffCtx
=== RUN   TestRetryNWithBackoffCtx/count_exceeded
=== RUN   TestRetryNWithBackoffCtx/retry_succeeded
=== RUN   TestRetryNWithBackoffCtx/cancel_context
--- PASS: TestRetryNWithBackoffCtx (0.00s)
    --- PASS: TestRetryNWithBackoffCtx/count_exceeded (0.00s)
    --- PASS: TestRetryNWithBackoffCtx/retry_succeeded (0.00s)
    --- PASS: TestRetryNWithBackoffCtx/cancel_context (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/retry	0.004s	coverage: 100.0% of statements
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/utils/ttime/mocks	[no test files]
?   	github.com/aws/amazon-vpc-cni-k8s/pkg/version	[no test files]
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
AWS VPC CNI requests NET_RAW capabilities by default. 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
