### PR TITLE
chore: Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/test/agent"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION

**What type of PR is this?**

chore

**Which issue does this PR fix**: https://github.com/aws/amazon-vpc-cni-k8s/issues/2393

**What does this PR do / Why do we need it**:

Adds dependabot to help us keep dependencies up to date. Dependabot will automatically open PRs -- we have the option to merge them immediately, or hold as necessary. Minimally, it helps to keep us aware of new versions as they're available.

This can help reduce time to mitigation for issues like https://github.com/aws/amazon-vpc-cni-k8s/issues/2393.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
