### PR TITLE
Update golang builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ export DOCKER_BUILDKIT=1
 GOARCH = $(TARGETARCH)
 
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE = public.ecr.aws/eks-distro-build-tooling/golang:1.19.5-1-gcc-al2
+GOLANG_IMAGE = public.ecr.aws/eks-distro-build-tooling/golang:1.19.6-3-gcc-al2
 # For the requested build, these are the set of Go specific build environment variables.
 export GOOS = linux
 export CGO_ENABLED = 0


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the golang builder image to `public.ecr.aws/eks-distro-build-tooling/golang:1.19.6-3-gcc-al2`. This is done periodically to get latest improvements and bug fixes.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Verified that all unit tests pass and images build without issue.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Update golang builder image
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

