### PR TITLE
Add DISABLE_CONTAINER_V6 to disable IPv6 networking in container network namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Note that enabling/disabling this feature only affects whether newly created pod
 
 ----
 
-#### `IP_COOLDOWN_PERIOD` (v1.14.1+)
+#### `IP_COOLDOWN_PERIOD` (v1.15.0+)
 
 Type: Integer as a String
 
@@ -692,6 +692,19 @@ Specifies the number of seconds an IP address is in cooldown after pod deletion.
 
 **Note:** 0 is a supported value, however it is highly discouraged.
 **Note:** Higher cooldown periods may lead to a higher number of EC2 API calls as IPs are in cooldown cache.
+
+----
+
+#### `DISABLE_POD_V6` (v1.15.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+When `DISABLE_POD_V6` is set, the [tuning plugin](https://www.cni.dev/plugins/current/meta/tuning/) is chained and configured to disable IPv6 networking in each newly created pod network namespace. Set this variable when you have an IPv4 cluster and containerized applications that cannot tolerate IPv6 being enabled.
+Container runtimes such as `containerd` will enable IPv6 in newly created container network namespaces regardless of host settings.
+
+Note that if you set this while using Multus, you must ensure that any chained plugins do not depend on IPv6 networking. You must also ensure that chained plugins do not also modify these sysctls.
 
 ### VPC CNI Feature Matrix
 

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -81,6 +81,7 @@ const (
 	defaultEnBandwidthPlugin     = false
 	defaultEnPrefixDelegation    = false
 	defaultIPCooldownPeriod      = 30
+	defaultDisablePodV6          = false
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -101,6 +102,7 @@ const (
 	envEnIPv6Egress          = "ENABLE_V6_EGRESS"
 	envRandomizeSNAT         = "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
+	envDisablePodV6          = "DISABLE_POD_V6"
 )
 
 // NetConfList describes an ordered list of networks.
@@ -116,11 +118,12 @@ type NetConfList struct {
 type NetConf struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name         string          `json:"name,omitempty"`
-	Type         string          `json:"type,omitempty"`
-	Capabilities map[string]bool `json:"capabilities,omitempty"`
-	IPAM         *IPAMConfig     `json:"ipam,omitempty"`
-	DNS          *types.DNS      `json:"dns,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Type         string            `json:"type,omitempty"`
+	Capabilities map[string]bool   `json:"capabilities,omitempty"`
+	IPAM         *IPAMConfig       `json:"ipam,omitempty"`
+	DNS          *types.DNS        `json:"dns,omitempty"`
+	Sysctl       map[string]string `json:"sysctl,omitempty"`
 
 	RawPrevResult map[string]interface{} `json:"prevResult,omitempty"`
 	PrevResult    types.Result           `json:"-"`
@@ -292,19 +295,40 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 
 	byteValue = []byte(netconf)
 
+	// Chain any requested CNI plugins
 	enBandwidthPlugin := utils.GetBoolAsStringEnvVar(envEnBandwidthPlugin, defaultEnBandwidthPlugin)
-	if enBandwidthPlugin {
+	disablePodV6 := utils.GetBoolAsStringEnvVar(envDisablePodV6, defaultDisablePodV6)
+	if enBandwidthPlugin || disablePodV6 {
+		// Unmarshall current conflist into data
 		data := NetConfList{}
 		err = json.Unmarshal(byteValue, &data)
 		if err != nil {
 			return err
 		}
 
-		bwPlugin := NetConf{
-			Type:         "bandwidth",
-			Capabilities: map[string]bool{"bandwidth": true},
+		// Chain the bandwidth plugin when enabled
+		if enBandwidthPlugin {
+			bwPlugin := NetConf{
+				Type:         "bandwidth",
+				Capabilities: map[string]bool{"bandwidth": true},
+			}
+			data.Plugins = append(data.Plugins, &bwPlugin)
 		}
-		data.Plugins = append(data.Plugins, &bwPlugin)
+
+		// Chain the tuning plugin (configured to disable IPv6 in pod network namespace) when requested
+		if disablePodV6 {
+			tuningPlugin := NetConf{
+				Type: "tuning",
+				Sysctl: map[string]string{
+					"net.ipv6.conf.all.disable_ipv6":     "1",
+					"net.ipv6.conf.default.disable_ipv6": "1",
+					"net.ipv6.conf.lo.disable_ipv6":      "1",
+				},
+			}
+			data.Plugins = append(data.Plugins, &tuningPlugin)
+		}
+
+		// Marshall data back into byteValue
 		byteValue, err = json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			return err

--- a/cmd/aws-vpc-cni/main_test.go
+++ b/cmd/aws-vpc-cni/main_test.go
@@ -26,9 +26,24 @@ func TestGenerateJSON(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Validate that generateJSON runs without error when bandwidth plugin is added to default conflist
+// Validate that generateJSON runs without error when bandwidth plugin is added to the default conflist
 func TestGenerateJSONPlusBandwidth(t *testing.T) {
 	_ = os.Setenv(envEnBandwidthPlugin, "true")
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
+	assert.NoError(t, err)
+}
+
+// Validate that generateJSON runs without error when tuning plugin is added to the default conflist
+func TestGenerateJSONPlusTuning(t *testing.T) {
+	_ = os.Setenv(envDisablePodV6, "true")
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
+	assert.NoError(t, err)
+}
+
+// Validate that generateJSON runs without error when the bandwidth and tuning plugins are added to the default conflist
+func TestGenerateJSONPlusBandwidthAndTuning(t *testing.T) {
+	_ = os.Setenv(envEnBandwidthPlugin, "true")
+	_ = os.Setenv(envDisablePodV6, "true")
 	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2483

**What does this PR do / Why do we need it**:
This PR introduces a new environment variable: `DISABLE_CONTAINER_V6`. When this environment variable is set, the `tuning` plugin will be chained in the AWS conflist (`/etc/cni/net.d/10-aws.conflist`) and configured to disable IPv6 networking in newly created container network namespaces. This is done to provide a solution to https://github.com/aws/amazon-vpc-cni-k8s/issues/2483.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
1. Create an IPv4 cluster with containerd as the container-runtime (EKS 1.24+)
2. Create a pod
3. See that IPv6 is enabled on the loopback interface within the container network namespace regardless of host sysctls.

**Testing done on this change**:
Manually verified that conflist is rendered correctly and IPv6 is disabled in newly created container network namespaces. Verified that all integration tests pass following this change.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Introduce DISABLE_CONTAINER_V6 to disable IPv6 networking in container namespaces.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
