### PR TITLE
Fix perf test in weekly integration test suite

### DIFF
--- a/scripts/test/config/perf-cluster.yml
+++ b/scripts/test/config/perf-cluster.yml
@@ -10,6 +10,7 @@ metadata:
 managedNodeGroups:
   - name: cni-test-single-node-mng
     ami: AMI_ID_PLACEHOLDER
+    amiFamily: AmazonLinux2
     instanceType: m5.16xlarge
     desiredCapacity: 1
     minSize: 1


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds the `amiFamily` parameter to the `eksctl` config script used for perf integration tests. This attribute is needed when passing custom AMI with newer versions of `eksctl`.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
None, fixing test

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
