### PR TITLE
Return AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER to chart and manifest

### DIFF
--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.2.2
+version: 1.2.1
 appVersion: "v1.12.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -29,6 +29,8 @@ env:
   ADDITIONAL_ENI_TAGS: "{}"
   AWS_VPC_CNI_NODE_PORT_SUPPORT: "true"
   AWS_VPC_ENI_MTU: "9001"
+  # TODO: remove AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER when v1.12.1 is released
+  AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER: "false"
   AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "false"
   AWS_VPC_K8S_CNI_EXTERNALSNAT: "false"
   AWS_VPC_K8S_CNI_LOG_FILE: "/host/var/log/aws-routed-eni/ipamd.log"

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -36,6 +36,8 @@ env:
   ADDITIONAL_ENI_TAGS: "{}"
   AWS_VPC_CNI_NODE_PORT_SUPPORT: "true"
   AWS_VPC_ENI_MTU: "9001"
+  # TODO: remove AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER when v1.12.1 is released
+  AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER: "false"
   AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "false"
   AWS_VPC_K8S_CNI_EXTERNALSNAT: "false"
   AWS_VPC_K8S_CNI_LOG_FILE: "/host/var/log/aws-routed-eni/ipamd.log"

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -168,6 +168,8 @@ spec:
               value: "true"
             - name: AWS_VPC_ENI_MTU
               value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
               value: "false"
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -168,6 +168,8 @@ spec:
               value: "true"
             - name: AWS_VPC_ENI_MTU
               value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
               value: "false"
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -168,6 +168,8 @@ spec:
               value: "true"
             - name: AWS_VPC_ENI_MTU
               value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
               value: "false"
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -168,6 +168,8 @@ spec:
               value: "true"
             - name: AWS_VPC_ENI_MTU
               value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
               value: "false"
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -167,6 +167,7 @@ local awsnode = {
                 ADDITIONAL_ENI_TAGS: "{}",
                 AWS_VPC_CNI_NODE_PORT_SUPPORT: "true",
                 AWS_VPC_ENI_MTU: "9001",
+                AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER: "false",
                 AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "false",
                 AWS_VPC_K8S_CNI_EXTERNALSNAT: "false",
                 AWS_VPC_K8S_CNI_LOGLEVEL: "DEBUG",

--- a/scripts/update-cni-images.sh
+++ b/scripts/update-cni-images.sh
@@ -30,4 +30,4 @@ fi
 echo "Applying amazon-vpc-cni-k8s/config/master/aws-k8s-cni.yaml manifest"
 kubectl apply -f $AWS_K8S_CNI_MANIFEST
 
-check_ds_rollout "aws-node" "kube-system" "4m"
+check_ds_rollout "aws-node" "kube-system" "10m"


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
In #2153 , `AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER` was deprecated. The current helm chart and master manifests use VPC CNI version v1.12.0, which requires `AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER` to be set to false in order for `aws-node` pod to start.

This PR restores `AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER` in helm chart and manifests. The environment variable will be removed after v1.12.1 releases.

This PR also increases the rollout waiting period in `scripts/update-cni-images.sh` from 4 minutes to 10 minutes. 4 minutes is not enough time for larger clusters.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that `config/master/aws-k8s-cni.yaml` can be applied successfully after adding env var.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, this fixes an upgrade/downgrade issue using the manifest. A running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
Restoring env var in daemonset.

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
