### PR TITLE
Add IPv6 egress support to eks IPv4 cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,23 @@ The following environment variables are available, and all of them are optional.
 
 ---
 
+#### `ENABLE_V6_EGRESS` (v1.13.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Specifies whether PODs in v4 cluster support IPv6 egress. If env is set to `true`, range `fd00::ac:00/118` is reserved for IPv6 egress.
+
+---
+
 #### `AWS_MANAGE_ENIS_NON_SCHEDULABLE` (v1.12.6+)
 
 Type: Boolean as a String
 
 Default: `false`
 
-Specifies whether IPAMD should allocate or deallocate ENIs on a non-schedulable node. 
+Specifies whether IPAMD should allocate or deallocate ENIs on a non-schedulable node.
 
 ---
 

--- a/cmd/aws-vpc-cni/main_test.go
+++ b/cmd/aws-vpc-cni/main_test.go
@@ -13,15 +13,22 @@ const (
 	nodeIP      = "10.0.0.0"
 )
 
+var getPrimaryIPMock = func(ipv4 bool) (string, error) {
+	if ipv4 {
+		return "10.0.0.0", nil
+	}
+	return "2600::", nil
+}
+
 // Validate that generateJSON runs against default conflist without error
 func TestGenerateJSON(t *testing.T) {
-	err := generateJSON(awsConflist, devNull, nodeIP)
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
 	assert.NoError(t, err)
 }
 
 // Validate that generateJSON runs without error when bandwidth plugin is added to default conflist
 func TestGenerateJSONPlusBandwidth(t *testing.T) {
 	_ = os.Setenv(envEnBandwidthPlugin, "true")
-	err := generateJSON(awsConflist, devNull, nodeIP)
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
 	assert.NoError(t, err)
 }

--- a/cmd/egress-cni-plugin/main_test.go
+++ b/cmd/egress-cni-plugin/main_test.go
@@ -31,13 +31,17 @@ import (
 
 const (
 	snatChainV4 = "CNI-E4-5740307710ebfd5fb24f5"
+	snatChainV6 = "CNI-E6-e335b08ae90730d0a659a"
+
+	containerIDV4 = "containerId-123"
+	containerIDV6 = "containerId-789"
 )
 
 func TestCmdAddV4(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	args := &skel.CmdArgs{
-		ContainerID: "containerId-123",
+		ContainerID: containerIDV4,
 		IfName:      "eth0",
 		StdinData: []byte(`{
 				"cniVersion":"0.4.0",
@@ -58,7 +62,7 @@ func TestCmdAddV4(t *testing.T) {
 							{"name":"eth0","sandbox":"/var/run/netns/cni-266298c1-b141-9c7f-f26b-97ff084f3fcc"},
 							{"name":"dummy36e5b0ee702","mac":"0","sandbox":"0"}],
 					"ips":
-						[{"version":"4","interface":1,"address":"192.168.13.226/32"}],
+						[{"version":"6","interface":1,"address":"2600:1f16:828:c404:af46:9f44:d2ea:4569/128"}],
 					"dns":{}
 					},
 				"type":"aws-cni",
@@ -66,12 +70,12 @@ func TestCmdAddV4(t *testing.T) {
 		}`),
 	}
 
-	ec := EgressContext{
+	ec := egressContext{
 		Procsys:       mock_procsyswrapper.NewMockProcSys(ctrl),
 		Ns:            mock_nswrapper.NewMockNS(ctrl),
 		NsPath:        "/var/run/netns/cni-xxxx",
 		ArgsIfName:    args.IfName,
-		IpTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
+		IPTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
 		Ipam:          mock_ipamwrapper.NewMockHostIpam(ctrl),
 		Link:          mock_netlinkwrapper.NewMockNetLink(ctrl),
 		Veth:          mock_veth.NewMockVeth(ctrl),
@@ -85,9 +89,9 @@ func TestCmdAddV4(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectIptablesRules := []string{
-		fmt.Sprintf("nat %s -d 224.0.0.0/4 -j ACCEPT -m comment --comment name: \"aws-cni\" id: \"containerId-123\"", snatChainV4),
-		fmt.Sprintf("nat %s -j SNAT --to-source 192.168.1.123 -m comment --comment name: \"aws-cni\" id: \"containerId-123\" --random-fully", snatChainV4),
-		fmt.Sprintf("nat POSTROUTING -s 169.254.172.10 -j %s -m comment --comment name: \"aws-cni\" id: \"containerId-123\"", snatChainV4)}
+		fmt.Sprintf("nat %s -d 224.0.0.0/4 -j ACCEPT -m comment --comment name: \"aws-cni\" id: \"%s\"", snatChainV4, containerIDV4),
+		fmt.Sprintf("nat %s -j SNAT --to-source 192.168.1.123 -m comment --comment name: \"aws-cni\" id: \"%s\" --random-fully", snatChainV4, containerIDV4),
+		fmt.Sprintf("nat POSTROUTING -s 169.254.172.10 -j %s -m comment --comment name: \"aws-cni\" id: \"%s\"", snatChainV4, containerIDV4)}
 	assert.EqualValues(t, expectIptablesRules, actualIptablesRules)
 
 	expectRouteDel := []string{"route del: {Ifindex: 2 Dst: 169.254.172.0/22 Src: <nil> Gw: <nil> Flags: [] Table: 0}"}
@@ -108,7 +112,7 @@ func TestCmdDelV4(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	args := &skel.CmdArgs{
-		ContainerID: "containerId-123",
+		ContainerID: containerIDV4,
 		IfName:      "eth0",
 		StdinData: []byte(`{
 				"cniVersion":"0.4.0",
@@ -137,27 +141,146 @@ func TestCmdDelV4(t *testing.T) {
 		}`),
 	}
 
-	ec := EgressContext{
+	ec := egressContext{
 		Ns:            mock_nswrapper.NewMockNS(ctrl),
 		NsPath:        "/var/run/netns/cni-xxxx",
-		IpTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
+		IPTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
 		Ipam:          mock_ipamwrapper.NewMockHostIpam(ctrl),
 		Link:          mock_netlinkwrapper.NewMockNetLink(ctrl),
 	}
 
-	var actualLinkDel, actualIptablesDel []string
-	err := SetupDelExpectV4(ec, &actualLinkDel, &actualIptablesDel)
+	var actualIptablesDel []string
+	err := SetupDelExpectV4(ec, &actualIptablesDel)
 	assert.Nil(t, err)
 
 	err = del(args, &ec)
 	assert.Nil(t, err)
 
-	expectLinkDel := []string{"link del - name: v4if0"}
-	assert.EqualValues(t, expectLinkDel, actualLinkDel)
-
 	expectIptablesDel := []string{
 		fmt.Sprintf("nat POSTROUTING -s 169.254.172.10 -j %s -m comment --comment name: \"aws-cni\" id: \"containerId-123\"", snatChainV4),
 		fmt.Sprintf("clear chain nat %s", snatChainV4),
 		fmt.Sprintf("del chain nat %s", snatChainV4)}
+	assert.EqualValues(t, expectIptablesDel, actualIptablesDel)
+}
+
+func TestCmdAddV6(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	args := &skel.CmdArgs{
+		ContainerID: containerIDV6,
+		IfName:      "eth0",
+		StdinData: []byte(`{
+				"cniVersion":"0.4.0",
+				"mtu":"9001",
+				"name":"aws-cni",
+				"enabled":"true",
+				"nodeIP": "2600::",
+				"ipam": {"type":"host-local","ranges":[[{"subnet": "fd00::ac:00/118"}]],"routes":[{"dst":"::/0"}],"dataDir":"/run/cni/v4pd/egress-v6-ipam"},
+				"pluginLogFile":"egress-plugin.log",
+				"pluginLogLevel":"DEBUG",
+				"podSGEnforcingMode":"strict",
+				"prevResult":
+					{
+					"cniVersion":"0.4.0",
+					"interfaces":
+						[
+							{"name":"eni36e5b0ee702"},
+							{"name":"eth0","sandbox":"/var/run/netns/cni-266298c1-b141-9c7f-f26b-97ff084f3fcc"},
+							{"name":"dummy36e5b0ee702","mac":"0","sandbox":"0"}],
+					"ips":
+						[{"version":"4","interface":1,"address":"192.168.13.226/32"}],
+					"dns":{}
+					},
+				"type":"aws-cni",
+				"vethPrefix":"eni"
+		}`),
+	}
+
+	ec := egressContext{
+		Procsys:       mock_procsyswrapper.NewMockProcSys(ctrl),
+		Ns:            mock_nswrapper.NewMockNS(ctrl),
+		NsPath:        "/var/run/netns/cni-xxxx",
+		ArgsIfName:    args.IfName,
+		IPTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
+		Ipam:          mock_ipamwrapper.NewMockHostIpam(ctrl),
+		Link:          mock_netlinkwrapper.NewMockNetLink(ctrl),
+		Veth:          mock_veth.NewMockVeth(ctrl),
+	}
+
+	var actualIptablesRules, actualRouteAdd, actualRouteReplace []string
+	err := SetupAddExpectV6(ec, snatChainV6, &actualIptablesRules, &actualRouteAdd, &actualRouteReplace)
+	assert.Nil(t, err)
+
+	err = add(args, &ec)
+	assert.Nil(t, err)
+
+	expectIptablesRules := []string{
+		fmt.Sprintf("nat %s -d ff00::/8 -j ACCEPT -m comment --comment name: \"aws-cni\" id: \"%s\"", snatChainV6, containerIDV6),
+		fmt.Sprintf("nat %s -j SNAT --to-source 2600:: -m comment --comment name: \"aws-cni\" id: \"%s\" --random-fully", snatChainV6, containerIDV6),
+		fmt.Sprintf("nat POSTROUTING -s fd00::10 -j %s -m comment --comment name: \"aws-cni\" id: \"%s\"", snatChainV6, containerIDV6)}
+	assert.EqualValues(t, expectIptablesRules, actualIptablesRules)
+
+	expectRouteAdd := []string{"{Ifindex: 100 Dst: fd00::10/128 Src: <nil> Gw: <nil> Flags: [] Table: 0}"}
+	assert.EqualValues(t, expectRouteAdd, actualRouteAdd)
+
+	expectRouteReplace := []string{"{Ifindex: 2 Dst: ::/0 Src: <nil> Gw: fe80::10 Flags: [] Table: 0}"}
+	assert.EqualValues(t, expectRouteReplace, actualRouteReplace)
+
+	// the unit test write some output string not ends with '\n' and this cause go runner unable to interpret that a test was run.
+	// Adding a newline, keeps a clean output
+	fmt.Println()
+}
+
+func TestCmdDelV6(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	args := &skel.CmdArgs{
+		ContainerID: containerIDV6,
+		IfName:      "eth0",
+		StdinData: []byte(`{
+				"cniVersion":"0.4.0",
+				"mtu":"9001",
+				"name":"aws-cni",
+				"enabled":"true",
+				"nodeIP": "2600::",
+				"ipam": {"type":"host-local","ranges":[[{"subnet": "fd00::ac:00/118"}]],"routes":[{"dst":"::/0"}],"dataDir":"/run/cni/v4pd/egress-v6-ipam"},
+				"pluginLogFile":"egress-plugin.log",
+				"pluginLogLevel":"DEBUG",
+				"podSGEnforcingMode":"strict",
+				"prevResult":
+					{
+					"cniVersion":"0.4.0",
+					"interfaces":
+						[
+							{"name":"eni36e5b0ee702"},
+							{"name":"eth0","sandbox":"/var/run/netns/cni-266298c1-b141-9c7f-f26b-97ff084f3fcc"},
+							{"name":"dummy36e5b0ee702","mac":"0","sandbox":"0"}],
+					"ips":
+						[{"version":"4","interface":1,"address":"192.168.13.226/32"}],
+					"dns":{}
+					},
+				"type":"aws-cni",
+				"vethPrefix":"eni"
+		}`),
+	}
+	ec := egressContext{
+		Ns:            mock_nswrapper.NewMockNS(ctrl),
+		NsPath:        "/var/run/netns/cni-xxxx",
+		Ipam:          mock_ipamwrapper.NewMockHostIpam(ctrl),
+		Link:          mock_netlinkwrapper.NewMockNetLink(ctrl),
+		IPTablesIface: mock_iptables.NewMockIPTablesIface(ctrl),
+	}
+
+	var actualIptablesDel []string
+	err := SetupDelExpectV6(ec, snatChainV6, &actualIptablesDel)
+	assert.Nil(t, err)
+
+	err = del(args, &ec)
+	assert.Nil(t, err)
+
+	expectIptablesDel := []string{
+		fmt.Sprintf("nat POSTROUTING -s fd00::10 -j %s -m comment --comment name: \"aws-cni\" id: \"%s\"", snatChainV6, containerIDV6),
+		fmt.Sprintf("clear chain nat %s", snatChainV6),
+		fmt.Sprintf("del chain nat %s", snatChainV6)}
 	assert.EqualValues(t, expectIptablesDel, actualIptablesDel)
 }

--- a/cmd/egress-cni-plugin/netconf.go
+++ b/cmd/egress-cni-plugin/netconf.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	// EgressIPv4InterfaceName interface name used in container ns for IPv4 egress traffic
-	EgressIPv4InterfaceName = "v4if0"
+	// egressIPv4InterfaceName interface name used in container ns for IPv4 egress traffic
+	egressIPv4InterfaceName = "v4if0"
 
-	// EgressIPv6InterfaceName interface name used in container ns for IPv6 egress traffic
-	EgressIPv6InterfaceName = "v6if0"
+	// egressIPv6InterfaceName interface name used in container ns for IPv6 egress traffic
+	egressIPv6InterfaceName = "v6if0"
 )
 
 // NetConf is our CNI config structure

--- a/cmd/egress-cni-plugin/snat/snat_test.go
+++ b/cmd/egress-cni-plugin/snat/snat_test.go
@@ -36,8 +36,8 @@ const (
 )
 
 var (
-	//containerIpv6 = net.ParseIP("fd00::10")
-	//nodeIPv6        = net.ParseIP("2600::")
+	containerIpv6 = net.ParseIP("fd00::10")
+	nodeIPv6      = net.ParseIP("2600::")
 	containerIPv4 = net.ParseIP("169.254.172.10")
 	nodeIPv4      = net.ParseIP("192.168.1.123")
 )

--- a/cmd/egress-cni-plugin/test_utils.go
+++ b/cmd/egress-cni-plugin/test_utils.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -35,13 +36,13 @@ const (
 )
 
 // SetupAddExpectV4 has all the mock EXPECT required when a container is added
-func SetupAddExpectV4(c EgressContext, chain string, actualIptablesRules, actualRouteAdd, actualRouteDel *[]string) error {
+func SetupAddExpectV4(ec egressContext, chain string, actualIptablesRules, actualRouteAdd, actualRouteDel *[]string) error {
 	nsParent, err := _ns.GetCurrentNS()
 	if err != nil {
 		return err
 	}
 
-	c.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ExecAdd("host-local", gomock.Any()).Return(
+	ec.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ExecAdd("host-local", gomock.Any()).Return(
 		&current.Result{
 			CNIVersion: "0.4.0",
 			IPs: []*current.IPConfig{
@@ -56,62 +57,62 @@ func SetupAddExpectV4(c EgressContext, chain string, actualIptablesRules, actual
 			},
 		}, nil)
 
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().NewChain("nat", chain).Return(nil)
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().NewChain("nat", chain).Return(nil)
 
 	macHost := [6]byte{0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F}
 	macCont := [6]byte{0xCC, 0xB8, 0x33, 0x4C, 0x88, 0x4F}
 
-	c.Ns.(*mock_ns.MockNS).EXPECT().WithNetNSPath(c.NsPath, gomock.Any()).Do(func(_nsPath string, f func(_ns.NetNS) error) {
+	ec.Ns.(*mock_ns.MockNS).EXPECT().WithNetNSPath(ec.NsPath, gomock.Any()).Do(func(_nsPath string, f func(_ns.NetNS) error) {
 		f(nsParent)
 	}).Return(nil)
 
-	c.Veth.(*mock_veth.MockVeth).EXPECT().Setup(EgressIPv4InterfaceName, 9001, gomock.Any()).Return(
+	ec.Veth.(*mock_veth.MockVeth).EXPECT().Setup(egressIPv4InterfaceName, 9001, gomock.Any()).Return(
 		net.Interface{
 			Name:         HostIfName,
 			HardwareAddr: macHost[:],
 		},
 		net.Interface{
-			Name:         EgressIPv4InterfaceName,
+			Name:         egressIPv4InterfaceName,
 			HardwareAddr: macCont[:],
 		},
 		nil)
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().AddrAdd(gomock.Any(), gomock.Any()).Return(nil)
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().AddrAdd(gomock.Any(), gomock.Any()).Return(nil)
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(HostIfName).Return(
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(HostIfName).Return(
 		&netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
 				Name:  HostIfName,
 				Index: 100,
 			},
 		}, nil)
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(EgressIPv4InterfaceName).Return(
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(egressIPv4InterfaceName).Return(
 		&netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
-				Name:  EgressIPv4InterfaceName,
+				Name:  egressIPv4InterfaceName,
 				Index: 2,
 			},
 		}, nil)
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().RouteDel(gomock.Any()).Do(func(arg1 interface{}) error {
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().RouteDel(gomock.Any()).Do(func(arg1 interface{}) error {
 		r := arg1.(*netlink.Route)
 		*actualRouteDel = append(*actualRouteDel, "route del: "+r.String())
 		return nil
 	}).Return(nil)
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().RouteAdd(gomock.Any()).Do(func(arg1 interface{}) error {
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().RouteAdd(gomock.Any()).Do(func(arg1 interface{}) error {
 		r := arg1.(*netlink.Route)
 		// container route adding
 		*actualRouteAdd = append(*actualRouteAdd, "route add: "+r.String())
 		return nil
 	}).Return(nil).Times(3)
 
-	c.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ConfigureIface(EgressIPv4InterfaceName, gomock.Any()).Return(nil)
-	c.Procsys.(*mock_procsys.MockProcSys).EXPECT().Get("net/ipv4/ip_forward").Return("0", nil)
-	c.Procsys.(*mock_procsys.MockProcSys).EXPECT().Set("net/ipv4/ip_forward", "1").Return(nil)
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().HasRandomFully().Return(true)
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ListChains("nat").Return([]string{"POSTROUTING"}, nil)
+	ec.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ConfigureIface(egressIPv4InterfaceName, gomock.Any()).Return(nil)
+	ec.Procsys.(*mock_procsys.MockProcSys).EXPECT().Get("net/ipv4/ip_forward").Return("0", nil)
+	ec.Procsys.(*mock_procsys.MockProcSys).EXPECT().Set("net/ipv4/ip_forward", "1").Return(nil)
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().HasRandomFully().Return(true)
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ListChains("nat").Return([]string{"POSTROUTING"}, nil)
 
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().AppendUnique("nat", gomock.Any(), gomock.Any()).Do(func(arg1, arg2 interface{}, arg3 ...interface{}) {
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().AppendUnique("nat", gomock.Any(), gomock.Any()).Do(func(arg1, arg2 interface{}, arg3 ...interface{}) {
 		actualResult := arg1.(string) + " " + arg2.(string)
 		for _, arg := range arg3 {
 			actualResult += " " + arg.(string)
@@ -123,7 +124,164 @@ func SetupAddExpectV4(c EgressContext, chain string, actualIptablesRules, actual
 }
 
 // SetupDelExpectV4 has all the mock EXPECT required when a container is deleted
-func SetupDelExpectV4(c EgressContext, actualLinkDel, actualIptablesDel *[]string) error {
+func SetupDelExpectV4(ec egressContext, actualIptablesDel *[]string) error {
+	nsParent, err := _ns.GetCurrentNS()
+	if err != nil {
+		return err
+	}
+
+	ec.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ExecDel("host-local", gomock.Any()).Return(nil)
+
+	ec.Ns.(*mock_ns.MockNS).EXPECT().WithNetNSPath(ec.NsPath, gomock.Any()).Do(func(_nsPath string, f func(_ns.NetNS) error) {
+		f(nsParent)
+	}).Return(nil)
+
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(egressIPv4InterfaceName).Return(
+		&netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:  egressIPv4InterfaceName,
+				Index: 2,
+			},
+		}, nil)
+
+	ec.Link.(*mock_netlink.MockNetLink).EXPECT().AddrList(gomock.Any(), netlink.FAMILY_V4).Return(
+		[]netlink.Addr{
+			{
+				IPNet: &net.IPNet{
+					IP:   net.ParseIP("169.254.172.10"),
+					Mask: net.CIDRMask(22, 32),
+				},
+				LinkIndex: 2,
+			},
+		}, nil)
+
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().Delete("nat", "POSTROUTING", gomock.Any()).Do(
+		func(arg1 interface{}, arg2 interface{}, arg3 ...interface{}) {
+			actualResult := arg1.(string) + " " + arg2.(string)
+			for _, arg := range arg3 {
+				actualResult += " " + arg.(string)
+			}
+			*actualIptablesDel = append(*actualIptablesDel, actualResult)
+		}).Return(nil).AnyTimes()
+
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ClearChain("nat", gomock.Any()).Do(
+		func(arg1 interface{}, arg2 interface{}) {
+			actualResult := arg1.(string) + " " + arg2.(string)
+			*actualIptablesDel = append(*actualIptablesDel, "clear chain "+actualResult)
+		}).Return(nil).AnyTimes()
+
+	ec.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().DeleteChain("nat", gomock.Any()).Do(
+		func(arg1 interface{}, arg2 interface{}) {
+			actualResult := arg1.(string) + " " + arg2.(string)
+			*actualIptablesDel = append(*actualIptablesDel, "del chain "+actualResult)
+		}).Return(nil).AnyTimes()
+
+	return nil
+}
+
+// SetupAddExpectV6 has all the mock EXPECT required when a container is added
+func SetupAddExpectV6(c egressContext, chain string, actualIptablesRules, actualRouteAdd, actualRouteReplace *[]string) error {
+	nsParent, err := _ns.GetCurrentNS()
+	if err != nil {
+		return err
+	}
+
+	c.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ExecAdd("host-local", gomock.Any()).Return(
+		&current.Result{
+			CNIVersion: "0.4.0",
+			IPs: []*current.IPConfig{
+				&current.IPConfig{
+					Version: "6",
+					Address: net.IPNet{
+						IP:   net.ParseIP("fd00::10"),
+						Mask: net.CIDRMask(8, 128),
+					},
+				},
+			},
+		}, nil)
+
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().NewChain("nat", chain).Return(nil)
+
+	macHost := [6]byte{0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F}
+	macCont := [6]byte{0xCC, 0xB8, 0x33, 0x4C, 0x88, 0x4F}
+
+	c.Ns.(*mock_ns.MockNS).EXPECT().WithNetNSPath(c.NsPath, gomock.Any()).Do(func(_nsPath string, f func(_ns.NetNS) error) {
+		f(nsParent)
+	}).Return(nil).AnyTimes()
+
+	c.Veth.(*mock_veth.MockVeth).EXPECT().Setup(egressIPv6InterfaceName, 9001, gomock.Any()).Return(
+		net.Interface{
+			Name:         HostIfName,
+			HardwareAddr: macHost[:],
+		},
+		net.Interface{
+			Name:         egressIPv6InterfaceName,
+			HardwareAddr: macCont[:],
+		},
+		nil)
+
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName("vethxxxx").Return(
+		&netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:  "vethxxxx",
+				Index: 100,
+			},
+		}, nil).AnyTimes()
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(egressIPv6InterfaceName).Return(
+		&netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:  "v6if0",
+				Index: 2,
+			},
+		}, nil).AnyTimes()
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().AddrList(gomock.Any(), netlink.FAMILY_V6).DoAndReturn(
+		func(arg1 interface{}, _ interface{}) ([]netlink.Addr, error) {
+			link := arg1.(netlink.Link)
+			if link.Attrs().Name == "vethxxxx" {
+				return []netlink.Addr{
+					{
+						IPNet: &net.IPNet{
+							IP:   net.ParseIP("fe80::10"),
+							Mask: net.CIDRMask(64, 128),
+						},
+						LinkIndex: 100,
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected call with link name %s", link.Attrs().Name)
+		}).AnyTimes()
+
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().RouteReplace(gomock.Any()).Do(func(arg1 interface{}) error {
+		r := arg1.(*netlink.Route)
+		*actualRouteReplace = append(*actualRouteReplace, r.String())
+		return nil
+	}).Return(nil)
+
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().RouteAdd(gomock.Any()).Do(func(arg1 interface{}) error {
+		r := arg1.(*netlink.Route)
+		// container route adding
+		*actualRouteAdd = append(*actualRouteAdd, r.String())
+		return nil
+	}).Return(nil).Times(1)
+
+	c.Ipam.(*mock_ipam.MockHostIpam).EXPECT().ConfigureIface(egressIPv6InterfaceName, gomock.Any()).Return(nil)
+	c.Procsys.(*mock_procsys.MockProcSys).EXPECT().Set("net/ipv6/conf/eth0/disable_ipv6", "1").Return(nil)
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().HasRandomFully().Return(true)
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ListChains("nat").Return([]string{"POSTROUTING", c.SnatChain}, nil)
+
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().AppendUnique("nat", gomock.Any(), gomock.Any()).Do(func(arg1 interface{}, arg2 interface{}, arg3 ...interface{}) {
+		actualResult := arg1.(string) + " " + arg2.(string)
+		for _, arg := range arg3 {
+			actualResult += " " + arg.(string)
+		}
+		*actualIptablesRules = append(*actualIptablesRules, actualResult)
+	}).Return(nil).Times(3)
+
+	return nil
+}
+
+// SetupDelExpectV6 has all the mock EXPECT required when a container is deleted
+func SetupDelExpectV6(c egressContext, chain string, actualIptablesDel *[]string) error {
 	nsParent, err := _ns.GetCurrentNS()
 	if err != nil {
 		return err
@@ -135,33 +293,26 @@ func SetupDelExpectV4(c EgressContext, actualLinkDel, actualIptablesDel *[]strin
 		f(nsParent)
 	}).Return(nil)
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(EgressIPv4InterfaceName).Return(
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkByName(egressIPv6InterfaceName).Return(
 		&netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
-				Name:  EgressIPv4InterfaceName,
+				Name:  egressIPv6InterfaceName,
 				Index: 2,
 			},
 		}, nil)
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().AddrList(gomock.Any(), netlink.FAMILY_V4).Return(
+	c.Link.(*mock_netlink.MockNetLink).EXPECT().AddrList(gomock.Any(), netlink.FAMILY_V6).Return(
 		[]netlink.Addr{
 			{
 				IPNet: &net.IPNet{
-					IP:   net.ParseIP("169.254.172.10"),
-					Mask: net.CIDRMask(22, 32),
+					IP:   net.ParseIP("fd00::10"),
+					Mask: net.CIDRMask(8, 128),
 				},
 				LinkIndex: 2,
 			},
-		}, nil)
+		}, nil).AnyTimes()
 
-	c.Link.(*mock_netlink.MockNetLink).EXPECT().LinkDel(gomock.Any()).Do(
-		func(arg1 interface{}) error {
-			link := arg1.(netlink.Link)
-			*actualLinkDel = append(*actualLinkDel, "link del - name: "+link.Attrs().Name)
-			return nil
-		}).Return(nil)
-
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().Delete("nat", "POSTROUTING", gomock.Any()).Do(
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().Delete("nat", "POSTROUTING", gomock.Any()).Do(
 		func(arg1 interface{}, arg2 interface{}, arg3 ...interface{}) {
 			actualResult := arg1.(string) + " " + arg2.(string)
 			for _, arg := range arg3 {
@@ -170,13 +321,13 @@ func SetupDelExpectV4(c EgressContext, actualLinkDel, actualIptablesDel *[]strin
 			*actualIptablesDel = append(*actualIptablesDel, actualResult)
 		}).Return(nil).AnyTimes()
 
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ClearChain("nat", gomock.Any()).Do(
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().ClearChain("nat", chain).Do(
 		func(arg1 interface{}, arg2 interface{}) {
 			actualResult := arg1.(string) + " " + arg2.(string)
 			*actualIptablesDel = append(*actualIptablesDel, "clear chain "+actualResult)
 		}).Return(nil).AnyTimes()
 
-	c.IpTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().DeleteChain("nat", gomock.Any()).Do(
+	c.IPTablesIface.(*mock_iptables.MockIPTablesIface).EXPECT().DeleteChain("nat", chain).Do(
 		func(arg1 interface{}, arg2 interface{}) {
 			actualResult := arg1.(string) + " " + arg2.(string)
 			*actualIptablesDel = append(*actualIptablesDel, "del chain "+actualResult)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1925 

**What does this PR do / Why do we need it**:
IPv6 egress support for IPv4 EKS cluster

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Manual testing - unit testing has finished
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

```
bash-5.1# ip -6 a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
5: v6if0@if130: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 state UP 
    inet6 fd00::34/8 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::e0ac:89ff:fe27:4bdb/64 scope link 
       valid_lft forever preferred_lft forever
bash-5.1# ip -6 r
fd00::/8 dev v6if0 proto kernel metric 256 pref medium
fe80::/64 dev v6if0 proto kernel metric 256 pref medium
default via fe80::5c51:9ff:fe55:3ab2 dev v6if0 metric 1024 pref medium
bash-5.1# ping6 2600::
PING 2600::(2600::) 56 data bytes
64 bytes from 2600::: icmp_seq=1 ttl=43 time=37.6 ms
64 bytes from 2600::: icmp_seq=2 ttl=43 time=37.6 ms
64 bytes from 2600::: icmp_seq=3 ttl=43 time=37.6 ms
^C
--- 2600:: ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 37.598/37.619/37.633/0.015 ms
```


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
no
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.