### PR TITLE
Set Kubeconfig path for running kops tests 

### DIFF
--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -1,6 +1,7 @@
 name: Weekly Cron tests
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: "0 16 * * 3" # every Wednesday
 

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -104,7 +104,7 @@ function up-kops-cluster {
 
     # kOps cluster by default comes with ebs-csi-node and coredns-autoscaler as an add-on which cannot be excluded on cluster creation
     # Since CNI tests don't really need any of these components for running tests, we delete these to avoid any flakiness
-
+    export KUBECONFIG=~/.kube/config
     kubectl delete daemonset ebs-csi-node -n kube-system
     kubectl delete deployment coredns-autoscaler -n kube-system
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
The weekly test fails with variable undefined error. This explicitly sets the KUBECONFIG path and passes it to the test

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A
**Testing done on this change**: 
N/A
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
