### PR TITLE
fix test script-check both vpc-cni & vpc-cni-init image exists in ecr

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -20,7 +20,6 @@ is_installed() {
 function display_timelines() {
     echo ""
     echo "Displaying all step durations."
-    echo "TIMELINE: Docker build took $DOCKER_BUILD_DURATION seconds."
     echo "TIMELINE: Upping test cluster took $UP_CLUSTER_DURATION seconds."
     if [[ $RUN_INTEGRATION_DEFAULT_CNI == true ]]; then
         echo "TIMELINE: Default CNI integration tests took $DEFAULT_INTEGRATION_DURATION seconds."

--- a/scripts/lib/integration.sh
+++ b/scripts/lib/integration.sh
@@ -63,3 +63,38 @@ function run_calico_test() {
   ginkgo -v e2e/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version --instance-type=$instance_type --install-calico=false
   popd
 }
+
+function check_and_build_image(){
+  repository_name=$1 
+  image_name=$2
+  image_tag=$3
+  command=$4
+  CNI_IMAGES_BUILD=false
+  ecr_image_query_result=$(aws ecr batch-get-image --repository-name=$repository_name --image-ids imageTag=$image_tag --query 'images[].imageId.imageTag' --region us-west-2)
+  if [[ $ecr_image_query_result != "[]" ]]; then
+    echo "CNI image $image_name:$image_tag already exists in repository. Skipping image build..."
+  else
+    echo "CNI image $image_name:$image_tag does not exist in repository."
+    build_and_push_image "$command" "$image_name" "$image_tag"
+    CNI_IMAGES_BUILD=true
+  fi
+  # cleanup if we make docker build and push images
+  if [[ "$CNI_IMAGES_BUILD" == true ]]; then
+    docker buildx rm "$BUILDX_BUILDER"
+    if [[ $TEST_IMAGE_VERSION != "$LOCAL_GIT_VERSION" ]]; then
+      popd
+    fi
+  fi
+}
+
+function build_and_push_image(){
+  command=$1
+  image_name=$2
+  image_tag=$3
+  START=$SECONDS
+  # Refer to https://github.com/docker/buildx#building-multi-platform-images for the multi-arch image build process.
+  # create the buildx container only if it doesn't exist already.
+  docker buildx inspect "$BUILDX_BUILDER" >/dev/null 2<&1 || docker buildx create --name="$BUILDX_BUILDER" --buildkitd-flags '--allow-insecure-entitlement network.host' --use >/dev/null
+  make $command IMAGE="$image_name" VERSION="$image_tag"
+  echo "TIMELINE: Docker build took $(($SECONDS - $START)) seconds."
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -142,26 +142,10 @@ ensure_ecr_repo "$AWS_ACCOUNT_ID" "$AWS_INIT_ECR_REPO_NAME"
 # Check to see if the image already exists in the ECR repository, and if
 # not, check out the CNI source code for that image tag, build the CNI
 # image and push it to the Docker repository
-ecr_image_query_result=$(aws ecr batch-get-image --repository-name=amazon-k8s-cni --image-ids imageTag=$TEST_IMAGE_VERSION --query 'images[].imageId.imageTag' --region us-west-2)
-if [[ $ecr_image_query_result != "[]" ]]; then
-    echo "CNI image $IMAGE_NAME:$TEST_IMAGE_VERSION already exists in repository. Skipping image build..."
-    DOCKER_BUILD_DURATION=0
-else
-    echo "CNI image $IMAGE_NAME:$TEST_IMAGE_VERSION does not exist in repository."
-    START=$SECONDS
-    # Refer to https://github.com/docker/buildx#building-multi-platform-images for the multi-arch image build process.
-    # create the buildx container only if it doesn't exist already.
-    docker buildx inspect "$BUILDX_BUILDER" >/dev/null 2<&1 || docker buildx create --name="$BUILDX_BUILDER" --buildkitd-flags '--allow-insecure-entitlement network.host' --use >/dev/null
-    make multi-arch-cni-build-push IMAGE="$IMAGE_NAME" VERSION="$TEST_IMAGE_VERSION"
-    DOCKER_BUILD_DURATION=$((SECONDS - START))
-    echo "TIMELINE: Docker build took $DOCKER_BUILD_DURATION seconds."
-    # Build matching init container
-    make multi-arch-cni-init-build-push INIT_IMAGE="$INIT_IMAGE_NAME" VERSION="$TEST_IMAGE_VERSION"
-    docker buildx rm "$BUILDX_BUILDER"
-    if [[ $TEST_IMAGE_VERSION != "$LOCAL_GIT_VERSION" ]]; then
-        popd
-    fi
-fi
+
+# $1=repository name, $2=image name, $3=tag, $4=make command
+check_and_build_image "$AWS_ECR_REPO_NAME" "$IMAGE_NAME" "$TEST_IMAGE_VERSION" "multi-arch-cni-build-push"
+check_and_build_image "$AWS_INIT_ECR_REPO_NAME" "$INIT_IMAGE_NAME" "$TEST_IMAGE_VERSION" "multi-arch-cni-init-build-push"
 
 echo "*******************************************************************************"
 echo "Running $TEST_ID on $CLUSTER_NAME in $AWS_DEFAULT_REGION"
@@ -236,10 +220,13 @@ fi
 
 echo "*******************************************************************************"
 echo "Updating CNI to image $IMAGE_NAME:$TEST_IMAGE_VERSION"
-echo "Using init container $INIT_IMAGE_NAME:$TEST_IMAGE_VERSION"
+echo "Updating CNI-INIT to image $INIT_IMAGE_NAME:$TEST_IMAGE_VERSION"
 START=$SECONDS
 $KUBECTL_PATH apply -f "$TEST_CONFIG_PATH"
 check_ds_rollout "aws-node" "kube-system" "10m"
+
+CNI_IMAGE_UPDATE_DURATION=$((SECONDS - START))
+echo "TIMELINE: Updating CNI image took $CNI_IMAGE_UPDATE_DURATION seconds."
 
 echo "*******************************************************************************"
 echo "Running integration tests on current image:"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fix integration tests/nightly tests- Handle cases when integration test run passed vpc-cni image build but failed during init image build. Re-run of the test previously only checked if vpc-cni image exists and continued with the test. This eventually fails when trying to update the image to the current test tag, as the init image is missing in the repository. 

**What does this PR do / Why do we need it**:
Changes to verify that both the vpc-cni and vpc-cni-init image is present in the ECR repository before running the integration tests. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Yes, tested locally. Also will trigger a manual integration run against the PR. 
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this change require updates to the CNI daemonset config files to work?**:
No.
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No.
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
