### PR TITLE
add AWS_EC2_ENDPOINT variable for custom endpoint (#2317)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,14 @@ Default: empty
 Specify a comma-separated list of IPv4 CIDRs that *must* be routed via main routing table. This is required for secondary ENIs to reach endpoints outside of VPC that are backed by a service.
 For every item in the list, an `ip rule` will be created with a priority greater than the `ip rule` capturing egress traffic from the container. If an item is not a valid IPv4 CIDR, it will be skipped.
 
+#### `AWS_EC2_ENDPOINT` (v1.13.0+)
+
+Type: String
+
+Default: empty
+
+Specify the EC2 endpoint to use. This is useful if you are using a custom endpoint for EC2. For example, if you are using a proxy for EC2, you can set this to the proxy endpoint.
+
 ### VPC CNI Feature Matrix
 
 IP Mode | Secondary IP Mode | Prefix Delegation | Security Groups Per Pod | WARM & MIN IP/Prefix Targets | External SNAT

--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Type: String
 
 Default: empty
 
-Specify the EC2 endpoint to use. This is useful if you are using a custom endpoint for EC2. For example, if you are using a proxy for EC2, you can set this to the proxy endpoint.
+Specify the EC2 endpoint to use. This is useful if you are using a custom endpoint for EC2. For example, if you are using a proxy for EC2, you can set this to the proxy endpoint. Any kind of URL or IP address is valid such as `https://localhost:8080` or `http://ec2.us-west-2.customaws.com`. If this is not set, the default EC2 endpoint will be used.
 
 ### VPC CNI Feature Matrix
 

--- a/pkg/awsutils/awssession/session.go
+++ b/pkg/awsutils/awssession/session.go
@@ -72,8 +72,7 @@ func New() *session.Session {
 		customResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 			if service == ec2.EndpointsID {
 				return endpoints.ResolvedEndpoint{
-					URL:           endpoint,
-					SigningRegion: region,
+					URL: endpoint,
 				}, nil
 			}
 			return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)

--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -25,15 +25,13 @@ func TestHttpTimeoutWithValueAbove10(t *testing.T) {
 
 func TestAwsEc2EndpointResolver(t *testing.T) {
 	customEndpoint := "https://ec2.us-west-2.customaws.com"
-	region := "us-west-2"
 
 	os.Setenv("AWS_EC2_ENDPOINT", customEndpoint)
 	defer os.Unsetenv("AWS_EC2_ENDPOINT")
 
 	sess := New()
 
-	resolvedEndpoint, err := sess.Config.EndpointResolver.EndpointFor(ec2.EndpointsID, region)
+	resolvedEndpoint, err := sess.Config.EndpointResolver.EndpointFor(ec2.EndpointsID, "")
 	assert.NoError(t, err)
 	assert.Equal(t, customEndpoint, resolvedEndpoint.URL)
-	assert.Equal(t, region, resolvedEndpoint.SigningRegion)
 }

--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,4 +21,19 @@ func TestHttpTimeoutWithValueAbove10(t *testing.T) {
 	defer os.Unsetenv(httpTimeoutEnv)
 	expectedHTTPTimeOut := time.Duration(12) * time.Second
 	assert.Equal(t, expectedHTTPTimeOut, getHTTPTimeout())
+}
+
+func TestAwsEc2EndpointResolver(t *testing.T) {
+	customEndpoint := "https://ec2.us-west-2.customaws.com"
+	region := "us-west-2"
+
+	os.Setenv("AWS_EC2_ENDPOINT", customEndpoint)
+	defer os.Unsetenv("AWS_EC2_ENDPOINT")
+
+	sess := New()
+
+	resolvedEndpoint, err := sess.Config.EndpointResolver.EndpointFor(ec2.EndpointsID, region)
+	assert.NoError(t, err)
+	assert.Equal(t, customEndpoint, resolvedEndpoint.URL)
+	assert.Equal(t, region, resolvedEndpoint.SigningRegion)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
-->
feature

**Which issue does this PR fix**:

#2317 

**What does this PR do / Why do we need it**:

This PR enables the usage of a custom endpoint for AWS API requests by reading the 'AWS_EC2_ENDPOINT' environment variable. This feature is particularly useful for testing environments that are compatible with the AWS API.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually verified that kubernetes cluster version 1.25.6 on testing environment. 

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note
Enable to configure a custom endpoint for EC2 service
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
