### PR TITLE
Remove check for initial state; switch CNI and IPAMD test order

### DIFF
--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -23,15 +23,17 @@ function run_integration_test() {
   : "${NG_LABEL_KEY:=kubernetes.io/os}"
   : "${NG_LABEL_VAL:=linux}"
   TEST_RESULT=success
-  echo "Running cni integration tests"
-  START=$SECONDS
-  cd $INTEGRATION_TEST_DIR/cni && CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v -timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
-  echo "cni test took $((SECONDS - START)) seconds."
+
   echo "Running ipamd integration tests"
   START=$SECONDS
   # NOTE: skipping ipamd_event_test.go until it can be triaged further
   cd $INTEGRATION_TEST_DIR/ipamd && CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --skip-file=ipamd_event_test.go -v -timeout 90m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
   echo "ipamd test took $((SECONDS - START)) seconds."
+
+  echo "Running cni integration tests"
+  START=$SECONDS
+  cd $INTEGRATION_TEST_DIR/cni && CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v -timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" || TEST_RESULT=fail
+  echo "cni test took $((SECONDS - START)) seconds."
 
   : "${CNI_METRICS_HELPER:=602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.12.6}"
   REPO_NAME=$(echo $CNI_METRICS_HELPER | cut -d ":" -f 1)

--- a/test/integration/common/util.go
+++ b/test/integration/common/util.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -200,20 +199,4 @@ func ValidateTraffic(f *framework.Framework, serverDeploymentBuilder *manifest.D
 	successRate, err := trafficTester.TestTraffic()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(successRate).Should(BeNumerically(">=", succesRate))
-
-}
-
-func WaitToReconcileInitialState(f *framework.Framework, primaryInstance *ec2.Instance, defaultEniCount int, defaultIpsPerEni int, DefaultPrefixPerEni int) {
-	By("Verifying number of enis, ips and ip prefixes before updating the parameters")
-	Eventually(func(g Gomega) {
-		primaryInstance, err := f.CloudServices.
-			EC2().DescribeInstance(*primaryInstance.InstanceId)
-
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(len(primaryInstance.NetworkInterfaces)).Should(Equal(defaultEniCount))
-		g.Expect(len(primaryInstance.NetworkInterfaces[0].PrivateIpAddresses)).
-			Should(Equal(defaultIpsPerEni))
-		g.Expect(len(primaryInstance.NetworkInterfaces[0].Ipv4Prefixes)).
-			Should(Equal(DefaultPrefixPerEni))
-	}).WithTimeout(time.Minute * 3).WithPolling(30 * time.Second).Should(Succeed())
 }

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -32,13 +32,10 @@ import (
 var primaryInstance *ec2.Instance
 var f *framework.Framework
 var err error
-var defaultEniCount int
-var defaultIpsPerEni int
 
 const (
 	CoreDNSDeploymentName = "coredns"
 	KubeSystemNamespace   = "kube-system"
-	DefaultPrefixPerEni   = 0
 )
 
 var coreDNSDeploymentCopy *v1.Deployment
@@ -104,12 +101,6 @@ var _ = BeforeSuite(func() {
 	instanceID = k8sUtils.GetInstanceIDFromNode(*primaryNode)
 	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
 	Expect(err).ToNot(HaveOccurred())
-
-	primaryInstanceDefaults, err := f.CloudServices.EC2().DescribeInstanceType(*primaryInstance.InstanceType)
-	Expect(err).ToNot(HaveOccurred())
-
-	defaultEniCount = len(primaryInstanceDefaults[0].NetworkInfo.NetworkCards)
-	defaultIpsPerEni = int(*primaryInstanceDefaults[0].NetworkInfo.Ipv4AddressesPerInterface)
 
 	// Set default values- WARM_ENI_TARGET to 1, and remove WARM_IP_TARGET, MINIMUM_IP_TARGET and WARM_PREFIX_TARGET
 	k8sUtils.UpdateEnvVarOnDaemonSetAndWaitUntilReady(f, "aws-node", "kube-system",

--- a/test/integration/ipamd/warm_target_test.go
+++ b/test/integration/ipamd/warm_target_test.go
@@ -18,7 +18,6 @@ import (
 
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
-	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,9 +33,6 @@ var _ = Describe("test warm target variables", func() {
 		var maxENI int
 
 		JustBeforeEach(func() {
-			common.WaitToReconcileInitialState(f, primaryInstance,
-				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
-
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
 				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
 				map[string]string{
@@ -95,10 +91,6 @@ var _ = Describe("test warm target variables", func() {
 		var minIPTarget int
 
 		JustBeforeEach(func() {
-
-			common.WaitToReconcileInitialState(f, primaryInstance,
-				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
-
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
 				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,

--- a/test/integration/ipamd/warm_target_test_PD_enabled.go
+++ b/test/integration/ipamd/warm_target_test_PD_enabled.go
@@ -19,7 +19,6 @@ import (
 
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
-	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,9 +34,6 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
-
-			common.WaitToReconcileInitialState(f, primaryInstance,
-				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
@@ -127,9 +123,6 @@ var _ = Describe("test warm target variables", func() {
 		var warmPrefixTarget int
 
 		JustBeforeEach(func() {
-			common.WaitToReconcileInitialState(f, primaryInstance,
-				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
-
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,
 				utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName,
@@ -178,9 +171,6 @@ var _ = Describe("test warm target variables", func() {
 
 		JustBeforeEach(func() {
 			var availPrefixes int
-
-			common.WaitToReconcileInitialState(f, primaryInstance,
-				defaultEniCount, defaultIpsPerEni, DefaultPrefixPerEni)
 
 			// Set the WARM IP TARGET
 			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f,


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR removes some initial state checks in IPAMD warm target tests. These checks should not be needed, as test cases should converge to the right result on their own. They also slow the tests down a bit. I also switched the order of IPAMD and CNI integration test runs in the release test suite.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Verified that tests pass locally

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
