### PR TITLE
refactoring eniconfig func to only take node as parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ build-aws-vpc-cni:    ## Build the VPC CNI container using the host's Go toolcha
 	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-vpc-cni     ./cmd/aws-vpc-cni
 
 # Build VPC CNI plugin & agent container image.
-docker:	setup-ec2-sdk-override	   ## Build VPC CNI plugin & agent container image.
+docker:	setup-ec2-sdk-override     ## Build VPC CNI plugin & agent container image.
 	docker build $(DOCKER_BUILD_FLAGS_CNI) \
 		-f scripts/dockerfiles/Dockerfile.release \
 		-t "$(IMAGE_NAME)" \

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -183,7 +183,7 @@ func TestNodeInit(t *testing.T) {
 
 	// Add IPs
 	m.awsutils.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
-
+	os.Setenv("MY_NODE_NAME", myNodeName)
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)
 }

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -1,11 +1,14 @@
 package k8sapi
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
@@ -140,4 +143,15 @@ func getRestConfig() (*rest.Config, error) {
 		restCfg.Host = endpoint
 	}
 	return restCfg, nil
+}
+
+func GetNode(ctx context.Context, k8sClient client.Client) (corev1.Node, error) {
+	log.Infof("Get Node Info for: %s", os.Getenv("MY_NODE_NAME"))
+	var node corev1.Node
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: os.Getenv("MY_NODE_NAME")}, &node)
+	if err != nil {
+		log.Errorf("error retrieving node: %s", err)
+		return node, err
+	}
+	return node, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Refactor a function in eniconfig package
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
exposing an API to VPC resource controller
**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
This PR refactor the function `GetNodeSpecificENIConfigName` which can exposes an API for VCP resource controller to call as a dependency.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
custom networking labels were tested after refactoring.
```
% k get no -oyaml | grep eniConfig
      vpc.amazonaws.com/eniConfig: us-west-2b
      vpc.amazonaws.com/eniConfig: us-west-2b
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/eniConfig: us-west-2b
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
no change on functionality
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
