### PR TITLE
IP_COOLDOWN_PERIOD environment variable for ip cooldown period configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,19 @@ This environment variable must be set for both the `aws-vpc-cni-init` and `aws-n
 
 Note that enabling/disabling this feature only affects whether newly created pods have an IPv6 interface created. Therefore, it is recommended that you reboot existing nodes after enabling/disabling this feature. Also note that if you are using this feature in conjunction with `ENABLE_POD_ENI` (Security Groups for Pods), the security group rules will NOT be applied to egressing IPv6 traffic.
 
+----
+
+#### `IP_COOLDOWN_PERIOD` (v1.14.1+)
+
+Type: Integer as a String
+
+Default: `30`
+
+Specifies the number of seconds an IP address is in cooldown after pod deletion. The cooldown period gives network proxies, such as kube-proxy, time to update node iptables rules when the IP was registered as a valid endpoint, such as for a service. Modify this value with caution, as kube-proxy update time scales with the number of nodes and services.
+
+**Note:** 0 is a supported value, however it is highly discouraged.
+**Note:** Higher cooldown periods may lead to a higher number of EC2 API calls as IPs are in cooldown cache.
+
 ### VPC CNI Feature Matrix
 
 IP Mode | Secondary IP Mode | Prefix Delegation | Security Groups Per Pod | WARM & MIN IP/Prefix Targets | External SNAT

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -80,6 +80,7 @@ const (
 	vpcCniInitDonePath           = "/vpc-cni-init/done"
 	defaultEnBandwidthPlugin     = false
 	defaultEnPrefixDelegation    = false
+	defaultIPCooldownPeriod      = 30
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -99,6 +100,7 @@ const (
 	envEnIPv6                = "ENABLE_IPv6"
 	envEnIPv6Egress          = "ENABLE_V6_EGRESS"
 	envRandomizeSNAT         = "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
+	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 )
 
 // NetConfList describes an ordered list of networks.
@@ -345,6 +347,13 @@ func validateEnvVars() bool {
 			log.Errorf("%s must be set to either 'strict' or 'standard'", envPodSGEnforcingMode)
 			return false
 		}
+	}
+
+	// Validate that IP_COOLDOWN_PERIOD is a valid integer
+	ipCooldownPeriod, err, input := utils.GetIntFromStringEnvVar(envIPCooldownPeriod, defaultIPCooldownPeriod)
+	if err != nil || ipCooldownPeriod < 0 {
+		log.Errorf("IP_COOLDOWN_PERIOD MUST be a valid positive integer. %s is invalid", input)
+		return false
 	}
 
 	prefixDelegationEn := utils.GetBoolAsStringEnvVar(envEnPrefixDelegation, defaultEnPrefixDelegation)

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -16,6 +16,7 @@ package datastore
 import (
 	"errors"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -888,6 +889,8 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 }
 
 func TestGetIPStatsV4(t *testing.T) {
+	os.Setenv(envIPCooldownPeriod, "1")
+	defer os.Unsetenv(envIPCooldownPeriod)
 	ds := NewDataStore(Testlog, NullCheckpoint{}, false)
 
 	_ = ds.AddENI("eni-1", 1, true, false, false)
@@ -925,8 +928,9 @@ func TestGetIPStatsV4(t *testing.T) {
 		*ds.GetIPStats("4"),
 	)
 
-	// wait 30s (cooldown period)
-	time.Sleep(30 * time.Second)
+	assert.Equal(t, ds.ipCooldownPeriod, 1*time.Second)
+	// wait 1s (cooldown period)
+	time.Sleep(ds.ipCooldownPeriod)
 
 	assert.Equal(t,
 		DataStoreStats{
@@ -939,6 +943,8 @@ func TestGetIPStatsV4(t *testing.T) {
 }
 
 func TestGetIPStatsV4WithPD(t *testing.T) {
+	os.Setenv(envIPCooldownPeriod, "1")
+	defer os.Unsetenv(envIPCooldownPeriod)
 	ds := NewDataStore(Testlog, NullCheckpoint{}, true)
 
 	_ = ds.AddENI("eni-1", 1, true, false, false)
@@ -976,8 +982,9 @@ func TestGetIPStatsV4WithPD(t *testing.T) {
 		*ds.GetIPStats("4"),
 	)
 
-	// wait 30s (cooldown period)
-	time.Sleep(30 * time.Second)
+	assert.Equal(t, ds.ipCooldownPeriod, 1*time.Second)
+	// wait 1s (cooldown period)
+	time.Sleep(ds.ipCooldownPeriod)
 
 	assert.Equal(t,
 		DataStoreStats{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,20 @@ func GetBoolAsStringEnvVar(env string, defaultVal bool) bool {
 	return defaultVal
 }
 
+// Parse environment variable and return integer representation of string, or default value if environment variable is unset
+func GetIntFromStringEnvVar(env string, defaultVal int) (int, error, string) {
+	if val, ok := os.LookupEnv(env); ok {
+		parsedVal, err := strconv.Atoi(val)
+		if err == nil {
+			return parsedVal, nil, val
+		}
+		log.Errorf("Failed to parse variable %s with value %s as integer", env, val)
+		return -1, err, val
+	}
+	// Environment variable is not set, so return default value
+	return defaultVal, nil, ""
+}
+
 // If environment variable is set, return set value, otherwise return default value
 func GetEnv(env, defaultVal string) string {
 	if val, ok := os.LookupEnv(env); ok {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,9 +10,11 @@ import (
 const (
 	defaultPathEnv = "/host/opt/cni/bin"
 	defaultBoolEnv = false
+	defaultIntEnv  = 30
 
 	envPath = "Path"
 	envBool = "Bool"
+	envInt  = "Integer"
 )
 
 // Validate that GetBoolAsStringEnvVar runs against acceptable format input without error
@@ -44,4 +46,22 @@ func TestGetEnv(t *testing.T) {
 	defer os.Unsetenv(envPath)
 	tmp = GetEnv(envPath, defaultPathEnv)
 	assert.Equal(t, tmp, "/host/opt/cni/bin/test")
+}
+
+// Validate that GetIntFromStringEnvVar runs against acceptable format input without error
+func TestGetIntFromStringEnvVar(t *testing.T) {
+	// Test environment flag variable not set
+	tmp, _, _ := GetIntFromStringEnvVar(envInt, defaultIntEnv)
+	assert.Equal(t, tmp, defaultIntEnv)
+
+	// Test basic Integer as string set with acceptable format
+	os.Setenv(envInt, "20")
+	tmp, _, _ = GetIntFromStringEnvVar(envInt, defaultIntEnv)
+	assert.Equal(t, tmp, 20)
+
+	// Test basic Integer as string set with unacceptable format
+	os.Setenv(envInt, "2O")
+	defer os.Unsetenv(envInt)
+	tmp, _, _ = GetIntFromStringEnvVar(envInt, defaultIntEnv)
+	assert.Equal(t, tmp, -1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Continuing PR #2397 

<!--
Add one of the following:
bug
cleanup
documentation
**feature**
-->

**Which issue does this PR fix**:
Issue #2378 

**What does this PR do / Why do we need it**:
Continuing PR #2397: Added new environment variable IP_COOLDOWN_PERIOD.  cmd/aws-vpc-cni/main.go defines two new variables in the const section, envIPCooldownPeriod with IP_COOLDOWN_PERIOD and defaultIPCooldownPeriod as 30s time.Duration. pkg/ipamd/datastore/data_store.go creates a new function getCooldownPeriod(), returns a time.Duration being either the default cooldown period of 30s or the custom one if it is not smaller than 0. getCooldownPeriod() is called when creating a new DataStore, storing the cooldown period value in a variable ipCooldownPeriod which is used in inCoolingPeriod(). pkg/ipamd/datastore/data_store_test.go creates a new test case TestGetIPStatsV4WithCustomIPCooldown(). util/utils.go adds a new function GetIntAsStringEnvVar() to parse the environment string into an integer.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!---->
Ran against cni and ipamd integration tests with IP_COOLDOWN_PERIOD values set as: unset, 0, 10, 20
<img width="437" alt="Screenshot 2023-08-09 at 2 25 25 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/3f90a108-95eb-4307-af1d-1a11ba0d49f2">
<img width="400" alt="Screenshot 2023-08-09 at 2 26 11 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/c04b340d-c0a1-46bd-8f24-4cef4980a77b">

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Have not updated a running cluster

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
#### `IP_COOLDOWN_PERIOD` (v1.13.4+)

Type: Integer as a String

Default: `30`

Specifies the number of seconds an IP address is in cooldown after pod deletion. The cooldown period gives kube-proxy time to update node iptables rules when the IP was registered as a valid endpoint, such as for a service. Modify this value with caution, as kube-proxy update time scales with the number of nodes and services.

**Note:** 0 is a supported value, however it is highly discouraged.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
