### PR TITLE
Scope the cached k8s client to the node

### DIFF
--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -8,19 +8,21 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 )
 
 var log = logger.Get()
@@ -45,11 +47,16 @@ func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
 		return nil, err
 	}
 	vpcCniScheme := runtime.NewScheme()
-	clientgoscheme.AddToScheme(vpcCniScheme)
-	eniconfigscheme.AddToScheme(vpcCniScheme)
+	err = clientgoscheme.AddToScheme(vpcCniScheme)
+	if err != nil {
+		return nil, err
+	}
+	err = eniconfigscheme.AddToScheme(vpcCniScheme)
+	if err != nil {
+		return nil, err
+	}
 
 	rawK8SClient, err := client.New(restCfg, client.Options{Scheme: vpcCniScheme, Mapper: mapper})
-
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +64,8 @@ func CreateKubeClient(mapper meta.RESTMapper) (client.Client, error) {
 	return rawK8SClient, nil
 }
 
-// CreateKubeClient creates a k8s client
+// CreateCachedKubeClient creates a k8s client which caches
+// pods.
 func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) (client.Client, error) {
 	restCfg, err := getRestConfig()
 	if err != nil {
@@ -66,16 +74,32 @@ func CreateCachedKubeClient(rawK8SClient client.Client, mapper meta.RESTMapper) 
 	restCfg.Burst = 100
 
 	vpcCniScheme := runtime.NewScheme()
-	clientgoscheme.AddToScheme(vpcCniScheme)
-	eniconfigscheme.AddToScheme(vpcCniScheme)
+	err = clientgoscheme.AddToScheme(vpcCniScheme)
+	if err != nil {
+		return nil, err
+	}
+	err = eniconfigscheme.AddToScheme(vpcCniScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	// we only care about pods on the current node.
+	// selecting every pod leads to high memory usage
+	// on larger clusters.
+	cacheOptions := crcache.Options{Scheme: vpcCniScheme, Mapper: mapper}
+	if nodeName := os.Getenv("MY_NODE_NAME"); nodeName != "" {
+		cacheOptions.SelectorsByObject = map[client.Object]crcache.ObjectSelector{&corev1.Pod{}: {
+			Field: fields.Set{"spec.nodeName": nodeName}.AsSelector(),
+		}}
+	}
 
 	stopChan := ctrl.SetupSignalHandler()
-	cache, err := cache.New(restCfg, cache.Options{Scheme: vpcCniScheme, Mapper: mapper})
+	cache, err := crcache.New(restCfg, cacheOptions)
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		cache.Start(stopChan)
+		_ = cache.Start(stopChan)
 	}()
 	cache.WaitForCacheSync(stopChan)
 

--- a/pkg/k8sapi/k8sutils_test.go
+++ b/pkg/k8sapi/k8sutils_test.go
@@ -5,33 +5,42 @@ import (
 	"os"
 	"testing"
 
-	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 )
 
 func TestGetNode(t *testing.T) {
+	var err error
 	ctx := context.Background()
 	k8sSchema := runtime.NewScheme()
-	clientgoscheme.AddToScheme(k8sSchema)
-	eniconfigscheme.AddToScheme(k8sSchema)
+	err = clientgoscheme.AddToScheme(k8sSchema)
+	assert.NoError(t, err)
+
+	err = eniconfigscheme.AddToScheme(k8sSchema)
+	assert.NoError(t, err)
 
 	fakeNode := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "testNode",
 		},
 	}
-	k8sClient := fake.NewFakeClientWithScheme(k8sSchema, fakeNode)
-	os.Setenv("MY_NODE_NAME", "testNode")
+	k8sClient := fake.NewClientBuilder().WithScheme(k8sSchema).WithObjects(fakeNode).Build()
+	err = os.Setenv("MY_NODE_NAME", "testNode")
+	assert.NoError(t, err)
+
 	node, err := GetNode(ctx, k8sClient)
 	assert.NoError(t, err)
 	assert.Equal(t, node.Name, "testNode")
 
-	os.Setenv("MY_NODE_NAME", "dummyNode")
+	err = os.Setenv("MY_NODE_NAME", "dummyNode")
+	assert.NoError(t, err)
+
 	_, err = GetNode(ctx, k8sClient)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** bug (regression)

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: https://github.com/aws/amazon-vpc-cni-k8s/issues/2436


**What does this PR do / Why do we need it**: CNI daemonsets should use as minimal memory as possible since they are run on most nodes.




**Testing done on this change**:

Deploy to a medium sized staging cluster (3000+ pods).

Before change
```
aws-cni-xw4ts                            5m           432Mi
aws-cni-zt5wr                            6m           446Mi
aws-cni-zxch8                            8m           453Mi
```

After scoping caching client
```
aws-cni-ppx92                            9m           72Mi
aws-cni-ppzml                            7m           39Mi
aws-cni-q27wl                            6m           42Mi
aws-cni-qg6ww                            5m           48Mi
aws-cni-r2lwc                            8m           77Mi
aws-cni-r5nr5                            9m           49Mi
aws-cni-rjxjj                            7m           76Mi
aws-cni-rmhzf                            2m           68Mi
aws-cni-rx7wq                            4m           53Mi
aws-cni-scpc6                            7m           44Mi
aws-cni-sfbkf                            6m           42Mi
```

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: reliance on `MY_NODE_NAME` being set via downward API.
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: This has been tested on a running cluster


**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: Substantially less memory usage (still more than before the caching client was used though).
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
