### PR TITLE
Add resources to init container

### DIFF
--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.2.2
+version: 1.2.3
 appVersion: "v1.12.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters for this chart and their d
 | `podAnnotations`        | annotations to add to each pod                          | `{}`                                |
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
-| `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
+| `resources`             | Resources for containers in pod                         | `requests.cpu: 25m`                 |
 | `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"`  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -48,6 +48,8 @@ spec:
 {{- end }}
         securityContext:
           {{- toYaml .Values.init.securityContext | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -129,6 +129,9 @@ spec:
             value: "false"
         securityContext:
             privileged: true
+        resources:
+          requests:
+            cpu: 25m
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -129,6 +129,9 @@ spec:
             value: "false"
         securityContext:
             privileged: true
+        resources:
+          requests:
+            cpu: 25m
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -129,6 +129,9 @@ spec:
             value: "false"
         securityContext:
             privileged: true
+        resources:
+          requests:
+            cpu: 25m
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -129,6 +129,9 @@ spec:
             value: "false"
         securityContext:
             privileged: true
+        resources:
+          requests:
+            cpu: 25m
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2191
https://github.com/aws/eks-charts/issues/470
https://github.com/aws/eks-charts/issues/738

**What does this PR do / Why do we need it**:
This PR sets the resources for the init container to the same value specified for the main container. The init container needed resources to be specified for the issues linked above, and since the init container is a short-lived container, the actual values are less important than simple configuration.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Verified that resources are applied to init container and that integration tests run without issue.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, this will not break upgrades or downgrades. A running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Add resources to VPC CNI init container
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
