### PR TITLE
Increment default Calico version for integration tests

### DIFF
--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -62,7 +62,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.TargetAddon, "target-addon-version", "", "Target CNI addon version after upgrade applied")
 	flag.StringVar(&options.InitialManifest, "initial-manifest-file", "", "Initial CNI manifest, can be local file path or remote Url")
 	flag.StringVar(&options.TargetManifest, "target-manifest-file", "", "Target CNI manifest, can be local file path or remote Url")
-	flag.StringVar(&options.CalicoVersion, "calico-version", "v3.25.0", "calico version to be tested")
+	flag.StringVar(&options.CalicoVersion, "calico-version", "v3.26.1", "calico version to be tested")
 	flag.StringVar(&options.ContainerRuntime, "container-runtime", "", "Optionally can specify it as 'containerd' for the test nodes")
 	flag.StringVar(&options.InstanceType, "instance-type", "amd64", "Optionally specify instance type as arm64 for the test nodes")
 	flag.BoolVar(&options.InstallCalico, "install-calico", true, "Install Calico operator before running tests")


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR updates the default Calico version to test against in integration tests to `v3.26.1`. The previous version was occasionally experiencing issues when installed via helm in integration tests, but all tests pass with this version, and we anyway want to test against the latest version.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that calico integration test suite passes.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
