### PR TITLE
Remove go mod download from Dockerfiles

### DIFF
--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -8,14 +8,8 @@ ARG TARGETARCH
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 
-# Copy modules in before the rest of the source to only expire cache on module changes:
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY Makefile ./
-RUN make plugins && make debug-script
-
 COPY . ./
+RUN make plugins && make debug-script
 RUN make build-aws-vpc-cni-init
 
 # Build from EKS minimal base + glibc by default

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -7,10 +7,6 @@ WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 
-# Copy modules in before the rest of the source to only expire cache on module changes:
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . ./
 RUN make build-metrics
 

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -8,11 +8,6 @@ ARG TARGETARCH
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 
-# Copy modules in before the rest of the source to only expire cache on module changes:
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY Makefile ./
 COPY . ./
 RUN make build-aws-vpc-cni && make build-linux
 


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR removes the `go mod download` step from the init, main, and metrics-helper Dockerfile. The motivation is to speedup initial image build times, which should help in reducing the flakiness of builds in GitHub Actions. Running `go mod download` installs all go modules in the image builder workspace, including many which are not needed by the image being built. The downside of removing this step is that it removes a caching layer, so subsequent local builds cannot take advantage of the modules downloaded by previous local builds. This tradeoff is considered worth it since all GitHub Actions builds only happen once, and the overhead for local builds is not worth the flakiness or initial wait time.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that images can still be built.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
