### PR TITLE
Add requirement on security group for cni-metric-helper

### DIFF
--- a/cmd/cni-metrics-helper/README.md
+++ b/cmd/cni-metrics-helper/README.md
@@ -13,8 +13,7 @@ The following diagram shows how `cni-metrics-helper` works in a cluster:
 
 ![](../../docs/images/cni-metrics-helper.png)
 
-As you can see in the diagram, the `cni-metrics-helper` connects to the API Server
-over https (`tcp/443`), and another connection is created from the API Server to the worker node over http (tcp/61678). If you deploy Amazon EKS with recommended [Restricting cluster traffic](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#security-group-restricting-cluster-traffic) then make sure that a security group is in place that allows the inbound connection from the API Server to the Worker Nodes over `tcp/61678`.
+As you can see in the diagram, the `cni-metrics-helper` connects to the API Server over https (`tcp/443`), and another connection is created from the API Server to the worker node over http (tcp/61678). If you deploy Amazon EKS with recommended [Restricting cluster traffic](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#security-group-restricting-cluster-traffic), then make sure that a security group is in place that allows the inbound connection from the API Server to the worker nodes over `tcp/61678`.
 
 ### Using IRSA
 As per [AWS EKS Security Best Practice](https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html), if you are using IRSA for pods then following requirements must be satisfied to succesfully publish metrics to CloudWatch

--- a/cmd/cni-metrics-helper/README.md
+++ b/cmd/cni-metrics-helper/README.md
@@ -13,6 +13,9 @@ The following diagram shows how `cni-metrics-helper` works in a cluster:
 
 ![](../../docs/images/cni-metrics-helper.png)
 
+As you can see in the diagram, the `cni-metrics-helper` connects to the API Server
+over https (`tcp/443`), and another connection is created from the API Server to the worker node over http (tcp/61678). If you deploy Amazon EKS with recommended [Restricting cluster traffic](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#security-group-restricting-cluster-traffic) then make sure that a security group is in place that allows the inbound connection from the API Server to the Worker Nodes over `tcp/61678`.
+
 ### Using IRSA
 As per [AWS EKS Security Best Practice](https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html), if you are using IRSA for pods then following requirements must be satisfied to succesfully publish metrics to CloudWatch
 


### PR DESCRIPTION
**What type of PR is this?**

Adds documentation on how the connection is made from the API Server to the Worker Nodes to pull the metrics using the `cni-metric-helper` and the user needs to configure a security group if using a strict networking configuration.

Add one of the following:
documentation


**Which issue does this PR fix**:

Fixes #2208 

**What does this PR do / Why do we need it**:

When deploying an EKS cluster with strict security group rules, is not obvious that the connection is not from node to node (ie pod to pod) and instead if from `cni-metric-helper` pod to API Server, then from API Server to worker node over port `61678`. This docs helps make the user aware to open the port from API Server to Worker Nodes.

**Testing done on this change**:
I deployed an EKS cluster with recommended strict security groups. The cni-metric-helper was not able to scrape got the errors
```
Failed to grab CNI endpoint: the server is currently unable to handle the request (get pods aws-node-ktpbn:61678)"}
Failed to grab CNI endpoint: the server is currently unable to handle the request (get pods aws-node-4tjv5:61678)"}
```
Then added a security group from API Servers (Control plane) to Worker Nodes (Data plane) allowing only inbound `tcp/61678` and then metrics started to be collected.

```release-note
Add documentation about network security between API Server and Worker Nodes for cni-metric-helper
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
