### PR TITLE
Remove Calico test suite from weekly integration tests

### DIFF
--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -71,15 +71,3 @@ jobs:
         run: |
           ./scripts/run-integration-tests.sh
         if: always()
-      - name: Run calico tests
-        env:
-          DISABLE_PROMPT: true
-          ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
-          RUN_CNI_INTEGRATION_TESTS: false
-          RUN_CALICO_TEST: true
-          RUN_LATEST_CALICO_VERSION: true
-          RUN_TESTER_LB_ADDONS: true
-        run: |
-          ./scripts/run-integration-tests.sh
-        if: always()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,11 +17,10 @@ This README covers the prerequisites and instructions for running the scripts.
 #### Tests
 The following tests are valid to run, and setting the respective environment variable to true will run them:
 1. CNI Integration Tests - `RUN_CNI_INTEGRATION_TESTS`
-2. Calico Tests - `RUN_CALICO_TEST`
-3. Conformance Tests - `RUN_CONFORMANCE`
-4. Performance Tests - `RUN_PERFORMANCE_TESTS`
-5. KOPS Tests - `RUN_KOPS_TEST`
-6. Bottlerocket Tests - `RUN_BOTTLEROCKET_TEST`
+2. Conformance Tests - `RUN_CONFORMANCE`
+3. Performance Tests - `RUN_PERFORMANCE_TESTS`
+4. KOPS Tests - `RUN_KOPS_TEST`
+5. Bottlerocket Tests - `RUN_BOTTLEROCKET_TEST`
 
 Example for running performance tests:
 ```

--- a/scripts/lib/integration.sh
+++ b/scripts/lib/integration.sh
@@ -24,39 +24,6 @@ function run_kops_conformance() {
     echo "TIMELINE: KOPS tests took $KOPS_TEST_DURATION seconds."
 
     sleep 240 #Workaround to avoid ENI leakage during cluster deletion: https://github.com/aws/amazon-vpc-cni-k8s/issues/1223
-
-}
-
-function run_calico_test() {
-  echo "Starting Helm installing Tigera operator and running Calico STAR tests"
-  pushd ./test
-  VPC_ID=$(eksctl get cluster $CLUSTER_NAME -oyaml | grep vpc | cut -d ":" -f 2 | awk '{$1=$1};1')
-
-  calico_version=$CALICO_VERSION
-  if [[ $1 == "true" ]]; then
-    # we can automatically use latest version in Calico repo, or use the known highest version (currently v3.23.0)
-    if [[ $RUN_LATEST_CALICO_VERSION == true ]]; then
-      version_tag=$(curl -i https://api.github.com/repos/projectcalico/calico/releases/latest | grep "tag_name") || true
-      if [[ -n $version_tag ]]; then
-        calico_version=$(echo $version_tag | cut -d ":" -f 2 | cut -d '"' -f 2 )
-      else
-        echo "Getting Calico latest version failed, will fall back to default/set version $calico_version instead"
-      fi
-    else echo "Using default Calico version"
-    fi
-    echo "Using Calico version $calico_version to test"
-  else
-    version=$(kubectl describe ds -n calico-system calico-node | grep "calico/node:" | cut -d ':' -f3)
-    echo "Calico has been installed in testing cluster, keep using the version $version"
-  fi
-
-  echo "Testing amd64"
-  instance_type="amd64"
-  ginkgo -v integration/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version --instance-type=$instance_type --install-calico=$1
-  echo "Testing arm64"
-  instance_type="arm64"
-  ginkgo -v integration/calico -- --cluster-kubeconfig=$KUBECONFIG --cluster-name=$CLUSTER_NAME --aws-region=$AWS_DEFAULT_REGION --aws-vpc-id=$VPC_ID --calico-version=$calico_version --instance-type=$instance_type --install-calico=false
-  popd
 }
 
 function build_and_push_image(){

--- a/scripts/run-release-tests.sh
+++ b/scripts/run-release-tests.sh
@@ -20,8 +20,3 @@ export RUN_KOPS_TEST=true
 echo "Running KOPS test"
 ./scripts/run-integration-tests.sh
 unset RUN_KOPS_TEST
-
-export RUN_CALICO_TEST=true
-echo "Running calico test"
-./scripts/run-integration-tests.sh
-unset RUN_CALICO_TEST

--- a/test/README.md
+++ b/test/README.md
@@ -26,9 +26,6 @@ Ginkgo Focus: [SMOKE]
 # Bottlerocket
     * set RUN_BOTTLEROCKET_TEST=true
 
-# Calico
-    * set RUN_CALICO_TEST=true
-
 ## How to Manually delete k8s tester Resources (order of deletion)
 Cloudformation - (all except cluster, vpc)
 EC2 - load balancers, key pair


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR removes the Calico integration test suite from weekly integration test runs. Now that AWS VPC CNI supports Kubernetes Network Policy natively (via https://github.com/aws/aws-network-policy-agent), we do not need to test against Calico's Network Policy implementation as frequently. We will still test against Calico's Network Policy implementation before every release and treat any failure as a release gate.

Removing `RUN_CALICO_TEST` decreases the complexity of `run-integration-tests` and decreases the overall runtime of our weekly integration test runner. 

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
None

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
