### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/cni-metrics-helper/metrics/metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/metrics_test.go
@@ -15,7 +15,7 @@ package metrics
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +40,7 @@ func newTestMetricsTarget(metricFile string, interestingMetrics map[string]metri
 }
 
 func (target *testMetricsTarget) grabMetricsFromTarget(ctx context.Context, targetName string) ([]byte, error) {
-	testMetrics, _ := ioutil.ReadFile(target.metricFile)
+	testMetrics, _ := os.ReadFile(target.metricFile)
 
 	return testMetrics, nil
 }

--- a/pkg/ipamd/datastore/checkpoint.go
+++ b/pkg/ipamd/datastore/checkpoint.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -78,7 +77,7 @@ func NewJSONFile(path string) *JSONFile {
 
 // Checkpoint implements the Checkpointer interface
 func (c *JSONFile) Checkpoint(data interface{}) error {
-	f, err := ioutil.TempFile(filepath.Dir(c.path), filepath.Base(c.path)+".tmp*")
+	f, err := os.CreateTemp(filepath.Dir(c.path), filepath.Base(c.path)+".tmp*")
 	if err != nil {
 		return err
 	}

--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -15,7 +15,7 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -73,7 +73,7 @@ type AWSAuthMapRole struct {
 // Create self managed node group stack
 func CreateAndWaitTillSelfManagedNGReady(f *framework.Framework, properties NodeGroupProperties) error {
 	templatePath := utils.GetProjectRoot() + CreateNodeGroupCFNTemplate
-	templateBytes, err := ioutil.ReadFile(templatePath)
+	templateBytes, err := os.ReadFile(templatePath)
 	if err != nil {
 		return fmt.Errorf("failed to read from %s, %v", templatePath, err)
 	}

--- a/test/integration/ipamd/ipamd_event_test.go
+++ b/test/integration/ipamd/ipamd_event_test.go
@@ -15,8 +15,8 @@ package ipamd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -79,7 +79,7 @@ var _ = Describe("test aws-node pod event", func() {
 			masterPolicyName = "masters." + *aws.String(f.Options.ClusterName)
 			nodePolicyName = "nodes." + *aws.String(f.Options.ClusterName)
 			dummyPolicyDocumentPath := utils.GetProjectRoot() + DummyPolicyDocument
-			dummyRolePolicyBytes, err := ioutil.ReadFile(dummyPolicyDocumentPath)
+			dummyRolePolicyBytes, err := os.ReadFile(dummyPolicyDocumentPath)
 			Expect(err).ToNot(HaveOccurred())
 
 			dummyRolePolicyData := string(dummyRolePolicyBytes)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
remove refs to deprecated io/ioutil

**What does this PR do / Why do we need it**:
Starting from Go 1.16, ioutil.ReadAll, ioutil.ReadFile and ioutil.ReadDir are deprecated, as the package io/ioutil is deprecated.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
