### PR TITLE
fix(chart): Switch base64 encoded cniConfig.fileContents to the binaryData

### DIFF
--- a/charts/aws-vpc-cni/templates/configmap.yaml
+++ b/charts/aws-vpc-cni/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "aws-vpc-cni.fullname" . }}
   labels:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
-data:
+binaryData:
   10-aws.conflist: {{ .Values.cniConfig.fileContents | b64enc }}
 {{- end -}}
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2551 

**What does this PR do / Why do we need it**:
 Currently it's stored as a base64 encoded JSON and the VPC CNI app doesn't decode this base64 and fails.  
This change switched the ConfigMap from `data` to the `binaryData` which natively will decode base64 from the ConfigMap with no need to introduce any changes to the app itself.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
After changing the `data` in ConfigMap to the `binaryData` everything works as intended:
```
apiVersion: v1
binaryData:
  10-aws.conflist: ewogICJjbmlWZXJzaW9uIjogIjAuNC4wIiwKICAibmFtZSI6ICJhd3MtY25pIiwKICAiZGlzYWJsZUNoZWNrIjogdHJ1ZSwKICAicGx1Z2lucyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAiYXdzLWNuaSIsCiAgICAgICJ0eXBlIjogImF3cy1jbmkiLAogICAgICAidmV0aFByZWZpeCI6ICJfX1ZFVEhQUkVGSVhfXyIsCiAgICAgICJtdHUiOiAiX19NVFVfXyIsCiAgICAgICJwb2RTR0VuZm9yY2luZ01vZGUiOiAiX19QT0RTR0VORk9SQ0lOR01PREVfXyIsCiAgICAgICJwbHVnaW5Mb2dGaWxlIjogIl9fUExVR0lOTE9HRklMRV9fIiwKICAgICAgInBsdWdpbkxvZ0xldmVsIjogIl9fUExVR0lOTE9HTEVWRUxfXyIKICAgIH0sCiAgICB7CiAgICAgICJuYW1lIjogImVncmVzcy1jbmkiLAogICAgICAidHlwZSI6ICJlZ3Jlc3MtY25pIiwKICAgICAgIm10dSI6ICI5MDAxIiwKICAgICAgImVuYWJsZWQiOiAiX19FR1JFU1NQTFVHSU5FTkFCTEVEX18iLAogICAgICAicmFuZG9taXplU05BVCI6ICJfX1JBTkRPTUlaRVNOQVRfXyIsCiAgICAgICJub2RlSVAiOiAiX19OT0RFSVBfXyIsCiAgICAgICJpcGFtIjogewogICAgICAgICJ0eXBlIjogImhvc3QtbG9jYWwiLAogICAgICAgICJyYW5nZXMiOiBbW3sic3VibmV0IjogIl9fRUdSRVNTUExVR0lOSVBBTVNVQk5FVF9fIn1dXSwKICAgICAgICAicm91dGVzIjogW3siZHN0IjogIl9fRUdSRVNTUExVR0lOSVBBTURTVF9fIn1dLAogICAgICAgICJkYXRhRGlyIjogIl9fRUdSRVNTUExVR0lOSVBBTURBVEFESVJfXyIKICAgICAgfSwKICAgICAgInBsdWdpbkxvZ0ZpbGUiOiAiX19FR1JFU1NQTFVHSU5MT0dGSUxFX18iLAogICAgICAicGx1Z2luTG9nTGV2ZWwiOiAiX19QTFVHSU5MT0dMRVZFTF9fIgogICAgfSwKICAgIHsKICAgICAgInR5cGUiOiAicG9ydG1hcCIsCiAgICAgICJjYXBhYmlsaXRpZXMiOiB7InBvcnRNYXBwaW5ncyI6IHRydWV9LAogICAgICAic25hdCI6IHRydWUKICAgIH0sCiAgICB7CiAgICAgICJ0eXBlIjogInR1bmluZyIsCiAgICAgICJzeXNjdGwiOiB7CiAgICAgICAgIm5ldC5pcHY2LmNvbmYuYWxsLmRpc2FibGVfaXB2NiI6ICIxIiwKICAgICAgICAibmV0LmlwdjYuY29uZi5kZWZhdWx0LmRpc2FibGVfaXB2NiI6ICIxIiwKICAgICAgICAibmV0LmlwdjYuY29uZi5sby5kaXNhYmxlX2lwdjYiOiAiMSIKICAgICAgfQogICAgfQogIF0KfQ==
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: aws-vpc-cni
    meta.helm.sh/release-namespace: kube-system
  creationTimestamp: "2023-09-07T13:07:22Z"
  labels:
    app.kubernetes.io/instance: aws-vpc-cni
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: aws-node
    app.kubernetes.io/version: v1.12.1
    helm.sh/chart: aws-vpc-cni-1.2.2
    k8s-app: aws-node
  name: aws-node
  namespace: kube-system
  resourceVersion: "331112026"
  uid: 201208f3-7f66-4cc7-97da-7202b0b4f984
```
```
Defaulted container "aws-node" out of: aws-node, aws-vpc-cni-init (init)
Installed /host/opt/cni/bin/aws-cni
Installed /host/opt/cni/bin/egress-cni
time="2023-09-07T13:33:27Z" level=info msg="Starting IPAM daemon... "
time="2023-09-07T13:33:27Z" level=info msg="Checking for IPAM connectivity... "
time="2023-09-07T13:33:28Z" level=info msg="Copying config file... "
time="2023-09-07T13:33:28Z" level=info msg="Successfully copied CNI plugin binary and config file."
```
**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
no
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
