### PR TITLE
Add metrics for ec2 api calls made by CNI and expose via prometheus

### DIFF
--- a/cmd/cni-metrics-helper/metrics/cni_metrics.go
+++ b/cmd/cni-metrics-helper/metrics/cni_metrics.go
@@ -147,6 +147,20 @@ var InterestingCNIMetrics = map[string]metricsConvert{
 				actionFunc: metricsAdd,
 				data:       &dataPoints{},
 				logToFile:  true}}},
+	"awscni_ec2api_req_count": {
+		actions: []metricsAction{
+			{cwMetricName: "ec2ApiReqCount",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{},
+				logToFile:  true}}},
+	"awscni_ec2api_error_count": {
+		actions: []metricsAction{
+			{cwMetricName: "ec2ApiErrCount",
+				matchFunc:  matchAny,
+				actionFunc: metricsAdd,
+				data:       &dataPoints{},
+				logToFile:  true}}},
 }
 
 // CNIMetricsTarget defines data structure for kube-state-metric target

--- a/cmd/cni-metrics-helper/metrics/cni_test1.data
+++ b/cmd/cni-metrics-helper/metrics/cni_test1.data
@@ -7,6 +7,16 @@ awscni_assigned_ip_addresses 1
 # HELP awscni_aws_api_error_count The number of times AWS API returns an error
 # TYPE awscni_aws_api_error_count counter
 awscni_aws_api_error_count{api="DeleteNetworkInterface",error="InvalidParameterValue"} 14
+# HELP awscni_ec2api_req_count The number of requests made to EC2 APIs by CNI
+# TYPE awscni_ec2api_req_count counter
+awscni_ec2api_req_count{fn="AssignPrivateIpAddresses"} 1
+awscni_ec2api_req_count{fn="AttachNetworkInterface"} 1
+awscni_ec2api_req_count{fn="CreateNetworkInterface"} 1
+awscni_ec2api_req_count{fn="DeleteNetworkInterface"} 1
+awscni_ec2api_req_count{fn="DescribeInstances"} 1
+awscni_ec2api_req_count{fn="DescribeNetworkInterfaces"} 13
+awscni_ec2api_req_count{fn="DetachNetworkInterface"} 1
+awscni_ec2api_req_count{fn="ModifyNetworkInterfaceAttribute"} 2
 # HELP awscni_aws_api_latency_ms AWS API call latency in ms
 # TYPE awscni_aws_api_latency_ms summary
 awscni_aws_api_latency_ms{api="AssignPrivateIpAddresses",error="false",quantile="0.5"} NaN

--- a/cmd/cni-metrics-helper/metrics/metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/metrics_test.go
@@ -72,6 +72,14 @@ func TestAPIServerMetric(t *testing.T) {
 	// verify awscni_assigned_ip_addresses value
 	assert.Equal(t, 1.0, actions[0].data.curSingleDataPoint)
 
+	// verify awscni_ec2api_req_count value
+	actions = InterestingCNIMetrics["awscni_ec2api_req_count"].actions
+	assert.Equal(t, 21.0, actions[0].data.curSingleDataPoint)
+
+	// verify awscni_ec2api_error_count value
+	actions = InterestingCNIMetrics["awscni_ec2api_error_count"].actions
+	assert.Equal(t, 0.0, actions[0].data.curSingleDataPoint)
+
 	actions = InterestingCNIMetrics["awscni_total_ip_addresses"].actions
 	// verify awscni_total_ip_addresses value
 	assert.Equal(t, 10.0, actions[0].data.curSingleDataPoint)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: https://github.com/aws/amazon-vpc-cni-k8s/issues/2035


**What does this PR do / Why do we need it**: 
We don't collect metrics about the number of calls made to EC2 APIs. This change adds the capability to track metrics about the number of calls made to EC2 API by IPAMD. `cni-metrics-helper` is configured to collect these metrics and push it to cloudwatch

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Yes this has been tested on EKS 1.23 cluster.

```
# HELP awscni_ec2api_req_count The number of requests made to EC2 APIs by CNI
# TYPE awscni_ec2api_req_count counter
awscni_ec2api_req_count{fn="AssignPrivateIpAddresses"} 1
awscni_ec2api_req_count{fn="AttachNetworkInterface"} 1
awscni_ec2api_req_count{fn="CreateNetworkInterface"} 1
awscni_ec2api_req_count{fn="DeleteNetworkInterface"} 1
awscni_ec2api_req_count{fn="DescribeInstances"} 1
awscni_ec2api_req_count{fn="DescribeNetworkInterfaces"} 13
awscni_ec2api_req_count{fn="DetachNetworkInterface"} 1
awscni_ec2api_req_count{fn="ModifyNetworkInterfaceAttribute"} 2
```

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->


**Automation added to e2e**:
N?A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: 
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: 
No breaking changes. Yes tested on EKS 1.23 cluster

**Does this change require updates to the CNI daemonset config files to work?**: 
Yes, updated image names for CNI and cni metrics helper image tags

<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: 
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
- CNI metrics helper can now report the number of EC2 API calls and number of failed calls and visualize it in cloud watch
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
