### PR TITLE
Add DISABLE_POD_V6 feature for v1.13 candidate image

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,17 @@ This environment variable must be set for both the `aws-vpc-cni-init` and `aws-n
 
 Note that enabling/disabling this feature only affects whether newly created pods have an IPv6 interface created. Therefore, it is recommended that you reboot existing nodes after enabling/disabling this feature. Also note that if you are using this feature in conjunction with `ENABLE_POD_ENI` (Security Groups for Pods), the security group rules will NOT be applied to egressing IPv6 traffic.
 
+#### `DISABLE_POD_V6` (v1.15.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+When `DISABLE_POD_V6` is set, the [tuning plugin](https://www.cni.dev/plugins/current/meta/tuning/) is chained and configured to disable IPv6 networking in each newly created pod network namespace. Set this variable when you have an IPv4 cluster and containerized applications that cannot tolerate IPv6 being enabled.
+Container runtimes such as `containerd` will enable IPv6 in newly created container network namespaces regardless of host settings.
+
+Note that if you set this while using Multus, you must ensure that any chained plugins do not depend on IPv6 networking. You must also ensure that chained plugins do not also modify these sysctls.
+
 ### VPC CNI Feature Matrix
 
 IP Mode | Secondary IP Mode | Prefix Delegation | Security Groups Per Pod | WARM & MIN IP/Prefix Targets | External SNAT

--- a/cmd/aws-vpc-cni/main_test.go
+++ b/cmd/aws-vpc-cni/main_test.go
@@ -26,9 +26,24 @@ func TestGenerateJSON(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Validate that generateJSON runs without error when bandwidth plugin is added to default conflist
+// Validate that generateJSON runs without error when bandwidth plugin is added to the default conflist
 func TestGenerateJSONPlusBandwidth(t *testing.T) {
 	_ = os.Setenv(envEnBandwidthPlugin, "true")
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
+	assert.NoError(t, err)
+}
+
+// Validate that generateJSON runs without error when tuning plugin is added to the default conflist
+func TestGenerateJSONPlusTuning(t *testing.T) {
+	_ = os.Setenv(envDisablePodV6, "true")
+	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
+	assert.NoError(t, err)
+}
+
+// Validate that generateJSON runs without error when the bandwidth and tuning plugins are added to the default conflist
+func TestGenerateJSONPlusBandwidthAndTuning(t *testing.T) {
+	_ = os.Setenv(envEnBandwidthPlugin, "true")
+	_ = os.Setenv(envDisablePodV6, "true")
 	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2483

**What does this PR do / Why do we need it**:
This PR adds https://github.com/aws/amazon-vpc-cni-k8s/pull/2499 to `release-1.13` branch in order to make a `v1.13.4` + tuning tagged image.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that integration tests pass and feature works.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
