### PR TITLE
Update GitHub runners to install ginkgo from `go.mod` in test directory

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,9 +26,12 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+          # Install ginkgo version from go.mod in test directory
+          pushd ./test
+          go install github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
+          popd
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -24,9 +24,12 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+          # Install ginkgo version from go.mod in test directory
+          pushd ./test
+          go install github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
+          popd
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -32,9 +32,12 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+          # Install ginkgo version from go.mod in test directory
+          pushd ./test
+          go install github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
+          popd
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -24,9 +24,12 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+          # Install ginkgo version from go.mod in test directory
+          pushd ./test
+          go install github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
+          popd
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -6,7 +6,7 @@ The package contains automated integration tests suites for `amazon-vpc-cni-k8s`
 The integration test requires 
 - At least 2 nodes in a node group.
 - Nodes in the nodegroup shouldn't have existing pods.
-- Ginkgo installed on your environment. To install `go install github.com/onsi/ginkgo/v2/ginkgo@latest`
+- Ginkgo installed on your environment. To install, run `go install github.com/onsi/ginkgo/v2/ginkgo` from the test (parent) directory.
 - Supports instance types having at least 3 ENIs and 16+ Secondary IPv4 Addresses across all ENIs.
 
 #### Testing


### PR DESCRIPTION
**What type of PR is this?**
Cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates GitHub runners to install the correct ginkgo version. It does so by installing the ginkgo version specified in `go.mod` in the test directory.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Coverage will be achieved through GitHub runner executing

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
