### PR TITLE
Restore node update permission to master until image tag can be updated

### DIFF
--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -61,7 +61,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get"]
+    verbs: ["list", "watch", "get", "update"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
As long as `master` chart and manifests point to `v1.13.4`, node update permission is required in `ClusterRole`. This PR adds the permission back. It will be removed following `v1.15.0` release.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that this fixes `aws-node` pod startup issue with manifest.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
