### PR TITLE
Update kops tests for 1.28 and fix generate-cni-yaml script

### DIFF
--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -55,8 +55,8 @@ jobs:
           RUN_CNI_INTEGRATION_TESTS: false
           RUN_KOPS_TEST: true
           RUN_TESTER_LB_ADDONS: true
-          K8S_VERSION: 1.26.5
-          KOPS_VERSION: v1.26.4
+          K8S_VERSION: 1.28.0
+          KOPS_VERSION: v1.28.0-alpha.2
         run: |
           ./scripts/run-integration-tests.sh
         if: always()

--- a/scripts/generate-cni-yaml.sh
+++ b/scripts/generate-cni-yaml.sh
@@ -65,18 +65,18 @@ jq -c '.[]' $REGIONS_FILE | while read i; do
 
     $BUILD_DIR/helm template aws-vpc-cni \
       --include-crds \
-      --set originalMatchLabels=true,\
-      --set init.image.region=$ecrRegion,\
-      --set init.image.account=$ecrAccount,\
-      --set init.image.domain=$ecrDomain,\
-      --set init.image.tag=$VERSION,\
-      --set image.tag=$VERSION,\
-      --set image.region=$ecrRegion,\
-      --set image.account=$ecrAccount,\
-      --set image.domain=$ecrDomain, \
-      --set nodeAgent.image.account=$ecrAccount, \
-      --set nodeAgent.image.region=$ecrRegion, \
-      --set nodeAgent.image.domain=$ecrDomain, \
+      --set originalMatchLabels=true \
+      --set init.image.region=$ecrRegion \
+      --set-string init.image.account=$ecrAccount \
+      --set init.image.domain=$ecrDomain \
+      --set init.image.tag=$VERSION \
+      --set image.tag=$VERSION \
+      --set image.region=$ecrRegion \
+      --set-string image.account=$ecrAccount \
+      --set image.domain=$ecrDomain  \
+      --set-string nodeAgent.image.account=$ecrAccount \
+      --set nodeAgent.image.region=$ecrRegion \
+      --set nodeAgent.image.domain=$ecrDomain \
       --set nodeAgent.image.tag=$VERSION \
       --namespace $NAMESPACE \
       $SCRIPTPATH/../charts/aws-vpc-cni > $NEW_CNI_RESOURCES_YAML
@@ -84,10 +84,10 @@ jq -c '.[]' $REGIONS_FILE | while read i; do
     sed -i '/helm.sh\|app.kubernetes.io\/managed-by: Helm/d' $NEW_CNI_RESOURCES_YAML
 
     $BUILD_DIR/helm template cni-metrics-helper \
-      --set image.region=$ecrRegion,\
-      --set image.account=$ecrAccount,\
+      --set image.region=$ecrRegion \
+      --set-string image.account=$ecrAccount \
       --set image.domain=$ecrDomain \
-      --set image.tag=$VERSION,\
+      --set image.tag=$VERSION \
       --namespace $NAMESPACE \
       $SCRIPTPATH/../charts/cni-metrics-helper > $NEW_METRICS_RESOURCES_YAML
     # Remove 'managed-by: Helm' annotation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Test scripts updates

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
This updates the kops weekly tests to run on 1.28 cluster and also pins the host instance type to ubuntu 20.04. 

**What does this PR do / Why do we need it**:
Weekly integration tests to run on upstream kops cluster


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
