### PR TITLE
Add cni version to userAgent

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -78,6 +78,7 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
+  VPC_CNI_VERSION: "v1.15.0"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -40,7 +40,7 @@ func _main() int {
 	version.RegisterMetric()
 
 	// Check API Server Connectivity
-	if err := k8sapi.CheckAPIServerConnectivity(appName); err != nil {
+	if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
 		log.Errorf("Failed to check API server connectivity: %s", err)
 		return 1
 	}

--- a/cmd/cni-metrics-helper/main.go
+++ b/cmd/cni-metrics-helper/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	log.Infof("Starting CNIMetricsHelper. Sending metrics to CloudWatch: %v, LogLevel %s, metricUpdateInterval %d", options.submitCW, logConfig.LogLevel, metricUpdateInterval)
 
-	clientSet, err := k8sapi.GetKubeClientSet(appName)
+	clientSet, err := k8sapi.GetKubeClientSet()
 	if err != nil {
 		log.Fatalf("Error Fetching Kubernetes Client: %s", err)
 		os.Exit(1)

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -459,6 +459,8 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: VPC_CNI_VERSION
+              value: "v1.15.0"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -459,6 +459,8 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: VPC_CNI_VERSION
+              value: "v1.15.0"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -459,6 +459,8 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: VPC_CNI_VERSION
+              value: "v1.15.0"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -459,6 +459,8 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: VPC_CNI_VERSION
+              value: "v1.15.0"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/pkg/awsutils/awssession/session.go
+++ b/pkg/awsutils/awssession/session.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -31,13 +32,13 @@ import (
 
 // Http client timeout env for sessions
 const (
-	httpTimeoutEnv = "HTTP_TIMEOUT"
-	maxRetries     = 10
+	httpTimeoutEnv   = "HTTP_TIMEOUT"
+	maxRetries       = 10
+	envVpcCniVersion = "VPC_CNI_VERSION"
 )
 
 var (
-	version string
-	log     = logger.Get()
+	log = logger.Get()
 	// HTTP timeout default value in seconds (10 seconds)
 	httpTimeoutValue = 10 * time.Second
 )
@@ -89,6 +90,7 @@ func New() *session.Session {
 
 // injectUserAgent will inject app specific user-agent into awsSDK
 func injectUserAgent(handlers *request.Handlers) {
+	version := utils.GetEnv(envVpcCniVersion, "")
 	handlers.Build.PushFrontNamed(request.NamedHandler{
 		Name: fmt.Sprintf("%s/user-agent", "amazon-vpc-cni-k8s"),
 		Fn: request.MakeAddToUserAgentHandler(

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -13,6 +13,7 @@ import (
 
 	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	rcscheme "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -86,7 +87,7 @@ func StartKubeClientCache(cache cache.Cache) {
 
 // CreateKubeClient creates a k8s client
 func CreateKubeClient(appName string) (client.Client, error) {
-	restCfg, err := getRestConfig(appName)
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -122,9 +123,9 @@ func CreateKubeClient(appName string) (client.Client, error) {
 	return k8sClient, nil
 }
 
-func GetKubeClientSet(appName string) (kubernetes.Interface, error) {
+func GetKubeClientSet() (kubernetes.Interface, error) {
 	// creates the in-cluster config
-	config, err := getRestConfig(appName)
+	config, err := getRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +138,8 @@ func GetKubeClientSet(appName string) (kubernetes.Interface, error) {
 	return clientSet, nil
 }
 
-func CheckAPIServerConnectivity(appName string) error {
-	restCfg, err := getRestConfig(appName)
+func CheckAPIServerConnectivity() error {
+	restCfg, err := getRestConfig()
 	if err != nil {
 		return err
 	}
@@ -166,12 +167,12 @@ func CheckAPIServerConnectivity(appName string) error {
 	})
 }
 
-func getRestConfig(appName string) (*rest.Config, error) {
+func getRestConfig() (*rest.Config, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
 	}
-	restCfg.UserAgent = appName
+	restCfg.UserAgent = os.Args[0] + "-" + utils.GetEnv("VPC_CNI_VERSION", "")
 	if endpoint, ok := os.LookupEnv("CLUSTER_ENDPOINT"); ok {
 		restCfg.Host = endpoint
 	}

--- a/pkg/utils/eventrecorder/eventrecorder.go
+++ b/pkg/utils/eventrecorder/eventrecorder.go
@@ -50,7 +50,7 @@ type EventRecorder struct {
 }
 
 func Init(k8sClient client.Client) error {
-	clientSet, err := k8sapi.GetKubeClientSet(appName)
+	clientSet, err := k8sapi.GetKubeClientSet()
 	if err != nil {
 		log.Fatalf("Error Fetching Kubernetes Client: %s", err)
 		return err

--- a/scripts/generate-cni-yaml.sh
+++ b/scripts/generate-cni-yaml.sh
@@ -79,6 +79,7 @@ jq -c '.[]' $REGIONS_FILE | while read i; do
       --set nodeAgent.image.region=$ecrRegion \
       --set nodeAgent.image.domain=$ecrDomain \
       --set nodeAgent.image.tag=$NODE_AGENT_VERSION \
+      --set env.VPC_CNI_VERSION=$VPC_CNI_VERSION \
       --namespace $NAMESPACE \
       $SCRIPTPATH/../charts/aws-vpc-cni > $NEW_CNI_RESOURCES_YAML
     # Remove 'managed-by: Helm' annotation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
enhancement

**Which issue does this PR fix**:
#2518 

**What does this PR do / Why do we need it**:
Includes current CNI version in userAgent.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually tested through looking at cloudwatch logs.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
No

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
