### PR TITLE
Add resources config option to cni metrics helper

### DIFF
--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cni-metrics-helper/templates/deployment.yaml
+++ b/charts/cni-metrics-helper/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
 {{- end }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
         name: cni-metrics-helper
         image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
       serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/charts/cni-metrics-helper/templates/deployment.yaml
+++ b/charts/cni-metrics-helper/templates/deployment.yaml
@@ -20,7 +20,9 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
 {{- end }}
+{{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
+{{- end }}
         name: cni-metrics-helper
         image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
       serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -24,3 +24,5 @@ serviceAccount:
   name:
   annotations: {}
     # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  
+
+resources: {}

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -24,5 +24,3 @@ serviceAccount:
   name:
   annotations: {}
     # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  
-
-resources: {}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#2140

**What does this PR do / Why do we need it**:
Adds an option to set resources in the cni metrics helper helm chart

**Testing done on this change**:
* `helm template` run against the cni metrics helper chart with a values file containing:

```
resources:
  requests:
    memory: 256Mi
    cpu: 10m
  limits:
    memory: 512Mi
    cpu: 50m
```

i.e. `helm template ./charts/cni-metrics-helper --values=test-resources.yaml --debug`

* Visually inspected that the resources are correct:

```
---
# Source: cni-metrics-helper/templates/deployment.yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: cni-metrics-helper
  namespace: default
  labels:
    k8s-app: cni-metrics-helper
spec:
  selector:
    matchLabels:
      k8s-app: cni-metrics-helper
  template:
    metadata:
      labels:
        k8s-app: cni-metrics-helper
    spec:
      containers:
      - env:
        - name: AWS_CLUSTER_ID
          value: ""
        - name: USE_CLOUDWATCH
          value: "true"
        resources:
          limits:
            cpu: 50m
            memory: 512Mi
          requests:
            cpu: 10m
            memory: 256Mi
        name: cni-metrics-helper
        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.11.4"
      serviceAccountName: cni-metrics-helper
```
* applied the chart to my running cluster (eks 1.22)

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No; tested an upgrade and it worked fine.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Added `resources` block to `cni-metrics-helper` helm chart
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
