### PR TITLE
Increase workflow role duration to 4 hours

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
-          role-duration-seconds: 7200
+          role-duration-seconds: 14400 # 4 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run e2e tests
         env:

--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 14400 # 4 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run e2e tests
         env:

--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 14400 # 4 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run e2e tests
         env:

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 14400 # 4 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run perf tests
         env:


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR increases the AWS role duration to 4 hours. This is primarily needed for the integration test workflow that had the duration set to 2 hours, but the tests occasionally take longer than 2 hours, which leads to issues cleaning up the cluster. 4 hours was chosen as it is the maximum time that the role can currently be assumed for.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
