### PR TITLE
Update networking test agent to Go1.20 and update golang.org/x/sys

### DIFF
--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.17-stretch as builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.20.4-5-gcc-al2 as builder
 
 WORKDIR /workspace
 ENV GOPROXY direct
@@ -29,10 +29,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
     -a -o snat-utils cmd/snat-utils/main.go
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum update -y && \
-    yum install -y iptables && \
-    yum clean all
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
 
 WORKDIR /
 COPY --from=builder /workspace/ .

--- a/test/agent/go.mod
+++ b/test/agent/go.mod
@@ -1,11 +1,11 @@
 module github.com/aws/amazon-vpc-cni-k8s/test/agent
 
-go 1.18
+go 1.20
 
 require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
+	golang.org/x/sys v0.8.0
 )
 
 require github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect

--- a/test/agent/go.sum
+++ b/test/agent/go.sum
@@ -5,5 +5,5 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
-golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the networking test agent used for integration tests to be built with Go1.20 and a minimal base image from EKS distro.

The motivation for this change is to address dependabot alerts for this test image and to bring this test image inline with other VPC CNI Dockerfiles. In a future PR, the hash used for this image (https://github.com/aws/amazon-vpc-cni-k8s/blob/master/test/framework/utils/const.go#L27) will be updated.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that image builds and can be run without issue

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
