### PR TITLE
Mimic VPC-RC limit struture

### DIFF
--- a/pkg/awsutils/vpc_ip_resource_limit.go
+++ b/pkg/awsutils/vpc_ip_resource_limit.go
@@ -36,723 +36,10380 @@ package awsutils
 // InstanceNetworkingLimits contains a mapping from instance type to networking limits for the type. Documentation found at
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI
 var InstanceNetworkingLimits = map[string]InstanceTypeLimits{
-	"a1.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"a1.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"a1.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"a1.medium":     {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"a1.metal":      {ENILimit: 8, IPv4Limit: 30, HypervisorType:"", IsBareMetal:true},
-	"a1.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"bmn-sf1.metal": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"unknown", IsBareMetal:true},
-	"c1.medium":     {ENILimit: 2, IPv4Limit: 6, HypervisorType:"xen", IsBareMetal:false},
-	"c1.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"c3.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"c3.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"c3.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"c3.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"c3.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"c4.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"c4.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"c4.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"c4.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"c4.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"c5.12xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.18xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.24xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.9xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c5.metal":      {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c5.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c5a.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"unknown", IsBareMetal:true},
-	"c5a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c5ad.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"unknown", IsBareMetal:true},
-	"c5ad.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.18xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.9xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c5d.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c5d.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.18xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.9xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c5n.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c5n.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.48xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6a.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c6g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gd.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c6gn.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6i.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6i.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.32xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6id.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6id.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.32xlarge": {ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c6in.metal":    {ENILimit: 7, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"c6in.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c7g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:true},
-	"c7g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"c7gn.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"cr1.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"unknown", IsBareMetal:false},
-	"d2.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"d2.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"d2.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"d2.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"d3.2xlarge":    {ENILimit: 4, IPv4Limit: 5, HypervisorType:"nitro", IsBareMetal:false},
-	"d3.4xlarge":    {ENILimit: 4, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"d3.8xlarge":    {ENILimit: 3, IPv4Limit: 20, HypervisorType:"nitro", IsBareMetal:false},
-	"d3.xlarge":     {ENILimit: 4, IPv4Limit: 3, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.12xlarge": {ENILimit: 3, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.2xlarge":  {ENILimit: 4, IPv4Limit: 5, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.4xlarge":  {ENILimit: 4, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.6xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.8xlarge":  {ENILimit: 4, IPv4Limit: 20, HypervisorType:"nitro", IsBareMetal:false},
-	"d3en.xlarge":   {ENILimit: 4, IPv4Limit: 3, HypervisorType:"nitro", IsBareMetal:false},
-	"dl1.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"f1.16xlarge":   {ENILimit: 8, IPv4Limit: 50, HypervisorType:"xen", IsBareMetal:false},
-	"f1.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"f1.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"g2.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"g2.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"g3.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"xen", IsBareMetal:false},
-	"g3.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"g3.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"g3s.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"g4ad.16xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g4ad.2xlarge":  {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"g4ad.4xlarge":  {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"g4ad.8xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g4ad.xlarge":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.16xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.2xlarge":  {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.4xlarge":  {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.8xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g4dn.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"g4dn.xlarge":   {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.12xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.16xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.24xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.48xlarge":   {ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g5.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g5g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"g5g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"g5g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g5g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"g5g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"g5g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"h1.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"xen", IsBareMetal:false},
-	"h1.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"h1.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"h1.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"hpc6a.48xlarge":{ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc6id.32xlarge":{ENILimit: 1, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7a.12xlarge":{ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7a.24xlarge":{ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7a.48xlarge":{ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7a.96xlarge":{ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7g.16xlarge":{ENILimit: 4, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7g.4xlarge": {ENILimit: 4, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hpc7g.8xlarge": {ENILimit: 4, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"hs1.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"unknown", IsBareMetal:false},
-	"i2.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"i2.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"i2.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"i2.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"i3.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"xen", IsBareMetal:false},
-	"i3.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"i3.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"i3.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"i3.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"i3.metal":      {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"i3.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"i3en.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.3xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.6xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"i3en.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"i3en.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"i4g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"i4i.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"i4i.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.16xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.2xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.4xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.8xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.large":   {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"im4gn.xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"inf1.24xlarge": {ENILimit: 11, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"inf1.2xlarge":  {ENILimit: 4, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"inf1.6xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"inf1.xlarge":   {ENILimit: 4, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"inf2.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"inf2.48xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"inf2.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"inf2.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.2xlarge":{ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.4xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.8xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.large":  {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.medium": {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"is4gen.xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m1.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"m1.medium":     {ENILimit: 2, IPv4Limit: 6, HypervisorType:"xen", IsBareMetal:false},
-	"m1.small":      {ENILimit: 2, IPv4Limit: 4, HypervisorType:"xen", IsBareMetal:false},
-	"m1.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"m2.2xlarge":    {ENILimit: 4, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m2.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m2.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"m3.2xlarge":    {ENILimit: 4, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m3.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"m3.medium":     {ENILimit: 2, IPv4Limit: 6, HypervisorType:"xen", IsBareMetal:false},
-	"m3.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"m4.10xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m4.16xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m4.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"m4.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"m4.large":      {ENILimit: 2, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"m4.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"m5.12xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.24xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5.metal":      {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m5.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5ad.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5d.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m5d.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5dn.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m5dn.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5n.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m5n.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.12xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.3xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.6xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m5zn.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m5zn.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.48xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6a.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"m6g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"m6gd.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6i.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6i.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.32xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6id.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6id.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.12xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.16xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.24xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.2xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.32xlarge":{ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.4xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.8xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.large":   {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6idn.metal":   {ENILimit: 7, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6idn.xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.32xlarge": {ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m6in.metal":    {ENILimit: 7, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m6in.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.48xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"m7a.metal-48xl":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m7a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"m7g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"m7g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"m7gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i-flex.2xlarge":{ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i-flex.4xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i-flex.8xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i-flex.large":{ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i-flex.xlarge":{ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.48xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"m7i.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"mac1.metal":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"", IsBareMetal:true},
-	"mac2.metal":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"", IsBareMetal:true},
-	"p2.16xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"p2.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"p2.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"p3.16xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"p3.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"p3.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"p3dn.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"p4d.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"p4de.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"p5.48xlarge":   {ENILimit: 2, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r3.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"r3.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"r3.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"r3.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"r3.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"r4.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"xen", IsBareMetal:false},
-	"r4.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"r4.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"r4.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"r4.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"r4.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"r5.12xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.16xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.24xlarge":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.4xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.8xlarge":    {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.large":      {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5.metal":      {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r5.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5ad.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5b.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r5b.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5d.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r5d.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5dn.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r5dn.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r5n.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r5n.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.48xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6a.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"r6g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"r6gd.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.32xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6i.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6i.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.32xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6id.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6id.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.12xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.16xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.24xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.2xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.32xlarge":{ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.4xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.8xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.large":   {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6idn.metal":   {ENILimit: 7, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6idn.xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.24xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.32xlarge": {ENILimit: 7, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r6in.metal":    {ENILimit: 7, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r6in.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.12xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.16xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.4xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.8xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.medium":    {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"r7g.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"r7g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"r7gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t1.micro":      {ENILimit: 2, IPv4Limit: 2, HypervisorType:"xen", IsBareMetal:false},
-	"t2.2xlarge":    {ENILimit: 3, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"t2.large":      {ENILimit: 3, IPv4Limit: 12, HypervisorType:"xen", IsBareMetal:false},
-	"t2.medium":     {ENILimit: 3, IPv4Limit: 6, HypervisorType:"xen", IsBareMetal:false},
-	"t2.micro":      {ENILimit: 2, IPv4Limit: 2, HypervisorType:"xen", IsBareMetal:false},
-	"t2.nano":       {ENILimit: 2, IPv4Limit: 2, HypervisorType:"xen", IsBareMetal:false},
-	"t2.small":      {ENILimit: 3, IPv4Limit: 4, HypervisorType:"xen", IsBareMetal:false},
-	"t2.xlarge":     {ENILimit: 3, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"t3.2xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.large":      {ENILimit: 3, IPv4Limit: 12, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.medium":     {ENILimit: 3, IPv4Limit: 6, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.micro":      {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.nano":       {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.small":      {ENILimit: 3, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"t3.xlarge":     {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.large":     {ENILimit: 3, IPv4Limit: 12, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.medium":    {ENILimit: 3, IPv4Limit: 6, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.micro":     {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.nano":      {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.small":     {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"t3a.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.large":     {ENILimit: 3, IPv4Limit: 12, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.medium":    {ENILimit: 3, IPv4Limit: 6, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.micro":     {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.nano":      {ENILimit: 2, IPv4Limit: 2, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.small":     {ENILimit: 3, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"t4g.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"trn1.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"trn1.32xlarge": {ENILimit: 5, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"trn1n.32xlarge":{ENILimit: 5, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-12tb1.112xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-12tb1.metal": {ENILimit: 5, IPv4Limit: 30, HypervisorType:"unknown", IsBareMetal:true},
-	"u-18tb1.112xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-18tb1.metal": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"unknown", IsBareMetal:true},
-	"u-24tb1.112xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-24tb1.metal": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"unknown", IsBareMetal:true},
-	"u-3tb1.56xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"u-6tb1.112xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-6tb1.56xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-6tb1.metal":  {ENILimit: 5, IPv4Limit: 30, HypervisorType:"unknown", IsBareMetal:true},
-	"u-9tb1.112xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"u-9tb1.metal":  {ENILimit: 5, IPv4Limit: 30, HypervisorType:"unknown", IsBareMetal:true},
-	"vt1.24xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"vt1.3xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"vt1.6xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x1.16xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"x1.32xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.16xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.32xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.4xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.8xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"xen", IsBareMetal:false},
-	"x1e.xlarge":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"xen", IsBareMetal:false},
-	"x2gd.12xlarge": {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.16xlarge": {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.2xlarge":  {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.4xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.8xlarge":  {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.large":    {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.medium":   {ENILimit: 2, IPv4Limit: 4, HypervisorType:"nitro", IsBareMetal:false},
-	"x2gd.metal":    {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"x2gd.xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"x2idn.16xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2idn.24xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2idn.32xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2idn.metal":   {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"x2iedn.16xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.24xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.2xlarge":{ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.32xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.4xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.8xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iedn.metal":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"x2iedn.xlarge": {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.12xlarge":{ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.2xlarge":{ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.4xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.6xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.8xlarge":{ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"x2iezn.metal":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"z1d.12xlarge":  {ENILimit: 15, IPv4Limit: 50, HypervisorType:"nitro", IsBareMetal:false},
-	"z1d.2xlarge":   {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
-	"z1d.3xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"z1d.6xlarge":   {ENILimit: 8, IPv4Limit: 30, HypervisorType:"nitro", IsBareMetal:false},
-	"z1d.large":     {ENILimit: 3, IPv4Limit: 10, HypervisorType:"nitro", IsBareMetal:false},
-	"z1d.metal":     {ENILimit: 15, IPv4Limit: 50, HypervisorType:"", IsBareMetal:true},
-	"z1d.xlarge":    {ENILimit: 4, IPv4Limit: 15, HypervisorType:"nitro", IsBareMetal:false},
+	"a1.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"a1.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"a1.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"a1.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"a1.metal":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"a1.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"bmn-sf1.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c1.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c1.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c3.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c3.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c3.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c4.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c4.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c4.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c4.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c4.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"c5.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.18xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.9xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c5.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5a.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c5a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5ad.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c5ad.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.18xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.9xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5d.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c5d.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.18xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.9xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c5n.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c5n.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6a.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gd.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6gn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6i.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6i.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6id.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6id.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.32xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c6in.metal":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"c6in.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: true,
+	},
+	"c7g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7gn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"cr1.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: false,
+	},
+	"d2.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"d2.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"d2.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"d2.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"d3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 5, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3.4xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3.8xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 20, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 3, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.12xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 5, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.4xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.6xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.8xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 20, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"d3en.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 3, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"dl1.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 1,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 2,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 3,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"f1.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"f1.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"f1.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g2.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g2.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g3.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g3.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g3.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g3s.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"g4ad.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4ad.2xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4ad.4xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4ad.8xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4ad.xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.16xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.2xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.4xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.8xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g4dn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"g4dn.xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.12xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.48xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"g5g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"g5g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"h1.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"h1.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"h1.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"h1.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"hpc6a.48xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc6id.32xlarge":	   {
+		ENILimit: 1, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 1,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 1,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7a.12xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7a.24xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7a.48xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7a.96xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7g.16xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7g.4xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hpc7g.8xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"hs1.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: false,
+	},
+	"i2.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i2.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i2.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i2.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"i3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"i3en.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.3xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i3en.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"i3en.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i4i.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"i4i.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"im4gn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf1.24xlarge":	   {
+		ENILimit: 11, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 11,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf1.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf1.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf1.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf2.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf2.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf2.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"inf2.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"is4gen.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m1.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m1.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m1.small":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m1.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m2.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m2.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m2.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m3.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m3.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.10xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.large":	   {
+		ENILimit: 2, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m4.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"m5.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m5.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5ad.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5d.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m5d.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5dn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m5dn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5n.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m5n.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.12xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.3xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m5zn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m5zn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6a.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6gd.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6i.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6i.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6id.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6id.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.32xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6idn.metal":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6idn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.32xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m6in.metal":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m6in.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7a.metal-48xl":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m7a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"m7g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"mac1.metal":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"mac2.metal":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"p2.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p2.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p2.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p3.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p3.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"p3dn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"p4d.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 1,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 2,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 3,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"p4de.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"p5.48xlarge":	   {
+		ENILimit: 2, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 1,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 2,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 3,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 4,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 5,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 6,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 7,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 8,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 9,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 10,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 11,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 12,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 13,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 14,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 15,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 16,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 17,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 18,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 19,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 20,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 21,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 22,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 23,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 24,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 25,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 26,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 27,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 28,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 29,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 30,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 31,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r3.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r3.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r3.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r4.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"r5.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r5.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5ad.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5b.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r5b.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5d.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r5d.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5dn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r5dn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r5n.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r5n.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6a.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6gd.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6i.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6i.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6id.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6id.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.32xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6idn.metal":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6idn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.32xlarge":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r6in.metal":	   {
+		ENILimit: 7, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 7,
+					NetworkCardIndex: 1,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r6in.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7g.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"r7g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"r7gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t1.micro":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.2xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 12, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.medium":	   {
+		ENILimit: 3, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.micro":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.nano":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.small":	   {
+		ENILimit: 3, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t2.xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"t3.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 12, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.medium":	   {
+		ENILimit: 3, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.micro":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.nano":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.small":	   {
+		ENILimit: 3, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 12, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.medium":	   {
+		ENILimit: 3, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.micro":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.nano":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.small":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t3a.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 12, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.medium":	   {
+		ENILimit: 3, 
+		IPv4Limit: 6, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.micro":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.nano":	   {
+		ENILimit: 2, 
+		IPv4Limit: 2, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.small":	   {
+		ENILimit: 3, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"t4g.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"trn1.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"trn1.32xlarge":	   {
+		ENILimit: 5, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 1,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 2,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 3,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 4,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 5,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 6,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 7,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"trn1n.32xlarge":	   {
+		ENILimit: 5, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 0,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 1,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 2,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 3,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 4,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 5,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 6,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 7,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 8,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 9,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 10,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 11,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 12,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 13,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 14,
+				},
+			
+				{
+					MaximumNetworkInterfaces: 5,
+					NetworkCardIndex: 15,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-12tb1.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-12tb1.metal":	   {
+		ENILimit: 5, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"u-18tb1.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-18tb1.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"u-24tb1.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-24tb1.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"u-3tb1.56xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-6tb1.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-6tb1.56xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-6tb1.metal":	   {
+		ENILimit: 5, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"u-9tb1.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u-9tb1.metal":	   {
+		ENILimit: 5, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"vt1.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"vt1.3xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"vt1.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x1.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1.32xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.16xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.32xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.4xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.8xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x1e.xlarge":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"x2gd.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.medium":	   {
+		ENILimit: 2, 
+		IPv4Limit: 4, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 2,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2gd.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"x2gd.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2idn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2idn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2idn.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2idn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"x2iedn.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.24xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.32xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iedn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"x2iedn.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.12xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.4xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.8xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"x2iezn.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"z1d.12xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"z1d.2xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"z1d.3xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"z1d.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"z1d.large":	   {
+		ENILimit: 3, 
+		IPv4Limit: 10, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 3,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"z1d.metal":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"z1d.xlarge":	   {
+		ENILimit: 4, 
+		IPv4Limit: 15, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Mimics the structure of VPC-RC limits file. This is the first step towards multi-card support as it is necessary to list out the available network cards. Eventually, VPC-CNI may be the source of all the instance limit info. Currently does not contain the info from internal endpoints since this script is open source in VPC-CNI.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
`make generate-limits`

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
