### PR TITLE
Artifacts for CNI v1.14.1 and Nodeagent v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.14.1
+
+* Improvement - [Update aws-eks-nodeagent image version to v1.0.2](https://github.com/aws/aws-network-policy-agent/pull/51) (@jayanthvn)
+
 ## v1.14.0
 
 * Feature - Starting Amazon VPC CNI v1.14, there will be 2 containers in the aws-node pods for supporting Kubernetes Network Policy.

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.14.0
-appVersion: "v1.14.0"
+version: 1.14.1
+appVersion: "v1.14.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enableWindowsIpam`     | Enable windows support for your cluster                  | `false`                            |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.14.0`                           |
+| `image.tag`             | Image tag                                               | `v1.14.1`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.14.0`                           |
+| `init.image.tag`        | Image tag                                               | `v1.14.1`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -62,7 +62,7 @@ The following table lists the configurable parameters for this chart and their d
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.1`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.2`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.14.0
+    tag: v1.14.1
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -25,7 +25,7 @@ init:
 
 nodeAgent:
   image:
-    tag: v1.0.1
+    tag: v1.0.2
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -45,7 +45,7 @@ nodeAgent:
   healthProbeBindAddr: "8163"
 
 image:
-  tag: v1.14.0
+  tag: v1.14.1
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.14.0
-appVersion: v1.14.0
+version: 1.14.1
+appVersion: v1.14.1
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.14.0            |
+| image.tag                    | Image tag                                                     | v1.14.1            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.14.0
+  tag: v1.14.1
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -353,7 +353,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -374,7 +374,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.14.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.14.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -395,7 +395,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.14.0"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.14.1"
           ports:
             - containerPort: 61678
               name: metrics
@@ -488,7 +488,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:v1.0.1"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:
@@ -519,7 +519,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path
+      - name: bpf-pin-path 
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,9 +278,9 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 data:
-  enable-windows-ipam: "false"	
+  enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -353,7 +353,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -374,7 +374,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.14.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.14.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -395,7 +395,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.14.0"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.14.1"
           ports:
             - containerPort: 61678
               name: metrics
@@ -488,7 +488,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -353,7 +353,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -374,7 +374,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.14.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.14.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -395,7 +395,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.14.0"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.14.1"
           ports:
             - containerPort: 61678
               name: metrics
@@ -488,7 +488,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -353,7 +353,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -374,7 +374,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.14.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.14.1"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -395,7 +395,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.14.0"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.14.1"
           ports:
             - containerPort: 61678
               name: metrics
@@ -488,7 +488,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,5 +66,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.14.0"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.14.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,5 +66,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.14.0"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.14.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,5 +66,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.14.0"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.14.1"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.14.0"
+    app.kubernetes.io/version: "v1.14.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,5 +66,5 @@ spec:
         - name: USE_CLOUDWATCH
           value: "true"
         name: cni-metrics-helper
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.14.0"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.14.1"
       serviceAccountName: cni-metrics-helper


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Upgrade node agent image to v1.0.2
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
This incorporates the race condition issue in SDK for generating access logs - https://github.com/aws/aws-network-policy-agent/pull/51 

**What does this PR do / Why do we need it**:
Upgrades Node agent image

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Yes, CNI is just rebuild of image and node agent testing can be found here - https://github.com/aws/aws-network-policy-agent/pull/51

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
Yes

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
 No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
