### PR TITLE
Update Troubleshooting docs for node operating system; fix script path

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -220,6 +220,21 @@ cni v1.10.x introduced 2 new env variables - ENABLE_IPv4 and ENABLE_IPv6. The ab
 kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.10/config/master/aws-k8s-cni.yaml
 ```
 
+## CNI Compatibility
+
+The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2 as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:
+
+- **iptables** - iptables is installed by default in `aws-node` container images. Newer distributions of RHEL (RHEL 8.x+), Ubuntu (Ubuntu 20.x+), etc. have moved to using `nftables`. This leads to issues such as [this](https://github.com/aws/amazon-vpc-cni-k8s/issues/1847) when running IPAMD.
+  
+  To resolve this issue on distributions that use `nftables`, there are currently two options:
+  1. Uninstall `nftables` and install `iptables-legacy` in base distribution
+  2. Build a custom CNI image based on `nftables`, such as:
+  ```
+  from $ACCOUNT.dkr.ecr.$REGION.amazonaws.com/amazon-k8s-cni:$IMAGE_TAG
+  run yum install iptables-nft -y
+  run cd /usr/sbin && rm iptables && ln -s xtables-nft-multi iptables
+  ```
+
 ## cni-metrics-helper
 
 See the [cni-metrics-helper README](../cmd/cni-metrics-helper/README.md).

--- a/scripts/lib/canary.sh
+++ b/scripts/lib/canary.sh
@@ -16,7 +16,7 @@ fi
 
 if [[ -z "${SKIP_MAKE_TEST_BINARIES}" ]]; then
   echo "making ginkgo test binaries"
-  (cd $SCRIPT_DIR/../test && make build-test-binaries)
+  (cd $SCRIPT_DIR/../ && make build-test-binaries)
 else
   echo "skipping making ginkgo test binaries"
 fi


### PR DESCRIPTION
… where make command is run

**What type of PR is this?**
cleanup and documentation

**Which issue does this PR fix**:
none

**What does this PR do / Why do we need it**:
This PR updates the troubleshooting document to add a section for aws-node compatibility with non-Amazon Linux 2 distributions. We need this to assist customers in debugging issues with aws-node on various distributions. This PR also fixes the path at which a `make` command was called by the canary script. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
A/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
