### PR TITLE
test: make tests more flexible

### DIFF
--- a/cmd/cni-metrics-helper/metrics/metrics.go
+++ b/cmd/cni-metrics-helper/metrics/metrics.go
@@ -376,7 +376,7 @@ func metricsListGrabAggregateConvert(ctx context.Context, t metricsTarget) (map[
 	resetMetrics(interestingMetrics)
 
 	targetList, _ := t.getTargetList(ctx)
-	t.getLogger().Debugf("Total TargetList pod count:- %v", len(targetList))
+	t.getLogger().Debugf("Total TargetList pod count: %d", len(targetList))
 	for _, target := range targetList {
 		rawOutput, err := t.grabMetricsFromTarget(ctx, target)
 		if err != nil {

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -19,14 +19,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/awssession"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadatawrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/pkg/errors"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/awssession"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadatawrapper"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 )
 
 const (

--- a/test/agent/cmd/networking/main.go
+++ b/test/agent/cmd/networking/main.go
@@ -14,8 +14,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/cmd/networking/tester"
@@ -71,8 +73,15 @@ func main() {
 	} else {
 		log.Print("testing network is teared down for regular pods")
 		err := tester.TestNetworkTearedDownForRegularPods(podNetworkingValidationInput)
-		if err != nil {
-			log.Fatalf("found 1 or more pod teardown validation failure: %v", err)
+		if len(err) > 0 {
+			var errs bytes.Buffer
+			for _, e := range err {
+				if errs.Len() > 0 {
+					fmt.Fprint(&errs, " / ")
+				}
+				fmt.Fprint(&errs, e.Error())
+			}
+			log.Fatalf("found 1 or more pod teardown validation failure: %s", errs)
 		}
 	}
 }

--- a/test/e2e/custom-networking/custom_networking_suite_test.go
+++ b/test/e2e/custom-networking/custom_networking_suite_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	awsUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	. "github.com/onsi/ginkgo/v2"

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -27,21 +27,25 @@ func init() {
 }
 
 type Options struct {
-	KubeConfig       string
-	ClusterName      string
-	AWSRegion        string
-	AWSVPCID         string
-	NgNameLabelKey   string
-	NgNameLabelVal   string
-	EKSEndpoint      string
-	CalicoVersion    string
-	ContainerRuntime string
-	InstanceType     string
-	InitialAddon     string
-	TargetAddon      string
-	InitialManifest  string
-	TargetManifest   string
-	InstallCalico    bool
+	KubeConfig         string
+	ClusterName        string
+	AWSRegion          string
+	AWSVPCID           string
+	NgNameLabelKey     string
+	NgNameLabelVal     string
+	EKSEndpoint        string
+	CalicoVersion      string
+	ContainerRuntime   string
+	InstanceType       string
+	InitialAddon       string
+	TargetAddon        string
+	InitialManifest    string
+	TargetManifest     string
+	InstallCalico      bool
+	PublicSubnets      string
+	PrivateSubnets     string
+	AvailabilityZones  string
+	PublicRouteTableID string
 }
 
 func (options *Options) BindFlags() {
@@ -60,6 +64,10 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.ContainerRuntime, "container-runtime", "", "Optionally can specify it as 'containerd' for the test nodes")
 	flag.StringVar(&options.InstanceType, "instance-type", "amd64", "Optionally specify instance type as arm64 for the test nodes")
 	flag.BoolVar(&options.InstallCalico, "install-calico", true, "Install Calico operator before running e2e tests")
+	flag.StringVar(&options.PublicSubnets, "public-subnets", "", "Comma separated list of public subnets (optional, if specified you must specify all of public/private-subnets, public-route-table-id,  and availability-zones)")
+	flag.StringVar(&options.PrivateSubnets, "private-subnets", "", "Comma separated list of private subnets (optional, if specified you must specify all of public/private-subnets, public-route-table-id,  and availability-zones)")
+	flag.StringVar(&options.AvailabilityZones, "availability-zones", "", "Comma separated list of private subnets (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
+	flag.StringVar(&options.PublicRouteTableID, "public-route-table-id", "", "Public route table ID (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
 }
 
 func (options *Options) Validate() error {

--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -229,6 +229,24 @@ func GetClusterVPCConfig(f *framework.Framework) (*ClusterVPCConfig, error) {
 		PrivateSubnetList: []string{},
 	}
 
+	if len(f.Options.PublicSubnets) > 0 {
+		clusterConfig.PublicSubnetList = strings.Split(f.Options.PublicSubnets, ",")
+	}
+	if len(f.Options.PrivateSubnets) > 0 {
+		clusterConfig.PrivateSubnetList = strings.Split(f.Options.PublicSubnets, ",")
+	}
+	if len(f.Options.AvailabilityZones) > 0 {
+		clusterConfig.AvailZones = strings.Split(f.Options.AvailabilityZones, ",")
+	}
+	if f.Options.PublicRouteTableID != "" {
+		clusterConfig.PublicRouteTableID = f.Options.PublicRouteTableID
+	}
+
+	// user provided the info so we don't need to look it up
+	if len(clusterConfig.PublicSubnetList) > 0 || len(clusterConfig.PrivateSubnetList) > 0 || len(clusterConfig.AvailZones) > 0 {
+		return clusterConfig, nil
+	}
+
 	describeClusterOutput, err := f.CloudServices.EKS().DescribeCluster(f.Options.ClusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe cluster %s: %v", f.Options.ClusterName, err)

--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -21,11 +21,12 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
 const CreateNodeGroupCFNTemplate = "/testdata/amazon-eks-nodegroup.yaml"
@@ -233,7 +234,7 @@ func GetClusterVPCConfig(f *framework.Framework) (*ClusterVPCConfig, error) {
 		clusterConfig.PublicSubnetList = strings.Split(f.Options.PublicSubnets, ",")
 	}
 	if len(f.Options.PrivateSubnets) > 0 {
-		clusterConfig.PrivateSubnetList = strings.Split(f.Options.PublicSubnets, ",")
+		clusterConfig.PrivateSubnetList = strings.Split(f.Options.PrivateSubnets, ",")
 	}
 	if len(f.Options.AvailabilityZones) > 0 {
 		clusterConfig.AvailZones = strings.Split(f.Options.AvailabilityZones, ",")
@@ -243,8 +244,13 @@ func GetClusterVPCConfig(f *framework.Framework) (*ClusterVPCConfig, error) {
 	}
 
 	// user provided the info so we don't need to look it up
-	if len(clusterConfig.PublicSubnetList) > 0 || len(clusterConfig.PrivateSubnetList) > 0 || len(clusterConfig.AvailZones) > 0 {
+	if clusterConfig.PublicRouteTableID != "" && len(clusterConfig.PublicSubnetList) > 0 && len(clusterConfig.AvailZones) > 0 {
 		return clusterConfig, nil
+	}
+
+	if clusterConfig.PublicRouteTableID != "" || len(clusterConfig.PublicSubnetList) > 0 ||
+		len(clusterConfig.PrivateSubnetList) > 0 || len(clusterConfig.AvailZones) > 0 {
+		return nil, fmt.Errorf("partial configuration, if supplying config via flags you need to provide at least public route table ID, public subnet list and availibility zone list")
 	}
 
 	describeClusterOutput, err := f.CloudServices.EKS().DescribeCluster(f.Options.ClusterName)

--- a/test/framework/resources/k8s/manifest/deployment.go
+++ b/test/framework/resources/k8s/manifest/deployment.go
@@ -70,7 +70,9 @@ func (d *DeploymentBuilder) Labels(labels map[string]string) *DeploymentBuilder 
 }
 
 func (d *DeploymentBuilder) NodeSelector(labelKey string, labelVal string) *DeploymentBuilder {
-	d.nodeSelector[labelKey] = labelVal
+	if labelKey != "" {
+		d.nodeSelector[labelKey] = labelVal
+	}
 	return d
 }
 

--- a/test/framework/resources/k8s/manifest/job.go
+++ b/test/framework/resources/k8s/manifest/job.go
@@ -14,11 +14,12 @@
 package manifest
 
 import (
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 )
 
 type JobBuilder struct {
@@ -50,7 +51,9 @@ func (j *JobBuilder) Name(name string) *JobBuilder {
 }
 
 func (j *JobBuilder) NodeSelector(selectorKey string, selectorVal string) *JobBuilder {
-	j.nodeSelector[selectorKey] = selectorVal
+	if selectorKey != "" {
+		j.nodeSelector[selectorKey] = selectorVal
+	}
 	return j
 }
 

--- a/test/framework/resources/k8s/manifest/pod.go
+++ b/test/framework/resources/k8s/manifest/pod.go
@@ -77,7 +77,9 @@ func (p *PodBuilder) NodeName(nodeName string) *PodBuilder {
 }
 
 func (p *PodBuilder) NodeSelector(nodeLabelKey string, nodeLabelVal string) *PodBuilder {
-	p.nodeSelector[nodeLabelKey] = nodeLabelVal
+	if nodeLabelKey != "" {
+		p.nodeSelector[nodeLabelKey] = nodeLabelVal
+	}
 	return p
 }
 

--- a/test/framework/resources/k8s/resources/job.go
+++ b/test/framework/resources/k8s/resources/job.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -64,7 +65,8 @@ func (d *defaultJobManager) CreateAndWaitTillJobCompleted(job *v1.Job) (*v1.Job,
 
 func (d *defaultJobManager) DeleteAndWaitTillJobIsDeleted(job *v1.Job) error {
 	ctx := context.Background()
-	err := d.k8sClient.Delete(ctx, job)
+	propagation := metav1.DeletePropagationForeground
+	err := d.k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagation})
 	if err != nil {
 		return err
 	}

--- a/test/integration/cni/pod_networking_suite_test.go
+++ b/test/integration/cni/pod_networking_suite_test.go
@@ -58,8 +58,8 @@ var _ = BeforeSuite(func() {
 
 	By("verifying more than 1 nodes are present for the test")
 	Expect(len(nodes.Items)).Should(BeNumerically(">", 1))
-	// Set the primary and secondary node for testing
 
+	// Set the primary and secondary node for testing, these are used for a pod traffic test between two pods
 	for i := range nodes.Items {
 		n := nodes.Items[i]
 		if len(n.Spec.Taints) == 0 {

--- a/test/integration/cni/pod_networking_suite_test.go
+++ b/test/integration/cni/pod_networking_suite_test.go
@@ -58,10 +58,21 @@ var _ = BeforeSuite(func() {
 
 	By("verifying more than 1 nodes are present for the test")
 	Expect(len(nodes.Items)).Should(BeNumerically(">", 1))
-
 	// Set the primary and secondary node for testing
-	primaryNode = nodes.Items[0]
-	secondaryNode = nodes.Items[1]
+
+	for i := range nodes.Items {
+		n := nodes.Items[i]
+		if len(n.Spec.Taints) == 0 {
+			if primaryNode.Name == "" {
+				primaryNode = n
+			} else {
+				secondaryNode = n
+				break
+			}
+		}
+	}
+	Expect(primaryNode.Name).To(Not(HaveLen(0)), "expected to find a non-tainted node")
+	Expect(secondaryNode.Name).To(Not(HaveLen(0)), "expected to find a non-tainted secondary node")
 
 	// Get the node security group
 	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)

--- a/test/integration/common/util.go
+++ b/test/integration/common/util.go
@@ -9,14 +9,15 @@ import (
 	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/agent"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
-	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	coreV1 "k8s.io/api/core/v1"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/agent"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 )
 
 type TestType int
@@ -203,6 +204,7 @@ func ValidateTraffic(f *framework.Framework, serverDeploymentBuilder *manifest.D
 }
 
 func WaitToReconcileInitialState(f *framework.Framework, primaryInstance *ec2.Instance, defaultEniCount int, defaultIpsPerEni int, DefaultPrefixPerEni int) {
+	return
 	By("Verifying number of enis, ips and ip prefixes before updating the parameters")
 	Eventually(func(g Gomega) {
 		primaryInstance, err := f.CloudServices.

--- a/test/integration/common/util.go
+++ b/test/integration/common/util.go
@@ -204,7 +204,6 @@ func ValidateTraffic(f *framework.Framework, serverDeploymentBuilder *manifest.D
 }
 
 func WaitToReconcileInitialState(f *framework.Framework, primaryInstance *ec2.Instance, defaultEniCount int, defaultIpsPerEni int, DefaultPrefixPerEni int) {
-	return
 	By("Verifying number of enis, ips and ip prefixes before updating the parameters")
 	Eventually(func(g Gomega) {
 		primaryInstance, err := f.CloudServices.

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 
 	// Add nodeSelector label to coredns deployment so coredns pods are scheduled on 'primary' node
 	coreDNSDeployment.Spec.Template.Spec.NodeSelector = map[string]string{
-		"kubernetes.io/hostname": primaryNode.Name,
+		"kubernetes.io/hostname": primaryNode.Labels["kubernetes.io/hostname"],
 	}
 	err = f.K8sResourceManagers.DeploymentManager().UpdateAndWaitTillDeploymentIsReady(coreDNSDeployment,
 		utils.DefaultDeploymentReadyTimeout)

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -18,13 +18,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
-	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 )
 
 var primaryInstance *ec2.Instance
@@ -60,11 +62,18 @@ var _ = BeforeSuite(func() {
 	numOfNodes = len(nodeList.Items)
 	Expect(numOfNodes).Should(BeNumerically(">", 1))
 
-	// Nominate the first node as the one to run coredns deployment against
+	// Nominate the first untainted node as the one to run coredns deployment against
 	By("adding nodeSelector in coredns deployment to be scheduled on single node")
-	primaryNode := nodeList.Items[0]
+	var primaryNode *corev1.Node
+	for _, n := range nodeList.Items {
+		if len(n.Spec.Taints) == 0 {
+			primaryNode = &n
+			break
+		}
+	}
+	Expect(primaryNode).To(Not(BeNil()), "expected to find a non-tainted node")
 	fmt.Fprintf(GinkgoWriter, "coredns node is %s\n", primaryNode.Name)
-	instanceID := k8sUtils.GetInstanceIDFromNode(primaryNode)
+	instanceID := k8sUtils.GetInstanceIDFromNode(*primaryNode)
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -85,9 +94,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Redefine primary node as node without coredns pods. Note that this node may have previously had coredns pods.
-	primaryNode = nodeList.Items[1]
+	for _, n := range nodeList.Items {
+		if len(n.Spec.Taints) == 0 && n.Name != primaryNode.Name {
+			primaryNode = &n
+			break
+		}
+	}
 	fmt.Fprintf(GinkgoWriter, "primary node is %s\n", primaryNode.Name)
-	instanceID = k8sUtils.GetInstanceIDFromNode(primaryNode)
+	instanceID = k8sUtils.GetInstanceIDFromNode(*primaryNode)
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/metrics-helper/metrics_helper_suite_test.go
+++ b/test/integration/metrics-helper/metrics_helper_suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	err = f.CloudServices.IAM().AttachRolePolicy(policyARN, ngRoleName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("unable to attach %s %s", policyARN, ngRoleName))
 
 	By("updating the aws-nodes to restart the metric count")
 	k8sUtil.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
@@ -154,7 +154,7 @@ var _ = AfterSuite(func() {
 
 	By("detaching role policy from the node IAM Role")
 	err = f.CloudServices.IAM().DetachRolePolicy(policyARN, ngRoleName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("unable to detach %s %s", policyARN, ngRoleName))
 
 	k8sUtil.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
 		utils.AwsNodeName, map[string]struct{}{"SOME_NON_EXISTENT_VAR": {}})


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

- Makes it possible to run some of the integration tests against a non-EKS cluster
- Replaces hard-coded sleep calls with `Eventually()` polling where possible to speed up test execution

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
