### PR TITLE
Add script to run full IPv6 integration test suite

### DIFF
--- a/scripts/lib/canary.sh
+++ b/scripts/lib/canary.sh
@@ -4,7 +4,7 @@
 
 SECONDS=0
 
-echo "Running Canary tests for amazon-vpc-cni-k8s with the following variables
+echo "Running tests for amazon-vpc-cni-k8s with the following variables
 KUBE_CONFIG_PATH:  $KUBE_CONFIG_PATH
 CLUSTER_NAME: $CLUSTER_NAME
 REGION: $REGION

--- a/scripts/run-ipv6-integration-tests.sh
+++ b/scripts/run-ipv6-integration-tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# The script runs the full IPv6 integration test suite
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
+
+source "$SCRIPT_DIR"/lib/add-on.sh
+source "$SCRIPT_DIR"/lib/cluster.sh
+source "$SCRIPT_DIR"/lib/canary.sh
+
+function run_ginkgo_test() {
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v --timeout 30m --no-color --fail-on-pending $GINKGO_TEST_BUILD/ipv6.test -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux")
+}
+
+load_cluster_details
+load_addon_details
+
+echo "Running IPv6 integration tests against the latest addon version"
+
+install_add_on "$LATEST_ADDON_VERSION"
+run_ginkgo_test
+
+echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds a bash script that can be invoked to install the latest VPC CNI addon version and run the full IPv6 integration test suite against it.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that script passes.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
