### PR TITLE
Remove ClusterRole permissions for extensions API group

### DIFF
--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.2.3
+version: 1.2.6
 appVersion: "v1.12.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -29,10 +29,6 @@ rules:
     resources:
       - nodes
     verbs: ["list", "watch", "get"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -57,15 +57,11 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
-    verbs: ["list", "watch", "get"]        
+    verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -57,15 +57,11 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
-    verbs: ["list", "watch", "get"]        
+    verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -57,15 +57,11 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
-    verbs: ["list", "watch", "get"]        
+    verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -57,15 +57,11 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
-    verbs: ["list", "watch", "get"]        
+    verbs: ["list", "watch", "get"]
   - apiGroups: [""]
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/manifests.jsonnet
+++ b/config/master/manifests.jsonnet
@@ -52,11 +52,6 @@ local awsnode = {
         apiGroups: [""],
         resources: ["nodes"],
         verbs: ["list", "watch", "get", "update"],
-      },
-      {
-        apiGroups: ["extensions"],
-        resources: ["*"],
-        verbs: ["list", "watch"],
       }
     ],
   },


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
#1232 

**What does this PR do / Why do we need it**:
This PR removes ClusterRole permissions for `extensions` API group. From what I can tell, the aws-node pod does not need list or watch permissions for any extensions.

Looking at the history, these permissions were originally added for `daemonsets`, but aws-node does not need to list or watch any other daemonsets. It does not need to list or watch any deployments or replicasets either.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually ran all IPv4 and IPv6 integration and e2e tests and did not run into any issues.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. A running cluster has been tested.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Remove ClusterRole permissions for extensions API group
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
