### PR TITLE
Fix for aws-vpc-cni chart with tolerations to produce syntax valid yaml

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -74,7 +74,7 @@ The following table lists the configurable parameters for this chart and their d
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
 | `livenessProbe`         | Livenness probe settings for daemonset                  | (see `values.yaml`)                 |
 | `readinessProbe`        | Readiness probe settings for daemonset                  | (see `values.yaml`)                 |
-| `tolerations`           | Optional deployment tolerations                         | `[]`                                |
+| `tolerations`           | Optional deployment tolerations                         | `[{"operator": "Exists"}]`          |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -54,8 +54,10 @@ spec:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
       terminationGracePeriodSeconds: 10
+    {{- with .Values.tolerations }}
       tolerations:
-        - operator: Exists
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -145,9 +147,5 @@ spec:
       {{- end }}
     {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -54,15 +54,15 @@ spec:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
       terminationGracePeriodSeconds: 10
-    {{- if eq (len .Values.tolerations) 0 }}
+{{- if eq (len .Values.tolerations) 0 }}
       tolerations:
         - operator: Exists
-    {{- else }}
+{{- else }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- end }}
+{{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -54,15 +54,10 @@ spec:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
       terminationGracePeriodSeconds: 10
-{{- if eq (len .Values.tolerations) 0 }}
-      tolerations:
-        - operator: Exists
-{{- else }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -54,9 +54,14 @@ spec:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
       terminationGracePeriodSeconds: 10
-    {{- with .Values.tolerations }}
+    {{- if eq (len .Values.tolerations) 0 }}
+      tolerations:
+        - operator: Exists
+    {{- else }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -103,7 +103,7 @@ updateStrategy:
 nodeSelector: {}
 
 tolerations:
-  operator: Exists
+  - operator: Exists
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -102,7 +102,8 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  operator: Exists
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -102,7 +102,8 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - operator: Exists
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/test.yaml
+++ b/charts/aws-vpc-cni/test.yaml
@@ -102,8 +102,7 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations:
-  - operator: Exists
+tolerations: []
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -126,7 +126,8 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  operator: Exists
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -126,8 +126,7 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations:
-  - operator: Exists
+tolerations: []
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -126,7 +126,8 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - operator: Exists
 
 affinity:
   nodeAffinity:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -127,7 +127,7 @@ updateStrategy:
 nodeSelector: {}
 
 tolerations:
-  operator: Exists
+  - operator: Exists
 
 affinity:
   nodeAffinity:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#2344 

**What does this PR do / Why do we need it**:
Chart fix for tolerations, moves default toleration to values.yaml allowing for use to generate valid YAML. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Gists: https://gist.github.com/Bourne-ID/cb5c411926e8e40a1433718d125f560c

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No - all part of the daemonset yaml so patch will be fine. 

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Moved default aws-vpc-cni tolerations to values.yaml 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
