### PR TITLE
Set iptables mode automatically and deprecate ENABLE_NFTABLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ configured to operate in IPv6 mode. Prefix delegation is only supported on nitro
 
 ---
 
-#### `ENABLE_NFTABLES` (v1.12.1+)
+#### `ENABLE_NFTABLES` (introduced in v1.12.1, deprecated in v1.13.1+)
 
 Type: Boolean as a String
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,6 +247,8 @@ The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-no
 
   In v1.12.1+, `iptables-legacy` and `iptables-nft` are present in the VPC CNI container image. Setting `ENABLE_NFTABLES` environment variable to `true` instructs VPC CNI to use `iptables-nft`. By default, `iptables-legacy` is used.
 
+  In v1.13.1+, `ENABLE_NFTABLES` is deprecated and the iptables mode is set automatically based on the mode kubelet is using.
+
 ## cni-metrics-helper
 
 See the [cni-metrics-helper README](../cmd/cni-metrics-helper/README.md).

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -23,4 +23,7 @@ COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/egress-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-vpc-cni /app/
 
+# Set iptables mode automatically based on kubelet hint
+RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]
+
 ENTRYPOINT ["/app/aws-vpc-cni"]


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
#2388 

**What does this PR do / Why do we need it**:
This PR sets the iptables mode for `aws-node` pod automatically. Rather than using `ENABLE_NFTABLES` to decide when to run `update-alternatives`, we now rely on the `iptables-wrapper` script to set the mode based on which mode kubelet is using (kubelet iptables hint).

This PR also deprecates `ENABLE_NFTABLES` environment variable as it is no longer needed.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that `iptables-wrapper` script is run.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Set iptables mode automatically and deprecate ENABLE_NFTABLES
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
