### PR TITLE
Reduce startup latency by removing some unneeded sleeps

### DIFF
--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -115,7 +115,7 @@ func CheckAPIServerConnectivity() error {
 	log.Infof("Testing communication with server")
 	// Reconcile the API server query after waiting for a second, as the request
 	// times out in one second if it fails to connect to the server
-	return wait.PollInfinite(2*time.Second, func() (bool, error) {
+	return wait.PollImmediateInfinite(2*time.Second, func() (bool, error) {
 		version, err := clientSet.Discovery().ServerVersion()
 		if err != nil {
 			// When times out return no error, so the PollInfinite will retry with the given interval

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -128,8 +128,6 @@ wait_for_ipam() {
         if ./grpc-health-probe -addr 127.0.0.1:50051 >/dev/null 2>&1; then
             return 0
         fi
-        # We sleep for 1 second between each retry
-        sleep 1
 	log_in_json info "Retrying waiting for IPAM-D"
     done
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A


**What does this PR do / Why do we need it**:
This PR reduces the latency of starting up the VPC CNI by 2-4 secs which results in a K8s node getting into the Ready state faster. 

When checking if kube-apiserver is accessible, the `wait.PollInfinite(2*time.Second, func()...)` func was used, which sleeps before any action and then executes the func. Since kube-apiserver is generally accessible when the CNI starts, this sleep was delaying a successful, quick request. I switched the wait func to use `wait.PollImmediateInfinite` instead which first executes the func and then sleeps if unsuccessful. 

There was also a sleep when checking if the ipamd daemon had started, but this sleep was unnecessary since there's already a 1 sec connection timeout in the grpc-health-probe. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

Before removing the sleeps:

```
## aws-node logs:

2022-10-06T22:39:55.171648812Z stdout F {"level":"info","ts":"2022-10-06T22:39:55.171Z","caller":"entrypoint.sh","msg":"Validating env variables ..."}
2022-10-06T22:39:55.172662433Z stdout F {"level":"info","ts":"2022-10-06T22:39:55.172Z","caller":"entrypoint.sh","msg":"Install CNI binaries.."}
2022-10-06T22:39:55.183080631Z stdout F {"level":"info","ts":"2022-10-06T22:39:55.182Z","caller":"entrypoint.sh","msg":"Starting IPAM daemon in the background ... "}
2022-10-06T22:39:55.18412313Z stdout F {"level":"info","ts":"2022-10-06T22:39:55.183Z","caller":"entrypoint.sh","msg":"Checking for IPAM connectivity ... "}
2022-10-06T22:39:57.190165337Z stdout F {"level":"info","ts":"2022-10-06T22:39:57.189Z","caller":"entrypoint.sh","msg":"Retrying waiting for IPAM-D"}
2022-10-06T22:39:59.196139932Z stdout F {"level":"info","ts":"2022-10-06T22:39:59.195Z","caller":"entrypoint.sh","msg":"Retrying waiting for IPAM-D"}
2022-10-06T22:39:59.21347371Z stdout F {"level":"info","ts":"2022-10-06T22:39:59.213Z","caller":"entrypoint.sh","msg":"Copying config file ... "}
2022-10-06T22:39:59.216869945Z stdout F {"level":"info","ts":"2022-10-06T22:39:59.216Z","caller":"entrypoint.sh","msg":"Successfully copied CNI plugin binary and config file."}
2022-10-06T22:39:59.217669859Z stdout F {"level":"info","ts":"2022-10-06T22:39:59.217Z","caller":"entrypoint.sh","msg":"Foregrounding IPAM daemon ..."}

## ipamd logs:

{"level":"info","ts":"2022-10-06T22:39:55.194Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-10-06T22:39:55.195Z","caller":"eniconfig/eniconfig.go:61","msg":"Initialized new logger as an existing instance was not found"}
{"level":"info","ts":"2022-10-06T22:39:55.203Z","caller":"aws-k8s-agent/main.go:28","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2022-10-06T22:39:55.203Z","caller":"aws-k8s-agent/main.go:39","msg":"Testing communication with server"}
{"level":"info","ts":"2022-10-06T22:39:57.220Z","caller":"wait/wait.go:211","msg":"Successful communication with the Cluster! Cluster Version is: v1.22+. git version: v1.22.13-eks-15b7512. git tree state: clean. commit: 94138dfbea757d7aaf3b205419578ef186dd5efb. platform: linux/amd64"}
```

After removing the sleeps:

```
## aws-node logs:

2022-10-06T22:33:09.610064979Z stdout F {"level":"info","ts":"2022-10-06T22:33:09.609Z","caller":"entrypoint.sh","msg":"Validating env variables ..."}
2022-10-06T22:33:09.61105197Z stdout F {"level":"info","ts":"2022-10-06T22:33:09.610Z","caller":"entrypoint.sh","msg":"Copying CNI plugin binaries ... "}
2022-10-06T22:33:09.623162424Z stdout F {"level":"info","ts":"2022-10-06T22:33:09.622Z","caller":"entrypoint.sh","msg":"Install CNI binaries.."}
2022-10-06T22:33:09.633499311Z stdout F {"level":"info","ts":"2022-10-06T22:33:09.633Z","caller":"entrypoint.sh","msg":"Starting IPAM daemon in the background ... "}
2022-10-06T22:33:09.63456762Z stdout F {"level":"info","ts":"2022-10-06T22:33:09.634Z","caller":"entrypoint.sh","msg":"Checking for IPAM connectivity ... "}
2022-10-06T22:33:10.639838542Z stdout F {"level":"info","ts":"2022-10-06T22:33:10.639Z","caller":"entrypoint.sh","msg":"Retrying waiting for IPAM-D"}
2022-10-06T22:33:11.644939741Z stdout F {"level":"info","ts":"2022-10-06T22:33:11.644Z","caller":"entrypoint.sh","msg":"Retrying waiting for IPAM-D"}
2022-10-06T22:33:11.660966276Z stdout F {"level":"info","ts":"2022-10-06T22:33:11.660Z","caller":"entrypoint.sh","msg":"Copying config file ... "}
2022-10-06T22:33:11.664213944Z stdout F {"level":"info","ts":"2022-10-06T22:33:11.664Z","caller":"entrypoint.sh","msg":"Successfully copied CNI plugin binary and config file."}
2022-10-06T22:33:11.665077664Z stdout F {"level":"info","ts":"2022-10-06T22:33:11.664Z","caller":"entrypoint.sh","msg":"Foregrounding IPAM daemon ..."}

## ipamd logs

{"level":"info","ts":"2022-10-06T22:33:09.645Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-10-06T22:33:09.645Z","caller":"eniconfig/eniconfig.go:61","msg":"Initialized new logger as an existing instance was not found"}
{"level":"info","ts":"2022-10-06T22:33:09.653Z","caller":"aws-k8s-agent/main.go:28","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2022-10-06T22:33:09.654Z","caller":"aws-k8s-agent/main.go:39","msg":"Testing communication with server"}
{"level":"info","ts":"2022-10-06T22:33:09.665Z","caller":"wait/wait.go:211","msg":"Successful communication with the Cluster! Cluster Version is: v1.22+. git version: v1.22.13-eks-15b7512. git tree state: clean. commit: 94138dfbea757d7aaf3b205419578ef186dd5efb. platform: linux/amd64"}
```

## Graph with latency reduction:

![Screen Shot 2022-10-06 at 18 22 14](https://user-images.githubusercontent.com/3503707/194435812-29bf8585-4bce-4fe9-a6f4-86b30d87ba2f.jpg)


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

See above

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

Nope

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

No

```release-note
Improve the startup time of the vpc-cni
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
