### PR TITLE
chore: Add memory request for avoiding EC2 OOM

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -118,6 +118,7 @@ readinessProbeTimeoutSeconds: 10
 resources:
   requests:
     cpu: 25m
+    memory: 100Mi
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
**What type of PR is this?**

enhancement

**Which issue does this PR fix**:

OOM on EC2 instances.


**What does this PR do / Why do we need it**:

When no memory request is specified for any pod running on the EC2's, the EC2 instance ends up going in to OOM and becoming non-responsive, leaving the kubelet to crash and leave the node in a not-ready state. Adding a minimum request for memory will allow VPC CNI to be always available and potentially trigger evictions for other application pods without CPU/Memory. 

The 200Mi has been set based on my observation across an average of 100 nodes used over two weeks.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

- run pods without CPU and Memory limits on the EKS Cluster, then watch the node come up as healthy and then go into an unhealthy state due to the VPC CNI not having memory request and other pods using up all the resources on the EC2.


**Will this PR introduce any new dependencies?**:

No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:

```release-note
Added minimum memory requests to avoid EC2 OOM cases causing kubelet to become unresponsive.

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
