### PR TITLE
Update recommended version for Kubernetes Release 1.26.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ For help, please consider the following venues (in order):
 For all Kubernetes releases, we recommend installing the latest VPC CNI release. The following table denotes our minimum recommended
 VPC CNI version for each actively supported Kubernetes release.
 
-| Kubernetes Release |    1.25    |    1.24    |    1.23    |    1.22    |
-| ------------------ | ---------- | ---------- | ---------- | ---------- |
-|  VPC CNI Version   |  v1.11.4+  |  v1.9.3+   |  v1.8.0+   |  v1.8.0+   |
+| Kubernetes Release |    1.26    |   1.25    |    1.24    |    1.23    |    1.22    |
+| ------------------ | ---------- | ----------| ---------- | ---------- | ---------- |
+|  VPC CNI Version   |  v1.12.0+  | v1.11.4+  |  v1.9.3+   |  v1.8.0+   |  v1.8.0+   |
 
 ## Version Upgrade
 


### PR DESCRIPTION
**What type of PR is this?**

documentation

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

Updated the recommendation to use 1.12 series for VPC CNI for K8S 1.26. 

In K8s 1.26, CRI v1alpha2 API which has been removed and using earlier VPC CNI versions will crash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
