### PR TITLE
Resolve flakiness in IPAMD warm target tests; update test go.sum

### DIFF
--- a/test/framework/resources/k8s/utils/daemonset.go
+++ b/test/framework/resources/k8s/utils/daemonset.go
@@ -86,7 +86,7 @@ func updateDaemonsetEnvVarsAndWait(f *framework.Framework, dsName string, dsName
 }
 
 func getDaemonSet(f *framework.Framework, dsName string, dsNamespace string) *v1.DaemonSet {
-	By(fmt.Sprintf("getting the %s daemon set in namesapce %s", dsName, dsNamespace))
+	By(fmt.Sprintf("getting the %s daemon set in namespace %s", dsName, dsNamespace))
 	ds, err := f.K8sResourceManagers.
 		DaemonSetManager().
 		GetDaemonSet(dsNamespace, dsName)

--- a/test/go.sum
+++ b/test/go.sum
@@ -553,6 +553,7 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/logger v1.0.3 h1:YaXOTHNPCvkqqA7w05A4v0k2tCdpr+sgFlgINbQ6gqc=
 github.com/gobuffalo/logger v1.0.3/go.mod h1:SoeejUwldiS7ZsyCBphOGURmWdwUFXs0J7TCjEhjKxM=
@@ -672,6 +673,7 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/test/integration/ipamd/warm_target_test.go
+++ b/test/integration/ipamd/warm_target_test.go
@@ -41,13 +41,14 @@ var _ = Describe("test warm target variables", func() {
 					"MAX_ENI":         strconv.Itoa(maxENI),
 				})
 
-			// Allow for IPAMD to reconcile it's state
+			// Allow for IPAMD to reconcile its state
 			time.Sleep(utils.PollIntervalLong * 5)
 
 			primaryInstance, err = f.CloudServices.
 				EC2().DescribeInstance(*primaryInstance.InstanceId)
 			Expect(err).ToNot(HaveOccurred())
 
+			// Validate number of allocated ENIs
 			Expect(len(primaryInstance.NetworkInterfaces)).
 				Should(Equal(MinIgnoreZero(warmENITarget, maxENI)))
 		})
@@ -58,13 +59,13 @@ var _ = Describe("test warm target variables", func() {
 				map[string]struct{}{"WARM_ENI_TARGET": {}, "MAX_ENI": {}})
 		})
 
-		Context("when WARM_ENI_TARGET = 2 and MAX_ENI = 1", func() {
+		Context("when WARM_ENI_TARGET = 3 and MAX_ENI = 2", func() {
 			BeforeEach(func() {
-				warmENITarget = 2
-				maxENI = 1
+				warmENITarget = 3
+				maxENI = 2
 			})
 
-			It("instance should have only 1 ENI", func() {})
+			It("instance should have only 2 ENIs", func() {})
 		})
 
 		Context("when WARM_ENI_TARGET = 3", func() {
@@ -76,13 +77,13 @@ var _ = Describe("test warm target variables", func() {
 			It("instance should have only 3 ENIs", func() {})
 		})
 
-		Context("when WARM_ENI_TARGET = 1", func() {
+		Context("when WARM_ENI_TARGET = 2", func() {
 			BeforeEach(func() {
-				warmENITarget = 1
+				warmENITarget = 2
 				maxENI = 0
 			})
 
-			It("instance should have only 1 ENI", func() {})
+			It("instance should have only 2 ENIs", func() {})
 		})
 
 	})

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -17,19 +17,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
-	"github.com/aws/aws-sdk-go/service/ec2"
-
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-var primaryInstance *ec2.Instance
-var f *framework.Framework
-var err error
 
 // IMPORTANT: THE NODEGROUP TO RUN THE TEST MUST NOT HAVE ANY POD
 // Ideally we should drain the node, but drain from go client is non trivial
@@ -113,7 +106,7 @@ var _ = Describe("test warm target variables", func() {
 				minIPTarget = 16
 			})
 
-			It("should have 1 prefixe", func() {})
+			It("should have 1 prefix", func() {})
 		})
 
 		Context("when MINIMUM_IP_TARGET = 6 and WARM_IP_TARGET = 10", func() {
@@ -258,7 +251,7 @@ var _ = Describe("test warm target variables", func() {
 				warmPrefixTarget = 0
 			})
 
-			It("should have 1 prefixe", func() {})
+			It("should have 1 prefix", func() {})
 		})
 
 		Context("when MINIMUM_IP_TARGET = 6, WARM_IP_TARGET = 10 and WARM_PREFIX_TARGET = 1", func() {
@@ -272,28 +265,3 @@ var _ = Describe("test warm target variables", func() {
 		})
 	})
 })
-
-func ceil(x, y int) int {
-	return (x + y - 1) / y
-}
-
-func Max(x, y int) int {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-// MinIgnoreZero returns smaller of two number, if any number is zero returns the other number
-func MinIgnoreZero(x, y int) int {
-	if x == 0 {
-		return y
-	}
-	if y == 0 {
-		return x
-	}
-	if x < y {
-		return x
-	}
-	return y
-}


### PR DESCRIPTION
**What type of PR is this?**
Cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR resolves flakiness in the IPAMD warm target integration tests. Using ENI values starting at 2 resolves issues from when coredns pods were previously running on node and IPAMD chooses not to prune extra ENI. I also moved global suite variables and functions to the suite file.

This PR also adds missing `go.sum` entries following the ginkgo upgrade to v2.3.1. Missing entries were discovered from failing nightly cron job: https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/3278661455/jobs/5397305965

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that cron job steps do not hit this issue anymore.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
