### PR TITLE
Increase timeout to remove flakiness in tests

### DIFF
--- a/test/framework/resources/k8s/resources/job.go
+++ b/test/framework/resources/k8s/resources/job.go
@@ -67,6 +67,11 @@ func (d *defaultJobManager) DeleteAndWaitTillJobIsDeleted(job *v1.Job) error {
 	ctx := context.Background()
 	propagation := metav1.DeletePropagationForeground
 	err := d.k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagation})
+
+	if errors.IsNotFound(err) {
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/test/integration/ipv6/ipv6_service_connectivity_test.go
+++ b/test/integration/ipv6/ipv6_service_connectivity_test.go
@@ -97,7 +97,7 @@ var _ = Describe("[CANARY] test service connectivity", func() {
 
 		testerContainer = manifest.NewBusyBoxContainerBuilder().
 			Command([]string{"wget"}).
-			Args([]string{"--spider", "-T", "1", fmt.Sprintf("[%s]:%d", service.Spec.ClusterIP,
+			Args([]string{"--spider", "-T", "5", fmt.Sprintf("[%s]:%d", service.Spec.ClusterIP,
 				service.Spec.Ports[0].Port)}).
 			Build()
 
@@ -114,7 +114,7 @@ var _ = Describe("[CANARY] test service connectivity", func() {
 		// Test connection to an unreachable port should fail
 		negativeTesterContainer = manifest.NewBusyBoxContainerBuilder().
 			Command([]string{"wget"}).
-			Args([]string{"--spider", "-T", "1", fmt.Sprintf("[%s]:%d", service.Spec.ClusterIP, 2273)}).
+			Args([]string{"--spider", "-T", "5", fmt.Sprintf("[%s]:%d", service.Spec.ClusterIP, 2273)}).
 			Build()
 
 		negativeTesterJob = manifest.NewDefaultJobBuilder().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Ipv6 canary tests intermittently runs into timeout issues with the test
```
   Pod logs test-job-rcffp : Connecting to [fdd0:3023:f81b::98fe]:80 ([fdd0:3023:f81b::98fe]:80)
    wget: download timed out
```

**What does this PR do / Why do we need it**:
This increases the wget timeout to 5 secs to remove the flakiness due to timeout. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Yes, tested it on all supported versions

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
