### PR TITLE
Remove timestamp from generated files (cont.)

### DIFF
--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"

--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -78,11 +78,9 @@ func main() {
 		log.Fatalf("Failed to create file: %v\n", err)
 	}
 	err = limitsTemplate.Execute(f, struct {
-		Timestamp string
 		ENILimits []string
 		Regions   []string
 	}{
-		Timestamp: time.Now().Format(time.RFC3339),
 		ENILimits: eniLimits,
 		Regions:   regions,
 	})
@@ -265,8 +263,6 @@ var eksMaxPodsTemplate = template.Must(template.New("").Parse(`# Copyright Amazo
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-#
-# This file was generated at {{ .Timestamp }}
 #
 # The regions queried were:
 {{- range $region := .Regions}}


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

This continues #2263, which removed the timestamp from the `eni-max-pods.txt` template parameters, but not from the template. Instead, the timestamp was removed from the go code template. 🤦 


**Testing done on this change**:

This succeeds and I verified no timestamps are in the generated files.
```
make generate-limits
```

**Automation added to e2e**: N/A
**Will this PR introduce any new dependencies?**: No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No
**Does this change require updates to the CNI daemonset config files to work?**: No
**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
