### PR TITLE
update docs and CNI logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Default: `DEBUG`
 
 Valid Values: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`. (Not case sensitive)
 
-Specifies the loglevel for `ipamd` and `cni-metric-helper`.
+Specifies the log level for `ipamd` and `cni-metric-helper`.
 
 ---
 
@@ -326,9 +326,13 @@ Type: String
 
 Default: `/host/var/log/aws-routed-eni/ipamd.log`
 
-Valid Values: `stdout` or a file path
+Valid Values: `stdout`, `stderr`, or a file path
 
-Specifies where to write the logging output of `ipamd`. Either to stdout or to override the default file (i.e., `/var/log/aws-routed-eni/ipamd.log`).
+Specifies where to write the logging output of `ipamd`: `stdout`, `stderr`, or a file path other than the default (`/var/log/aws-routed-eni/ipamd.log`).
+
+Note: `/host/var/log/...` is the container file-system path, which maps to `/var/log/...` on the node.
+
+Note: The IPAMD process runs within the `aws-node` pod, so writing to `stdout` or `stderr` will write to `aws-node` pod logs.
 
 ---
 
@@ -338,12 +342,15 @@ Type: String
 
 Default: `/var/log/aws-routed-eni/plugin.log`
 
-Valid Values: `stderr` or a file path
+Valid Values: `stderr` or a file path. Note that setting to the empty string is an alias for `stderr`, and this comes from upstream kubernetes best practices.
 
-Specifies where to write the logging output for `aws-cni` plugin. Either to `stderr` or to override the default file (i.e., `/var/log/aws-routed-eni/plugin.log`).
-`Stdout` cannot be supported for plugin log, please refer to [#1248](https://github.com/aws/amazon-vpc-cni-k8s/issues/1248) for more details.
+Specifies where to write the logging output for `aws-cni` plugin: `stderr` or a file path other than the default (`/var/log/aws-routed-eni/plugin.log`).
 
-Note: If chaining an external plugin (i.e Cilium) that does not provide a `pluginLogFile` in its config file, the CNI plugin will by default write to `os.Stderr`. The output of `cmdAdd` are available in the Kubelet logs.
+Note: `stdout` cannot be supported for plugin log. Please refer to [#1248](https://github.com/aws/amazon-vpc-cni-k8s/issues/1248) for more details.
+
+Note: In EKS 1.24+, the CNI plugin is exec'ed by the container runtime, so `stderr` is for the container-runtime process, NOT the `aws-node` pod. In older versions, the CNI plugin was exec'ed by kubelet, so `stderr` is for the kubelet process.
+
+Note: If chaining an external plugin (i.e. Cilium) that does not provide a `pluginLogFile` in its config file, the CNI plugin will by default write to `os.Stderr`.
 
 ---
 

--- a/cmd/cni-metrics-helper/metrics/pod_watcher.go
+++ b/cmd/cni-metrics-helper/metrics/pod_watcher.go
@@ -56,6 +56,6 @@ func (d *defaultPodWatcher) GetCNIPods(ctx context.Context) ([]string, error) {
 		CNIPods = append(CNIPods, pod.Name)
 	}
 
-	d.log.Infof("Total aws-node pod count:- ", len(CNIPods))
+	d.log.Infof("Total aws-node pod count: %d", len(CNIPods))
 	return CNIPods, nil
 }

--- a/pkg/utils/logger/zaplogger.go
+++ b/pkg/utils/logger/zaplogger.go
@@ -130,14 +130,14 @@ func (logConfig *Configuration) newZapLogger() *structuredLogger {
 func getPluginLogFilePath(logFilePath string) zapcore.WriteSyncer {
 	var writer zapcore.WriteSyncer
 
-	if logFilePath == "" {
+	// When path is explicitly empty, write to stderr
+	if logFilePath == "" || strings.ToLower(logFilePath) == "stderr" {
 		writer = zapcore.Lock(os.Stderr)
-	} else if strings.ToLower(logFilePath) != "stdout" {
-		writer = getLogWriter(logFilePath)
-	} else {
+	} else if strings.ToLower(logFilePath) == "stdout" {
 		writer = zapcore.Lock(os.Stdout)
+	} else {
+		writer = getLogWriter(logFilePath)
 	}
-
 	return writer
 }
 


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2420
https://github.com/aws/amazon-vpc-cni-k8s/issues/2418

**What does this PR do / Why do we need it**:
This PR updates the documentation for `AWS_VPC_K8S_CNI_LOGLEVEL` and `AWS_VPC_K8S_CNI_LOG_FILE`. It also simplifies the logic in `pkg/utils/logger/zaplogger.go` and fixes the formatting string bug mentioned in #2420 .

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified log outputs on running cluster

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
