### PR TITLE
Allow for pullInterval of metrics to be configurable via ENV VAR PULL…

### DIFF
--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -99,7 +99,7 @@ func main() {
 	// should be name/identifier for the cluster if specified
 	clusterID, _ := os.LookupEnv("AWS_CLUSTER_ID")
 
-	log.Infof("Starting CNIMetricsHelper. Sending metrics to CloudWatch: %v, LogLevel %s, pullInterval %d", options.submitCW, logConfig.LogLevel, pullInterval)
+	log.Infof("Starting CNIMetricsHelper. Sending metrics to CloudWatch: %v, LogLevel %s, metricUpdateInterval %d", options.submitCW, logConfig.LogLevel, metricUpdateInterval)
 
 	clientSet, err := k8sapi.GetKubeClientSet()
 	if err != nil {

--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -81,13 +81,13 @@ func main() {
 		}
 	}
 
-	pullIntervalEnv, found := os.LookupEnv("METRIC_PULL_INTERVAL")
+	metricUpdateIntervalEnv, found := os.LookupEnv("METRIC_UPDATE_INTERVAL")
 	if !found {
-		pullIntervalEnv = "30"
+		metricUpdateIntervalEnv = "30"
 	}
-	pullInterval, err := strconv.Atoi(pullIntervalEnv)
+	metricUpdateInterval, err := strconv.Atoi(metricUpdateIntervalEnv)
 	if err != nil {
-		log.Fatalf("pullInterval (%s) format invalid. Integer required. Expecting seconds: %s", pullIntervalEnv, err)
+		log.Fatalf("METRIC_UPDATE_INTERVAL (%s) format invalid. Integer required. Expecting seconds: %s", metricUpdateIntervalEnv, err)
 		os.Exit(1)
 	}
 
@@ -131,7 +131,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to create publisher: %v", err)
 		}
-		var publishInterval = pullInterval * 2
+		publishInterval := metricUpdateInterval * 2
 		go cw.Start(publishInterval)
 		defer cw.Stop()
 	}
@@ -140,7 +140,7 @@ func main() {
 	var cniMetric = metrics.CNIMetricsNew(clientSet, cw, options.submitCW, log, podWatcher)
 
 	// metric loop
-	for range time.Tick(time.Duration(pullInterval) * time.Second) {
+	for range time.Tick(time.Duration(metricUpdateInterval) * time.Second) {
 		log.Info("Collecting metrics ...")
 		metrics.Handler(ctx, cniMetric)
 	}

--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 	}
 
-	pullIntervalEnv, found := os.LookupEnv("PULL_INTERVAL")
+	pullIntervalEnv, found := os.LookupEnv("METRIC_PULL_INTERVAL")
 	if !found {
 		pullIntervalEnv = "30"
 	}

--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -131,7 +131,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to create publisher: %v", err)
 		}
-		go cw.Start()
+		var publishInterval = pullInterval * 2
+		go cw.Start(publishInterval)
 		defer cw.Stop()
 	}
 

--- a/pkg/publisher/mock_publisher/mock_publisher.go
+++ b/pkg/publisher/mock_publisher/mock_publisher.go
@@ -48,8 +48,8 @@ func (mr *MockPublisherMockRecorder) Publish(metricDataPoints ...interface{}) *g
 }
 
 // Start mocks base method
-func (m *MockPublisher) Start() {
-	m.ctrl.Call(m, "Start")
+func (m *MockPublisher) Start(publishInterval int) {
+	m.ctrl.Call(m, "Start", publishInterval)
 }
 
 // Start indicates an expected call of Start

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -135,8 +135,8 @@ func New(ctx context.Context, region string, clusterID string, log logger.Logger
 
 // Start is used to set up the monitor loop
 func (p *cloudWatchPublisher) Start(publishInterval int) {
-	p.log.Infof("Starting monitor loop for CloudWatch publisher with interval (%d)", publishInterval)
-	var publishIntervalDuration = time.Second * time.Duration(publishInterval)
+	p.log.Infof("Starting monitor loop for CloudWatch publisher with push interval of %d seconds", publishInterval)
+	publishIntervalDuration := time.Second * publishInterval
 	p.monitor(publishIntervalDuration)
 }
 

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -136,7 +136,7 @@ func New(ctx context.Context, region string, clusterID string, log logger.Logger
 // Start is used to set up the monitor loop
 func (p *cloudWatchPublisher) Start(publishInterval int) {
 	p.log.Infof("Starting monitor loop for CloudWatch publisher with push interval of %d seconds", publishInterval)
-	publishIntervalDuration := time.Second * publishInterval
+	publishIntervalDuration := time.Second * time.Duration(publishInterval)
 	p.monitor(publishIntervalDuration)
 }
 

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	// defaultInterval for monitoring the watch list
-	defaultInterval = time.Second * 60
-
 	// cloudwatchMetricNamespace for custom metrics
 	cloudwatchMetricNamespace = "Kubernetes"
 
@@ -64,7 +61,7 @@ type Publisher interface {
 	Publish(metricDataPoints ...*cloudwatch.MetricDatum)
 
 	// Start is to initiate the batch and publish operation
-	Start()
+	Start(publishInterval int)
 
 	// Stop is to terminate the batch and publish operation
 	Stop()
@@ -136,10 +133,11 @@ func New(ctx context.Context, region string, clusterID string, log logger.Logger
 	}, nil
 }
 
-// Start is used to setup the monitor loop
-func (p *cloudWatchPublisher) Start() {
-	p.log.Info("Starting monitor loop for CloudWatch publisher")
-	p.monitor(defaultInterval)
+// Start is used to set up the monitor loop
+func (p *cloudWatchPublisher) Start(publishInterval int) {
+	p.log.Infof("Starting monitor loop for CloudWatch publisher with interval (%d)", publishInterval)
+	var publishIntervalDuration = time.Second * time.Duration(publishInterval)
+	p.monitor(publishIntervalDuration)
 }
 
 // Stop is used to cancel the monitor loop


### PR DESCRIPTION
…_INTERVAL

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
[Allows for pullInterval to be configurable](https://github.com/aws/amazon-vpc-cni-k8s/issues/2171)

**What does this PR do / Why do we need it**:
Allows for pullInterval to be configurable via an environment variable

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Notice that the modified log entry shows what the pullInterval is to demonstrate the ENV VAR is parsing correctly.

***Manual: No ENV Vars***
```
GOROOT=/opt/homebrew/Cellar/go/1.19.4/libexec #gosetup
GOPATH=/Users/dnatic/go #gosetup
/opt/homebrew/Cellar/go/1.19.4/libexec/bin/go build -o /private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___go_build_main_go /Users/dnatic/workspace/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/main.go #gosetup
/private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___go_build_main_go
2022-12-20 14:18:19.256157 -0500 EST m=+0.012941168 write error: can't make directories for new logfile: mkdir /host: read-only file system
2022-12-20 14:18:19.256319 -0500 EST m=+0.013102835 write error: can't make directories for new logfile: mkdir /host: read-only file system
{"level":"info","ts":"2022-12-20T14:18:19.260-0500","caller":"cni-metrics-helper/main.go:46","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-12-20T14:18:19.260-0500","caller":"runtime/proc.go:250","msg":"Starting CNIMetricsHelper. Sending metrics to CloudWatch: true, LogLevel Debug, pullInterval 30"}
{"level":"error","ts":"2022-12-20T14:18:50.069-0500","caller":"runtime/proc.go:250","msg":"Failed to initialize kube client mapper: Get \"https://CC5534A988E436850F100114397BF816.gr7.eu-west-1.eks.amazonaws.com/api?timeout=32s\": dial tcp 10.188.68.82:443: i/o timeout"}

Process finished with the exit code 1

```

***Manual: PULL_INTERVAL=60***
```
Cellar/go/1.19.4/libexec #gosetup
GOPATH=/Users/dnatic/go #gosetup
/opt/homebrew/Cellar/go/1.19.4/libexec/bin/go build -o /private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___1go_build_main_go /Users/dnatic/workspace/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/main.go #gosetup
/private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___1go_build_main_go
2022-12-20 14:20:18.623736 -0500 EST m=+0.014495085 write error: can't make directories for new logfile: mkdir /host: read-only file system
2022-12-20 14:20:18.624018 -0500 EST m=+0.014776126 write error: can't make directories for new logfile: mkdir /host: read-only file system
{"level":"info","ts":"2022-12-20T14:20:18.627-0500","caller":"cni-metrics-helper/main.go:46","msg":"Constructed new logger instance"}
{"level":"info","ts":"2022-12-20T14:20:18.627-0500","caller":"runtime/proc.go:250","msg":"Starting CNIMetricsHelper. Sending metrics to CloudWatch: true, LogLevel Debug, pullInterval 60"}
{"level":"error","ts":"2022-12-20T14:20:49.549-0500","caller":"runtime/proc.go:250","msg":"Failed to initialize kube client mapper: Get \"https://CC5534A988E436850F100114397BF816.gr7.eu-west-1.eks.amazonaws.com/api?timeout=32s\": dial tcp 10.188.72.64:443: i/o timeout"}

Process finished with the exit code 1
```

***Manual: PULL_INTERVAL=bad-value-fail***
```
GOROOT=/opt/homebrew/Cellar/go/1.19.4/libexec #gosetup
GOPATH=/Users/dnatic/go #gosetup
/opt/homebrew/Cellar/go/1.19.4/libexec/bin/go build -o /private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___2go_build_main_go /Users/dnatic/workspace/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/main.go #gosetup
/private/var/folders/7h/y0_07xp15tb2fxy0bsr7v9qm0000gn/T/GoLand/___2go_build_main_go
2022-12-20 14:21:34.703325 -0500 EST m=+0.014378918 write error: can't make directories for new logfile: mkdir /host: read-only file system
2022-12-20 14:21:34.703531 -0500 EST m=+0.014585293 write error: can't make directories for new logfile: mkdir /host: read-only file system
{"level":"info","ts":"2022-12-20T14:21:34.707-0500","caller":"cni-metrics-helper/main.go:46","msg":"Constructed new logger instance"}
{"level":"fatal","ts":"2022-12-20T14:21:34.707-0500","caller":"runtime/proc.go:250","msg":"pullInterval (bad-value-fail) format invalid. Integer required. Expecting seconds: strconv.Atoi: parsing \"bad-value-fail\": invalid syntax"}

Process finished with the exit code 1
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
There are no tests in the `main` package. Not applicable

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
