### PR TITLE
Handle private IP exceeded error (#2210)

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -618,7 +618,7 @@ func TestAllocIPAddressesAlreadyFull(t *testing.T) {
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().AssignPrivateIpAddressesWithContext(gomock.Any(), input, gomock.Any()).Return(nil, retErr)
 	// If EC2 says that all IPs are already attached, then DS is out of sync so alloc will fail
-	_, err := cache.AllocIPAddresses(eniID, 14)
+	_, err := ins.AllocIPAddresses(eniID, 14)
 	assert.Error(t, err)
 }
 
@@ -655,7 +655,7 @@ func TestAllocPrefixesAlreadyFull(t *testing.T) {
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().AssignPrivateIpAddressesWithContext(gomock.Any(), input, gomock.Any()).Return(nil, retErr)
 	// If EC2 says that all IPs are already attached, then DS is out of sync so alloc will fail
-	_, err := cache.AllocIPAddresses(eniID, 1)
+	_, err := ins.AllocIPAddresses(eniID, 1)
 	assert.Error(t, err)
 }
 

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -617,9 +617,9 @@ func TestAllocIPAddressesAlreadyFull(t *testing.T) {
 
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().AssignPrivateIpAddressesWithContext(gomock.Any(), input, gomock.Any()).Return(nil, retErr)
-	// If EC2 says that all IPs are already attached, we do nothing
-	_, err := ins.AllocIPAddresses(eniID, 14)
-	assert.NoError(t, err)
+	// If EC2 says that all IPs are already attached, then DS is out of sync so alloc will fail
+	_, err := cache.AllocIPAddresses(eniID, 14)
+	assert.Error(t, err)
 }
 
 func TestAllocPrefixAddresses(t *testing.T) {
@@ -654,9 +654,9 @@ func TestAllocPrefixesAlreadyFull(t *testing.T) {
 
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().AssignPrivateIpAddressesWithContext(gomock.Any(), input, gomock.Any()).Return(nil, retErr)
-	// If EC2 says that all IPs are already attached, we do nothing
-	_, err := ins.AllocIPAddresses(eniID, 1)
-	assert.NoError(t, err)
+	// If EC2 says that all IPs are already attached, then DS is out of sync so alloc will fail
+	_, err := cache.AllocIPAddresses(eniID, 1)
+	assert.Error(t, err)
 }
 
 func Test_badENIID(t *testing.T) {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -355,6 +355,14 @@ func containsInsufficientCIDRsOrSubnetIPs(err error) bool {
 	return false
 }
 
+// containsPrivateIPAddressLimitExceededError returns whether exceeds ENI's IP address limit
+func containsPrivateIPAddressLimitExceededError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		return aerr.Code() == "PrivateIpAddressLimitExceeded"
+	}
+	return false
+}
+
 // inInsufficientCidrCoolingPeriod checks whether IPAMD is in insufficientCidrErrorCooldown
 func (c *IPAMContext) inInsufficientCidrCoolingPeriod() bool {
 	return time.Since(c.lastInsufficientCidrError) <= insufficientCidrErrorCooldown
@@ -933,25 +941,36 @@ func (c *IPAMContext) tryAssignIPs() (increasedPool bool, err error) {
 		// Try to allocate all available IPs for this ENI
 		resourcesToAllocate := min((c.maxIPsPerENI - currentNumberOfAllocatedIPs), toAllocate)
 		output, err := c.awsClient.AllocIPAddresses(eni.ID, resourcesToAllocate)
-		if err != nil {
+		if err != nil && !containsPrivateIPAddressLimitExceededError(err) {
 			log.Warnf("failed to allocate all available IP addresses on ENI %s, err: %v", eni.ID, err)
 			// Try to just get one more IP
 			output, err = c.awsClient.AllocIPAddresses(eni.ID, 1)
-			if err != nil {
+			if err != nil && !containsPrivateIPAddressLimitExceededError(err) {
 				ipamdErrInc("increaseIPPoolAllocIPAddressesFailed")
 				return false, errors.Wrap(err, fmt.Sprintf("failed to allocate one IP addresses on ENI %s, err ", eni.ID))
 			}
 		}
 
-		if output == nil {
-			ipamdErrInc("increaseIPPoolGetENIaddressesFailed")
-			return true, errors.Wrap(err, "failed to get ENI IP addresses during IP allocation")
-		}
-
 		var ec2ip4s []*ec2.NetworkInterfacePrivateIpAddress
-		ec2Addrs := output.AssignedPrivateIpAddresses
-		for _, ec2Addr := range ec2Addrs {
-			ec2ip4s = append(ec2ip4s, &ec2.NetworkInterfacePrivateIpAddress{PrivateIpAddress: aws.String(aws.StringValue(ec2Addr.PrivateIpAddress))})
+		if containsPrivateIPAddressLimitExceededError(err) {
+			log.Debug("AssignPrivateIpAddresses returned PrivateIpAddressLimitExceeded. This can happen if the data store is out of sync." +
+				"Returning without an error here since we will verify the actual state by calling EC2 to see what addresses have already assigned to this ENI.")
+			// This call to EC2 is needed to verify which IPs got attached to this ENI.
+			ec2ip4s, err = c.awsClient.GetIPv4sFromEC2(eni.ID)
+			if err != nil {
+				ipamdErrInc("increaseIPPoolGetENIaddressesFailed")
+				return true, errors.Wrap(err, "failed to get ENI IP addresses during IP allocation")
+			}
+		} else {
+			if output == nil {
+				ipamdErrInc("increaseIPPoolGetENIaddressesFailed")
+				return true, errors.Wrap(err, "failed to get ENI IP addresses during IP allocation")
+			}
+
+			ec2Addrs := output.AssignedPrivateIpAddresses
+			for _, ec2Addr := range ec2Addrs {
+				ec2ip4s = append(ec2ip4s, &ec2.NetworkInterfacePrivateIpAddress{PrivateIpAddress: aws.String(aws.StringValue(ec2Addr.PrivateIpAddress))})
+			}
 		}
 		c.addENIsecondaryIPsToDataStore(ec2ip4s, eni.ID)
 		return true, nil
@@ -1007,20 +1026,32 @@ func (c *IPAMContext) tryAssignPrefixes() (increasedPool bool, err error) {
 		currentNumberOfAllocatedPrefixes := len(eni.AvailableIPv4Cidrs)
 		resourcesToAllocate := min((c.maxPrefixesPerENI - currentNumberOfAllocatedPrefixes), toAllocate)
 		output, err := c.awsClient.AllocIPAddresses(eni.ID, resourcesToAllocate)
-		if err != nil {
+		if err != nil && !containsPrivateIPAddressLimitExceededError(err) {
 			log.Warnf("failed to allocate all available IPv4 Prefixes on ENI %s, err: %v", eni.ID, err)
 			// Try to just get one more prefix
 			output, err = c.awsClient.AllocIPAddresses(eni.ID, 1)
-			if err != nil {
+			if err != nil && !containsPrivateIPAddressLimitExceededError(err) {
 				ipamdErrInc("increaseIPPoolAllocIPAddressesFailed")
 				return false, errors.Wrap(err, fmt.Sprintf("failed to allocate one IPv4 prefix on ENI %s, err: %v", eni.ID, err))
 			}
 		}
-		if output == nil {
-			ipamdErrInc("increaseIPPoolGetENIprefixedFailed")
-			return true, errors.Wrap(err, "failed to get ENI Prefix addresses during IPv4 Prefix allocation")
+		var ec2Prefixes []*ec2.Ipv4PrefixSpecification
+		if containsPrivateIPAddressLimitExceededError(err) {
+			log.Debug("AssignPrivateIpAddresses returned PrivateIpAddressLimitExceeded. This can happen if the data store is out of sync." +
+				"Returning without an error here since we will verify the actual state by calling EC2 to see what addresses have already assigned to this ENI.")
+			// This call to EC2 is needed to verify which IPs got attached to this ENI.
+			ec2Prefixes, err = c.awsClient.GetIPv4PrefixesFromEC2(eni.ID)
+			if err != nil {
+				ipamdErrInc("increaseIPPoolGetENIaddressesFailed")
+				return true, errors.Wrap(err, "failed to get ENI IP addresses during IP allocation")
+			}
+		} else {
+			if output == nil {
+				ipamdErrInc("increaseIPPoolGetENIprefixedFailed")
+				return true, errors.Wrap(err, "failed to get ENI Prefix addresses during IPv4 Prefix allocation")
+			}
+			ec2Prefixes = output.AssignedIpv4Prefixes
 		}
-		ec2Prefixes := output.AssignedIpv4Prefixes
 		c.addENIv4prefixesToDataStore(ec2Prefixes, eni.ID)
 		return true, nil
 	}


### PR DESCRIPTION
* Handle private IP exceeded error

* Check for err when adding extra 1 IP

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cherry-pick
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2210 

**What does this PR do / Why do we need it**:
With 1.11.4 we optimized to reduce the number of EC2 calls - https://github.com/aws/amazon-vpc-cni-k8s/pull/1975.

But this introduced a regression when PrivateIPAddressLimitExceed error is returned in a corner case. I.e, If IMDS goes out of sync and aws-node restarts then IPAMD DS will have the ENI but will be missing IPs since IMDS is out of sync. Reconciler will try allocate IPs but EC2 will return PrivateIpAddressLimitExceeded since from EC2 point of view IPs are allocated. With PrivateIpAddressLimitExceeded we used to return without an error since we will verify the actual state by calling EC2 to see what addresses have already assigned to this ENI. Pre-1.11.4, IPAMD used to make a call to EC2 to confirm the actual state - https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.11.3/pkg/ipamd/ipamd.go#L946

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
In this PR, we will revert to old behavior but make EC2 call only when PrivateIpAddressLimitExceeded

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Testing will be re-run as part of release.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
