### PR TITLE
using instance id instead of node name for event regarding UID

### DIFF
--- a/pkg/utils/eventrecorder/eventrecorder.go
+++ b/pkg/utils/eventrecorder/eventrecorder.go
@@ -44,6 +44,7 @@ type EventRecorder struct {
 	Recorder        events.EventRecorder
 	RawK8SClient    client.Client
 	CachedK8SClient client.Client
+	HostID          string
 }
 
 func New(rawK8SClient, cachedK8SClient client.Client) (*EventRecorder, error) {
@@ -117,7 +118,7 @@ func (e *EventRecorder) SendNodeEvent(eventType, reason, action, message string)
 	// that are listed in 'kubectl describe node' output. So setting the node UID to
 	// nodename before sending the event
 	nodeCopy := node.DeepCopy()
-	nodeCopy.SetUID(types.UID(MyNodeName))
+	nodeCopy.SetUID(types.UID(e.HostID))
 
 	e.Recorder.Eventf(nodeCopy, nil, eventType, reason, action, message)
 	log.Debugf("Sent node event: eventType: %s, reason: %s, message: %s, action %s", eventType, reason, message, action)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
This PR is changing the node event to VPC resource controller to use instance id as event regarding UID.
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature
**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
This will enable VPC resource controller to cache on events for better performance.
Referring to this PR
https://github.com/aws/amazon-vpc-resource-controller-k8s/pull/160

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
manual tests were done
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
e2e will be followed up to wait for the other controller being available in EKS.
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
