### PR TITLE
Handle pod deletion when PrevResult has VLAN 0

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -431,8 +431,12 @@ func tryDelWithPrevResult(driverClient driver.NetworkAPIs, conf *NetConf, k8sArg
 		return false, nil
 	}
 	podVlanID, err := strconv.Atoi(dummyIface.Mac)
-	if err != nil || podVlanID == 0 {
+	if err != nil {
 		return true, errors.Errorf("malformed vlanID in prevResult: %s", dummyIface.Mac)
+	}
+	// If VLAN value is 0, return without handling so that normal delete logic can occur.
+	if podVlanID == 0 {
+		return false, nil
 	}
 	if isNetnsEmpty(netNS) {
 		log.Infof("Ignoring TeardownPodENI as Netns is empty for SG pod:%s namespace: %s containerID:%s", k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_INFRA_CONTAINER_ID)

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -47,9 +47,11 @@ import (
 	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
 )
 
-const ipamdAddress = "127.0.0.1:50051"
-
-const dummyVlanInterfacePrefix = "dummy"
+const (
+	ipamdAddress             = "127.0.0.1:50051"
+	dummyVlanInterfacePrefix = "dummy"
+	reservedVlanID           = 0
+)
 
 var version string
 
@@ -214,7 +216,7 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	var dummyVlanInterface *current.Interface
 
 	// Non-zero value means pods are using branch ENI
-	if r.PodVlanId != 0 {
+	if r.PodVlanId != reservedVlanID {
 		hostVethNamePrefix := sgpp.BuildHostVethNamePrefix(conf.VethPrefix, conf.PodSGEnforcingMode)
 		hostVethName = generateHostVethName(hostVethNamePrefix, string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 		err = driverClient.SetupBranchENIPodNetwork(hostVethName, args.IfName, args.Netns, v4Addr, v6Addr, int(r.PodVlanId), r.PodENIMAC,
@@ -395,7 +397,7 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		}
 
 		// vlanID != 0 means pod using security group
-		if r.PodVlanId != 0 {
+		if r.PodVlanId != reservedVlanID {
 			if isNetnsEmpty(args.Netns) {
 				log.Infof("Ignoring TeardownPodENI as Netns is empty for SG pod:%s namespace: %s containerID:%s", k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_INFRA_CONTAINER_ID)
 				return nil
@@ -435,7 +437,7 @@ func tryDelWithPrevResult(driverClient driver.NetworkAPIs, conf *NetConf, k8sArg
 		return true, errors.Errorf("malformed vlanID in prevResult: %s", dummyIface.Mac)
 	}
 	// If VLAN value is 0, return without handling so that normal delete logic can occur.
-	if podVlanID == 0 {
+	if podVlanID == reservedVlanID {
 		return false, nil
 	}
 	if isNetnsEmpty(netNS) {

--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -604,7 +604,7 @@ func Test_tryDelWithPrevResult(t *testing.T) {
 			wantErr: errors.New("malformed vlanID in prevResult: xxx"),
 		},
 		{
-			name:   "malformed vlanID in prevResult - 0",
+			name:   "vlanID in prevResult - 0",
 			fields: fields{},
 			args: args{
 				conf: &NetConf{
@@ -643,7 +643,7 @@ func Test_tryDelWithPrevResult(t *testing.T) {
 				},
 				contVethName: "eth0",
 			},
-			wantErr: errors.New("malformed vlanID in prevResult: 0"),
+			want: false,
 		},
 		{
 			name:   "confVeth don't exists",


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#2321 

**What does this PR do / Why do we need it**:
This PR handles the case where a pod being deleted has a PrevResult entry with a VLAN of 0. This fix is needed in the 1.11 release train so that if a customer creates a pod with v1.12.1+ and then decides they need to downgrade to 1.11, the pod can be deleted without issue. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually created pods with v1.12.1+, then downgraded to an image with this change and verified that pods could be deleted. Also verified that integration tests pass.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Handle pod deletion when PrevResult has VLAN 0 in 1.11 release train
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
