### PR TITLE
doc: document AWS_VPC_K8S_CNI_LOGLEVEL for cni-metric-helper helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Default: `DEBUG`
 
 Valid Values: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`. (Not case sensitive)
 
-Specifies the loglevel for `ipamd`.
+Specifies the loglevel for `ipamd` and cni-metric-helper.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Default: `DEBUG`
 
 Valid Values: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`. (Not case sensitive)
 
-Specifies the loglevel for `ipamd` and cni-metric-helper.
+Specifies the loglevel for `ipamd` and `cni-metric-helper`.
 
 ---
 

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 0.1.15
+version: 0.1.16
 appVersion: v1.12.1
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -43,20 +43,21 @@ $ helm uninstall cni-metrics-helper --namespace kube-system
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                  | Description                                                   | Default            |
-|----------------------------|---------------------------------------------------------------|--------------------|
-| fullnameOverride           | Override the fullname of the chart                            | cni-metrics-helper |
-| image.region               | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                  | Image tag                                                     | v1.12.1            |
-| image.account              | ECR repository account number                                 | 602401143452       |
-| image.domain               | ECR repository domain                                         | amazonaws.com      |
-| env.USE_CLOUDWATCH         | Whether to export CNI metrics to CloudWatch                   | true               |
-| env.AWS_CLUSTER_ID         | ID of the cluster to use when exporting metrics to CloudWatch | default            |
-| env.METRIC_UPDATE_INTERVAL | Interval at which to update CloudWatch metrics, in seconds.   |                    |
-|                            | Metrics are published to CloudWatch at 2x the interval        | 30                 |
-| serviceAccount.name        | The name of the ServiceAccount to use                         | nil                |
-| serviceAccount.create      | Specifies whether a ServiceAccount should be created          | true               |
-| serviceAccount.annotations | Specifies the annotations for ServiceAccount                  | {}                 |
+| Parameter                    | Description                                                   | Default            |
+|------------------------------|---------------------------------------------------------------|--------------------|
+| fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
+| image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
+| image.tag                    | Image tag                                                     | v1.12.1            |
+| image.account                | ECR repository account number                                 | 602401143452       |
+| image.domain                 | ECR repository domain                                         | amazonaws.com      |
+| env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |
+| env.AWS_CLUSTER_ID           | ID of the cluster to use when exporting metrics to CloudWatch | default            |
+| env.AWS_VPC_K8S_CNI_LOGLEVEL | Log verbosity level (ie. FATAL, ERROR, WARN, INFO, DEBUG)     | INFO               |
+| env.METRIC_UPDATE_INTERVAL   | Interval at which to update CloudWatch metrics, in seconds.   |                    |
+|                              | Metrics are published to CloudWatch at 2x the interval        | 30                 |
+| serviceAccount.name          | The name of the ServiceAccount to use                         | nil                |
+| serviceAccount.create        | Specifies whether a ServiceAccount should be created          | true               |
+| serviceAccount.annotations   | Specifies the annotations for ServiceAccount                  | {}                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -13,6 +13,7 @@ image:
 env:
   USE_CLOUDWATCH: "true"
   AWS_CLUSTER_ID: ""
+  AWS_VPC_K8S_CNI_LOGLEVEL: "INFO"
 
 fullnameOverride: "cni-metrics-helper"
 


### PR DESCRIPTION
**What type of PR is this?**

Document the variable `AWS_VPC_K8S_CNI_LOGLEVEL` and set the default value to `INFO`

Add one of the following:
cleanup
documentation


**Which issue does this PR fix**:
Fixes #2207 

```release-note
Document environment variable `AWS_VPC_K8S_CNI_LOGLEVEL` for cni-metric-helper
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
