### PR TITLE
Fixed the image incorrect image version

### DIFF
--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -266,7 +266,22 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.14.0"
+---
+# Source: aws-vpc-cni/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.14.0"
+data:
+  enable-windows-ipam: "false"
+  enable-network-policy-controller: "false"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -277,7 +292,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.14.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -379,7 +379,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.14.0"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -400,7 +400,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.14.0"
           ports:
             - containerPort: 61678
               name: metrics
@@ -522,7 +522,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path 
+      - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
The yaml are still pointing to older 1.13.4 instead of 1.14.0

**What does this PR do / Why do we need it**:
NetworkPolicy support which was launched with VPC CNI 1.14.0 doesn't work because of this incorrect image version of aws-node and aws-init containers.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
If you do kubectl apply -f with the existing CNI file you will see aws-node running with both vpc-cni and aws-node but when you create policy and it doesn't have any effect.

**Testing done on this change**:
Were able to deploy and see network security policy taking effect.

**Automation added to e2e**:
NA

**Will this PR introduce any new dependencies?**:
NA

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
NA

**Does this change require updates to the CNI daemonset config files to work?**:
NA

**Does this PR introduce any user-facing change?**:
NA

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
