### PR TITLE
feat(chart): Refactored image template logic for endpoint flexibility

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -41,17 +41,19 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.tag`             | Image tag                                               | `v1.12.6`                           |
-| `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
+| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
+| `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.tag`        | Image tag                                               | `v1.12.6`                           |
-| `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
+| `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
+| `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |
 | `init.image.override`   | A custom docker image to use                            | `nil`                               |
 | `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |

--- a/charts/aws-vpc-cni/templates/_helpers.tpl
+++ b/charts/aws-vpc-cni/templates/_helpers.tpl
@@ -55,3 +55,25 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The aws-vpc-cni-init image to use
+*/}}
+{{- define "aws-vpc-cni.initImage" -}}
+{{- if .Values.init.image.override }}
+{{- .Values.init.image.override }}
+{{- else }}
+{{- printf "%s.dkr.%s.%s.%s/amazon-k8s-cni-init:%s" .Values.init.image.account .Values.init.image.endpoint .Values.init.image.region .Values.init.image.domain .Values.init.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+The aws-vpc-cni image to use
+*/}}
+{{- define "aws-vpc-cni.image" -}}
+{{- if .Values.image.override }}
+{{- .Values.image.override }}
+{{- else }}
+{{- printf "%s.dkr.%s.%s.%s/amazon-k8s-cni:%s" .Values.image.account .Values.image.endpoint .Values.image.region .Values.image.domain .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
+        image: {{ include "aws-vpc-cni.initImage" . }}
         env:
 {{- range $key, $value := .Values.init.env }}
           - name: {{ $key }}
@@ -64,7 +64,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: aws-node
-          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
+          image: {{ include "aws-vpc-cni.image" . }}
           ports:
             - containerPort: 61678
               name: metrics

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -9,11 +9,13 @@ nameOverride: aws-node
 init:
   image:
     tag: v1.12.6
+    domain: amazonaws.com
     region: us-west-2
-    account: "602401143452"   
+    endpoint: ecr
+    account: "602401143452"
     pullPolicy: Always
-    domain: "amazonaws.com"  
     # Set to use custom image
+    override:
     # override: "repo/org/image:tag"
   env:
     DISABLE_TCP_EARLY_DEMUX: "false"
@@ -22,12 +24,14 @@ init:
     privileged: true
 
 image:
-  region: us-west-2
   tag: v1.12.6
-  account: "602401143452"   
-  domain: "amazonaws.com"  
+  domain: amazonaws.com
+  region: us-west-2
+  endpoint: ecr
+  account: "602401143452"
   pullPolicy: Always
   # Set to use custom image
+  override:
   # override: "repo/org/image:tag"
 
 # The CNI supports a number of environment variable settings


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #2070

**What does this PR do / Why do we need it**:
This PR enables providing a different endpoint to the default `ecr` which supports using `ecr-fips` without needing to manually override the image version.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
I've tested this locally and it should be a no-op unless the new value is used.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
This change should be tested as part of any existing chart automation.

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
- Improvement - Added support for customising the Helm chart OCI images with `init.image.endpoint` & `image.endpoint`, this will allow the use of ECR FIPS endpoints without needing to use a full override.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
