### PR TITLE
For k8s client cache, only cache pods on this node

### DIFF
--- a/pkg/k8sapi/k8sutils_test.go
+++ b/pkg/k8sapi/k8sutils_test.go
@@ -5,33 +5,42 @@ import (
 	"os"
 	"testing"
 
-	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 )
 
 func TestGetNode(t *testing.T) {
+	var err error
 	ctx := context.Background()
 	k8sSchema := runtime.NewScheme()
-	clientgoscheme.AddToScheme(k8sSchema)
-	eniconfigscheme.AddToScheme(k8sSchema)
+	err = clientgoscheme.AddToScheme(k8sSchema)
+	assert.NoError(t, err)
+
+	err = eniconfigscheme.AddToScheme(k8sSchema)
+	assert.NoError(t, err)
 
 	fakeNode := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "testNode",
 		},
 	}
-	k8sClient := fake.NewFakeClientWithScheme(k8sSchema, fakeNode)
-	os.Setenv("MY_NODE_NAME", "testNode")
+	k8sClient := fake.NewClientBuilder().WithScheme(k8sSchema).WithObjects(fakeNode).Build()
+	err = os.Setenv("MY_NODE_NAME", "testNode")
+	assert.NoError(t, err)
+
 	node, err := GetNode(ctx, k8sClient)
 	assert.NoError(t, err)
 	assert.Equal(t, node.Name, "testNode")
 
-	os.Setenv("MY_NODE_NAME", "dummyNode")
+	err = os.Setenv("MY_NODE_NAME", "dummyNode")
+	assert.NoError(t, err)
+
 	_, err = GetNode(ctx, k8sClient)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
**What type of PR is this?**
enhancement

**Which issue does this PR fix**:
#2436 

**What does this PR do / Why do we need it**:
This PR is a replacement of https://github.com/aws/amazon-vpc-cni-k8s/pull/2439 to speed up the merging process. See that PR for more details.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that integration tests pass and memory usage is decreased.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Restrict pod caching in kubernetes client cache to only pods on node
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
