### PR TITLE
Add troubleshooting entry for NetworkingManager-cloud-setup package

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -224,6 +224,9 @@ kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/releas
 This policy may cause the MAC address assigned to the host veth interface for a pod to change after the interface is moved to the host network namespace. The CNI plugin installs a static ARP binding for the default gateway in the pod network namespace pointing to the host veth MAC, so the MAC changing leads to pod connectivity issues.
 The workaround for this issue is to set `MACAddressPolicy=none`, as shown [here](https://github.com/aws/amazon-vpc-cni-k8s/issues/2103#issuecomment-1321698870). This issue is known to affect Ubuntu 22.04+, and long-term solutions are being evaluated.
 
+- **NetworkManager-cloud-setup** - The `nm-cloud-setup` service is incompatible with AWS VPC CNI. This service overwrites and clears ip rules installed for pods, which breaks pod networking. This package may be present in RHEL8 AMIs. See [here](https://access.redhat.com/solutions/6319811) for a RedHat thread explaining the issue.
+The symptom for this issue is the presence of routing table 30200 or 30400.
+
 ## CNI Compatibility
 
 The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2 as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
none

**What does this PR do / Why do we need it**:
This PR adds a troubleshooting entry for a package that may be present in RHEL AMIs that is incompatible with VPC CNI.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Issue happens whenever `NetworkManager-cloud-setup` package is installed and `nm-cloud-service` is running.

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
