### PR TITLE
Update test agent image

### DIFF
--- a/test/agent/Makefile
+++ b/test/agent/Makefile
@@ -37,7 +37,7 @@ check-env:
 	@:$(call check_var, AWS_REGION, AWS region for publishing docker images)
 
 check-env-public:
-	@:$(call check_var, REGISTRY_ID, Registery ID for publishing docker images to public ECR Repo)
+	@:$(call check_var, REGISTRY_ID, Registry ID for publishing docker images to public ECR Repo)
 
 check_var = \
     $(strip $(foreach 1,$1, \

--- a/test/agent/README.md
+++ b/test/agent/README.md
@@ -64,9 +64,10 @@ Apart from running the tests on your local environment. For some test cases wher
 
 #### Running the docker Image
 
-Run the following command to build the agent image and push to ECR. This needs an existing repository with name "aws-vpc-cni-test-helper"
+Run the following command to build the agent image and push to ECR public. This needs an existing repository with name "aws-vpc-cni-test-helper"
 ```
-AWS_ACCOUNT=<account> AWS_REGION=<region> make docker-build docker-push
+export REGISTRY_ID=eks
+make publish-public-image
 ``` 
 Change the agent image in the Go code and run the test case as usual.
 

--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -24,7 +24,7 @@ const (
 	MultusContainerName  = "kube-multus"
 
 	// See https://gallery.ecr.aws/eks/aws-vpc-cni-test-helper
-	TestAgentImage = "networking-e2e-test-images/aws-vpc-cni-test-helper:770278ef"
+	TestAgentImage = "networking-e2e-test-images/aws-vpc-cni-test-helper:b9ec2ff5"
 	BusyBoxImage   = "networking-e2e-test-images/busybox:latest"
 	NginxImage     = "networking-e2e-test-images/nginx:1.21.4"
 	NetCatImage    = "networking-e2e-test-images/netcat-openbsd:v1.0"


### PR DESCRIPTION
**What type of PR is this?**
test agent image update

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the networking test agent image to resolve CVEs in image. It follows https://github.com/aws/amazon-vpc-cni-k8s/pull/2413

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that test agent image works

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
