### PR TITLE
Introduce `DISABLE_LEAKED_ENI_CLEANUP` to disable leaked ENI cleanup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,15 @@ Default: empty
 
 Specify the EC2 endpoint to use. This is useful if you are using a custom endpoint for EC2. For example, if you are using a proxy for EC2, you can set this to the proxy endpoint. Any kind of URL or IP address is valid such as `https://localhost:8080` or `http://ec2.us-west-2.customaws.com`. If this is not set, the default EC2 endpoint will be used.
 
+#### `DISABLE_LEAKED_ENI_CLEANUP` (v1.13.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+On IPv4 clusters, IPAMD schedules an hourly background task per node that cleans up leaked ENIs. Setting this environment variable to `true` disables that job. The primary motivation to disable this task is to decrease the amount of EC2 API calls made from each node.
+Note that disabling this task should be considered carefully, as it requires users to manually cleanup ENIs leaked in their account. See [#1223](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223) for a related discussion.
+
 ### VPC CNI Feature Matrix
 
 IP Mode | Secondary IP Mode | Prefix Delegation | Security Groups Per Pod | WARM & MIN IP/Prefix Targets | External SNAT

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -396,7 +396,7 @@ func (i instrumentedIMDS) GetMetadataWithContext(ctx context.Context, p string) 
 }
 
 // New creates an EC2InstanceMetadataCache
-func New(useCustomNetworking, disableENIProvisioning, v4Enabled, v6Enabled bool, eventRecorder *eventrecorder.EventRecorder) (*EC2InstanceMetadataCache, error) {
+func New(useCustomNetworking, disableLeakedENICleanup, v4Enabled, v6Enabled bool, eventRecorder *eventrecorder.EventRecorder) (*EC2InstanceMetadataCache, error) {
 	//ctx is passed to initWithEC2Metadata func to cancel spawned go-routines when tests are run
 	ctx := context.Background()
 
@@ -437,7 +437,7 @@ func New(useCustomNetworking, disableENIProvisioning, v4Enabled, v6Enabled bool,
 	}
 
 	// Clean up leaked ENIs in the background
-	if !disableENIProvisioning {
+	if !disableLeakedENICleanup {
 		go wait.Forever(cache.cleanUpLeakedENIs, time.Hour)
 	}
 
@@ -1807,7 +1807,6 @@ func (cache *EC2InstanceMetadataCache) getLeakedENIs() ([]*ec2.NetworkInterface,
 	}
 
 	err := cache.getENIsFromPaginatedDescribeNetworkInterfaces(input, filterFn)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "awsutils: unable to obtain filtered list of network interfaces")
 	}

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1503,11 +1503,11 @@ func TestDisablingENIProvisioning(t *testing.T) {
 	defer m.ctrl.Finish()
 
 	_ = os.Setenv(envDisableENIProvisioning, "true")
-	disabled := disablingENIProvisioning()
+	disabled := disableENIProvisioning()
 	assert.True(t, disabled)
 
 	_ = os.Unsetenv(envDisableENIProvisioning)
-	disabled = disablingENIProvisioning()
+	disabled = disableENIProvisioning()
 	assert.False(t, disabled)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#2360 

**What does this PR do / Why do we need it**:
This PR adds a new environment variable, `DISABLE_LEAKED_ENI_CLEANUP`, that disables the leaked ENI cleanup task that IPAMD runs every hour. It also disables the task for IPv6 clusters. The task runs on each node every hour and creates a burst of EC2 API calls that can lead to throttling in larger accounts. Eventually, the task of cleaning up leaked ENIs will move to the VPC Resource Controller. This solution is to help customers in the interim.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that task does not run when environment variable is set and that existing integration tests pass.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Introduce DISABLE_LEAKED_ENI_CLEANUP to disable leaked ENI cleanup task
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
