### PR TITLE
Improve CNI Metrics Helper Integration Test Resilience

### DIFF
--- a/test/integration/metrics-helper/metric_helper_test.go
+++ b/test/integration/metrics-helper/metric_helper_test.go
@@ -35,7 +35,7 @@ var _ = Describe("test cni-metrics-helper publishes metrics", func() {
 			// Create a new deployment to verify addReqCount is updated
 			var deployment *v1.Deployment
 			deployment = manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
-				Replicas(10).
+				Replicas(30).
 				NodeName(nodeName).
 				Build()
 
@@ -56,7 +56,7 @@ var _ = Describe("test cni-metrics-helper publishes metrics", func() {
 				},
 				MetricName: aws.String("addReqCount"),
 				Namespace:  aws.String("Kubernetes"),
-				Period:     aws.Int64(int64(60)),
+				Period:     aws.Int64(int64(30)),
 				// Start time should sync with when when this test started
 				StartTime:  aws.Time(time.Now().Add(time.Duration(-10) * time.Minute)),
 				EndTime:    aws.Time(time.Now()),


### PR DESCRIPTION
**What type of PR is this?**
test enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR improves the CNI metrics helper integration test by increasing the number of replicas in the deployment that gets created and decreasing the sampling period. The test would occasionally fail as it would not see an increase in the number of pod add requests depending on when the same was taken.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that this fixes the flakiness.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
