### PR TITLE
Increase datastore pool at startup

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -397,7 +397,7 @@ func (i instrumentedIMDS) GetMetadataWithContext(ctx context.Context, p string) 
 
 // New creates an EC2InstanceMetadataCache
 func New(useCustomNetworking, disableLeakedENICleanup, v4Enabled, v6Enabled bool, eventRecorder *eventrecorder.EventRecorder) (*EC2InstanceMetadataCache, error) {
-	//ctx is passed to initWithEC2Metadata func to cancel spawned go-routines when tests are run
+	// ctx is passed to initWithEC2Metadata func to cancel spawned go-routines when tests are run
 	ctx := context.Background()
 
 	// Initializes prometheus metrics

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -184,13 +184,13 @@ type AddressInfo struct {
 
 // CidrInfo
 type CidrInfo struct {
-	//Either v4/v6 Host or LPM Prefix
+	// Either v4/v6 Host or LPM Prefix
 	Cidr net.IPNet
-	//Key is individual IP addresses from the Prefix - /32 (v4) or /128 (v6)
+	// Key is individual IP addresses from the Prefix - /32 (v4) or /128 (v6)
 	IPAddresses map[string]*AddressInfo
-	//true if Cidr here is an LPM prefix
+	// true if Cidr here is an LPM prefix
 	IsPrefix bool
-	//IP Address Family of the Cidr
+	// IP Address Family of the Cidr
 	AddressFamily string
 }
 
@@ -200,8 +200,8 @@ func (cidr *CidrInfo) Size() int {
 }
 
 func (e *ENI) findAddressForSandbox(ipamKey IPAMKey) (*CidrInfo, *AddressInfo) {
-	//Either v4 or v6 for now.
-	//Check in V4 prefixes
+	// Either v4 or v6 for now.
+	// Check in V4 prefixes
 	for _, availableCidr := range e.AvailableIPv4Cidrs {
 		for _, addr := range availableCidr.IPAddresses {
 			if addr.IPAMKey == ipamKey {
@@ -210,7 +210,7 @@ func (e *ENI) findAddressForSandbox(ipamKey IPAMKey) (*CidrInfo, *AddressInfo) {
 		}
 	}
 
-	//Check in V6 prefixes
+	// Check in V6 prefixes
 	for _, availableCidr := range e.IPv6Cidrs {
 		for _, addr := range availableCidr.IPAddresses {
 			if addr.IPAMKey == ipamKey {
@@ -495,7 +495,7 @@ func (ds *DataStore) AddENI(eniID string, deviceNumber int, isPrimary, isTrunk, 
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
-	ds.log.Debugf("DataStore Add an ENI %s", eniID)
+	ds.log.Debugf("DataStore add an ENI %s", eniID)
 
 	_, ok := ds.eniPool[eniID]
 	if ok {
@@ -712,7 +712,7 @@ func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey, ipamMetadata IPAMMeta
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
-	ds.log.Debugf("AssignIPv4Address: IP address pool stats: total: %d, assigned %d", ds.total, ds.assigned)
+	ds.log.Debugf("AssignIPv4Address: IP address pool stats: total %d, assigned %d", ds.total, ds.assigned)
 
 	if eni, _, addr := ds.eniPool.FindAddressForSandbox(ipamKey); addr != nil {
 		ds.log.Infof("AssignPodIPv4Address: duplicate pod assign for sandbox %s", ipamKey)
@@ -1123,8 +1123,7 @@ func (ds *DataStore) RemoveENIFromDataStore(eniID string, force bool) error {
 func (ds *DataStore) UnassignPodIPAddress(ipamKey IPAMKey) (e *ENI, ip string, deviceNumber int, err error) {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
-	ds.log.Debugf("UnassignPodIPAddress: IP address pool stats: total:%d, assigned %d, sandbox %s",
-		ds.total, ds.assigned, ipamKey)
+	ds.log.Debugf("UnassignPodIPAddress: IP address pool stats: total %d, assigned %d, sandbox %s", ds.total, ds.assigned, ipamKey)
 
 	eni, availableCidr, addr := ds.eniPool.FindAddressForSandbox(ipamKey)
 	if addr == nil {
@@ -1241,7 +1240,7 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 		tmpENIInfo := *eniInfo
 		tmpENIInfo.AvailableIPv4Cidrs = make(map[string]*CidrInfo, len(eniInfo.AvailableIPv4Cidrs))
 		tmpENIInfo.IPv6Cidrs = make(map[string]*CidrInfo, len(eniInfo.IPv6Cidrs))
-		for cidr, _ := range eniInfo.AvailableIPv4Cidrs {
+		for cidr := range eniInfo.AvailableIPv4Cidrs {
 			tmpENIInfo.AvailableIPv4Cidrs[cidr] = &CidrInfo{
 				Cidr:        eniInfo.AvailableIPv4Cidrs[cidr].Cidr,
 				IPAddresses: make(map[string]*AddressInfo, len(eniInfo.AvailableIPv4Cidrs[cidr].IPAddresses)),
@@ -1253,7 +1252,7 @@ func (ds *DataStore) GetENIInfos() *ENIInfos {
 				tmpENIInfo.AvailableIPv4Cidrs[cidr].IPAddresses[ip] = &ipAddrInfo
 			}
 		}
-		for cidr, _ := range eniInfo.IPv6Cidrs {
+		for cidr := range eniInfo.IPv6Cidrs {
 			tmpENIInfo.IPv6Cidrs[cidr] = &CidrInfo{
 				Cidr:        eniInfo.IPv6Cidrs[cidr].Cidr,
 				IPAddresses: make(map[string]*AddressInfo, len(eniInfo.IPv6Cidrs[cidr].IPAddresses)),

--- a/scripts/run-ginkgo-integration-suite.sh
+++ b/scripts/run-ginkgo-integration-suite.sh
@@ -36,7 +36,7 @@ function load_test_parameters(){
 }
 
 function run_ginkgo_test() {
-  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v --timeout 30m --no-color --fail-on-pending $GINKGO_TEST_BUILD/$SUITE_NAME.test -- \
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v --timeout 60m --no-color --fail-on-pending $GINKGO_TEST_BUILD/$SUITE_NAME.test -- \
     --cluster-kubeconfig="$KUBE_CONFIG_PATH" \
     --cluster-name="$CLUSTER_NAME" \
     --aws-region="$REGION" \

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	PrivateSubnets     string
 	AvailabilityZones  string
 	PublicRouteTableID string
+	NgK8SVersion       string
 }
 
 func (options *Options) BindFlags() {
@@ -68,6 +69,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.PrivateSubnets, "private-subnets", "", "Comma separated list of private subnets (optional, if specified you must specify all of public/private-subnets, public-route-table-id,  and availability-zones)")
 	flag.StringVar(&options.AvailabilityZones, "availability-zones", "", "Comma separated list of private subnets (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
 	flag.StringVar(&options.PublicRouteTableID, "public-route-table-id", "", "Public route table ID (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
+	flag.StringVar(&options.NgK8SVersion, "ng-kubernetes-version", "1.25", `Kubernetes version for self-managed node groups (optional, default is "1.25")`)
 }
 
 func (options *Options) Validate() error {

--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -29,11 +29,11 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 )
 
-const CreateNodeGroupCFNTemplate = "/testdata/amazon-eks-nodegroup.yaml"
-
-// Docker will be default, if not specified
 const (
-	CONTAINERD = "containerd"
+	// Docker will be default, if not specified
+	CONTAINERD                 = "containerd"
+	CreateNodeGroupCFNTemplate = "/testdata/amazon-eks-nodegroup.yaml"
+	NodeImageIdSSMParam        = "/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id"
 )
 
 type NodeGroupProperties struct {
@@ -123,6 +123,10 @@ func CreateAndWaitTillSelfManagedNGReady(f *framework.Framework, properties Node
 		{
 			ParameterKey:   aws.String("NodeGroupName"),
 			ParameterValue: aws.String(properties.NodeGroupName),
+		},
+		{
+			ParameterKey:   aws.String("NodeImageIdSSMParam"),
+			ParameterValue: aws.String(fmt.Sprintf(NodeImageIdSSMParam, f.Options.NgK8SVersion)),
 		},
 		{
 			ParameterKey:   aws.String("NodeAutoScalingGroupMinSize"),

--- a/test/framework/resources/k8s/resources/node.go
+++ b/test/framework/resources/k8s/resources/node.go
@@ -89,8 +89,6 @@ func (d *defaultNodeManager) WaitTillNodesReady(nodeLabelKey string, nodeLabelVa
 				}
 			}
 		}
-
 		return true, nil
-
 	}, context.Background().Done())
 }

--- a/test/integration/custom-networking/custom_networking_test.go
+++ b/test/integration/custom-networking/custom_networking_test.go
@@ -164,15 +164,11 @@ var _ = Describe("Custom Networking Test", func() {
 			err = f.CloudServices.EC2().TerminateInstance(instanceIDs)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("waiting for the node to be removed")
+			By("waiting for nodes to be removed")
 			time.Sleep(time.Second * 120)
 
-			By("waiting for all nodes to become ready")
-			err = f.K8sResourceManagers.NodeManager().
-				WaitTillNodesReady(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal,
-					nodeGroupProperties.AsgSize)
-			Expect(err).ToNot(HaveOccurred())
-
+			// Nodes should be stuck in NotReady state since no ENIs could be attached and no pod
+			// IP addresses are available.
 			deployment := manifest.NewBusyBoxDeploymentBuilder().
 				Replicas(2).
 				NodeSelector(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal).

--- a/testdata/amazon-eks-nodegroup.yaml
+++ b/testdata/amazon-eks-nodegroup.yaml
@@ -74,7 +74,6 @@ Parameters:
 
   NodeImageIdSSMParam:
     Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    Default: /aws/service/eks/optimized-ami/1.22/amazon-linux-2/recommended/image_id
     Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances. Change this value to match the version of Kubernetes you are using.
 
   DisableIMDSv1:


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#1724 

**What does this PR do / Why do we need it**:
This PR fixes two issues:
1. The container entrypoint was not properly validating IPAMD startup.
2. During node initialization, IPAMD used to only build datastore from already attached ENIs and available CIDRs. Now, if the datastore pool is too low (based on settings), it tries to increase the datastore pool by attaching ENIs. This improves the startup time for custom networking and branch ENIs. There is also a check for custom networking such that if the datastore is empty after the increase attempt, there must be a configuration error, so IPAMD returns an error, which will put the pod into a CrashLoopBackOff until the configuration error is resolved. In the future, we want to generate an event for this case.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that when ENIConfigs are missing, node remains in "Not Ready" state as IPAMD returns error. Also verified that when ENIConfigs are present, ENIs are attached during node initialization.

Verified that CNI integration release tests pass. Scheduling GitHub runner as well.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Enhance node initialization to attach ENIs if needed.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
