### PR TITLE
Introducing new AWS_EC2_ENDPOINT env variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,16 @@ configured to operate in IPv6 mode. Prefix delegation is only supported on nitro
 
 ---
 
+#### `AWS_EC2_ENDPOINT` (v1.11.5+)
+
+Type: String
+
+Default: None
+
+Overrides default (`https://ec2.<region>.amazonaws.com`) EC2 API endpoint, useful in case when it's preferred to use private VPC endpoint URLs instead of "public" address.
+
+---
+
 ### VPC CNI Feature Matrix
 
 IP Mode | Secondary IP Mode | Prefix Delegation | Security Groups Per Pod | WARM & MIN IP/Prefix Targets | External SNAT

--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -1,6 +1,7 @@
 package awssession
 
 import (
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"os"
 	"testing"
 	"time"
@@ -20,4 +21,22 @@ func TestHttpTimeoutWithValueAbove10(t *testing.T) {
 	defer os.Unsetenv(httpTimeoutEnv)
 	expectedHTTPTimeOut := time.Duration(12) * time.Second
 	assert.Equal(t, expectedHTTPTimeOut, getHTTPTimeout())
+}
+
+func TestAwsEc2EndpointOverride(t *testing.T) {
+	customUrl := "custom-url"
+	region := "us-west-2"
+	os.Setenv(awsEc2EndpointOverride, customUrl)
+	defer os.Unsetenv(awsEc2EndpointOverride)
+	session := New()
+	resolvedEndpoint, err := session.Config.EndpointResolver.EndpointFor(endpoints.Ec2ServiceID, region)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		endpoints.ResolvedEndpoint{
+			URL:           customUrl,
+			SigningRegion: region,
+		},
+		resolvedEndpoint,
+	)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds ability to override default EC2 API endpoint - (https://ec2.<region>.amazonaws.com), useful in case when it's preferred to use private VPC endpoint URLs instead of "public" address (and in cases when private DNS doesn't help due to complex potentially complex corporate DNS setup). Also, to set this plugin features on par of another aws plugin - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/pkg/cloud/cloud.go#L250

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Unit tests / successful use in DropBox e2e infra testing.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Adding new env variable option (default variant works as before), doesn't change anything else

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
