### PR TITLE
Fix MTU parameter in egress-v4-cni plugin

### DIFF
--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -217,16 +217,9 @@ func isValidJSON(inFile string) error {
 	return json.Unmarshal([]byte(inFile), &result)
 }
 
-func generateJSON(jsonFile string, outFile string) error {
+func generateJSON(jsonFile string, outFile string, nodeIP string) error {
 	byteValue, err := ioutil.ReadFile(jsonFile)
 	if err != nil {
-		return err
-	}
-
-	var nodeIP string
-	nodeIP, err = getNodePrimaryV4Address()
-	if err != nil {
-		log.Errorf("Failed to get Node IP")
 		return err
 	}
 
@@ -391,8 +384,16 @@ func _main() int {
 	//	return 1
 	//}
 
+	// Get node IP for conflist
+	var nodeIP string
+	nodeIP, err = getNodePrimaryV4Address()
+	if err != nil {
+		log.Errorf("Failed to get Node IP, error: %v", err)
+		return 1
+	}
+
 	log.Infof("Copying config file... ")
-	err = generateJSON(defaultAWSconflistFile, tmpAWSconflistFile)
+	err = generateJSON(defaultAWSconflistFile, tmpAWSconflistFile, nodeIP)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to generate 10-awsconflist")
 		return 1

--- a/cmd/aws-vpc-cni/main_test.go
+++ b/cmd/aws-vpc-cni/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	awsConflist = "../../misc/10-aws.conflist"
+	devNull     = "/dev/null"
+	nodeIP      = "10.0.0.0"
+)
+
+// Validate that generateJSON runs against default conflist without error
+func TestGenerateJSON(t *testing.T) {
+	err := generateJSON(awsConflist, devNull, nodeIP)
+	assert.NoError(t, err)
+}
+
+// Validate that generateJSON runs without error when bandwidth plugin is added to default conflist
+func TestGenerateJSONPlusBandwidth(t *testing.T) {
+	_ = os.Setenv(envEnBandwidthPlugin, "true")
+	err := generateJSON(awsConflist, devNull, nodeIP)
+	assert.NoError(t, err)
+}

--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -15,7 +15,7 @@
     {
       "name": "egress-v4-cni",
       "type": "egress-v4-cni",
-      "mtu": 9001,
+      "mtu": "9001",
       "enabled": "__EGRESSV4PLUGINENABLED__",
       "randomizeSNAT": "__RANDOMIZESNAT__",
       "nodeIP": "__NODEIP__",


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#2293 

**What does this PR do / Why do we need it**:
This PR updates the default `10-aws.conflist` so that the MTU set for `egress-v4-cni` plugin is a string rather than an integer. This was causing an issue when `ENABLE_BANDWIDTH_PLUGIN` environment variable was set, as we call `json.Unmarshal` on the default conflist and fail to parse `9001` as a string.

I added a unit test in `cmd/aws-vpc-cni/` to cover this specific case. I explicitly avoided using `gomock` for this test case to keep things simple.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Added a unit test to validate json marshaling of conflist.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Fix conflist parsing when ENABLE_BANDWIDTH_PLUGIN is set.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
