### PR TITLE
Reduce Startup Latency by moving the init container to a regular container

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -38,29 +38,23 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
       hostNetwork: true
-      initContainers:
-      - name: aws-vpc-cni-init
-        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
-        env:
+      containers:
+        - name: aws-vpc-cni-init
+          image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
+          env:
 {{- range $key, $value := .Values.init.env }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
 {{- end }}
-        securityContext:
-          {{- toYaml .Values.init.securityContext | nindent 12 }}
-        volumeMounts:
+          resources:
+            {{- toYaml .Values.init.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.init.securityContext | nindent 12 }}
+          volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      containers:
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
         - name: aws-node
           image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
           ports:
@@ -103,6 +97,8 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
           {{- with .Values.extraVolumeMounts  }}
           {{- toYaml .| nindent 10 }}
           {{- end }}
@@ -129,6 +125,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      - name: vpc-cni-init-dir
+        emptyDir:
+          sizeLimit: 1Ki
       {{- with .Values.extraVolumes  }}
       {{- toYaml .| nindent 6 }}
       {{- end }}
@@ -140,6 +139,15 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -20,6 +20,9 @@ init:
     ENABLE_IPv6: "false"
   securityContext:
     privileged: true
+  resources:
+    requests:
+      cpu: 5m
 
 image:
   region: us-west-2

--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/cp"
@@ -179,17 +180,17 @@ func _main() int {
 		return 1
 	}
 
-	// TODO: In order to speed up pod launch time, VPC CNI init container is not a Kubernetes init container.
+	// In order to speed up pod launch time, VPC CNI init container is not a Kubernetes init container.
 	// The VPC CNI container blocks on the existence of vpcCniInitDonePath
-	//err = cp.TouchFile(vpcCniInitDonePath)
-	//if err != nil {
-	//	log.WithError(err).Errorf("Failed to set VPC CNI init done")
-	//	return 1
-	//}
+	err = cp.TouchFile(vpcCniInitDonePath)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to set VPC CNI init done")
+		return 1
+	}
 
 	log.Infof("CNI init container done")
 
-	// TODO: Since VPC CNI init container is a real container, it never exits
-	// time.Sleep(time.Duration(1<<63 - 1))
+	// Since VPC CNI init container is a real container, it never exits
+	time.Sleep(time.Duration(1<<63 - 1))
 	return 0
 }

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -390,10 +390,10 @@ func _main() int {
 	}
 
 	// Wait for init container to complete
-	//if err := waitForInit(); err != nil {
-	//	log.WithError(err).Errorf("Init container failed to complete")
-	//	return 1
-	//}
+	if err := waitForInit(); err != nil {
+		log.WithError(err).Errorf("Init container failed to complete")
+		return 1
+	}
 
 	log.Infof("Copying config file... ")
 	err = generateJSON(defaultAWSconflistFile, tmpAWSconflistFile)

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -119,25 +119,24 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: aws-node
       hostNetwork: true
-      initContainers:
-      - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.0"
-        env:
-          - name: DISABLE_TCP_EARLY_DEMUX
-            value: "false"
-          - name: ENABLE_IPv6
-            value: "false"
-        securityContext:
+      containers:
+        - name: aws-vpc-cni-init
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.0"
+          env:
+            - name: DISABLE_TCP_EARLY_DEMUX
+              value: "false"
+            - name: ENABLE_IPv6
+              value: "false"
+          resources:
+            requests:
+              cpu: 5m
+          securityContext:
             privileged: true
-        volumeMounts:
+          volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
-      securityContext:
-        {}
-      containers:
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
         - name: aws-node
           image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.12.0"
           ports:
@@ -227,6 +226,8 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -245,6 +246,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      - name: vpc-cni-init-dir
+        emptyDir:
+          sizeLimit: 1Ki
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -263,3 +267,8 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -119,25 +119,24 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: aws-node
       hostNetwork: true
-      initContainers:
-      - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
-        env:
-          - name: DISABLE_TCP_EARLY_DEMUX
-            value: "false"
-          - name: ENABLE_IPv6
-            value: "false"
-        securityContext:
+      containers:
+        - name: aws-vpc-cni-init
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
+          env:
+            - name: DISABLE_TCP_EARLY_DEMUX
+              value: "false"
+            - name: ENABLE_IPv6
+              value: "false"
+          resources:
+            requests:
+              cpu: 5m
+          securityContext:
             privileged: true
-        volumeMounts:
+          volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
-      securityContext:
-        {}
-      containers:
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
         - name: aws-node
           image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.12.0"
           ports:
@@ -227,6 +226,8 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -245,6 +246,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      - name: vpc-cni-init-dir
+        emptyDir:
+          sizeLimit: 1Ki
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -263,3 +267,8 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -119,25 +119,24 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: aws-node
       hostNetwork: true
-      initContainers:
-      - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
-        env:
-          - name: DISABLE_TCP_EARLY_DEMUX
-            value: "false"
-          - name: ENABLE_IPv6
-            value: "false"
-        securityContext:
+      containers:
+        - name: aws-vpc-cni-init
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
+          env:
+            - name: DISABLE_TCP_EARLY_DEMUX
+              value: "false"
+            - name: ENABLE_IPv6
+              value: "false"
+          resources:
+            requests:
+              cpu: 5m
+          securityContext:
             privileged: true
-        volumeMounts:
+          volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
-      securityContext:
-        {}
-      containers:
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
         - name: aws-node
           image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.12.0"
           ports:
@@ -227,6 +226,8 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -245,6 +246,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      - name: vpc-cni-init-dir
+        emptyDir:
+          sizeLimit: 1Ki
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -263,3 +267,8 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -119,25 +119,24 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: aws-node
       hostNetwork: true
-      initContainers:
-      - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
-        env:
-          - name: DISABLE_TCP_EARLY_DEMUX
-            value: "false"
-          - name: ENABLE_IPv6
-            value: "false"
-        securityContext:
+      containers:
+        - name: aws-vpc-cni-init
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0"
+          env:
+            - name: DISABLE_TCP_EARLY_DEMUX
+              value: "false"
+            - name: ENABLE_IPv6
+              value: "false"
+          resources:
+            requests:
+              cpu: 5m
+          securityContext:
             privileged: true
-        volumeMounts:
+          volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
-      securityContext:
-        {}
-      containers:
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
         - name: aws-node
           image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0"
           ports:
@@ -227,6 +226,8 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          - name: vpc-cni-init-dir
+            mountPath: /vpc-cni-init
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -245,6 +246,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      - name: vpc-cni-init-dir
+        emptyDir:
+          sizeLimit: 1Ki
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -263,3 +267,8 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+      securityContext:
+        {}
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
 - feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/awslabs/amazon-eks-ami/issues/1099


**What does this PR do / Why do we need it**:
 - The VPC CNI controls when a node becomes usable for pod scheduling and execution so the startup time of the CNI should be optimized to bring nodes online faster. This PR improves the startup time of the VPC CNI by >50% (from 9 sec to 4 sec) by moving the init container to a regular container in the pod and synchronizing the vpc-cni container via a shared emptyDir volume. This allows the containers to initialize in parallel and avoids the kubelet latency of switching between the init container and the regular container. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

I installed the changes into my cluster (1.22) via helm and ran tests on the current production version (v1.12.0) and my change. Below are representative samples across 10 runs. 

The "VPC CNI Plugin Initialized" event is when the CNI config file is moved to the `/etc/cni/net.d` dir, signaling to the container runtime that networking is ready. 

**Previous aws-node startup timing (9 secs):**
```
|     Event                     | Timestamp | t  |
|-------------------------------|-----------|----|
| VPC CNI Init Container Starts | 05:29:42  | 0s |
| AWS Node Container Starts     | 05:29:49  | 7s |
| VPC CNI Plugin Initialized    | 05:29:51  | 9s |
```

**After this change startup timing (4 secs):**
```
|     Event                     | Timestamp | t  |
|-------------------------------|-----------|----|
| AWS Node Container Starts     | 05:30:30  | 0s |
| VPC CNI Init Container Starts | 05:30:32  | 2s |
| VPC CNI Plugin Initialized    | 05:30:34  | 4s |
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

I have not tested updating a running cluster, but the changes are only on improving the startup sequence.

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

Yes, this change requires moving the previous init-container under the regular containers list in the DaemonSet and involves adding an emptyDir volume and mapping in both containers. 

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
