### PR TITLE
Revert manifest changes from #2149

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["extensions"]
     resources:
       - '*'


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#2212

**What does this PR do / Why do we need it**:
This PR reverts the manifest changes made in #2149 . Those manifest changes are not compatible with the `v1.12.1` image. The chart changes from that PR are fine, as the official chart is published on eks-charts, but we need to hold off on updating `config/master/aws-k8s-cni*` until a compatible image is present in manifest (`v1.12.2` or `v1.13.0`).

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Verified that manifest can be applied and aws-node pods come up

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades, and a running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes, reverting change.

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
