### PR TITLE
selinux permission denied, change mv to cp to maintain file context 

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -196,7 +196,7 @@ if [[ "$ENABLE_BANDWIDTH_PLUGIN" == "true" ]]; then
     mv "$TMP_AWS_BW_CONFLIST_FILE" "$TMP_AWS_CONFLIST_FILE" 
 fi
 
-mv "$TMP_AWS_CONFLIST_FILE" "$HOST_CNI_CONFDIR_PATH/10-aws.conflist"
+cp "$TMP_AWS_CONFLIST_FILE" "$HOST_CNI_CONFDIR_PATH/10-aws.conflist" && rm -rf "$TMP_AWS_CONFLIST_FILE"
 
 log_in_json info "Successfully copied CNI plugin binary and config file."
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug 


**Which issue does this PR fix**:
#2079 


**What does this PR do / Why do we need it**:
This fixes the permissions issue experienced when SELinux enforcing mode is enabled. Entrypoint.sh script uses **_mv_** command([link](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/entrypoint.sh#L199)) to write to host file system. When the aws-node container is killed or restarted it tries to write to the same file while has a different context(from the old container) and its not allowed by policies in SeLinux. To make it work with SeLinux, changing the **_mv_** command to **_cp_** works as **_cp_** maintains the context of file while writing.


**Testing done on this change**:
Unit testing
Tested with custom container image for amazon-k8s-cni 



**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
