### PR TITLE
Update node agent tag in charts and manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Improvement - [Update instance limits for upcoming vpc-cni release](https://github.com/aws/amazon-vpc-cni-k8s/pull/2506) (@jchen6585 )
 * Improvement - [Upgrade controller-runtime to v0.15.0](https://github.com/aws/amazon-vpc-cni-k8s/pull/2481) (@jdn5126 )
 
+## v1.14.1
+
+* Improvement - [Update aws-eks-nodeagent image version to v1.0.2](https://github.com/aws/aws-network-policy-agent/pull/51) (@jayanthvn)
+
 ## v1.14.0
 
 * Feature - `v1.14.0` introduces Kubernetes Network Policy support. This is accomplished via the `aws-eks-nodeagent` container, which is now present in the `aws-node` pod.

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -62,7 +62,7 @@ The following table lists the configurable parameters for this chart and their d
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.1`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.2`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -25,7 +25,7 @@ init:
 
 nodeAgent:
   image:
-    tag: v1.0.1
+    tag: v1.0.2
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -493,7 +493,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:v1.0.1"
+          image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -493,7 +493,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -493,7 +493,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -493,7 +493,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.1"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.2"
           env:
             - name: MY_NODE_NAME
               valueFrom:


### PR DESCRIPTION
**What type of PR is this?**
chart update

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the node agent image tag for the `v1.15.0` release.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
None

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
