### PR TITLE
install all core CNI plugins via init container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@ aws-k8s-agent
 aws-cni
 aws-vpc-cni
 aws-vpc-cni-init
-bandwidth
-host-local
-loopback
 verify-aws
 verify-network
 *~
@@ -17,6 +14,7 @@ portmap
 grpc-health-probe
 cni-metrics-helper
 coverage.txt
+core-plugins/
 build/
 vendor
 egress-v4-cni

--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -140,18 +140,13 @@ func main() {
 
 func _main() int {
 	log.Debug("Started Initialization")
-	pluginBins := []string{"loopback", "portmap", "bandwidth", "host-local", "aws-cni-support.sh"}
 	var err error
-	for _, plugin := range pluginBins {
-		if _, err = os.Stat(plugin); err != nil {
-			log.WithError(err).Fatalf("Required executable: %s not found", plugin)
-			return 1
-		}
-	}
 
 	log.Infof("Copying CNI plugin binaries ...")
 	hostCNIBinPath := getEnv(envHostCniBinPath, defaultHostCNIBinPath)
-	err = cp.InstallBinaries(pluginBins, hostCNIBinPath)
+	excludeBins := map[string]bool{"aws-vpc-cni-init": true}
+	// Copy all binaries from workdir to host bin dir except container init binary
+	err = cp.InstallBinariesFromDir(".", hostCNIBinPath, excludeBins)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to install binaries")
 		return 1

--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -24,10 +24,7 @@ FROM $base_image
 WORKDIR /init
 
 COPY --from=builder \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/loopback \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/portmap \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/bandwidth \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/host-local \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/core-plugins/* \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni-support.sh \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-vpc-cni-init /init/
 

--- a/utils/cp/cp.go
+++ b/utils/cp/cp.go
@@ -74,3 +74,27 @@ func InstallBinaries(pluginBins []string, hostCNIBinPath string) error {
 	}
 	return nil
 }
+
+func InstallBinariesFromDir(readDir string, hostCNIBinPath string, excludeBins map[string]bool) error {
+	bins, err := os.ReadDir(readDir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s, error: %s", readDir, err)
+	}
+
+	for _, file := range bins {
+		// Only copy files
+		if !file.Type().IsRegular() {
+			continue
+		}
+		// Exclude binaries in deny-list
+		if _, ok := excludeBins[file.Name()]; ok {
+			continue
+		}
+		target := fmt.Sprintf("%s/%s", hostCNIBinPath, file.Name())
+		source := fmt.Sprintf("%s", file.Name())
+		if err := CopyFile(source, target); err != nil {
+			return fmt.Errorf("Failed to install %s: %s", target, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
#2332 

**What does this PR do / Why do we need it**:
This PR modifies VPC CNI init container to install all core CNI plugins (from containernetworking) in `/opt/cni/bin` on node. This is needed so that EKS AMI no longer needs to worry about installing CNI plugin binaries.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that plugin binaries are installed in `/opt/cni/bin` on host node.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Install all CNI plugins from containernetworking on host node
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
