### PR TITLE
Update release tag to v1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.12.4
+## v1.12.5
 
 * Bug - [Handle private IP exceeded error](https://github.com/aws/amazon-vpc-cni-k8s/pull/2210) (@jayanthvn )
 * Documentation - [doc: document AWS_VPC_K8S_CNI_LOGLEVEL for cni-metric-helper helm chart](https://github.com/aws/amazon-vpc-cni-k8s/pull/2226) (@csantanapr )
@@ -11,6 +11,7 @@
 * Improvement - [Add M7g, R7g instance](https://github.com/aws/amazon-vpc-cni-k8s/pull/2250) (@Issacwww )
 * Improvement - [Update client-go and k8s packages](https://github.com/aws/amazon-vpc-cni-k8s/pull/2204) (@jaydeokar )
 * Improvement - [Refactor cni-metrics-helper chart for eks charts release](https://github.com/aws/amazon-vpc-cni-k8s/pull/2201) (@jdn5126 )
+* Improvement - [fix: Upgrade to golang.org/x/net@v0.7.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/2273) (@ellistarn )
 
 ## v1.12.2
 

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
 version: 1.2.7
-appVersion: "v1.12.4"
+appVersion: "v1.12.5"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -42,14 +42,14 @@ The following table lists the configurable parameters for this chart and their d
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.12.4`                           |
+| `image.tag`             | Image tag                                               | `v1.12.5`                           |
 | `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `init.image.tag`        | Image tag                                               | `v1.12.4`                           |
+| `init.image.tag`        | Image tag                                               | `v1.12.5`                           |
 | `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.12.4
+    tag: v1.12.5
     region: us-west-2
     account: "602401143452"
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.12.4
+  tag: v1.12.5
   account: "602401143452"
   domain: "amazonaws.com"
   pullPolicy: Always

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
 version: 0.1.17
-appVersion: v1.12.4
+appVersion: v1.12.5
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.12.4            |
+| image.tag                    | Image tag                                                     | v1.12.5            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.12.4
+  tag: v1.12.5
   account: "602401143452"
   domain: "amazonaws.com"   
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.4"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.5"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.12.4"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.12.5"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.4"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.5"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.12.4"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.12.5"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.4"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.5"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.12.4"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.12.5"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -121,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.4"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.5"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.4"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.5"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,8 +61,10 @@ spec:
       - env:
         - name: AWS_CLUSTER_ID
           value: ""
+        - name: AWS_VPC_K8S_CNI_LOGLEVEL
+          value: "INFO"
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.12.4"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.12.5"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,8 +61,10 @@ spec:
       - env:
         - name: AWS_CLUSTER_ID
           value: ""
+        - name: AWS_VPC_K8S_CNI_LOGLEVEL
+          value: "INFO"
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.12.4"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.12.5"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,8 +61,10 @@ spec:
       - env:
         - name: AWS_CLUSTER_ID
           value: ""
+        - name: AWS_VPC_K8S_CNI_LOGLEVEL
+          value: "INFO"
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.12.4"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.12.5"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,8 +61,10 @@ spec:
       - env:
         - name: AWS_CLUSTER_ID
           value: ""
+        - name: AWS_VPC_K8S_CNI_LOGLEVEL
+          value: "INFO"
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.12.4"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.12.5"
       serviceAccountName: cni-metrics-helper


### PR DESCRIPTION
**What type of PR is this?**
release update

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the image tag and release information for v1.12.5. Note that v1.12.3 and v1.12.4 were skipped.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
