### PR TITLE
Refactor cni-metrics-helper chart for eks charts release

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -91,7 +91,6 @@ WARNING: Substitute YOUR_HELM_RELEASE_NAME_HERE with the name of your helm relea
 
 set -euo pipefail
 
-# don't import the crd. Helm cant manage the lifecycle of it anyway.
 for kind in daemonSet clusterRole clusterRoleBinding serviceAccount; do
   echo "setting annotations and labels on $kind/aws-node"
   kubectl -n kube-system annotate --overwrite $kind aws-node meta.helm.sh/release-name=YOUR_HELM_RELEASE_NAME_HERE

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -91,8 +91,8 @@ spec:
           - mountPath: /host/etc/cni/net.d
             name: cni-net-dir
 {{- if .Values.cniConfig.enabled }}
-            # the dockerfile copies the baked in config to this location, lets overwrite it with ours
-            # the entrypoint.sh script will then copy our config to /host/etc/cni/net.d on boot
+            # The dockerfile copies the baked in config to this location, so overwrite it with ours.
+            # The entrypoint process will then copy our config to /host/etc/cni/net.d on boot.
           - name: cni-config
             mountPath: /app/10-aws.conflist
             subPath: 10-aws.conflist

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,23 +1,19 @@
 apiVersion: v2
 name: cni-metrics-helper
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+version: 0.1.15
 appVersion: v1.12.1
+description: A Helm chart for the AWS VPC CNI Metrics Helper
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+home: https://github.com/aws/amazon-vpc-cni-k8s
+sources:
+  - https://github.com/aws/amazon-vpc-cni-k8s
+keywords:
+  - eks
+  - cni
+  - networking
+  - vpc
+maintainers:
+  - name: Jayanth Varavani
+    url: https://github.com/jayanthvn
+    email: jayanthvn@users.noreply.github.com
+engine: gotpl

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -9,15 +9,34 @@ This chart provides a Kubernetes deployment for the Amazon VPC CNI Metrics Helpe
 
 ## Installing the Chart
 
-Clone the Amazon VPC CNI for Kubernetes repository to your local machine.
+First add the EKS repository to Helm:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name `cni-metrics-helper` and default configuration:
+
+```shell
+$ helm install cni-metrics-helper --namespace kube-system eks/cni-metrics-helper
+```
+
+To install manually, clone the Amazon VPC CNI for Kubernetes repository to your local machine:
 
 ```shell
 $ git clone https://github.com/aws/amazon-vpc-cni-k8s.git
 ```
-Use the helm install command to install the chart into your Kubernetes cluster
+
+Use the helm install command to install the chart into your Kubernetes cluster:
 
 ```shell
-$ helm install cni-metrics-helper ./amazon-vpc-cni-k8s/charts/cni-metrics-helper
+$ helm install cni-metrics-helper --namespace kube-system ./charts/cni-metrics-helper
+```
+
+To uninstall:
+
+```shell
+$ helm uninstall cni-metrics-helper --namespace kube-system
 ```
 
 ## Configuration
@@ -33,17 +52,21 @@ The following table lists the configurable parameters for this chart and their d
 | image.domain               | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH         | Whether to export CNI metrics to CloudWatch                   | true               |
 | env.AWS_CLUSTER_ID         | ID of the cluster to use when exporting metrics to CloudWatch | default            |
-| env.METRIC_UPDATE_INTERVAL | Interval at which to update CloudWatch metrics, in seconds Metrics are published to CloudWatch at 2*METRIC_UPDATE_INTERVAL   | 30                 |
+| env.METRIC_UPDATE_INTERVAL | Interval at which to update CloudWatch metrics, in seconds.   |                    |
+|                            | Metrics are published to CloudWatch at 2x the interval        | 30                 |
 | serviceAccount.name        | The name of the ServiceAccount to use                         | nil                |
 | serviceAccount.create      | Specifies whether a ServiceAccount should be created          | true               |
 | serviceAccount.annotations | Specifies the annotations for ServiceAccount                  | {}                 |
 
-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 
 ```shell
-$ helm install my-release ./amazon-vpc-cni-k8s/charts/cni-metrics-helper --set useCloudwatch=false --values values.yaml
+$ helm install cni-metrics-handler --namespace kube-system eks/cni-metrics-handler --values values.yaml
+```
 
+Manual install:
+```shell
+$ helm install cni-metrics-helper --namespace kube-system ./charts/cni-metrics-helper --values values.yaml
 ```
 
 ## Resources
@@ -52,9 +75,8 @@ $ helm install my-release ./amazon-vpc-cni-k8s/charts/cni-metrics-helper --set u
 |---------------------------|------------------------------------------------|---------|
 |    resources              | Resources for the pods.                        |   `{}`  |
 
-
-for example, to set a CPU limit of 200m and a memory limit of 256Mi for the cni-metrics-helper pods, you can use the following command:
+For example, to set a CPU limit of 200m and a memory limit of 256Mi for the cni-metrics-helper pods, you can use the following command:
 
 ```shell
-$ helm install my-release ./amazon-vpc-cni-k8s/charts/cni-metrics-helper --set resources.limits.cpu=200m,resources.limits.memory=256Mi
+$ helm install cni-metrics-helper ./charts/cni-metrics-helper --namespace kube-system --set resources.limits.cpu=200m,resources.limits.memory=256Mi
 ```


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR cleans up cni-metrics-helper chart so that it can be published to eks-charts: https://github.com/aws/eks-charts

The eks-charts PR is https://github.com/aws/eks-charts/pull/870

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that chart can be installed via helm

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. A running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
