### PR TITLE
Fix VPC CNI manifest in release-1.15 branch

### DIFF
--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -268,6 +268,21 @@ metadata:
     k8s-app: aws-node
     app.kubernetes.io/version: "v1.15.0"
 ---
+# Source: aws-vpc-cni/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.15.0"
+data:
+  enable-windows-ipam: "false"
+  enable-network-policy-controller: "false"
+---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -507,7 +522,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path 
+      - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -522,7 +522,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path 
+      - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -522,7 +522,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path 
+      - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir


### PR DESCRIPTION
**What type of PR is this?**
manifest fix

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR fixes `config/master/aws-k8s-cni-us-gov-east-1.yaml` following a miss in https://github.com/aws/amazon-vpc-cni-k8s/pull/2519.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A

**Does this PR introduce any user-facing change?**:
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
