### PR TITLE
optionally allow CLUSTER_ENDPOINT to be used rather than the cluster-ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,17 @@ Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag
 
 ---
 
+#### `CLUSTER_ENDPOINT`
+
+Type: String
+
+Default: `""`
+
+Specifies the cluster endpoint to use for connecting to the api-server without relying on kube-proxy. 
+This is an optional configuration parameter that can improve the initialization time of the AWS VPC CNI.
+
+---
+
 #### `ENABLE_POD_ENI` (v1.7.0+)
 
 Type: Boolean as a String

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Specifies the cluster name to tag allocated ENIs with. See the "Cluster Name tag
 
 ---
 
-#### `CLUSTER_ENDPOINT`
+#### `CLUSTER_ENDPOINT` (v1.12.1+)
 
 Type: String
 

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -36,7 +36,7 @@ func _main() int {
 	version.RegisterMetric()
 
 	// Check API Server Connectivity
-	if err := k8sapi.CheckAPIServerConnectivity(false); err != nil {
+	if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
 		log.Errorf("Failed to check API server connectivity: %s", err)
 		return 1
 	}
@@ -75,12 +75,6 @@ func _main() int {
 
 	// CNI introspection endpoints
 	go ipamContext.ServeIntrospection()
-
-	// Check API Server Connectivity w/ cluster ip to make sure kube-proxy is finished
-	if err := k8sapi.CheckAPIServerConnectivity(true); err != nil {
-		log.Errorf("Failed to check API server connectivity, there may be something wrong with kube-proxy: %s", err)
-		return 1
-	}
 
 	// Start the RPC listener
 	err = ipamContext.RunRPCHandler(version.Version)

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -29,14 +29,14 @@ func main() {
 }
 
 func _main() int {
-	//Do not add anything before initializing logger
+	// Do not add anything before initializing logger
 	log := logger.Get()
 
 	log.Infof("Starting L-IPAMD %s  ...", version.Version)
 	version.RegisterMetric()
 
-	//Check API Server Connectivity
-	if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
+	// Check API Server Connectivity
+	if err := k8sapi.CheckAPIServerConnectivity(false); err != nil {
 		log.Errorf("Failed to check API server connectivity: %s", err)
 		return 1
 	}
@@ -75,6 +75,12 @@ func _main() int {
 
 	// CNI introspection endpoints
 	go ipamContext.ServeIntrospection()
+
+	// Check API Server Connectivity w/ cluster ip to make sure kube-proxy is finished
+	if err := k8sapi.CheckAPIServerConnectivity(true); err != nil {
+		log.Errorf("Failed to check API server connectivity, there may be something wrong with kube-proxy: %s", err)
+		return 1
+	}
 
 	// Start the RPC listener
 	err = ipamContext.RunRPCHandler(version.Version)

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -23,11 +23,11 @@ import (
 var log = logger.Get()
 
 func InitializeRestMapper() (meta.RESTMapper, error) {
-	restCfg, err := ctrl.GetConfig()
-	restCfg.Burst = 200
+	restCfg, err := getRestConfig(false)
 	if err != nil {
 		return nil, err
 	}
+	restCfg.Burst = 200
 	mapper, err := apiutil.NewDynamicRESTMapper(restCfg)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func InitializeRestMapper() (meta.RESTMapper, error) {
 
 // CreateKubeClient creates a k8s client
 func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
-	restCfg, err := ctrl.GetConfig()
+	restCfg, err := getRestConfig(false)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +56,12 @@ func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
 
 // CreateKubeClient creates a k8s client
 func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) (client.Client, error) {
-	restCfg, err := ctrl.GetConfig()
-	restCfg.Burst = 100
-
+	restCfg, err := getRestConfig(false)
 	if err != nil {
 		return nil, err
 	}
+	restCfg.Burst = 100
+
 	vpcCniScheme := runtime.NewScheme()
 	clientgoscheme.AddToScheme(vpcCniScheme)
 	eniconfigscheme.AddToScheme(vpcCniScheme)
@@ -89,7 +89,7 @@ func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) 
 }
 func GetKubeClientSet() (kubernetes.Interface, error) {
 	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
+	config, err := getRestConfig(false)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func GetKubeClientSet() (kubernetes.Interface, error) {
 	return clientSet, nil
 }
 
-func CheckAPIServerConnectivity() error {
-	restCfg, err := ctrl.GetConfig()
+func CheckAPIServerConnectivity(clusterIPOnly bool) error {
+	restCfg, err := getRestConfig(clusterIPOnly)
 	if err != nil {
 		return err
 	}
@@ -129,4 +129,15 @@ func CheckAPIServerConnectivity() error {
 			version.Major, version.Minor, version.GitVersion, version.GitTreeState, version.GitCommit, version.Platform)
 		return true, nil
 	})
+}
+
+func getRestConfig(clusterIPOnly bool) (*rest.Config, error) {
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	if endpoint, ok := os.LookupEnv("CLUSTER_ENDPOINT"); !clusterIPOnly && ok {
+		restCfg.Host = endpoint
+	}
+	return restCfg, nil
 }

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -23,7 +23,7 @@ import (
 var log = logger.Get()
 
 func InitializeRestMapper() (meta.RESTMapper, error) {
-	restCfg, err := getRestConfig(false)
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func InitializeRestMapper() (meta.RESTMapper, error) {
 
 // CreateKubeClient creates a k8s client
 func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
-	restCfg, err := getRestConfig(false)
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
 
 // CreateKubeClient creates a k8s client
 func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) (client.Client, error) {
-	restCfg, err := getRestConfig(false)
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) 
 }
 func GetKubeClientSet() (kubernetes.Interface, error) {
 	// creates the in-cluster config
-	config, err := getRestConfig(false)
+	config, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func GetKubeClientSet() (kubernetes.Interface, error) {
 	return clientSet, nil
 }
 
-func CheckAPIServerConnectivity(clusterIPOnly bool) error {
-	restCfg, err := getRestConfig(clusterIPOnly)
+func CheckAPIServerConnectivity() error {
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return err
 	}
@@ -131,12 +131,12 @@ func CheckAPIServerConnectivity(clusterIPOnly bool) error {
 	})
 }
 
-func getRestConfig(clusterIPOnly bool) (*rest.Config, error) {
+func getRestConfig() (*rest.Config, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
 	}
-	if endpoint, ok := os.LookupEnv("CLUSTER_ENDPOINT"); !clusterIPOnly && ok {
+	if endpoint, ok := os.LookupEnv("CLUSTER_ENDPOINT"); ok {
 		restCfg.Host = endpoint
 	}
 	return restCfg, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
 - feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/awslabs/amazon-eks-ami/issues/1099

**What does this PR do / Why do we need it**:

When a node is starting, kube-proxy and the VPC CNI DaemonSets get scheduled and started on the node at roughly the same time. This causes a race in the VPC CNI since it currently depends on kube-proxy to finish setting up cluster-ip routes on the node. If the VPC CNI hits the k8s server check first, then there is a 5 sec delay since that is the current timeout value set. This delays the node from getting to a Ready state.  


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Installed with and without setting `env.CLUSTER_ENDPOINT`:

```
helm upgrade --install aws-node-ce -n kube-system charts/aws-vpc-cni/ --set image.override=xxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/vpc-cni:ce --set init.image.override=xxxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/vpc-cni:init-ce --set env.CLUSTER_ENDPOINT=https://xxxxx.xxx.us-west-2.eks.amazonaws.com
```
This log shows a race where kube-proxy wasn't finished when aws-node reached out to the api-server through the cluster ip, resulting in a delay in initialization:

```
|     Event                     | Timestamp | t  |
|-------------------------------|-----------|----|
| kube-proxy Started            | 07:30:54  | 0  |
| AWS Node Container Starts     | 07:30:55  | 1  |
| VPC CNI Init Container Starts | 07:30:55  | 1  |
| VPC CNI Plugin Initialized    | 07:31:05  | 10 |
```

```
{"level":"info","ts":"2022-11-11T07:30:56.231Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-11-11T07:30:56.235Z","caller":"eniconfig/eniconfig.go:61","msg":"Initialized new logger as an existing instance was not found"}
{"level":"info","ts":"2022-11-11T07:30:56.321Z","caller":"aws-k8s-agent/main.go:28","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2022-11-11T07:30:56.329Z","caller":"aws-k8s-agent/main.go:39","msg":"Testing communication with server"}
{"level":"error","ts":"2022-11-11T07:31:01.329Z","caller":"wait/wait.go:211","msg":"Unable to reach API Server, Get \"https://10.100.0.1:443/version?timeout=5s\": context deadline exceeded"}
{"level":"info","ts":"2022-11-11T07:31:03.351Z","caller":"wait/wait.go:211","msg":"Successful communication with the Cluster! Cluster Version is: v1.22+. git version: v1.22.15-eks-fb459a0. git tree state: clean. commit: be82fa628e60d024275efaa239bfe53a9119c2d9. platform: linux/amd64"}
```

This PR adds an option CLUSTER_ENDPOINT environment variable that can be passed which allows aws-node to initialize without waiting on kube-proxy. Kube-proxy is still required before aws-node finishes initializing the CNI plugin. 


This log shows the components starting at the same time where kube-proxy is not completed, but aws-node can continue bootstrapping with the CLUSTER_ENDPOINT:

```
|     Event                     | Timestamp | t  |
|-------------------------------|-----------|----|
| AWS Node Container Starts     | 07:40:39  | 0  |
| kube-proxy Started            | 07:40:39  | 0  |
| VPC CNI Init Container Starts | 07:40:39  | 0  |
| VPC CNI Plugin Initialized    | 07:40:41  | 2  |
```

```
{"level":"info","ts":"2022-11-11T07:40:39.878Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-11-11T07:40:39.881Z","caller":"eniconfig/eniconfig.go:61","msg":"Initialized new logger as an existing instance was not found"}
{"level":"info","ts":"2022-11-11T07:40:39.974Z","caller":"aws-k8s-agent/main.go:28","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2022-11-11T07:40:39.982Z","caller":"aws-k8s-agent/main.go:39","msg":"Testing communication with server"}
{"level":"info","ts":"2022-11-11T07:40:40.014Z","caller":"wait/wait.go:211","msg":"Successful communication with the Cluster! Cluster Version is: v1.22+. git version: v1.22.15-eks-fb459a0. git tree state: clean. commit: be82fa628e60d024275efaa239bfe53a9119c2d9. platform: linux/amd64"}

...

{"level":"info","ts":"2022-11-11T07:40:41.407Z","caller":"wait/wait.go:211","msg":"Successful communication with the Cluster! Cluster Version is: v1.22+. git version: v1.22.15-eks-fb459a0. git tree state: clean. commit: be82fa628e60d024275e
faa239bfe53a9119c2d9. platform: linux/amd64"}
```

The first api-server connectivity check uses the CLUSTER_ENDPOINT passed in and the second one uses the cluster ip to make sure that kube-proxy is finished. The second check blocks the CNI from initializing.  

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

NO

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

Have not tested upgrading a cluster, but this change only affects the endpoint being used. 


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
CLUSTER_ENDPOINT can now be specified to allow the VPC CNI to initialize before kube-proxy has finished setting up cluster IP routes.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
