### PR TITLE
[Test] Wait for ipamd to reconcile enis and prefixes before starting new test

### DIFF
--- a/test/integration/common/util.go
+++ b/test/integration/common/util.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
@@ -199,4 +200,19 @@ func ValidateTraffic(f *framework.Framework, serverDeploymentBuilder *manifest.D
 	Expect(err).ToNot(HaveOccurred())
 	Expect(successRate).Should(BeNumerically(">=", succesRate))
 
+}
+
+func WaitToReconcileInitialState(f *framework.Framework, primaryInstance *ec2.Instance, defaultEniCount int, defaultIpsPerEni int, DefaultPrefixPerEni int) {
+	By("Verifying number of enis, ips and ip prefixes before updating the parameters")
+	Eventually(func(g Gomega) {
+		primaryInstance, err := f.CloudServices.
+			EC2().DescribeInstance(*primaryInstance.InstanceId)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(len(primaryInstance.NetworkInterfaces)).Should(Equal(defaultEniCount))
+		g.Expect(len(primaryInstance.NetworkInterfaces[0].PrivateIpAddresses)).
+			Should(Equal(defaultIpsPerEni))
+		g.Expect(len(primaryInstance.NetworkInterfaces[0].Ipv4Prefixes)).
+			Should(Equal(DefaultPrefixPerEni))
+	}).WithTimeout(time.Minute * 3).WithPolling(30 * time.Second).Should(Succeed())
 }

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -30,10 +30,13 @@ import (
 var primaryInstance *ec2.Instance
 var f *framework.Framework
 var err error
+var defaultEniCount int
+var defaultIpsPerEni int
 
 const (
 	CoreDNSDeploymentName = "coredns"
 	KubeSystemNamespace   = "kube-system"
+	DefaultPrefixPerEni   = 0
 )
 
 var coreDNSDeploymentCopy *v1.Deployment
@@ -87,6 +90,12 @@ var _ = BeforeSuite(func() {
 	instanceID = k8sUtils.GetInstanceIDFromNode(primaryNode)
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
+
+	primaryInstanceDefaults, err := f.CloudServices.EC2().DescribeInstanceType(*primaryInstance.InstanceType)
+	Expect(err).ToNot(HaveOccurred())
+
+	defaultEniCount = len(primaryInstanceDefaults[0].NetworkInfo.NetworkCards)
+	defaultIpsPerEni = int(*primaryInstanceDefaults[0].NetworkInfo.Ipv4AddressesPerInterface)
 
 	// Set default values- WARM_ENI_TARGET to 1, and remove WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET
 	k8sUtils.UpdateEnvVarOnDaemonSetAndWaitUntilReady(f, "aws-node", "kube-system",

--- a/test/integration/ipamd/warm_target_test.go
+++ b/test/integration/ipamd/warm_target_test.go
@@ -19,6 +19,7 @@ import (
 
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,9 @@ var _ = Describe("test warm target variables", func() {
 		var maxENI int
 
 		JustBeforeEach(func() {
+			common.WaitToReconcileInitialState(f, primaryInstance,
+				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
+
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
 				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
 				map[string]string{
@@ -94,6 +98,9 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availIPs int
+
+			common.WaitToReconcileInitialState(f, primaryInstance,
+				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -19,6 +19,7 @@ import (
 
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,9 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
+
+			common.WaitToReconcileInitialState(f, primaryInstance,
+				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
@@ -125,6 +129,9 @@ var _ = Describe("test warm target variables", func() {
 		JustBeforeEach(func() {
 			var availPrefixes int
 
+			common.WaitToReconcileInitialState(f, primaryInstance,
+				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
+
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
 				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
@@ -173,6 +180,9 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
+
+			common.WaitToReconcileInitialState(f, primaryInstance,
+				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: 
N/A


**What does this PR do / Why do we need it**:
With warm target tests, we don't wait for ipamd to reconcile back to the old state before beginning new test. This sometimes results in flaky test as the enis/ips from the last run are not yet recycled. With this change, we poll the APIs every 30 sec (with timeout for 2 mins) to check if the original state has been reconciled and then move forward to the test.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**: 
Yes, tested this on 1.24 cluster
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
