### PR TITLE
Documentation for upgrade and version recommendation; fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout latest commit in the PR
         uses: actions/checkout@v3
         with:
-          ref: "refs/tags/{{ github.event.release.tag_name }}"
+          ref: "refs/tags/${{ github.event.release.tag_name }}"
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,24 @@ For help, please consider the following venues (in order):
 * [File an issue](https://github.com/aws/amazon-vpc-cni-k8s/issues/new/choose)
 * Chat with us on the `#aws-vpc-cni` channel in the [Kubernetes Slack](https://kubernetes.slack.com/) community.
 
+## Recommended Version
+
+For all Kubernetes releases, we recommend installing the latest VPC CNI release. The following table denotes our minimum recommended
+VPC CNI version for each actively supported Kubernetes release.
+
+| Kubernetes Release |    1.25    |    1.24    |    1.23    |    1.22    |
+| ------------------ | ---------- | ---------- | ---------- | ---------- |
+|  VPC CNI Version   |  v1.11.4+  |  v1.9.3+   |  v1.8.0+   |  v1.8.0+   |
+
+## Version Upgrade
+
+Upgrading (or downgrading) the VPC CNI version should result in no downtime. Existing pods should not be affected and will not lose network connectivity.
+New pods will be in pending state until the VPC CNI is fully initialized and can assign pod IP addresses. In v1.12.0+, VPC CNI state is
+restored via an on-disk file: `/var/run/aws-node/ipam.json`. In lower versions, state is restored via calls to container runtime.
+
 ## ENI Allocation
 
-When a worker node first joins the cluster, there is only 1 ENI along with all of its addresses in the ENI. Without any
+When a worker node first joins the cluster, there is only 1 ENI along with all of the addresses on the ENI. Without any
 configuration, ipamd always tries to keep one extra ENI.
 
 When the number of pods running on the node exceeds the number of addresses on a single ENI, the CNI backend starts allocating

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -36,7 +36,6 @@ ARCH=$(go env GOARCH)
 : "${CALICO_VERSION:=v3.23.0}"
 : "${RUN_CALICO_TEST_WITH_PD:=true}"
 
-
 __cluster_created=0
 __cluster_deprovisioned=0
 


### PR DESCRIPTION
**What type of PR is this?**
documentation
bug

**Which issue does this PR fix**:
#2244 
#2194 

**What does this PR do / Why do we need it**:
This PR adds the following documentation:
1. A table with the minimum recommended VPC CNI version for each k8s version
2. A paragraph about VPC CNI version upgrade

This PR also fixes variable usage in release workflow.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
