### PR TITLE
Run cni release test for deveks

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -7,6 +7,14 @@ function load_cluster_details() {
   K8S_VERSION=$(echo "$DESCRIBE_CLUSTER_OP" | jq .cluster.version -r)
 }
 
+function load_deveks_cluster_details() {
+
+  echo "loading cluster details $CLUSTER_NAME"
+  PROVIDER_ID=$(kubectl get nodes --kubeconfig $KUBE_CONFIG_PATH -ojson | jq -r '.items[0].spec.providerID')
+  INSTANCE_ID=${PROVIDER_ID##*/}
+  VPC_ID=$(aws ec2 describe-instances --instance-ids ${INSTANCE_ID} --no-cli-pager | jq -r '.Reservations[].Instances[].VpcId')
+}
+
 function down-test-cluster() {
     echo -n "Deleting cluster  (this may take ~10 mins) ... "
     eksctl delete cluster $CLUSTER_NAME >>$CLUSTER_MANAGE_LOG_PATH 2>&1 ||

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -9,6 +9,7 @@
 # KUBE_CONFIG_PATH: path to the kubeconfig file, default ~/.kube/config
 # NG_LABEL_KEY: nodegroup label key, default "kubernetes.io/os"
 # NG_LABEL_VAL: nodegroup label val, default "linux"
+# RUN_DEVEKS_TEST: Set this variable for tests to run on a deveks cluster
 # CNI_METRICS_HELPER: cni metrics helper image tag, default "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.12.6"
 
 set -e
@@ -53,7 +54,12 @@ fi
 
 echo "Running release tests on cluster: $CLUSTER_NAME in region: $REGION"
 
-load_cluster_details
+if [[ -z $RUN_DEVEKS_TEST ]]; then
+  load_cluster_details
+else
+  load_deveks_cluster_details
+fi
+
 START=$SECONDS
 run_integration_test
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
To get cluster information during integration tests on deveks cluster

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Yes
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
