### PR TITLE
[driver] refactor pod network configuration not to use static ARP entry

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -187,16 +187,15 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 		}
 	}
 
-	// Add an onlink route to a dummy next hop (169.254.1.1 or fe80::1)
-	// # ip route show
-	// default via 169.254.1.1 dev eth0 onlink
 	vethConfig := createVethContext.vethConfiguration()
 	if err = createVethContext.netLink.AddrAdd(contVeth, vethConfig.contVethAddress); err != nil {
 		return errors.Wrapf(err, "setup NS network: failed to add IP addr to %q", createVethContext.contVethName)
 	}
 
-	// Add a default route via dummy next hop(169.254.1.1 or fe80::1). Then all outgoing traffic will be routed by this
-	// default route via dummy next hop (169.254.1.1 or fe80::1)
+	// Add a default onlink route via dummy next hop(169.254.1.1 or fe80::1).
+	// Then all outgoing traffic will be routed by this default route via dummy next hop (169.254.1.1 or fe80::1)
+	// # ip route show
+	// default via 169.254.1.1 dev eth0 onlink
 	defaultRoute := &netlink.Route{
 		LinkIndex: contVeth.Attrs().Index,
 		Scope:     netlink.SCOPE_UNIVERSE,


### PR DESCRIPTION
**What type of PR is this?**
bugfix

**Which issue does this PR fix**:
Fixes: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103

**What does this PR do / Why do we need it**:
This PR changes pod network confuguration so static ARP entry for host's veth mac address is no longer need.
**Previous configuration:**
* host veth doesn't have an IP address asigned
* pod veth has a direct route to fake router IP address
* pod veth has default route via fake router IP address
* fake router IP address has static arp entry in pod namespace pointed to host system's veth interface
```
$ ip addr sho dev enidbd62a3316e
18037: enidbd62a3316e@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
    link/ether 46:a9:d3:46:96:82 brd ff:ff:ff:ff:ff:ff link-netns  cni-9fc9c11a-2553-b00c-4ba8-98228b5a846a
    inet6 fe80::98df:3bff:feb0:dcf2/64 scope link
       valid_lft forever preferred_lft forever

$ sudo ip netns exec cni-9fc9c11a-2553-b00c-4ba8-98228b5a846a ip ro
default via 169.254.1.1 dev eth0
169.254.1.1 dev eth0 scope link
$ sudo ip netns exec cni-9fc9c11a-2553-b00c-4ba8-98228b5a846a arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
169.254.1.1              ether   46:a9:d3:46:96:82   CM                    eth0
```

**Updated configuration:**
* host veth has link-local address assigned (all interfaces have same address)
* pod has an onlink default route to host's veth interface
```
$ sudo ip netns exec cni-0e566121-8e96-b032-a3e3-15ca97a87f01 ip ro
default via 169.254.1.1 dev eth0 onlink

$ ip addr sho dev enibd675d21895
18038: enibd675d21895@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
    link/ether a2:f3:e2:0c:5b:8b brd ff:ff:ff:ff:ff:ff link-netns cni-978889f6-92c0-8067-14a7-f509f39fa7f9
    inet 169.254.1.1/32 scope global enibd675d21895
       valid_lft forever preferred_lft forever
    inet6 fe80::1057:1eff:fe7d:fe0b/64 scope link
       valid_lft forever preferred_lft forever
```

More details in https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
TLDR: on Ubuntu 22.04+ udevd assigns permanent mac address to host system veth interface once it's moved to host network namespace.  Since it happens after the pod network is configured with non-permanent mac address - pod has no network connectivity.
**Why not fix existing pod network configuration?**
I was not able to find a good way to monitor the udev-induced mac address change. The only option would be to add a sleep with some arbitrary timeout which either will slow-down pod allocation or will not be enough on heavy-loaded systems.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Verified updated configuration works on k8s cluster running on AWS EC2.

**Automation added to e2e**:
-

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Should not/No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
It changes pod network configuration as well as adds link-local address to host system's veth interface.


```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
