### PR TITLE
fix warm target tests in ipamd integration test

### DIFF
--- a/test/framework/resources/k8s/resources/deployment.go
+++ b/test/framework/resources/k8s/resources/deployment.go
@@ -21,13 +21,18 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type DeploymentManager interface {
 	CreateAndWaitTillDeploymentIsReady(deployment *v1.Deployment, timeout time.Duration) (*v1.Deployment, error)
 	DeleteAndWaitTillDeploymentIsDeleted(deployment *v1.Deployment) error
+	UpdateAndWaitTillDeploymentIsReady(deployment *v1.Deployment, timeout time.Duration) error
+	GetDeployment(name, namespace string) (*v1.Deployment, error)
+	WaitTillDeploymentReady(deployment *v1.Deployment, timeout time.Duration) (*v1.Deployment, error)
 }
 
 type defaultDeploymentManager struct {
@@ -46,19 +51,7 @@ func (d defaultDeploymentManager) CreateAndWaitTillDeploymentIsReady(deployment 
 	// Allow for the cache to sync
 	time.Sleep(utils.PollIntervalShort)
 
-	observed := &v1.Deployment{}
-	return observed, wait.PollImmediate(utils.PollIntervalShort, timeout, func() (bool, error) {
-		if err := d.k8sClient.Get(ctx, utils.NamespacedName(deployment), observed); err != nil {
-			return false, err
-		}
-		if observed.Status.UpdatedReplicas == (*observed.Spec.Replicas) &&
-			observed.Status.Replicas == (*observed.Spec.Replicas) &&
-			observed.Status.AvailableReplicas == (*observed.Spec.Replicas) &&
-			observed.Status.ObservedGeneration >= observed.Generation {
-			return true, nil
-		}
-		return false, nil
-	})
+	return d.WaitTillDeploymentReady(deployment, timeout)
 }
 
 //
@@ -78,6 +71,56 @@ func (d defaultDeploymentManager) DeleteAndWaitTillDeploymentIsDeleted(deploymen
 		}
 		return false, nil
 	}, ctx.Done())
+}
+
+func (d defaultDeploymentManager) UpdateAndWaitTillDeploymentIsReady(deployment *v1.Deployment, timeout time.Duration) error {
+	ctx := context.Background()
+	observed := &v1.Deployment{}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Retrieve the latest version of Deployment before attempting update
+		err := d.k8sClient.Get(ctx, utils.NamespacedName(deployment), observed)
+		if err != nil {
+			return err
+		}
+		return d.k8sClient.Update(ctx, deployment)
+	})
+
+	if retryErr != nil {
+		return retryErr
+	}
+	_, err := d.WaitTillDeploymentReady(deployment, timeout)
+	return err
+
+}
+
+func (d defaultDeploymentManager) GetDeployment(name, namespace string) (*v1.Deployment, error) {
+	ctx := context.Background()
+	deployment := &v1.Deployment{}
+
+	err := d.k8sClient.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, deployment)
+
+	return deployment, err
+}
+
+func (d defaultDeploymentManager) WaitTillDeploymentReady(deployment *v1.Deployment, timeout time.Duration) (*v1.Deployment, error) {
+	ctx := context.Background()
+	observed := &v1.Deployment{}
+	return observed, wait.PollImmediate(utils.PollIntervalShort, timeout, func() (bool, error) {
+		if err := d.k8sClient.Get(ctx, utils.NamespacedName(deployment), observed); err != nil {
+			return false, err
+		}
+		if observed.Status.UpdatedReplicas == (*observed.Spec.Replicas) &&
+			observed.Status.Replicas == (*observed.Spec.Replicas) &&
+			observed.Status.AvailableReplicas == (*observed.Spec.Replicas) &&
+			observed.Status.ObservedGeneration >= observed.Generation {
+			return true, nil
+		}
+		return false, nil
+	})
 }
 
 func NewDefaultDeploymentManager(k8sClient client.Client) DeploymentManager {

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -22,7 +22,15 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
 )
+
+const (
+	CoreDNSDeploymentName      = "coredns"
+	CoreDNSDeploymentNameSpace = "kube-system"
+)
+
+var coreDNSDeploymentCopy *v1.Deployment
 
 func TestIPAMD(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -43,22 +51,54 @@ var _ = BeforeSuite(func() {
 	numOfNodes = len(nodeList.Items)
 	Expect(numOfNodes).Should(BeNumerically(">", 1))
 
-	// Nominate the first node as the primary node
-	primaryNode = nodeList.Items[0]
-
-	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)
+	// Nominate the first node as the 'primary' node and force coredns deployment on this
+	By("adding nodeSelector in coredns deployment to be scheduled on single node")
+	instanceID := k8sUtils.GetInstanceIDFromNode(nodeList.Items[0])
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Remove WARM_ENI_TARGET, WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET before running IPAMD tests
-	k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, "aws-node", "kube-system",
-		"aws-node", map[string]struct{}{"WARM_ENI_TARGET": {}, "WARM_IP_TARGET": {}, "MINIMUM_IP_TARGET": {}, "WARM_PREFIX_TARGET": {}})
+	// Add nodeSelector label to coredns deployment so coredns pods are scheduled on 'primary' node
+	By("getting node with no pods scheduled to run tests")
+	coreDNSDeployment, err := f.K8sResourceManagers.DeploymentManager().GetDeployment(CoreDNSDeploymentName,
+		CoreDNSDeploymentNameSpace)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Copy the deployment to restore later
+	coreDNSDeploymentCopy = coreDNSDeployment.DeepCopy()
+
+	coreDNSDeployment.Spec.Template.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": *primaryInstance.PrivateDnsName,
+	}
+
+	err = f.K8sResourceManagers.DeploymentManager().UpdateAndWaitTillDeploymentIsReady(coreDNSDeployment,
+		utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Nominate primaryInstance to node without coredns pods
+	instanceID = k8sUtils.GetInstanceIDFromNode(nodeList.Items[1])
+	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Default values- Set WARM_ENI_TARGET to 1, and remove WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET before running IPAMD tests
+	k8sUtils.UpdateEnvVarOnDaemonSetAndWaitUntilReady(f, "aws-node", "kube-system",
+		"aws-node", map[string]string{
+			"WARM_ENI_TARGET": "1"},
+		map[string]struct{}{
+			"WARM_IP_TARGET":     {},
+			"MINIMUM_IP_TARGET":  {},
+			"WARM_PREFIX_TARGET": {},
+		})
 
 	// Allow reconciler to free up ENIs if any
 	time.Sleep(utils.PollIntervalLong)
 })
 
 var _ = AfterSuite(func() {
+	// Restore coredns deployment
+	By("restoring coredns deployment")
+	err = f.K8sResourceManagers.DeploymentManager().UpdateAndWaitTillDeploymentIsReady(coreDNSDeploymentCopy,
+		utils.DefaultDeploymentReadyTimeout)
+
 	By("deleting test namespace")
 	f.K8sResourceManagers.NamespaceManager().
 		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Default values- Set WARM_ENI_TARGET to 1, and remove WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET before running IPAMD tests
+	// Set default values- WARM_ENI_TARGET to 1, and remove WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET
 	k8sUtils.UpdateEnvVarOnDaemonSetAndWaitUntilReady(f, "aws-node", "kube-system",
 		"aws-node", map[string]string{
 			"WARM_ENI_TARGET": "1"},

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -14,7 +14,6 @@
 package ipamd
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -42,8 +41,6 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
-			podLabelKey := "eks.amazonaws.com/component"
-			podLabelVal := "coredns"
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
@@ -62,27 +59,13 @@ var _ = Describe("test warm target variables", func() {
 				EC2().DescribeInstance(*primaryInstance.InstanceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			//Query for coredns pods
-			podList, perr := f.K8sResourceManagers.PodManager().
-				GetPodsWithLabelSelector(podLabelKey, podLabelVal)
-			Expect(perr).ToNot(HaveOccurred())
-
-			assigned := 0
-			for _, pod := range podList.Items {
-				By(fmt.Sprintf("verifying in node %s but pod's IP %s address belongs to node name %s",
-					*primaryInstance.PrivateDnsName, pod.Status.PodIP, pod.Spec.NodeName))
-				if pod.Spec.NodeName == *primaryInstance.PrivateDnsName {
-					assigned++
-				}
-			}
-
 			// Sum all the IPs on all network interfaces minus the primary IPv4 address per ENI
 			for _, networkInterface := range primaryInstance.NetworkInterfaces {
 				availPrefixes += len(networkInterface.Ipv4Prefixes)
 			}
 
 			// Validated avail IP equals the warm IP Size
-			prefixNeededForWarmIPTarget := ceil(assigned+warmIPTarget, 16)
+			prefixNeededForWarmIPTarget := ceil(warmIPTarget, 16)
 			prefixNeededForMinIPTarget := ceil(minIPTarget, 16)
 			Expect(availPrefixes).Should(Equal(Max(prefixNeededForWarmIPTarget, prefixNeededForMinIPTarget)))
 		})
@@ -148,8 +131,6 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
-			podLabelKey := "eks.amazonaws.com/component"
-			podLabelVal := "coredns"
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
@@ -167,29 +148,13 @@ var _ = Describe("test warm target variables", func() {
 				EC2().DescribeInstance(*primaryInstance.InstanceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			//Query for coredns pods
-			podList, perr := f.K8sResourceManagers.PodManager().
-				GetPodsWithLabelSelector(podLabelKey, podLabelVal)
-			Expect(perr).ToNot(HaveOccurred())
-
-			assigned := 0
-			for _, pod := range podList.Items {
-				By(fmt.Sprintf("verifying in node %s but pod's IP %s address belongs to node name %s",
-					*primaryInstance.PrivateDnsName, pod.Status.PodIP, pod.Spec.NodeName))
-				if pod.Spec.NodeName == *primaryInstance.PrivateDnsName {
-					assigned++
-					break
-				}
-			}
-
 			// Sum all the IPs on all network interfaces minus the primary IPv4 address per ENI
 			for _, networkInterface := range primaryInstance.NetworkInterfaces {
 				availPrefixes += len(networkInterface.Ipv4Prefixes)
 			}
 
 			// Validated avail IP equals the warm IP Size
-			prefixNeededForAssignedPods := ceil(assigned, 16)
-			Expect(availPrefixes).Should(Equal(prefixNeededForAssignedPods + warmPrefixTarget))
+			Expect(availPrefixes).Should(Equal(warmPrefixTarget))
 		})
 
 		JustAfterEach(func() {
@@ -215,8 +180,6 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
-			podLabelKey := "eks.amazonaws.com/component"
-			podLabelVal := "coredns"
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
@@ -236,28 +199,13 @@ var _ = Describe("test warm target variables", func() {
 				EC2().DescribeInstance(*primaryInstance.InstanceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			//Query for coredns pods
-			podList, perr := f.K8sResourceManagers.PodManager().
-				GetPodsWithLabelSelector(podLabelKey, podLabelVal)
-			Expect(perr).ToNot(HaveOccurred())
-
-			assigned := 0
-			for _, pod := range podList.Items {
-				By(fmt.Sprintf("verifying in node %s but pod's IP %s address belongs to node name %s",
-					*primaryInstance.PrivateDnsName, pod.Status.PodIP, pod.Spec.NodeName))
-				if pod.Spec.NodeName == *primaryInstance.PrivateDnsName {
-					assigned++
-					break
-				}
-			}
-
 			// Sum all the IPs on all network interfaces minus the primary IPv4 address per ENI
 			for _, networkInterface := range primaryInstance.NetworkInterfaces {
 				availPrefixes += len(networkInterface.Ipv4Prefixes)
 			}
 
 			// Validated avail IP equals the warm IP Size
-			prefixNeededForWarmIPTarget := ceil(assigned+warmIPTarget, 16)
+			prefixNeededForWarmIPTarget := ceil(warmIPTarget, 16)
 			prefixNeededForMinIPTarget := ceil(minIPTarget, 16)
 			Expect(availPrefixes).Should(Equal(Max(prefixNeededForWarmIPTarget, prefixNeededForMinIPTarget)))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup, bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Fix failures in warm target integration tests.

We require to not have any pods scheduled on the node for running warm target tests. Previously, the primary node we choose could have a coredns pod running on the node and was handled by accounting for the coredns pods in available IP/ENI calculations as seen in [test/integration/ipamd/warm_target_test_PD_enabled.go](https://github.com/aws/amazon-vpc-cni-k8s/pull/2068/files#diff-237a40a86a7004620c7e78d94f0145b9efa67db6e730fd5e2fa4970166ea9114). 
This was missed in test/integration/ipamd/warm_target_test.go. After adding similar changes in warm_target_test.go, some failures were fixed, but still few tests were flaky. 

Changes in this PR: Force coredns pods to be scheduled on a single node by adding nodeSelector label in coredns deployment. Then, we pick a different node with no pods scheduled to run ipamd tests. This avoids additional calculations and the failures we've seen before with warm target tests since we ensure that the test is run on node with no pods.


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
Run integration test
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
n/a
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
