### PR TITLE
Use GetNodes in metrics-helper; explicitly install latest addon

### DIFF
--- a/cmd/cni-metrics-helper/metrics/pod_watcher.go
+++ b/cmd/cni-metrics-helper/metrics/pod_watcher.go
@@ -27,8 +27,8 @@ func NewDefaultPodWatcher(k8sClient client.Client, log logger.Logger) *defaultPo
 	}
 }
 
-//Returns aws-node pod info. Below function assumes CNI pods follow aws-node* naming format
-//and so the function has to be updated if the CNI pod name format changes.
+// Returns aws-node pod info. Below function assumes CNI pods follow aws-node* naming format
+// and so the function has to be updated if the CNI pod name format changes.
 func (d *defaultPodWatcher) GetCNIPods(ctx context.Context) ([]string, error) {
 	var CNIPods []string
 	var podList corev1.PodList

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -310,7 +310,7 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	log.Debugf("Prev Result: %v\n", conf.PrevResult)
 
 	if err != nil {
-		return errors.Wrap(err, "add cmd: error loading config from args")
+		return errors.Wrap(err, "del cmd: error loading config from args")
 	}
 
 	log.Infof("Received CNI del request: ContainerID(%s) Netns(%s) IfName(%s) Args(%s) Path(%s) argsStdinData(%s)",

--- a/pkg/apis/crd/v1alpha1/groupversion_info.go
+++ b/pkg/apis/crd/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the crd v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=crd.example.com
+// +kubebuilder:object:generate=true
+// +groupName=crd.example.com
 package v1alpha1
 
 import (

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -310,7 +310,7 @@ func prometheusRegister() {
 	}
 }
 
-//StringSet is a set of strings
+// StringSet is a set of strings
 type StringSet struct {
 	sync.RWMutex
 	data sets.String
@@ -780,7 +780,7 @@ func (cache *EC2InstanceMetadataCache) AllocENI(useCustomCfg bool, sg []*string,
 	return eniID, nil
 }
 
-//  attachENI calls EC2 API to attach the ENI and returns the attachment id
+// attachENI calls EC2 API to attach the ENI and returns the attachment id
 func (cache *EC2InstanceMetadataCache) attachENI(eniID string) (string, error) {
 	// attach to instance
 	freeDevice, err := cache.awsGetFreeDeviceNumber()
@@ -1829,7 +1829,7 @@ func (cache *EC2InstanceMetadataCache) GetPrimaryENImac() string {
 	return cache.primaryENImac
 }
 
-//SetUnmanagedENIs Set unmanaged ENI set
+// SetUnmanagedENIs Set unmanaged ENI set
 func (cache *EC2InstanceMetadataCache) SetUnmanagedENIs(eniIDs []string) {
 	cache.unmanagedENIs.Set(eniIDs)
 }
@@ -1839,7 +1839,7 @@ func (cache *EC2InstanceMetadataCache) GetInstanceID() string {
 	return cache.instanceID
 }
 
-//IsUnmanagedENI returns if the eni is unmanaged
+// IsUnmanagedENI returns if the eni is unmanaged
 func (cache *EC2InstanceMetadataCache) IsUnmanagedENI(eniID string) bool {
 	if len(eniID) != 0 {
 		return cache.unmanagedENIs.Has(eniID)
@@ -1872,7 +1872,7 @@ func (cache *EC2InstanceMetadataCache) getENIsFromPaginatedDescribeNetworkInterf
 	return innerErr
 }
 
-//SetCNIUnmanagedENIs Set unmanaged ENI set
+// SetCNIUnmanagedENIs Set unmanaged ENI set
 func (cache *EC2InstanceMetadataCache) SetCNIUnmanagedENIs(eniID []string) error {
 	if len(eniID) != 0 {
 		cache.cniunmanagedENIs.Set(eniID)
@@ -1880,7 +1880,7 @@ func (cache *EC2InstanceMetadataCache) SetCNIUnmanagedENIs(eniID []string) error
 	return nil
 }
 
-//IsCNIUnmanagedENI returns if the eni is unmanaged
+// IsCNIUnmanagedENI returns if the eni is unmanaged
 func (cache *EC2InstanceMetadataCache) IsCNIUnmanagedENI(eniID string) bool {
 	if len(eniID) != 0 {
 		return cache.cniunmanagedENIs.Has(eniID)
@@ -1888,7 +1888,7 @@ func (cache *EC2InstanceMetadataCache) IsCNIUnmanagedENI(eniID string) bool {
 	return false
 }
 
-//IsPrimaryENI returns if the eni is unmanaged
+// IsPrimaryENI returns if the eni is unmanaged
 func (cache *EC2InstanceMetadataCache) IsPrimaryENI(eniID string) bool {
 	if len(eniID) != 0 && eniID == cache.GetPrimaryENI() {
 		return true

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -61,7 +61,7 @@ func New() *Client {
 	return &Client{}
 }
 
-//GetRunningPodSandboxes get running sandboxIDs
+// GetRunningPodSandboxes get running sandboxIDs
 func (c *Client) GetRunningPodSandboxes(log logger.Logger) ([]SandboxInfo, error) {
 	ctx := context.TODO()
 

--- a/pkg/ec2wrapper/ec2wrapper.go
+++ b/pkg/ec2wrapper/ec2wrapper.go
@@ -1,4 +1,4 @@
-//Package ec2wrapper is used to wrap around the ec2 service APIs
+// Package ec2wrapper is used to wrap around the ec2 service APIs
 package ec2wrapper
 
 import (
@@ -27,7 +27,7 @@ type EC2Wrapper struct {
 	instanceIdentityDocument ec2metadata.EC2InstanceIdentityDocument
 }
 
-//NewMetricsClient returns an instance of the EC2 wrapper
+// NewMetricsClient returns an instance of the EC2 wrapper
 func NewMetricsClient() (*EC2Wrapper, error) {
 	sess := awssession.New()
 	ec2MetadataClient := ec2metadatawrapper.New(sess)

--- a/pkg/eniconfig/eniconfig_test.go
+++ b/pkg/eniconfig/eniconfig_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. A copy of the
 // License is located at
 //
-//     http://aws.amazon.com/apache2.0/
+//	http://aws.amazon.com/apache2.0/
 //
 // or in the "license" file accompanying this file. This file is distributed
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -129,8 +129,9 @@ var (
 )
 
 // IPAMKey is the IPAM primary key.  Quoting CNI spec:
-//   Plugins that store state should do so using a primary key of
-//   (network name, CNI_CONTAINERID, CNI_IFNAME).
+//
+//	Plugins that store state should do so using a primary key of
+//	(network name, CNI_CONTAINERID, CNI_IFNAME).
 type IPAMKey struct {
 	NetworkName string `json:"networkName"`
 	ContainerID string `json:"containerID"`
@@ -232,7 +233,7 @@ func (e *ENI) AssignedIPv4Addresses() int {
 	return count
 }
 
-//AssignedIPAddressesInCidr is the number of IP addresses already assigned in the IPv4 CIDR
+// AssignedIPAddressesInCidr is the number of IP addresses already assigned in the IPv4 CIDR
 func (cidr *CidrInfo) AssignedIPAddressesInCidr() int {
 	count := 0
 	//SIP : This will run just once and count will be 0 if addr is not assigned or addr is not allocated yet(unused IP)
@@ -1467,7 +1468,7 @@ func getNextIPAddr(ip net.IP) {
 	}
 }
 
-//Function to return PD defaults supported by VPC
+// Function to return PD defaults supported by VPC
 func GetPrefixDelegationDefaults() (int, int, int) {
 	numPrefixesPerENI := 1
 	numIPsPerPrefix := 16

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2122,7 +2122,7 @@ func (c *IPAMContext) warmPrefixTargetDefined() bool {
 	return c.warmPrefixTarget >= defaultWarmPrefixTarget && c.enablePrefixDelegation
 }
 
-//DeallocCidrs frees IPs and Prefixes from EC2
+// DeallocCidrs frees IPs and Prefixes from EC2
 func (c *IPAMContext) DeallocCidrs(eniID string, deletableCidrs []datastore.CidrInfo) {
 	var deletableIPs []string
 	var deletablePrefixes []string

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -239,7 +239,7 @@ func (n *linuxNetwork) SetupRuleToBlockNodeLocalV4Access() error {
 	return n.setupRuleToBlockNodeLocalV4Access()
 }
 
-//Setup a rule to block traffic directed to v4 interface of the Pod
+// Setup a rule to block traffic directed to v4 interface of the Pod
 func (n *linuxNetwork) setupRuleToBlockNodeLocalV4Access() error {
 	ipt, err := n.newIptables(iptables.ProtocolIPv4)
 	if err != nil {

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -14,13 +14,13 @@
 // Package logger is the CNI Logger interface, using zap
 package logger
 
-//Log is global variable so that log functions can be directly accessed
+// Log is global variable so that log functions can be directly accessed
 var log Logger
 
-//Fields Type to pass when we want to call WithFields for structured logging
+// Fields Type to pass when we want to call WithFields for structured logging
 type Fields map[string]interface{}
 
-//Logger is our contract for the logger
+// Logger is our contract for the logger
 type Logger interface {
 	Debugf(format string, args ...interface{})
 
@@ -55,7 +55,7 @@ func Get() Logger {
 	return log
 }
 
-//New logger initializes logger
+// New logger initializes logger
 func New(inputLogConfig *Configuration) Logger {
 	log = inputLogConfig.newZapLogger()
 	log.Info("Constructed new logger instance")

--- a/pkg/utils/logger/zaplogger.go
+++ b/pkg/utils/logger/zaplogger.go
@@ -141,7 +141,7 @@ func getPluginLogFilePath(logFilePath string) zapcore.WriteSyncer {
 	return writer
 }
 
-//getLogWriter is for lumberjack
+// getLogWriter is for lumberjack
 func getLogWriter(logFilePath string) zapcore.WriteSyncer {
 	lumberJackLogger := &lumberjack.Logger{
 		Filename:   logFilePath,

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -18,6 +18,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration"
 CALICO_TEST_DIR="$SCRIPT_DIR/../test/e2e/calico"
 
+source "$SCRIPT_DIR"/lib/add-on.sh
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/integration.sh
 
@@ -66,9 +67,14 @@ if [[ -n "${ENDPOINT}" ]]; then
   ENDPOINT_FLAG="--endpoint $ENDPOINT"
 fi
 
-echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION"
 load_cluster_details
+load_addon_details
+install_add_on "$LATEST_ADDON_VERSION"
+
+echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION on the latest addon version"
+
 START=$SECONDS
 run_integration_test
 run_calico_tests
+
 echo "Completed running all tests in $((SECONDS - START)) seconds."

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -18,7 +18,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 INTEGRATION_TEST_DIR="$SCRIPT_DIR/../test/integration"
 CALICO_TEST_DIR="$SCRIPT_DIR/../test/e2e/calico"
 
-source "$SCRIPT_DIR"/lib/add-on.sh
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/integration.sh
 
@@ -67,12 +66,10 @@ if [[ -n "${ENDPOINT}" ]]; then
   ENDPOINT_FLAG="--endpoint $ENDPOINT"
 fi
 
+
+echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION"
+
 load_cluster_details
-load_addon_details
-install_add_on "$LATEST_ADDON_VERSION"
-
-echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION on the latest addon version"
-
 START=$SECONDS
 run_integration_test
 run_calico_tests

--- a/scripts/run-ipv6-canary-test.sh
+++ b/scripts/run-ipv6-canary-test.sh
@@ -7,6 +7,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
 
+source "$SCRIPT_DIR"/lib/add-on.sh
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/canary.sh
 
@@ -17,9 +18,11 @@ function run_ginkgo_test() {
 }
 
 load_cluster_details
+load_addon_details
 
-echo "Running IPv6 Canary tests"
+echo "Running IPv6 Canary tests on the latest addon version"
 
+install_add_on "$LATEST_ADDON_VERSION"
 run_ginkgo_test "CANARY"
 
 echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/scripts/update-cni-images.sh
+++ b/scripts/update-cni-images.sh
@@ -13,14 +13,19 @@ source "$SCRIPTS_DIR/lib/k8s.sh"
 AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni.yaml"
 MANIFEST_IMG_VERSION=`grep "image:" $AWS_K8S_CNI_MANIFEST | cut -d ":" -f3 | cut -d "\"" -f1 | head -1`
 
-# Replace the images in aws-k8s-cni.yaml with the tester images
-echo "Replacing images in aws-k8s-cni manifest with $AMAZON_K8S_CNI and $AMAZON_K8S_CNI_INIT"
-sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI," "$AWS_K8S_CNI_MANIFEST"
-sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI_INIT," "$AWS_K8S_CNI_MANIFEST"
-
-# grep to verify replacement
-grep -r -q $AMAZON_K8S_CNI $AWS_K8S_CNI_MANIFEST
-grep -r -q $AMAZON_K8S_CNI_INIT $AWS_K8S_CNI_MANIFEST
+# Replace the images in aws-k8s-cni.yaml with the tester images when environment variables are set
+if [[ -z $AWS_K8S_CNI ]]; then
+    echo "Applying latest CNI image from aws-k8s-cni manifest"
+else
+    echo "Replacing CNI image in aws-k8s-cni manifest with $AMAZON_K8S_CNI"
+    sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI," "$AWS_K8S_CNI_MANIFEST"
+fi
+if [[ -z $AWS_K8S_CNI_INIT ]]; then
+    echo "Applying latest CNI init image from aws-k8s-cni manifest"
+else
+    echo "Replacing CNI image in aws-k8s-cni manifest with $AMAZON_K8S_CNI"
+    sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI_INIT," "$AWS_K8S_CNI_MANIFEST"
+fi
 
 echo "Applying aws-k8s-cni.yaml manifest to aws-node daemonset"
 kubectl apply -f $AWS_K8S_CNI_MANIFEST

--- a/test/e2e/snat/snat_suite_test.go
+++ b/test/e2e/snat/snat_suite_test.go
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 		CreateNamespace(testUtils.DefaultTestNamespace)
 
 	By("Getting existing nodes in the cluster")
-	nodes, err := f.K8sResourceManagers.NodeManager().GetAllNodes()
+	nodes, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("verifying more than 1 nodes are present for the test")

--- a/test/framework/resources/k8s/resources/deployment.go
+++ b/test/framework/resources/k8s/resources/deployment.go
@@ -54,7 +54,6 @@ func (d defaultDeploymentManager) CreateAndWaitTillDeploymentIsReady(deployment 
 	return d.WaitTillDeploymentReady(deployment, timeout)
 }
 
-//
 func (d defaultDeploymentManager) DeleteAndWaitTillDeploymentIsDeleted(deployment *v1.Deployment) error {
 	ctx := context.Background()
 	err := d.k8sClient.Delete(ctx, deployment)

--- a/test/integration/metrics-helper/metrics_helper_suite_test.go
+++ b/test/integration/metrics-helper/metrics_helper_suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 		CreateNamespace(utils.DefaultTestNamespace)
 
 	By("getting the node list")
-	nodeList, err := f.K8sResourceManagers.NodeManager().GetAllNodes()
+	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(len(nodeList.Items)).To(BeNumerically(">", 0))
 


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
N/A


**What does this PR do / Why do we need it**:
This PR updates metrics-helper and e2e/snat integration tests to get nodes to test against from the set matching the given node group name/value.

This PR also updates `update-cni-image.sh` script to install latest CNI image from manifest by default. The goal is for integration test callers to run this script before running the test, as it adds flexibility to the chosen image.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified integration test scripts pass.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
