### PR TITLE
Make all the aws vpc cni environmental variables case insensitive

### DIFF
--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper"
+	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/cp"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/imds"
 	"github.com/pkg/errors"
@@ -26,22 +27,17 @@ import (
 )
 
 const (
-	defaultHostCNIBinPath = "/host/opt/cni/bin"
-	vpcCniInitDonePath    = "/vpc-cni-init/done"
-	metadataLocalIP       = "local-ipv4"
-	metadataMAC           = "mac"
+	defaultHostCNIBinPath           = "/host/opt/cni/bin"
+	vpcCniInitDonePath              = "/vpc-cni-init/done"
+	metadataLocalIP                 = "local-ipv4"
+	metadataMAC                     = "mac"
+	defaultDisableIPv4TcpEarlyDemux = false
+	defaultEnableIPv6               = false
 
 	envDisableIPv4TcpEarlyDemux = "DISABLE_TCP_EARLY_DEMUX"
 	envEnableIPv6               = "ENABLE_IPv6"
 	envHostCniBinPath           = "HOST_CNI_BIN_PATH"
 )
-
-func getEnv(env, defaultVal string) string {
-	if val, ok := os.LookupEnv(env); ok {
-		return val
-	}
-	return defaultVal
-}
 
 func getNodePrimaryIF() (string, error) {
 	var primaryIF string
@@ -83,8 +79,8 @@ func configureSystemParams(procSys procsyswrapper.ProcSys, primaryIF string) err
 	// Note that older kernels may not support tcp_early_demux, so we must first check that it exists.
 	entry = "net/ipv4/tcp_early_demux"
 	if _, err := procSys.Get(entry); err == nil {
-		disableIPv4EarlyDemux := getEnv(envDisableIPv4TcpEarlyDemux, "false")
-		if disableIPv4EarlyDemux == "true" {
+		disableIPv4EarlyDemux := utils.GetBoolAsStringEnvVar(envDisableIPv4TcpEarlyDemux, defaultDisableIPv4TcpEarlyDemux)
+		if disableIPv4EarlyDemux {
 			err = procSys.Set(entry, "0")
 			if err != nil {
 				return errors.Wrap(err, "Failed to disable tcp_early_demux")
@@ -105,8 +101,8 @@ func configureIPv6Settings(procSys procsyswrapper.ProcSys, primaryIF string) err
 	var err error
 	// Enable IPv6 when environment variable is set
 	// Note that IPv6 is not disabled when environment variable is unset. This is omitted to preserve default host semantics.
-	enableIPv6 := getEnv(envEnableIPv6, "false")
-	if enableIPv6 == "true" {
+	enableIPv6 := utils.GetBoolAsStringEnvVar(envEnableIPv6, defaultEnableIPv6)
+	if enableIPv6 {
 		entry := "net/ipv6/conf/all/disable_ipv6"
 		err = procSys.Set(entry, "0")
 		if err != nil {
@@ -150,7 +146,7 @@ func _main() int {
 	}
 
 	log.Infof("Copying CNI plugin binaries ...")
-	hostCNIBinPath := getEnv(envHostCniBinPath, defaultHostCNIBinPath)
+	hostCNIBinPath := utils.GetEnv(envHostCniBinPath, defaultHostCNIBinPath)
 	err = cp.InstallBinaries(pluginBins, hostCNIBinPath)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to install binaries")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Parse environment variable and return boolean representation of string, or default value if environment variable is unset
+func GetBoolAsStringEnvVar(env string, defaultVal bool) bool {
+	if val, ok := os.LookupEnv(env); ok {
+		parsedVal, err := strconv.ParseBool(val)
+		if err == nil {
+			return parsedVal
+		}
+		log.Errorf("Failed to parse variable %s with value %s as boolean", env, val)
+		return defaultVal
+	}
+	// Environment variable is not set, so return default value
+	return defaultVal
+}
+
+// If environment variable is set, return set value, otherwise return default value
+func GetEnv(env, defaultVal string) string {
+	if val, ok := os.LookupEnv(env); ok {
+		return val
+	}
+	return defaultVal
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultPathEnv = "/host/opt/cni/bin"
+	defaultBoolEnv = false
+
+	envPath = "Path"
+	envBool = "Bool"
+)
+
+// Validate that GetBoolAsStringEnvVar runs against acceptable format input without error
+func TestGetBoolAsStringEnvVar(t *testing.T) {
+	// Test environment flag variable not set
+	tmp := GetBoolAsStringEnvVar(envBool, defaultBoolEnv)
+	assert.Equal(t, tmp, defaultBoolEnv)
+
+	// Test basic Boolean as string set with acceptable format
+	os.Setenv(envBool, "True")
+	tmp = GetBoolAsStringEnvVar(envBool, defaultBoolEnv)
+	assert.Equal(t, tmp, true)
+
+	// Test basic Boolean as string set with unacceptable format
+	os.Setenv(envBool, "TrUe")
+	defer os.Unsetenv(envBool)
+	tmp = GetBoolAsStringEnvVar(envBool, defaultBoolEnv)
+	assert.Equal(t, tmp, defaultBoolEnv)
+}
+
+// Validate that GetEnv runs without error against environment variable with type other than boolean as string
+func TestGetEnv(t *testing.T) {
+	// Test environment flag variable not set
+	tmp := GetEnv(envPath, defaultPathEnv)
+	assert.Equal(t, tmp, defaultPathEnv)
+
+	// Test environment flag variable set
+	os.Setenv(envPath, "/host/opt/cni/bin/test")
+	defer os.Unsetenv(envPath)
+	tmp = GetEnv(envPath, defaultPathEnv)
+	assert.Equal(t, tmp, "/host/opt/cni/bin/test")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#2311 

**What does this PR do / Why do we need it**:
Originally, we have several aws-vpc-cni environmental variables with the type Boolean as a String which against good coding standards. Having case insensitive values for Boolean can avoid users meet situation that spend 2+ weeks to figure out the case sensitivity cause the problem.

**Testing done on this change**:
Manually tested the code change in testing cluster with setting environmental variables in case insensitivity. Both unit tests and integration tests passed

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
