### PR TITLE
Silences nightly cron jobs for forks

### DIFF
--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   nightly-cron-test:
+    if: github.repository == 'aws/amazon-vpc-cni-k8s'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
If you have a fork of this repo, the nightly cron jobs will fail unless you set them up. Forks don't need the nightly cron jobs, IMO, unless you're intentionally testing them.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
Fork the repo.

**Testing done on this change**:
none

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
