### PR TITLE
fix clusterrole permissions:  watch cninodes

### DIFF
--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -45,4 +45,4 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "patch", "watch"]

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "patch", "watch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "patch", "watch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "patch", "watch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "patch", "watch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Fix permissions issue

**Which issue does this PR fix**:
VPC CNI errors:
```
E0914 13:07:56.908969      12 reflector.go:148] pkg/mod/k8s.io/client-go@v0.27.3/tools/cache/reflector.go:231: Failed to watch *v1alpha1.CNINode: unknown (get cninodes.vpcresources.k8s.aws)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
