### PR TITLE
Fix event recorder initialization and add check to log

### DIFF
--- a/pkg/utils/eventrecorder/eventrecorder.go
+++ b/pkg/utils/eventrecorder/eventrecorder.go
@@ -23,15 +23,20 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var log = logger.Get()
 var MyNodeName = os.Getenv("MY_NODE_NAME")
 var MyPodName = os.Getenv("MY_POD_NAME")
+
+// Global variable for EventRecorder allows dependent packages to simply call Get
+var eventRecorder *EventRecorder
 
 const (
 	EventReason = sgpp.VpcCNIEventReason
@@ -39,17 +44,15 @@ const (
 
 type EventRecorder struct {
 	Recorder        events.EventRecorder
-	RawK8SClient    client.Client
 	CachedK8SClient client.Client
-	HostID          string
 	hostPod         corev1.Pod
 }
 
-func New(rawK8SClient, cachedK8SClient client.Client) (*EventRecorder, error) {
+func Init(cachedK8SClient client.Client) error {
 	clientSet, err := k8sapi.GetKubeClientSet()
 	if err != nil {
 		log.Fatalf("Error Fetching Kubernetes Client: %s", err)
-		return nil, err
+		return err
 	}
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{
 		Interface: clientSet.EventsV1(),
@@ -59,15 +62,17 @@ func New(rawK8SClient, cachedK8SClient client.Client) (*EventRecorder, error) {
 
 	eventRecorder := &EventRecorder{}
 	eventRecorder.Recorder = eventBroadcaster.NewRecorder(clientgoscheme.Scheme, "aws-node")
-	eventRecorder.RawK8SClient = rawK8SClient
 	eventRecorder.CachedK8SClient = cachedK8SClient
 
 	if eventRecorder.hostPod, err = findMyPod(eventRecorder.CachedK8SClient); err != nil {
 		log.Errorf("Failed to find host aws-node pod: %s", err)
+		// EventRecorder is not considered critical, so no error is returned if host pod cannot be queried
 	}
+	return nil
+}
 
-	return eventRecorder, nil
-
+func Get() *EventRecorder {
+	return eventRecorder
 }
 
 // SendPodEvent will raise event on aws-node with given type, reason, & message
@@ -88,4 +93,17 @@ func findMyPod(cachedK8SClient client.Client) (corev1.Pod, error) {
 		log.Debugf("Node found %s - labels - %d", pod.Name, len(pod.Labels))
 	}
 	return pod, err
+}
+
+// Functions used for mocking package
+func InitMockEventRecorder() *events.FakeRecorder {
+	fakeRecorder := events.NewFakeRecorder(3)
+	k8sSchema := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sSchema)
+
+	eventRecorder = &EventRecorder{
+		Recorder:        fakeRecorder,
+		CachedK8SClient: testclient.NewClientBuilder().WithScheme(k8sSchema).Build(),
+	}
+	return fakeRecorder
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2466
https://github.com/aws/amazon-vpc-cni-k8s/issues/2448

**What does this PR do / Why do we need it**:
For #2466 , this PR fixes an issue with creating events when IAM permissions are missing. The EventRecorder object was not being properly initialized. Also, the `EventRecorder` package is now more modular, so dependent packages can simply call `eventrecorder.Get()` to get the object. Initialization is left to `aws-k8s-agent` on startup.

For #2448 , this PR fixes a logging issue where a malformed EC2 response (missing `Attachment`) was trying to access the missing field in order to log.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that integration tests pass. Scheduling runner against this PR.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Fix issue where missing IAM permissions did not generate Event; handle malformed EC2 response
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
