### PR TITLE
fix metrics-helper test to detach role policy early 

### DIFF
--- a/test/integration/metrics-helper/metrics_helper_suite_test.go
+++ b/test/integration/metrics-helper/metrics_helper_suite_test.go
@@ -142,12 +142,13 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	k8sUtil.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
-		utils.AwsNodeName, map[string]struct{}{"SOME_NON_EXISTENT_VAR": {}})
 
 	By("detaching role policy from the node IAM Role")
 	err = f.CloudServices.IAM().DetachRolePolicy(policyARN, ngRoleName)
 	Expect(err).ToNot(HaveOccurred())
+
+	k8sUtil.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+		utils.AwsNodeName, map[string]struct{}{"SOME_NON_EXISTENT_VAR": {}})
 
 	By("uninstalling cni-metrics-helper using helm")
 	err := f.InstallationManager.UnInstallCNIMetricsHelper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
We have seen cases where the AfterSuite timed out while updating the `aws-node` daemonset before detaching the policy from the role. This prevents the node role cleanup and requires user to manually detach the policy before deleting the node role and the node group. 

Changes in the PR is to avoid this issue and detach the policy from the node role first before updating the `aws-node` daemonset. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Yes, ran metrics-helper test
```
AfterSuite] PASSED [86.575 seconds]
[AfterSuite] 
/Users/ravsushm/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/metrics-helper/metrics_helper_suite_test.go:144

  Begin Captured GinkgoWriter Output >>
    STEP: detaching role policy from the node IAM Role 10/26/22 21:40:38.421
    STEP: removing the environment variables from the ds map[SOME_NON_EXISTENT_VAR:{}] 10/26/22 21:40:38.983
    STEP: getting the aws-node daemon set in namespace kube-system 10/26/22 21:40:38.984
    STEP: updating the daemon set with new environment variable 10/26/22 21:40:39.248
    STEP: uninstalling cni-metrics-helper using helm 10/26/22 21:41:55.489
    STEP: deleting test namespace 10/26/22 21:41:58.77
  << End Captured GinkgoWriter Output
------------------------------
```
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this change require updates to the CNI daemonset config files to work?**:
No.
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No.
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
