### PR TITLE
Fix integration test workflows installing ginkgo

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,8 +26,8 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          # Download ginkgo version from go.mod
-          go mod download github.com/onsi/ginkgo/v2
+          # Install ginkgo version from go.mod
+          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials

--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -24,8 +24,8 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          # Download ginkgo version from go.mod
-          go mod download github.com/onsi/ginkgo/v2
+          # Install ginkgo version from go.mod
+          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials

--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -32,8 +32,8 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          # Download ginkgo version from go.mod
-          go mod download github.com/onsi/ginkgo/v2
+          # Install ginkgo version from go.mod
+          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -24,8 +24,8 @@ jobs:
           go-version: "1.19"
       - name: Set up tools
         run: |
-          # Download ginkgo version from go.mod
-          go mod download github.com/onsi/ginkgo/v2
+          # Install ginkgo version from go.mod
+          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials


### PR DESCRIPTION
**What type of PR is this?**
Bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR fixes integration test workflows that need to install ginkgo. https://github.com/aws/amazon-vpc-cni-k8s/pull/2188 switched `go install` to `go mod download`, as `go install` would fail unless `go get` was run first to pull in some extra packages that should not be needed.

Now, we use `go install -mod=mod`, which should succeed and skip those extra, unneeded packages. If this does not work, I will move back to `go get && go install`.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
