### PR TITLE
test: fix event type

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -17,23 +17,23 @@ import (
 	"context"
 	"log"
 
-	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/controller"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/helm"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s"
-	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	sgp "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/controller"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/helm"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 )
 
 type Framework struct {
@@ -62,7 +62,7 @@ func New(options Options) *Framework {
 
 	cache, err := cache.New(config, cache.Options{Scheme: k8sSchema})
 	Expect(err).NotTo(HaveOccurred())
-	err = cache.IndexField(context.TODO(), &eventsv1.Event{}, "reason", func(o client.Object) []string {
+	err = cache.IndexField(context.TODO(), &v1.Event{}, "reason", func(o client.Object) []string {
 		return []string{o.(*v1.Event).Reason}
 	}) // default indexing only on ns, need this for ipamd_event_test
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

Corrects integration test to use the same event type to eliminate panic:
```
2023/01/13 11:35:36 [ginkgo] E0113 11:35:36.251153   44598 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x2fd5980), concrete:(*runtime._type)(0x3048700), asserted:(*runtime._type)(0x3044b00), missingMethod:""} (interface conversion: client.Object is *v1.Event, not *v1.Event (types from different packages))
```

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
