### PR TITLE
Change default Node Agent ports for health and metrics

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `enableWindowsIpam`     | Enable windows support for your cluster                  | `false`                            |
-| `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                          |
+| `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.tag`             | Image tag                                               | `v1.14.0`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
@@ -65,12 +65,14 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.1`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
-| `nodeAgent.image.account`    | ECR repository account number                           | `602401143452`                      |
+| `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |
+| `nodeAgent.image.account`    | ECR repository account number                      | `602401143452`                      |
 | `nodeAgent.image.pullPolicy` | Container pull policy                              | `IfNotPresent`                      |
 | `nodeAgent.securityContext`  | Node Agent container Security context              | `capabilities: add: - "NET_ADMIN" privileged: true`  |
 | `nodeAgent.enableCloudWatchLogs`  | Enable CW logging for Node Agent              | `false`                             |
-| `nodeAgent.enableIpv6`
+| `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
+| `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
+| `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
 | `extraVolumes`          | Array to add extra volumes                              | `[]`                                |
 | `extraVolumeMounts`     | Array to add extra mount                                | `[]`                                |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |

--- a/charts/aws-vpc-cni/templates/_helpers.tpl
+++ b/charts/aws-vpc-cni/templates/_helpers.tpl
@@ -88,3 +88,17 @@ The aws-network-policy-agent image to use
 {{- printf "%s.dkr.%s.%s.%s/amazon/aws-network-policy-agent:%s" .Values.nodeAgent.image.account .Values.nodeAgent.image.endpoint .Values.nodeAgent.image.region .Values.nodeAgent.image.domain .Values.nodeAgent.image.tag }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The aws-network-policy-agent port to bind to for metrics
+*/}}
+{{- define "aws-vpc-cni.nodeAgentMetricsBindAddr" -}}
+{{- printf ":%s" .Values.nodeAgent.metricsBindAddr }}
+{{- end -}}
+
+{{/*
+The aws-network-policy-agent port to bind to for health probes
+*/}}
+{{- define "aws-vpc-cni.nodeAgentHealthProbeBindAddr" -}}
+{{- printf ":%s" .Values.nodeAgent.healthProbeBindAddr }}
+{{- end -}}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -128,6 +128,8 @@ spec:
             - --enable-ipv6={{ .Values.nodeAgent.enableIpv6 }}
             - --enable-network-policy={{ .Values.enableNetworkPolicy }}
             - --enable-cloudwatch-logs={{ .Values.nodeAgent.enableCloudWatchLogs }}
+            - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
+            - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -41,6 +41,8 @@ nodeAgent:
     privileged: true
   enableCloudWatchLogs: "false"
   enableIpv6: "false"
+  metricsBindAddr: "8162"
+  healthProbeBindAddr: "8163"
 
 image:
   tag: v1.14.0

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -499,6 +499,8 @@ spec:
             - --enable-ipv6=false
             - --enable-network-policy=false
             - --enable-cloudwatch-logs=false
+            - --metrics-bind-addr=:8162
+            - --health-probe-bind-addr=:8163
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -499,6 +499,8 @@ spec:
             - --enable-ipv6=false
             - --enable-network-policy=false
             - --enable-cloudwatch-logs=false
+            - --metrics-bind-addr=:8162
+            - --health-probe-bind-addr=:8163
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -499,6 +499,8 @@ spec:
             - --enable-ipv6=false
             - --enable-network-policy=false
             - --enable-cloudwatch-logs=false
+            - --metrics-bind-addr=:8162
+            - --health-probe-bind-addr=:8163
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -499,6 +499,8 @@ spec:
             - --enable-ipv6=false
             - --enable-network-policy=false
             - --enable-cloudwatch-logs=false
+            - --metrics-bind-addr=:8162
+            - --health-probe-bind-addr=:8163
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2540
ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2539

**What does this PR do / Why do we need it**:
This PR modifies the default ports that the EKS Node Agent binds to for health and metrics. The default ports, 8080 and 8081, are common enough values that they are more likely to conflict with other applications.

This PR also makes the ports configurable from the helm chart.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that command line arguments can be passed.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
Yes

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Update default node agent ports for health and metrics to 8163 and 8162
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
