### PR TITLE
Added enviroment variable to allow ipamd to manage the ENIs on a non schedulable node

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following environment variables are available, and all of them are optional.
 
 ---
 
-#### `AWS_MANAGE_ENIS_NON_SCHEDULABLE` 
+#### `AWS_MANAGE_ENIS_NON_SCHEDULABLE` (v1.13.0+)
 
 Type: Boolean as a String
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ Default: `false`
 
 Specifies whether IPAMD should allocate or deallocate ENIs on a non-schedulable node. 
 
-This could be useful in scenarios where user sets `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG` where the primary interface will not used 
-and there are system pods which needs to get IP from a secondary ENI to complete the bootrstap of a node.  
-
 ---
 
 #### `AWS_VPC_CNI_NODE_PORT_SUPPORT`

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ The following environment variables are available, and all of them are optional.
 
 ---
 
+#### `AWS_MANAGE_ENIS_NON_SCHEDULABLE` 
+
+Type: Boolean as a String
+
+Default: `false`
+
+Specifies whether IPAMD should allocate or deallocate ENIs on a non-schedulable node. 
+
+This could be useful in scenarios where user sets `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG` where the primary interface will not used 
+and there are system pods which needs to get IP from a secondary ENI to complete the bootrstap of a node.  
+
+---
+
 #### `AWS_VPC_CNI_NODE_PORT_SUPPORT`
 
 Type: Boolean as a String

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -112,6 +112,9 @@ const (
 	// When it is NOT set or set to false, ipamd will use primary interface security group and subnet for Pod network.
 	envCustomNetworkCfg = "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG"
 
+	// This environment variable specifies whether IPAMD should allocate or deallocate ENIs on a non-schedulable node (default false).
+	envManageENIsNonSchedulable = "AWS_MANAGE_ENIS_NON_SCHEDULABLE"
+
 	// eniNoManageTagKey is the tag that may be set on an ENI to indicate ipamd
 	// should not manage it in any form.
 	eniNoManageTagKey = "node.k8s.amazonaws.com/no_manage"
@@ -238,25 +241,26 @@ var (
 
 // IPAMContext contains node level control information
 type IPAMContext struct {
-	awsClient            awsutils.APIs
-	dataStore            *datastore.DataStore
-	rawK8SClient         client.Client
-	cachedK8SClient      client.Client
-	enableIPv4           bool
-	enableIPv6           bool
-	useCustomNetworking  bool
-	networkClient        networkutils.NetworkAPIs
-	maxIPsPerENI         int
-	maxENI               int
-	maxPrefixesPerENI    int
-	unmanagedENI         int
-	warmENITarget        int
-	warmIPTarget         int
-	minimumIPTarget      int
-	warmPrefixTarget     int
-	primaryIP            map[string]string // primaryIP is a map from ENI ID to primary IP of that ENI
-	lastNodeIPPoolAction time.Time
-	lastDecreaseIPPool   time.Time
+	awsClient                      awsutils.APIs
+	dataStore                      *datastore.DataStore
+	rawK8SClient                   client.Client
+	cachedK8SClient                client.Client
+	enableIPv4                     bool
+	enableIPv6                     bool
+	useCustomNetworking            bool
+	manageENIsNonScheduleable      bool
+	networkClient                  networkutils.NetworkAPIs
+	maxIPsPerENI                   int
+	maxENI                         int
+	maxPrefixesPerENI              int
+	unmanagedENI                   int
+	warmENITarget                  int
+	warmIPTarget                   int
+	minimumIPTarget                int
+	warmPrefixTarget               int
+	primaryIP                      map[string]string // primaryIP is a map from ENI ID to primary IP of that ENI
+	lastNodeIPPoolAction           time.Time
+	lastDecreaseIPPool             time.Time
 	// reconcileCooldownCache keeps timestamps of the last time an IP address was unassigned from an ENI,
 	// so that we don't reconcile and add it back too quickly if IMDS lags behind reality.
 	reconcileCooldownCache    ReconcileCooldownCache
@@ -386,6 +390,7 @@ func New(rawK8SClient client.Client, cachedK8SClient client.Client) (*IPAMContex
 	c.cachedK8SClient = cachedK8SClient
 	c.networkClient = networkutils.New()
 	c.useCustomNetworking = UseCustomNetworkCfg()
+	c.manageENIsNonScheduleable = ManageENIsOnNonSchedulableNode()
 	c.enablePrefixDelegation = usePrefixDelegation()
 	c.enableIPv4 = isIPv4Enabled()
 	c.enableIPv6 = isIPv6Enabled()
@@ -754,7 +759,7 @@ func (c *IPAMContext) tryFreeENI() {
 		return
 	}
 
-	if c.isNodeNonSchedulable() {
+	if !c.manageENIsNonScheduleable && c.isNodeNonSchedulable() {
 		log.Debug("AWS CNI is on a non schedulable node, not detaching any ENIs")
 		return
 	}
@@ -848,7 +853,7 @@ func (c *IPAMContext) increaseDatastorePool(ctx context.Context) {
 		log.Debug("AWS CNI is terminating, will not try to attach any new IPs or ENIs right now")
 		return
 	}
-	if c.isNodeNonSchedulable() {
+	if !c.manageENIsNonScheduleable && c.isNodeNonSchedulable() {
 		log.Debug("AWS CNI is on a non schedulable node, will not try to attach any new IPs or ENIs right now")
 		return
 	}
@@ -1765,14 +1770,23 @@ func (c *IPAMContext) verifyAndAddPrefixesToDatastore(eni string, attachedENIPre
 
 // UseCustomNetworkCfg returns whether Pods needs to use pod specific configuration or not.
 func UseCustomNetworkCfg() bool {
-	if strValue := os.Getenv(envCustomNetworkCfg); strValue != "" {
+	return parseBoolEnvVar(envCustomNetworkCfg, false)
+}
+
+// ManageENIsOnNonSchedulableNode returns whether IPAMd should manage ENIs on the node or not.
+func ManageENIsOnNonSchedulableNode() bool {
+	return parseBoolEnvVar(envManageENIsNonSchedulable, false)
+}
+
+func parseBoolEnvVar(envVariableName string, defaultVal bool) bool {
+	if strValue := os.Getenv(envVariableName); strValue != "" {
 		parsedValue, err := strconv.ParseBool(strValue)
 		if err == nil {
 			return parsedValue
 		}
-		log.Warnf("Failed to parse %s; using default: false, err: %v", envCustomNetworkCfg, err)
+		log.Warnf("Failed to parse %s; using default: %v, err: %v", envVariableName, defaultVal, err)
 	}
-	return false
+	return defaultVal
 }
 
 func dsBackingStorePath() string {
@@ -1979,9 +1993,10 @@ func (c *IPAMContext) isNodeNonSchedulable() bool {
 // GetConfigForDebug returns the active values of the configuration env vars (for debugging purposes).
 func GetConfigForDebug() map[string]interface{} {
 	return map[string]interface{}{
-		envWarmIPTarget:     getWarmIPTarget(),
-		envWarmENITarget:    getWarmENITarget(),
-		envCustomNetworkCfg: UseCustomNetworkCfg(),
+		envWarmIPTarget:             getWarmIPTarget(),
+		envWarmENITarget:            getWarmENITarget(),
+		envCustomNetworkCfg:         UseCustomNetworkCfg(),
+		envManageENIsNonSchedulable: ManageENIsOnNonSchedulableNode(),
 	}
 }
 
@@ -2297,7 +2312,6 @@ func (c *IPAMContext) initENIAndIPLimits() (err error) {
 
 func (c *IPAMContext) isConfigValid() bool {
 	//Validate that only one among v4 and v6 is enabled.
-	if c.enableIPv4 && c.enableIPv6 {
 		log.Errorf("IPv4 and IPv6 are both enabled. VPC CNI currently doesn't support dual stack mode")
 		return false
 	} else if !c.enableIPv4 && !c.enableIPv6 {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -241,26 +241,26 @@ var (
 
 // IPAMContext contains node level control information
 type IPAMContext struct {
-	awsClient                      awsutils.APIs
-	dataStore                      *datastore.DataStore
-	rawK8SClient                   client.Client
-	cachedK8SClient                client.Client
-	enableIPv4                     bool
-	enableIPv6                     bool
-	useCustomNetworking            bool
-	manageENIsNonScheduleable      bool
-	networkClient                  networkutils.NetworkAPIs
-	maxIPsPerENI                   int
-	maxENI                         int
-	maxPrefixesPerENI              int
-	unmanagedENI                   int
-	warmENITarget                  int
-	warmIPTarget                   int
-	minimumIPTarget                int
-	warmPrefixTarget               int
-	primaryIP                      map[string]string // primaryIP is a map from ENI ID to primary IP of that ENI
-	lastNodeIPPoolAction           time.Time
-	lastDecreaseIPPool             time.Time
+	awsClient                 awsutils.APIs
+	dataStore                 *datastore.DataStore
+	rawK8SClient              client.Client
+	cachedK8SClient           client.Client
+	enableIPv4                bool
+	enableIPv6                bool
+	useCustomNetworking       bool
+	manageENIsNonScheduleable bool
+	networkClient             networkutils.NetworkAPIs
+	maxIPsPerENI              int
+	maxENI                    int
+	maxPrefixesPerENI         int
+	unmanagedENI              int
+	warmENITarget             int
+	warmIPTarget              int
+	minimumIPTarget           int
+	warmPrefixTarget          int
+	primaryIP                 map[string]string // primaryIP is a map from ENI ID to primary IP of that ENI
+	lastNodeIPPoolAction      time.Time
+	lastDecreaseIPPool        time.Time
 	// reconcileCooldownCache keeps timestamps of the last time an IP address was unassigned from an ENI,
 	// so that we don't reconcile and add it back too quickly if IMDS lags behind reality.
 	reconcileCooldownCache    ReconcileCooldownCache
@@ -2312,6 +2312,7 @@ func (c *IPAMContext) initENIAndIPLimits() (err error) {
 
 func (c *IPAMContext) isConfigValid() bool {
 	//Validate that only one among v4 and v6 is enabled.
+	if c.enableIPv4 && c.enableIPv6 {
 		log.Errorf("IPv4 and IPv6 are both enabled. VPC CNI currently doesn't support dual stack mode")
 		return false
 	} else if !c.enableIPv4 && !c.enableIPv6 {


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2265

**What does this PR do / Why do we need it**:
TLDR, we need the ipamd to allocate pod IP from non primary ENI on a scheduling disabled node to run a key cluster daemonset component. 
Details regarding the bug can be found under the [issue](https://github.com/aws/amazon-vpc-cni-k8s/issues/2265)

**Testing done on this change**:
Tested with unit test `TestIncreaseIPPoolCustomENIOnNonSchedulableNode`.
<img width="705" alt="image" src="https://user-images.githubusercontent.com/6300095/222046734-1a249fad-a9f5-473c-afba-94560772ddcf.png">

**Automation added to e2e**:
No

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note
ipamd can manage ENIs on nonschedulable node when `AWS_VPC_K8S_CNI_MANAGE_ENIS_ON_NON_SCHEDULABLE_NODE` is set to `true`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
