### PR TITLE
v1.13.2 release: CHANGELOG, chart, and manifest updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.13.2
+
+* Bug - [Sync node security groups to cache before node initialization](https://github.com/aws/amazon-vpc-cni-k8s/pull/2427) (@jdn5126 )
+* Improvement - [Fix hard-coded nitro instance types: p4de.24xlarge and c7g.metal](https://github.com/aws/amazon-vpc-cni-k8s/pull/2428) (@jdn5126 )
+* Improvement - [Upgrade to Go 1.20 and apply dependabot updates](https://github.com/aws/amazon-vpc-cni-k8s/pull/2412)
+* Improvement - [Set iptables mode automatically and deprecate ENABLE_NFTABLES](https://github.com/aws/amazon-vpc-cni-k8s/pull/2402) (@jdn5126 )
+* Improvement - [Upgrade client-go and controller-runtime modules](https://github.com/aws/amazon-vpc-cni-k8s/pull/2396) (@jdn5126 )
+
 ## v1.13.0
 
 * Bug - [Increase datastore pool at startup](https://github.com/aws/amazon-vpc-cni-k8s/pull/2354) (@jdn5126 )

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ configured to operate in IPv6 mode. Prefix delegation is only supported on nitro
 
 ---
 
-#### `ENABLE_NFTABLES` (introduced in v1.12.1, deprecated in v1.13.1+)
+#### `ENABLE_NFTABLES` (introduced in v1.12.1, deprecated in v1.13.2+)
 
 Type: Boolean as a String
 

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.13.0
-appVersion: "v1.13.0"
+version: 1.13.2
+appVersion: "v1.13.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.13.0`                           |
+| `image.tag`             | Image tag                                               | `v1.13.2`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -49,7 +49,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.13.0`                           |
+| `init.image.tag`        | Image tag                                               | `v1.13.2`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.13.0
+    tag: v1.13.2
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -24,7 +24,7 @@ init:
     privileged: true
 
 image:
-  tag: v1.13.0
+  tag: v1.13.2
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.13.0
-appVersion: v1.13.0
+version: 1.13.2
+appVersion: v1.13.2
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.13.0            |
+| image.tag                    | Image tag                                                     | v1.13.2            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.13.0
+  tag: v1.13.2
   account: "602401143452"
   domain: "amazonaws.com"   
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.13.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.13.2"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.13.0"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.13.2"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.13.2"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.13.0"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.13.2"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.13.2"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.13.0"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.13.2"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -117,7 +117,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.2"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -138,7 +138,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.0"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.2"
           ports:
             - containerPort: 61678
               name: metrics

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.13.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.13.2"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.13.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.13.2"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.13.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.13.2"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.13.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,5 +64,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.13.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.13.2"
       serviceAccountName: cni-metrics-helper


### PR DESCRIPTION
**What type of PR is this?**
release

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the charts, manifests, and CHANGELOG for the pending VPC CNI `v1.13.2` release. `v1.13.1` is skipped as that image tag was already built before new changes were required.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
Yes, image tags are updated

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
