### PR TITLE
Login to ECR public before docker image build

### DIFF
--- a/.github/workflows/pr-automated-tests.yaml
+++ b/.github/workflows/pr-automated-tests.yaml
@@ -42,6 +42,17 @@ jobs:
     steps:
       - name: Checkout latest commit in the PR
         uses: actions/checkout@v3
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
+          role-duration-seconds: 14400 # 4 hours
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR will help with throttling from ECR public when building CNI container images on GitHub runners. The `pr-automated-tests.yaml` workflow runs against every PR, and we were often seeing image build failures due to throttling from ECR public. This throttling can be prevented by authenticating to ECR public before issuing `docker pull` commands.

Documentation for this action comes from https://github.com/aws-actions/amazon-ecr-login

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
