### PR TITLE
Add custom-networking integration test covering ENIConfig objects with no security groups

### DIFF
--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -218,12 +218,10 @@ func CreateAndWaitTillSelfManagedNGReady(f *framework.Framework, properties Node
 }
 
 func DeleteAndWaitTillSelfManagedNGStackDeleted(f *framework.Framework, properties NodeGroupProperties) error {
-	err := f.CloudServices.CloudFormation().
-		WaitTillStackDeleted(properties.NodeGroupName)
+	err := f.CloudServices.CloudFormation().WaitTillStackDeleted(properties.NodeGroupName)
 	if err != nil {
 		return fmt.Errorf("failed to delete node group cfn stack: %v", err)
 	}
-
 	return nil
 }
 

--- a/test/framework/resources/k8s/manifest/eniconfig.go
+++ b/test/framework/resources/k8s/manifest/eniconfig.go
@@ -52,13 +52,24 @@ func (e *ENIConfigBuilder) Build() (*v1alpha1.ENIConfig, error) {
 		return nil, fmt.Errorf("subnet id is a required field")
 	}
 
-	return &v1alpha1.ENIConfig{
-		ObjectMeta: v1.ObjectMeta{
-			Name: e.name,
-		},
-		Spec: v1alpha1.ENIConfigSpec{
-			SecurityGroups: e.securityGroup,
-			Subnet:         e.subnetID,
-		},
-	}, nil
+	if e.securityGroup == nil {
+		return &v1alpha1.ENIConfig{
+			ObjectMeta: v1.ObjectMeta{
+				Name: e.name,
+			},
+			Spec: v1alpha1.ENIConfigSpec{
+				Subnet: e.subnetID,
+			},
+		}, nil
+	} else {
+		return &v1alpha1.ENIConfig{
+			ObjectMeta: v1.ObjectMeta{
+				Name: e.name,
+			},
+			Spec: v1alpha1.ENIConfigSpec{
+				SecurityGroups: e.securityGroup,
+				Subnet:         e.subnetID,
+			},
+		}, nil
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds integration test coverage for `custom-networking` when ENIConfig objects are created without any security groups. The test does the following:
1. Deletes existing ENIConfigs and recreates them without security groups
2. Terminates nodes and waits for them to be recycled
3. Creates a deployment and verifies that it succeeds

More connectivity cases may be added in the future, but pod connectivity is skipped from this new case as it is trivial and covered in the above cases. It also significantly increases the runtime.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Stress tested case to make sure that it is not flaky

**Automation added to e2e**:
Added test case

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
