### PR TITLE
Automation test update for ip cooldown env var

### DIFF
--- a/test/integration/cni/pod_networking_suite_test.go
+++ b/test/integration/cni/pod_networking_suite_test.go
@@ -119,7 +119,8 @@ var _ = AfterSuite(func() {
 			"AWS_VPC_K8S_CNI_VETHPREFIX": DEFAULT_VETH_PREFIX,
 		},
 		map[string]struct{}{
-			"WARM_IP_TARGET":  {},
-			"WARM_ENI_TARGET": {},
+			"WARM_IP_TARGET":     {},
+			"WARM_ENI_TARGET":    {},
+			"IP_COOLDOWN_PERIOD": {},
 		})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2498 

**What does this PR do / Why do we need it**:
Ensures that IP's are being reused by setting a max amount of ENI's that are allowed and checking if the allocated number of ENI's are less than or equal to the max amount of ENI's. It does this by setting IP_COOLDOWN_PERIOD to 5 seconds, and then sleeping for 5 seconds in between test cases to allow for ip's to cooldown.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Tested against the modified file (test/integration/cni/service_connectivity_test.go)
<img width="409" alt="Screenshot 2023-08-17 at 3 28 36 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/36118d58-6a30-4c9a-b487-8696c3c05758">


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
