### PR TITLE
Minimal base image for cni-metrics-helper minimal base image

### DIFF
--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -6,17 +6,15 @@ WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 
-# Copy modules in before the rest of the source to only expire cache on module
-# changes:
+# Copy modules in before the rest of the source to only expire cache on module changes:
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
 RUN make build-metrics
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum update -y && \
-	yum clean all
+# Build from EKS minimal base + glibc
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
 
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR moves `cni-metrics-helper` image to be based on EKS minimal base image + glibc. This is needed to reduce the size of the `cni-metrics-helper` image and to reduce the footprint for CVEs.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually updated images on running cluster and ran integration tests.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. A running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Move cni-metrics-helper to EKS minimal build image
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
