### PR TITLE
adding ip check for annotatePod in ipamd

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2051,7 +2051,7 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 }
 
 // AnnotatePod annotates the pod with the provided key and value
-func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val, ip string) error {
+func (c *IPAMContext) AnnotatePod(podName string, podNamespace string, key string, newVal string, releasedIP string) error {
 	ctx := context.TODO()
 	var err error
 
@@ -2070,26 +2070,30 @@ func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val, ip string) er
 			newPod.Annotations = make(map[string]string)
 		}
 		// On CNI ADD, always set new annotation
-		if val != ""{
-			newPod.Annotations[key] = val
+		oldVal, ok := newPod.Annotations[key]
+		if newVal != "" {
+			//If the new pod annotation is as the same as the old one, return immediately without extra cost
+			if ok && oldVal == newVal {
+				log.Infof("Patch updating not needed")
+				return nil
+			}
+			newPod.Annotations[key] = newVal
 		} else {
 			// On CNI DEL, set annotation to empty string if IP is the one we are releasing
-			oldVal, ok := newPod.Annotations[key]
 			if ok {
 				log.Debugf("Existing annotation value: %s", oldVal)
-				if oldVal != ip {
-					log.Debugf("Released IP %s does not match existing annotation. Not patching pod.", ip)
-					return fmt.Errorf("Released IP %s does not match existing annotation. Not patching pod.", ip)
+				if oldVal != releasedIP {
+					return fmt.Errorf("Released IP %s does not match existing annotation. Not patching pod.", releasedIP)
 				}
 				newPod.Annotations[key] = ""
 			}
 		}
 
 		if err = c.rawK8SClient.Patch(ctx, newPod, client.MergeFrom(pod)); err != nil {
-			log.Errorf("Failed to annotate %s the pod with %s, error %v", key, val, err)
+			log.Errorf("Failed to annotate %s the pod with %s, error %v", key, newVal, err)
 			return err
 		}
-		log.Debugf("Annotates pod %s with %s: %s", podName, key, val)
+		log.Debugf("Annotates pod %s with %s: %s", podName, key, newVal)
 		return nil
 	})
 

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2051,7 +2051,7 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 }
 
 // AnnotatePod annotates the pod with the provided key and value
-func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val string) error {
+func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val, ip string) error {
 	ctx := context.TODO()
 	var err error
 
@@ -2069,7 +2069,22 @@ func (c *IPAMContext) AnnotatePod(podName, podNamespace, key, val string) error 
 		if newPod.Annotations == nil {
 			newPod.Annotations = make(map[string]string)
 		}
-		newPod.Annotations[key] = val
+		// On CNI ADD, always set new annotation
+		if val != ""{
+			newPod.Annotations[key] = val
+		} else {
+			// On CNI DEL, set annotation to empty string if IP is the one we are releasing
+			oldVal, ok := newPod.Annotations[key]
+			if ok {
+				log.Debugf("Existing annotation value: %s", oldVal)
+				if oldVal != ip {
+					log.Debugf("Released IP %s does not match existing annotation. Not patching pod.", ip)
+					return fmt.Errorf("Released IP %s does not match existing annotation. Not patching pod.", ip)
+				}
+				newPod.Annotations[key] = ""
+			}
+		}
+
 		if err = c.rawK8SClient.Patch(ctx, newPod, client.MergeFrom(pod)); err != nil {
 			log.Errorf("Failed to annotate %s the pod with %s, error %v", key, val, err)
 			return err

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2069,10 +2069,12 @@ func (c *IPAMContext) AnnotatePod(podName string, podNamespace string, key strin
 		if newPod.Annotations == nil {
 			newPod.Annotations = make(map[string]string)
 		}
-		// On CNI ADD, always set new annotation
+
 		oldVal, ok := newPod.Annotations[key]
+
+		// On CNI ADD, always set new annotation
 		if newVal != "" {
-			//If the new pod annotation is as the same as the old one, return immediately without extra cost
+			// Skip patch operation if new value is the same as existing value
 			if ok && oldVal == newVal {
 				log.Infof("Patch updating not needed")
 				return nil

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -2345,14 +2345,12 @@ func TestIsConfigValid(t *testing.T) {
 
 }
 
-
-func TestAnnotatePod(t *testing.T){
-	//Createa fake IPAMContext object for testing
+func TestAnnotatePod(t *testing.T) {
 	m := setup(t)
 	defer m.ctrl.Finish()
 	ctx := context.Background()
 
-	// Test ADD opreation
+	// Define the Pod objects to test
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -2364,10 +2362,6 @@ func TestAnnotatePod(t *testing.T){
 		awsClient:       m.awsutils,
 		rawK8SClient:    m.rawK8SClient,
 		cachedK8SClient: m.cachedK8SClient,
-		maxIPsPerENI:    14,
-		maxENI:          4,
-		warmENITarget:   1,
-		warmIPTarget:    3,
 		primaryIP:       make(map[string]string),
 		terminating:     int32(0),
 		networkClient:   m.network,
@@ -2378,63 +2372,56 @@ func TestAnnotatePod(t *testing.T){
 
 	mockContext.rawK8SClient.Create(ctx, &pod)
 
-	testPod, err := mockContext.GetPod(pod.Name, pod.Namespace)
+	ipOne := "10.0.0.1"
+	ipTwo := "10.0.0.2"
+	ipThree := "10.0.0.3"
 
-	assert.NoError(t, err)
-	assert.NotNil(t, testPod)
-
-	// add, should add, shouldn.t add, should delete , shouldn't delete
-
-	// Test ADD operation
-	// add always success
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "10.0.0.1", "")
+	//Test basic add operation for new pod
+	err := mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipOne, "")
 	assert.NoError(t, err)
 
 	updatedPod, err := mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
-	assert.Equal(t, "10.0.0.1", updatedPod.Annotations["ip-address"])
+	assert.Equal(t, ipOne, updatedPod.Annotations["ip-address"])
 
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "10.0.0.2", "")
+	//Test that add operation is idempotent
+	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipOne, "")
 	assert.NoError(t, err)
 
 	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
-	assert.Equal(t, "10.0.0.2", updatedPod.Annotations["ip-address"])
+	assert.Equal(t, ipOne, updatedPod.Annotations["ip-address"])
 
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "10.0.0.3", "10.0.0.2")
+	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipTwo, "")
 	assert.NoError(t, err)
 
 	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
-	assert.Equal(t, "10.0.0.3", updatedPod.Annotations["ip-address"])
+	assert.Equal(t, ipTwo, updatedPod.Annotations["ip-address"])
 
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "10.0.0.4", "10.0.0.2")
+	//Test that add operation always overwrites value for existing pod
+	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipThree, ipTwo)
 	assert.NoError(t, err)
 
-	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
-	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
-	assert.Equal(t, "10.0.0.4", updatedPod.Annotations["ip-address"])
-
-	// Test DEL operation
-	// shouldn't delete
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", "10.0.0.1")
+	//Test that delete operation will not overwrite if IP being released does not match existing value
+	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", ipOne)
 	assert.Error(t, err)
+	assert.Equal(t, fmt.Errorf("Released IP 10.0.0.1 does not match existing annotation. Not patching pod."), err)
 
 	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
-	assert.Equal(t, "10.0.0.4", updatedPod.Annotations["ip-address"])
+	assert.Equal(t, ipThree, updatedPod.Annotations["ip-address"])
 
-	// should delete
-	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", "10.0.0.4")
+	//Test that delete operation succeeds when IP being released matches existing value
+	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", ipThree)
 	assert.NoError(t, err)
 
 	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	assert.NotNil(t, updatedPod.Annotations["ip-address"])
 	assert.Equal(t, "", updatedPod.Annotations["ip-address"])
+
+	//Test that delete on a non-existant pod fails without crashing
+	err = mockContext.AnnotatePod("no-exist-name", "no-exist-namespace", "ip-address", "", ipThree)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Errorf("error while trying to retrieve pod info: pods \"no-exist-name\" not found"), err)
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -2376,7 +2376,7 @@ func TestAnnotatePod(t *testing.T) {
 	ipTwo := "10.0.0.2"
 	ipThree := "10.0.0.3"
 
-	//Test basic add operation for new pod
+	// Test basic add operation for new pod
 	err := mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipOne, "")
 	assert.NoError(t, err)
 
@@ -2384,7 +2384,7 @@ func TestAnnotatePod(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ipOne, updatedPod.Annotations["ip-address"])
 
-	//Test that add operation is idempotent
+	// Test that add operation is idempotent
 	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipOne, "")
 	assert.NoError(t, err)
 
@@ -2399,20 +2399,20 @@ func TestAnnotatePod(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ipTwo, updatedPod.Annotations["ip-address"])
 
-	//Test that add operation always overwrites value for existing pod
+	// Test that add operation always overwrites value for existing pod
 	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", ipThree, ipTwo)
 	assert.NoError(t, err)
 
-	//Test that delete operation will not overwrite if IP being released does not match existing value
+	// Test that delete operation will not overwrite if IP being released does not match existing value
 	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", ipOne)
 	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("Released IP 10.0.0.1 does not match existing annotation. Not patching pod."), err)
+	assert.Equal(t, fmt.Errorf("Released IP %s does not match existing annotation. Not patching pod.", ipOne), err)
 
 	updatedPod, err = mockContext.GetPod(pod.Name, pod.Namespace)
 	assert.NoError(t, err)
 	assert.Equal(t, ipThree, updatedPod.Annotations["ip-address"])
 
-	//Test that delete operation succeeds when IP being released matches existing value
+	// Test that delete operation succeeds when IP being released matches existing value
 	err = mockContext.AnnotatePod(pod.Name, pod.Namespace, "ip-address", "", ipThree)
 	assert.NoError(t, err)
 
@@ -2420,7 +2420,7 @@ func TestAnnotatePod(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", updatedPod.Annotations["ip-address"])
 
-	//Test that delete on a non-existant pod fails without crashing
+	// Test that delete on a non-existant pod fails without crashing
 	err = mockContext.AnnotatePod("no-exist-name", "no-exist-namespace", "ip-address", "", ipThree)
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("error while trying to retrieve pod info: pods \"no-exist-name\" not found"), err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -179,6 +179,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
+		//on ADD, we pass empty string as there is no IP being released
 		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr, "")
 	}
 	resp := rpc.AddNetworkReply{
@@ -273,7 +274,11 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "", ip)
+		//on DEL, we pass IP being released
+		err = s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "", ip)
+		if err != nil {
+			log.Errorf("Failed to delete the pod annotation: %v", err)
+		}
 	}
 
 	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -179,7 +179,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
-		//on ADD, we pass empty string as there is no IP being released
+		// On ADD, we pass empty string as there is no IP being released
 		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr, "")
 	}
 	resp := rpc.AddNetworkReply{
@@ -274,7 +274,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
-		//on DEL, we pass IP being released
+		// On DEL, we pass IP being released
 		err = s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "", ip)
 		if err != nil {
 			log.Errorf("Failed to delete the pod annotation: %v", err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -180,7 +180,10 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 
 	if s.ipamContext.enablePodIPAnnotation {
 		// On ADD, we pass empty string as there is no IP being released
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr, "")
+		err = s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr, "")
+		if err != nil {
+			log.Errorf("Failed to add the pod annotation: %v", err)
+		}
 	}
 	resp := rpc.AddNetworkReply{
 		Success:         err == nil,

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -179,7 +179,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr)
+		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, ipv4Addr, "")
 	}
 	resp := rpc.AddNetworkReply{
 		Success:         err == nil,
@@ -273,7 +273,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 	}
 
 	if s.ipamContext.enablePodIPAnnotation {
-		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "")
+		s.ipamContext.AnnotatePod(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, vpccniPodIPKey, "", ip)
 	}
 
 	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#2281 

**What does this PR do / Why do we need it**:
This PR adds a check login in annotatePod() of ipamd.go to make sure when deleting the Pod IP, the IP is the one we are releasing.

**Testing done on this change**:
New unit test added in ipamd_test.go. Both unit tests and integration tests passed.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
