### PR TITLE
Documentation and image tag changes for VPC CNI v1.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v1.13.0
+
+* Bug - [Increase datastore pool at startup](https://github.com/aws/amazon-vpc-cni-k8s/pull/2354) (@jdn5126 )
+* Bug - [Deallocate IP address according to warm IP target when multiple enis are present](https://github.com/aws/amazon-vpc-cni-k8s/pull/2368) (@bikashmishra100 )
+* Bug - [Return success from CNI DEL when IPAMD is unreachable](https://github.com/aws/amazon-vpc-cni-k8s/pull/2350) (@jdn5126 )
+* Bug - [Fix for aws-vpc-cni chart with tolerations to produce syntax valid yaml](https://github.com/aws/amazon-vpc-cni-k8s/pull/2345) (@Bourne-ID )
+* Bug - [adding ip check for annotatePod in ipamd](https://github.com/aws/amazon-vpc-cni-k8s/pull/2328) (@jerryhe1999 )
+* Feature - [Introduce DISABLE_LEAKED_ENI_CLEANUP to disable leaked ENI cleanup task](https://github.com/aws/amazon-vpc-cni-k8s/pull/2370) (@jdn5126 )
+* Feature - [Add IPv6 egress support to eks IPv4 cluster](https://github.com/aws/amazon-vpc-cni-k8s/pull/2361) (@wanyufe )
+* Feature - [feat(chart): Refactored image template logic for endpoint flexibility](https://github.com/aws/amazon-vpc-cni-k8s/pull/2335) (@stevehipwell )
+* Feature - [add AWS_EC2_ENDPOINT variable for custom endpoint](https://github.com/aws/amazon-vpc-cni-k8s/pull/2326) (@jihunseol )
+* Improvement - [Refactor egress-v4-cni plugin to support unit testing](https://github.com/aws/amazon-vpc-cni-k8s/pull/2353) (@wanyufe )
+* Improvement - [Update instance limits and core plugins version in preparation for upcoming VPC CNI release](https://github.com/aws/amazon-vpc-cni-k8s/pull/2390) (@jdn5126 )
+* Improvement - [refactoring eniconfig func to only take node as parameter](https://github.com/aws/amazon-vpc-cni-k8s/pull/2387) (@haouc )
+* Improvement - [Remove go mod download from Dockerfiles](https://github.com/aws/amazon-vpc-cni-k8s/pull/2383) (@jdn5126 )
+* Improvement - [Add apiVersion to MY_NODE_NAME](https://github.com/aws/amazon-vpc-cni-k8s/pull/2372) (@jdn5126 )
+* Improvement - [install all core CNI plugins via init container](https://github.com/aws/amazon-vpc-cni-k8s/pull/2355) (@jdn5126 )
+* Improvement - [Make all the aws vpc cni environmental variables case insensitive](https://github.com/aws/amazon-vpc-cni-k8s/pull/2334) (@jerryhe1999 )
+* Improvement - [resource limit on init container in eks addon](https://github.com/aws/amazon-vpc-cni-k8s/issues/2191 ) (@pdeva )
+* Testing - [Add integration test for POD v4/v6 egress traffic](https://github.com/aws/amazon-vpc-cni-k8s/pull/2371) (@wanyufe )
+
 ## v1.12.6
 
 * Bug - [Fix MTU parameter in egress-v4-cni plugin](https://github.com/aws/amazon-vpc-cni-k8s/pull/2295) (@jdn5126 )
@@ -63,6 +84,10 @@
 * Testing - [Resolve flakiness in IPAMD warm target tests](https://github.com/aws/amazon-vpc-cni-k8s/pull/2112) (@jdn5126 )
 * Testing - [VPC CNI Integration Test Fixes](https://github.com/aws/amazon-vpc-cni-k8s/pull/2105)  (@jdn5126 )
 * Testing - [Update CNI canary integration test and cleanup for ginkgo v2](https://github.com/aws/amazon-vpc-cni-k8s/pull/2088) (@jdn5126 )
+
+## v1.11.5
+
+* Bug - [Handle pod deletion when PrevResult has VLAN 0](https://github.com/aws/amazon-vpc-cni-k8s/pull/2323) (@jdn5126 )
 
 ## v1.11.4
 

--- a/README.md
+++ b/README.md
@@ -105,18 +105,6 @@ The following environment variables are available, and all of them are optional.
 
 ---
 
-#### `ENABLE_V6_EGRESS` (v1.13.0+)
-
-🚨 This feature is under active development. This feature is not released. 
-
-Type: Boolean as a String
-
-Default: `false`
-
-Specifies whether PODs in v4 cluster support IPv6 egress. If env is set to `true`, range `fd00::ac:00/118` is reserved for IPv6 egress.
-
----
-
 #### `AWS_MANAGE_ENIS_NON_SCHEDULABLE` (v1.12.6+)
 
 Type: Boolean as a String
@@ -668,6 +656,20 @@ Default: `false`
 
 On IPv4 clusters, IPAMD schedules an hourly background task per node that cleans up leaked ENIs. Setting this environment variable to `true` disables that job. The primary motivation to disable this task is to decrease the amount of EC2 API calls made from each node.
 Note that disabling this task should be considered carefully, as it requires users to manually cleanup ENIs leaked in their account. See [#1223](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223) for a related discussion.
+
+---
+
+#### `ENABLE_V6_EGRESS` (v1.13.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Specifies whether PODs in an IPv4 cluster support IPv6 egress. If env is set to `true`, range `fd00::ac:00/118` is reserved for IPv6 egress.
+
+This environment variable must be set for both the `aws-vpc-cni-init` and `aws-node` containers in order for this feature to work properly. This feature also requires that the node has an IPv6 address assigned to its primary ENI, as this address is used for SNAT to IPv6 endpoints outside of the cluster. If the configuration prerequisites are not met, the `egress-cni` plugin is not enabled and an error log is printed in the `aws-node` container.
+
+Note that enabling/disabling this feature only affects whether newly created pods have an IPv6 interface created. Therefore, it is recommended that you reload existing nodes after enabling/disabling this feature. Also note that if you are using this feature in conjunction with `ENABLE_POD_ENI` (Security Groups for Pods), the security group rules will NOT be applied to egressing IPv6 traffic.
 
 ### VPC CNI Feature Matrix
 

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.12.6
-appVersion: "v1.12.6"
+version: 1.13.0
+appVersion: "v1.13.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.12.6`                           |
+| `image.tag`             | Image tag                                               | `v1.13.0`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -49,7 +49,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.12.6`                           |
+| `init.image.tag`        | Image tag                                               | `v1.13.0`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.12.6
+    tag: v1.13.0
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -24,7 +24,7 @@ init:
     privileged: true
 
 image:
-  tag: v1.12.6
+  tag: v1.13.0
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.12.6
-appVersion: v1.12.6
+version: 1.13.0
+appVersion: v1.13.0
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.12.6            |
+| image.tag                    | Image tag                                                     | v1.13.0            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.12.6
+  tag: v1.13.0
   account: "602401143452"
   domain: "amazonaws.com"   
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.6"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.13.0"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.12.6"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.13.0"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.13.0"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.12.6"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.13.0"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.0"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.12.6"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.13.0"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.12.6"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.13.0"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.12.6"
+    app.kubernetes.io/version: "v1.13.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.12.6"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.13.0"
       serviceAccountName: cni-metrics-helper


### PR DESCRIPTION
**What type of PR is this?**
release prep

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the following:
1. CHANGELOG for VPC CNI v1.13.0 release
2. Charts and manifests for VPC CNI v1.13.0 release
3. Documentation for `ENABLE_V6_EGRESS` feature

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Release testing is in progress

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Release testing is in progress

**Does this change require updates to the CNI daemonset config files to work?**:
Image tag is updated

**Does this PR introduce any user-facing change?**:
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
