### PR TITLE
Add README note for enabling CLUSTER_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ Default: `""`
 Specifies the cluster endpoint to use for connecting to the api-server without relying on kube-proxy. 
 This is an optional configuration parameter that can improve the initialization time of the AWS VPC CNI.
 
+**NOTE!** When setting CLUSTER_ENDPOINT, it is *STRONGLY RECOMMENDED* that you enable private endpoint access for your API server, otherwise VPC CNI requests can traverse the public NAT gateway and may result in additional charges.
+
 ---
 
 #### `ENABLE_POD_ENI` (v1.7.0+)


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds a note to the README for CLUSTER_ENDPOINT recommending customers enable private endpoint access to their API server, otherwise requests will traverse the public NAT gateway and incur charges.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
