### PR TITLE
Fix Weekly Cron Tests

### DIFF
--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -50,5 +50,6 @@ jobs:
           ROLE_CREATE: false
           ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_CONFORMANCE: true
+          RUN_INTEGRATION_DEFAULT_CNI: false
         run: |
           ./scripts/run-integration-tests.sh

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
-          role-duration-seconds: 14400 # 4 hours
+          role-duration-seconds: 28800 # 8 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run perf tests
         env:
@@ -40,10 +40,11 @@ jobs:
           S3_BUCKET_CREATE: false
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           PERFORMANCE_TEST_S3_BUCKET_NAME: cni-performance-tests
           RUN_PERFORMANCE_TESTS: true
           RUN_TESTER_LB_ADDONS: true
+          RUN_INTEGRATION_DEFAULT_CNI: false
         run: |
           ./scripts/run-integration-tests.sh
       - name: Run kops tests
@@ -52,9 +53,10 @@ jobs:
           S3_BUCKET_CREATE: false
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_KOPS_TEST: true
           RUN_TESTER_LB_ADDONS: true
+          RUN_INTEGRATION_DEFAULT_CNI: false
         run: |
           ./scripts/run-integration-tests.sh
         if: always()
@@ -64,9 +66,10 @@ jobs:
           S3_BUCKET_CREATE: false
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_BOTTLEROCKET_TEST: true
           RUN_TESTER_LB_ADDONS: true
+          RUN_INTEGRATION_DEFAULT_CNI: false
         run: |
           ./scripts/run-integration-tests.sh
         if: always()
@@ -76,10 +79,11 @@ jobs:
           S3_BUCKET_CREATE: false
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.ROLE_ARN }}
+          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_CALICO_TEST: true
           RUN_LATEST_CALICO_VERSION: true
           RUN_TESTER_LB_ADDONS: true
+          RUN_INTEGRATION_DEFAULT_CNI: false
         run: |
           ./scripts/run-integration-tests.sh
         if: always()

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -22,8 +22,9 @@ function display_timelines() {
     echo "Displaying all step durations."
     echo "TIMELINE: Docker build took $DOCKER_BUILD_DURATION seconds."
     echo "TIMELINE: Upping test cluster took $UP_CLUSTER_DURATION seconds."
-    echo "TIMELINE: Default CNI integration tests took $DEFAULT_INTEGRATION_DURATION seconds." 
-    echo "TIMELINE: Updating CNI image took $CNI_IMAGE_UPDATE_DURATION seconds."
+    if [[ $RUN_INTEGRATION_DEFAULT_CNI == true ]]; then
+        echo "TIMELINE: Default CNI integration tests took $DEFAULT_INTEGRATION_DURATION seconds."
+    fi
     echo "TIMELINE: Current image integration tests took $CURRENT_IMAGE_INTEGRATION_DURATION seconds."
     if [[ "$RUN_CONFORMANCE" == true ]]; then
         echo "TIMELINE: Conformance tests took $CONFORMANCE_DURATION seconds."


### PR DESCRIPTION
**What type of PR is this?**
test cleanup

**Which issue does this PR fix**:
#2152 

**What does this PR do / Why do we need it**:
This PR fixes the weekly cron tests. Three issues were addressed:
1. Assumption of `OSS_TEST_ROLE_ARN` was increased from 4 hours to 8 hours. Tests late in the pipeline would fail whenever > 4 hours had already passed.
2. CANARY integration tests against default CNI version now only run against `integration-tests` and `nightly-cron-tests` workflow. They no longer run against `weekly-cron-tests` or `pr-manual-tests` workflow.
3. The permissions for `OSS_TEST_ROLE_ARN` were updated to prevent s3 bucket creation failure in kops test. This was done external to this PR.

Also, I updated the integration test script to reuse `check_ds_rollout`.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Coverage will be attained by running weekly cron job action against this branch.

**Automation added to e2e**:
None

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
