### PR TITLE
Support GOLANG_IMAGE and BASE_IMAGE variables for all make docker targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@
 VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 # GOLANG_IMAGE is the building golang container image used.
 GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:1.19.6-3-gcc-al2
-# BASE_IMAGE_PRIMARY is the base layer image for the primary AWS VPC CNI plugin container
-BASE_IMAGE_PRIMARY ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
-# BASE_IMAGE_SECONDARY is the base layer image for the AWS VPC CNI init container and metrics publisher sidecar container
-BASE_IMAGE_SECONDARY ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+# BASE_IMAGE_CNI is the base layer image for the primary AWS VPC CNI plugin container
+BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+# BASE_IMAGE_CNI_INIT is the base layer image for the AWS VPC CNI init container
+BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+# BASE_IMAGE_CNI_METRICS is the base layer image for the AWS VPC CNI metrics publisher sidecar container
+BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .
@@ -92,10 +94,22 @@ PLUGIN_BINS = ./loopback ./portmap ./bandwidth ./host-local
 DOCKER_ARGS =
 # DOCKER_RUN_FLAGS is set the flags passed during runs of containers.
 DOCKER_RUN_FLAGS = --rm -ti $(DOCKER_ARGS)
-# DOCKER_BUILD_FLAGS is the set of flags passed during container image builds
-# based on the requested build.
-DOCKER_BUILD_FLAGS = --build-arg golang_image="$(GOLANG_IMAGE)" \
-					  --build-arg base_image="$(call reconcile_base_image,$1)"	\
+# DOCKER_BUILD_FLAGS_CNI is the set of flags passed during CNI container image 
+# builds based on the requested build.
+DOCKER_BUILD_FLAGS_CNI = --build-arg golang_image="$(GOLANG_IMAGE)" \
+					  --build-arg base_image="$(BASE_IMAGE_CNI)"	\
+					  --network=host \
+	  		          $(DOCKER_ARGS)
+# DOCKER_BUILD_FLAGS_CNI_INIT is the set of flags passed during CNI init 
+# container image builds based on the requested build.
+DOCKER_BUILD_FLAGS_CNI_INIT = --build-arg golang_image="$(GOLANG_IMAGE)" \
+					  --build-arg base_image="$(BASE_IMAGE_CNI_INIT)"	\
+					  --network=host \
+	  		          $(DOCKER_ARGS)
+# DOCKER_BUILD_FLAGS_CNI_METRICS is the set of flags passed during metrics 
+# container image builds based on the requested build.
+DOCKER_BUILD_FLAGS_CNI_METRICS = --build-arg golang_image="$(GOLANG_IMAGE)" \
+					  --build-arg base_image="$(BASE_IMAGE_CNI_METRICS)"	\
 					  --network=host \
 	  		          $(DOCKER_ARGS)
 
@@ -136,14 +150,14 @@ build-aws-vpc-cni:    ## Build the VPC CNI container using the host's Go toolcha
 
 # Build VPC CNI plugin & agent container image.
 docker:	setup-ec2-sdk-override	   ## Build VPC CNI plugin & agent container image.
-	docker build $(call DOCKER_BUILD_FLAGS,primary) \
+	docker build $(DOCKER_BUILD_FLAGS_CNI) \
 		-f scripts/dockerfiles/Dockerfile.release \
 		-t "$(IMAGE_NAME)" \
 		.
 	@echo "Built Docker image \"$(IMAGE_NAME)\""
 
 docker-init:     ## Build VPC CNI plugin Init container image.
-	docker build $(call DOCKER_BUILD_FLAGS,secondary) \
+	docker build $(DOCKER_BUILD_FLAGS_CNI_INIT) \
 		-f scripts/dockerfiles/Dockerfile.init \
 		-t "$(INIT_IMAGE_NAME)" \
 		.
@@ -156,7 +170,7 @@ docker-func-test: docker     ## Run the built CNI container image to use in func
 
 ## Build multi-arch VPC CNI plugin container image.
 multi-arch-cni-build:		
-	docker buildx build $(call DOCKER_BUILD_FLAGS,primary) \
+	docker buildx build $(DOCKER_BUILD_FLAGS_CNI) \
 		-f scripts/dockerfiles/Dockerfile.release \
 		--platform "$(MULTI_PLATFORM_BUILD_TARGETS)"\
 		--cache-from=type=gha \
@@ -165,7 +179,7 @@ multi-arch-cni-build:
 
 ## Build and push multi-arch VPC CNI plugin container image.
 multi-arch-cni-build-push:		
-	docker buildx build $(call DOCKER_BUILD_FLAGS,primary) \
+	docker buildx build $(DOCKER_BUILD_FLAGS_CNI) \
 		-f scripts/dockerfiles/Dockerfile.release \
 		--platform "$(MULTI_PLATFORM_BUILD_TARGETS)"\
 		-t "$(IMAGE_NAME)" \
@@ -174,7 +188,7 @@ multi-arch-cni-build-push:
 
 ## Build VPC CNI plugin Init container image. 
 multi-arch-cni-init-build:     
-	docker buildx build $(call DOCKER_BUILD_FLAGS,secondary) \
+	docker buildx build $(DOCKER_BUILD_FLAGS_CNI_INIT) \
 		-f scripts/dockerfiles/Dockerfile.init \
 		--platform "$(MULTI_PLATFORM_BUILD_TARGETS)"\
 		--cache-from=type=gha \
@@ -183,7 +197,7 @@ multi-arch-cni-init-build:
 
 ## Build and push VPC CNI plugin Init container image.
 multi-arch-cni-init-build-push:     
-	docker buildx build $(call DOCKER_BUILD_FLAGS,secondary) \
+	docker buildx build $(DOCKER_BUILD_FLAGS_CNI_INIT) \
 		-f scripts/dockerfiles/Dockerfile.init \
 		--platform "$(MULTI_PLATFORM_BUILD_TARGETS)"\
 		-t "$(INIT_IMAGE_NAME)" \
@@ -212,7 +226,7 @@ unit-test-race:     ## Run unit tests with race detection (can only be run nativ
 ##@ Build and Run Unit Tests 
 # Build the unit test driver container image.
 build-docker-test:     ## Build the unit test driver container image.
-	docker build $(call DOCKER_BUILD_FLAGS,secondary) \
+	docker build $(DOCKER_BUILD_FLAGS_CNI) \
 		-f scripts/dockerfiles/Dockerfile.test \
 		-t $(TEST_IMAGE_NAME) \
 		.
@@ -237,7 +251,7 @@ build-metrics:     ## Build metrics helper agent.
 
 # Build metrics helper agent Docker image.
 docker-metrics:    ## Build metrics helper agent Docker image.
-	docker build $(call DOCKER_BUILD_FLAGS,secondary) \
+	docker build $(DOCKER_BUILD_FLAGS_CNI_METRICS) \
 		-f scripts/dockerfiles/Dockerfile.metrics \
 		-t "$(METRICS_IMAGE_NAME)" \
 		.
@@ -385,5 +399,3 @@ clean:    ## Clean temporary files and build artifacts from the project.
 
 help:   ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-
-reconcile_base_image = $(if $(filter $1,primary),$(BASE_IMAGE_PRIMARY),$(BASE_IMAGE_SECONDARY))

--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -1,4 +1,5 @@
 ARG golang_image
+ARG base_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
@@ -17,8 +18,8 @@ RUN make plugins && make debug-script
 COPY . ./
 RUN make build-aws-vpc-cni-init
 
-# Build from EKS minimal base + glibc
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+# Build from EKS minimal base + glibc by default
+FROM $base_image
 
 WORKDIR /init
 

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -1,4 +1,5 @@
 ARG golang_image
+ARG base_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
@@ -13,8 +14,8 @@ RUN go mod download
 COPY . ./
 RUN make build-metrics
 
-# Build from EKS minimal base + glibc
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+# Build from EKS minimal base + glibc by default
+FROM $base_image
 
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,4 +1,5 @@
 ARG golang_image
+ARG base_image
 
 FROM $golang_image as builder
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
@@ -15,8 +16,8 @@ COPY Makefile ./
 COPY . ./
 RUN make build-aws-vpc-cni && make build-linux
 
-# Build from EKS minimal base + iptables
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+# Build from EKS minimal base + iptables by default
+FROM $base_image
 
 WORKDIR /app
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->


**Which issue does this PR fix**:
N/A but can create one if needed

**What does this PR do / Why do we need it**:
This PR allows users to customize GOLANG_IMAGE and BASE_IMAGE for all docker builds through Makefile

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Ran `BASE_IMAGE_CNI=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:2023-03-23-1679598055.2023 BASE_IMAGE_CNI_INIT=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2023-03-23-1679598055.2023 BASE_IMAGE_CNI_METRICS=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2023-03-23-1679598055.2023 GOLANG_IMAGE=public.ecr.aws/eks-distro-build-tooling/golang:1.19.7-4-gcc-al2 make docker docker-init build-docker-test docker-metrics` locally. Confirmed the BASE_IMAGEs and GOLANG_IMAGE overrides were successful and all the referenced make target were able to be built successfully.

(Outdated test for commit db3dd8432aabfd988915089268dad28a20f76522:
<del>Ran `BASE_IMAGE_PRIMARY=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:2023-03-23-1679598055.2023 BASE_IMAGE_SECONDARY=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2023-03-23-1679598055.2023 GOLANG_IMAGE=public.ecr.aws/eks-distro-build-tooling/golang:1.19.7-4-gcc-al2 make docker docker-init build-docker-test docker-metrics` locally. Confirmed the BASE_IMAGE and GOLANG_IMAGE overrides were successful and all the referenced make target were able to be built successfully. </del>)


<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No breaking change introduced

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No. The only change is that for any developer who wants to build docker targets from Makefile, they can now customize the base and build images. The default base and build images are not altered by this PR.

<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
