### PR TITLE
RefreshSecurityGroups must be called after unmanaged ENIs are set

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -538,7 +538,9 @@ func (c *IPAMContext) nodeInit() error {
 		vpcV4CIDRs = c.updateCIDRsRulesOnChange(vpcV4CIDRs)
 	}, 30*time.Second)
 
-	// Retrieve security groups
+	// RefreshSGIDs populates the ENI cache with ENI -> security group ID mappings, and so it must be called:
+	// 1. after managed/unmanaged ENIs have been determined
+	// 2. before any new ENIs are attached
 	if c.enableIPv4 && !c.disableENIProvisioning {
 		if err := c.awsClient.RefreshSGIDs(primaryENIMac); err != nil {
 			return err

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -150,8 +150,8 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs, nil)
 	m.awsutils.EXPECT().GetPrimaryENImac().Return("")
 	m.network.EXPECT().SetupHostNetwork(cidrs, "", &primaryIP, false, true, false).Return(nil)
-
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
+	m.awsutils.EXPECT().RefreshSGIDs(gomock.Any()).AnyTimes().Return(nil)
 
 	eniMetadataSlice := []awsutils.ENIMetadata{eni1, eni2}
 	resp := awsutils.DescribeAllENIsResult{
@@ -179,7 +179,7 @@ func TestNodeInit(t *testing.T) {
 		Spec:       v1.NodeSpec{},
 		Status:     v1.NodeStatus{},
 	}
-	_ = m.cachedK8SClient.Create(ctx, &fakeNode)
+	m.cachedK8SClient.Create(ctx, &fakeNode)
 
 	// Add IPs
 	m.awsutils.EXPECT().AllocIPAddresses(gomock.Any(), gomock.Any())
@@ -236,8 +236,8 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs, nil)
 	m.awsutils.EXPECT().GetPrimaryENImac().Return("")
 	m.network.EXPECT().SetupHostNetwork(cidrs, "", &primaryIP, false, true, false).Return(nil)
-
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
+	m.awsutils.EXPECT().RefreshSGIDs(gomock.Any()).AnyTimes().Return(nil)
 
 	eniMetadataSlice := []awsutils.ENIMetadata{eni1, eni2}
 	resp := awsutils.DescribeAllENIsResult{
@@ -264,8 +264,9 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 		Spec:       v1.NodeSpec{},
 		Status:     v1.NodeStatus{},
 	}
-	_ = m.cachedK8SClient.Create(ctx, &fakeNode)
+	m.cachedK8SClient.Create(ctx, &fakeNode)
 
+	os.Setenv("MY_NODE_NAME", myNodeName)
 	err := mockContext.nodeInit()
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2470

**What does this PR do / Why do we need it**:
This PR moves the call to `RefreshSGIDs` to `nodeInit` after unmanaged ENIs are set. This is required to fix a regression where security groups on unmanaged ENIs were getting modified during node init.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
This is caused by https://github.com/aws/amazon-vpc-cni-k8s/pull/2427, which fixed https://github.com/aws/amazon-vpc-cni-k8s/issues/2426. I manually verified that https://github.com/aws/amazon-vpc-cni-k8s/issues/2426 is still fixed.

I also manually verified the dependencies on the ordering here. All integration tests pass, and I am kicking off a GitHub runner for this as well.

I filed https://github.com/aws/amazon-vpc-cni-k8s/issues/2474 to add more integration test coverage for unmanaged ENIs.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Fix regression where unmanaged ENIs had their security groups modified during init.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
