### PR TITLE
Integration test cleanup: Security Groups for Pods

### DIFF
--- a/test/integration/custom-networking/custom_networking_suite_test.go
+++ b/test/integration/custom-networking/custom_networking_suite_test.go
@@ -205,22 +205,3 @@ var _ = AfterSuite(func() {
 	}
 	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred())
 })
-
-func TerminateInstances(f *framework.Framework) {
-	By("getting the list of nodes created")
-	nodeList, err := f.K8sResourceManagers.NodeManager().
-		GetNodes(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal)
-	Expect(err).ToNot(HaveOccurred())
-
-	var instanceIDs []string
-	for _, node := range nodeList.Items {
-		instanceIDs = append(instanceIDs, k8sUtils.GetInstanceIDFromNode(node))
-	}
-
-	By("terminating all the nodes")
-	err = f.CloudServices.EC2().TerminateInstance(instanceIDs)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("waiting for nodes to be recycled")
-	time.Sleep(time.Second * 300)
-}

--- a/test/integration/custom-networking/custom_networking_test.go
+++ b/test/integration/custom-networking/custom_networking_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"strconv"
 
+	awsUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
@@ -140,7 +141,9 @@ var _ = Describe("Custom Networking Test", func() {
 		})
 
 		It("deployment should not become ready", func() {
-			TerminateInstances(f)
+			By("terminating instances")
+			err := awsUtils.TerminateInstances(f, nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal)
+			Expect(err).ToNot(HaveOccurred())
 
 			// Nodes should be stuck in NotReady state since no ENIs could be attached and no pod
 			// IP addresses are available.
@@ -181,7 +184,10 @@ var _ = Describe("Custom Networking Test", func() {
 		})
 
 		It("deployment should become ready", func() {
-			TerminateInstances(f)
+			By("terminating instances")
+			err := awsUtils.TerminateInstances(f, nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal)
+			Expect(err).ToNot(HaveOccurred())
+
 			deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Replicas(2).
 				NodeSelector(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal).

--- a/testdata/amazon-eks-nodegroup.yaml
+++ b/testdata/amazon-eks-nodegroup.yaml
@@ -142,6 +142,7 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
       Path: /
 
   NodeInstanceProfile:


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR refactors the `pod-eni` integration test suite. The suite was previously failing due to scheduling issues, i.e. the test made assumptions about when pods should be scheduled on the self-managed node group that it created vs the existing managed node group. This PR removes the self-managed node group and runs the suite against the existing managed node group. This fixes the issues, decreases the complexity of the suite, and decreases the suite runtime.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that the `pod-eni` suite passes following this change.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
