### PR TITLE
Decrease memory usage by K8S Clients

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -52,7 +52,7 @@ func _main() int {
 		return 1
 	}
 
-	cacheK8SClient, err := k8sapi.CreateCachedKubeClient(rawK8SClient, mapper)
+	cacheK8SClient, err := k8sapi.CreateCachedKubeClient(rawK8SClient, mapper, true)
 	if err != nil {
 		log.Errorf("Failed to create cached kube client: %s", err)
 		return 1

--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -118,7 +118,7 @@ func main() {
 		log.Fatalf("Error creating Kubernetes Client: %s", err)
 		os.Exit(1)
 	}
-	k8sClient, err := k8sapi.CreateCachedKubeClient(rawK8SClient, mapper)
+	k8sClient, err := k8sapi.CreateCachedKubeClient(rawK8SClient, mapper, false)
 	if err != nil {
 		log.Fatalf("Error creating Cached Kubernetes Client: %s", err)
 		os.Exit(1)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -568,7 +568,7 @@ func (c *IPAMContext) nodeInit() error {
 
 	node, err := k8sapi.GetNode(ctx, c.cachedK8SClient)
 	if err != nil {
-		log.Errorf("Failed to host node", err)
+		log.Errorf("Failed to get node", err)
 		podENIErrInc("nodeInit")
 		return err
 	}

--- a/pkg/k8sapi/k8sutils_test.go
+++ b/pkg/k8sapi/k8sutils_test.go
@@ -10,14 +10,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetNode(t *testing.T) {
 	ctx := context.Background()
 	k8sSchema := runtime.NewScheme()
-	clientgoscheme.AddToScheme(k8sSchema)
+	corev1.AddToScheme(k8sSchema)
 	eniconfigscheme.AddToScheme(k8sSchema)
 
 	fakeNode := &corev1.Node{
@@ -25,7 +24,7 @@ func TestGetNode(t *testing.T) {
 			Name: "testNode",
 		},
 	}
-	k8sClient := fake.NewFakeClientWithScheme(k8sSchema, fakeNode)
+	k8sClient := fake.NewClientBuilder().WithScheme(k8sSchema).WithObjects(fakeNode).Build()
 	os.Setenv("MY_NODE_NAME", "testNode")
 	node, err := GetNode(ctx, k8sClient)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2436

**What does this PR do / Why do we need it**:
This PR modifies the schemas used by the raw and cached Kubernetes clients in the IPAMD and Metrics Helper agents. These clients only need to add the `corev1` scheme: https://github.com/kubernetes/api/blob/v0.26.5/core/v1/register.go#L45 , as the clients only make GET and LIST calls for objects added by this scheme.

Decreasing the number of objects loaded decreases the memory consumed by these clients. For IPAMD, a selector is added for pods such that only pods on the deployed node are cached. Metrics Helper does not add this selector, as it needs to query `aws-node` pods on all nodes. Metrics Helper already has a label selector in its pod watcher.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Running the performance tests yielded the following memory decrease:
`v1.13.2`:
* Base memory usage of aws-node pod: 44Mi
* After deploying 5000 pods: 107Mi
* After scaling down to 0 pods: 70Mi

`this PR`:
* Base memory usage of aws-node pod: 30Mi
* After deploying 5000 pods: 45Mi
* After scaling down to 0 pods: 45Mi

I also validated that all integration tests pass. I will schedule a manual run against this PR as well.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Decrease `aws-node` and `cni-metrics-helper` memory usage.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
