### PR TITLE
Changelog for v1.11.4 release (#2081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.11.4
+
+* Improvement - [update aws-node clusterrole permissions](https://github.com/aws/amazon-vpc-cni-k8s/pull/2058) (@sushrk)
+* Improvement - [IPAMD optimizations and makefile changes](https://github.com/aws/amazon-vpc-cni-k8s/pull/1975) (@jayanthvn)
+* Documentation - [Fix minor typo on documentation](https://github.com/aws/amazon-vpc-cni-k8s/pull/2059) (@guikcd)
+* Documentation - [Fixing prefixes per ENI value in example](https://github.com/aws/amazon-vpc-cni-k8s/pull/2060) (@mkarakas)
+* New release - [multus manifest for release v3.9.0-eksbuild.2](https://github.com/aws/amazon-vpc-cni-k8s/pull/2057) (@sushrk)
+* Bug - [Setting AWS_VPC_K8S_CNI_RANDOMIZESNAT to the default value](https://github.com/aws/amazon-vpc-cni-k8s/pull/2028) (@vgunapati)
+* New instance support - [Updated new instances](https://github.com/aws/amazon-vpc-cni-k8s/pull/2062) (@jayanthvn)
+
 ## v1.11.3
 
 * Improvement -  [Increase cpu requests limit](https://github.com/aws/amazon-vpc-cni-k8s/pull/2040) (@vikasmb)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
documentation - cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Update changelog on master

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
n/a

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
n/a

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
n/a
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
