### PR TITLE
Document HOST_CNI_BIN_PATH and HOST_CNI_CONFDIR_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ To select an `ENIConfig` based upon availability zone set this to `topology.kube
 
 ---
 
+#### `HOST_CNI_BIN_PATH`
+
+Type: String
+
+Default: `/host/opt/cni/bin`
+
+Specifies the location to install CNI binaries. Note that the `aws-node` daemonset mounts `/opt/cni/bin` to `/host/opt/cni/bin`. The value you choose must be a location that the `aws-node` pod can write to.
+
+---
+
+#### `HOST_CNI_CONFDIR_PATH`
+
+Type: String
+
+Default: `/host/etc/cni/net.d`
+
+Specifies the location to install the VPC CNI conflist. Note that the `aws-node` daemonset mounts `/etc/cni/net.d` to `/host/etc/cni/net.d`. The value you choose must be a location that the `aws-node` pod can write to.
+
 #### `AWS_VPC_ENI_MTU` (v1.6.0+)
 
 Type: Integer as a String

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -61,8 +61,8 @@ const (
 	egressPluginIpamDstV6        = "::/0"
 	egressPluginIpamDataDirV4    = "/run/cni/v6pd/egress-v4-ipam"
 	egressPluginIpamDataDirV6    = "/run/cni/v4pd/egress-v6-ipam"
-	defaultHostCNIBinPath        = "/host/opt/cni/bin"
-	defaultHostCNIConfDirPath    = "/host/etc/cni/net.d"
+	defaultHostCniBinPath        = "/host/opt/cni/bin"
+	defaultHostCniConfDirPath    = "/host/etc/cni/net.d"
 	defaultAWSconflistFile       = "/app/10-aws.conflist"
 	tmpAWSconflistFile           = "/tmp/10-aws.conflist"
 	defaultVethPrefix            = "eni"
@@ -404,7 +404,7 @@ func _main() int {
 	}
 
 	pluginBins := []string{"aws-cni", "egress-cni"}
-	hostCNIBinPath := utils.GetEnv(envHostCniBinPath, defaultHostCNIBinPath)
+	hostCNIBinPath := utils.GetEnv(envHostCniBinPath, defaultHostCniBinPath)
 	err := cp.InstallBinaries(pluginBins, hostCNIBinPath)
 	if err != nil {
 		log.WithError(err).Error("Failed to install CNI binaries")
@@ -445,7 +445,8 @@ func _main() int {
 		return 1
 	}
 
-	err = cp.CopyFile(tmpAWSconflistFile, defaultHostCNIConfDirPath+awsConflistFile)
+	hostCniConfDirPath := utils.GetEnv(envHostCniConfDirPath, defaultHostCniConfDirPath)
+	err = cp.CopyFile(tmpAWSconflistFile, hostCniConfDirPath+awsConflistFile)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to copy %s", awsConflistFile)
 		return 1


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR documents the `HOST_CNI_BIN_PATH` environment variable, which allows users to specify the file system path to install CNI binaries. It also documents `HOST_CNI_CONFDIR_PATH` and makes it actually configurable. This variable allows users to specify the file system path to install the VPC CNI conflist.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that env vars can be set and integration tests pass.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Document HOST_CNI_BIN_PATH and HOST_CNI_CONFDIR_PATH environment variables.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
