### PR TITLE
Run Integration Tests against latest EKS version.

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -19,8 +19,8 @@ OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
 
 : "${AWS_DEFAULT_REGION:=us-west-2}"
-: "${K8S_VERSION:=1.21.2}"
-: "${EKS_CLUSTER_VERSION:=1.21}"
+: "${K8S_VERSION:=1.25.7}"
+: "${EKS_CLUSTER_VERSION:=1.25}"
 : "${PROVISION:=true}"
 : "${DEPROVISION:=true}"
 : "${BUILD:=true}"


### PR DESCRIPTION
**What type of PR is this?**

Bug / 

**Which issue does this PR fix**:

* Test against latest EKS version


**What does this PR do / Why do we need it**:

I noticed nightly cron test https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/4310188116/jobs/7518375515 

failing with 

```
 Copying test cluster config to /home/runner/work/amazon-vpc-cni-k8s/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-4419/cni-test-4419.yaml
Error: invalid version, 1.21 is no longer supported, supported values: 1.22, 1.23, 1.24, 1.25
see also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

```

* https://dl.k8s.io/v1.25.7/kubernetes-test-linux-amd64.tar.gz - substitution works.
* EKS 1.25 is available as given by the output int the error message.



**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
