### PR TITLE
Add ENABLE_V4_EGRESS env var to control IPv4 egress in IPv6 clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,17 @@ Specifies whether PODs in an IPv4 cluster support IPv6 egress. If env is set to 
 
 This environment variable must be set for both the `aws-vpc-cni-init` and `aws-node` containers in order for this feature to work properly. This feature also requires that the node has an IPv6 address assigned to its primary ENI, as this address is used for SNAT to IPv6 endpoints outside of the cluster. If the configuration prerequisites are not met, the `egress-cni` plugin is not enabled and an error log is printed in the `aws-node` container.
 
-Note that enabling/disabling this feature only affects whether newly created pods have an IPv6 interface created. Therefore, it is recommended that you reboot existing nodes after enabling/disabling this feature. Also note that if you are using this feature in conjunction with `ENABLE_POD_ENI` (Security Groups for Pods), the security group rules will NOT be applied to egressing IPv6 traffic.
+Note that enabling/disabling this feature only affects whether newly created pods have an IPv6 interface created. Therefore, it is recommended that you reboot existing nodes after enabling/disabling this feature.
+
+#### `ENABLE_V4_EGRESS` (v1.15.1+)
+
+Type: Boolean as a String
+
+Default: `true`
+
+Specifies whether PODs in an IPv6 cluster support IPv4 egress. If env is set to `true`, range `169.254.172.0/22` is reserved for IPv4 egress. When enabled, traffic egressing an IPv6 pod destined to an IPv4 endpoint will be SNAT'ed via the node IPv4 address.
+
+Note that enabling/disabling this feature only affects whether newly created pods have an IPv4 interface created. Therefore, it is recommended that you reboot existing nodes after enabling/disabling this feature.
 
 #### `IP_COOLDOWN_PERIOD` (v1.15.0+)
 

--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -114,7 +114,7 @@ func configureIPv6Settings(procSys procsyswrapper.ProcSys, primaryIF string) err
 		val, _ := procSys.Get(entry)
 		log.Infof("Updated %s to %s", entry, val)
 	}
-	// Check if IPv6 egress supporting is enabled in IPv4 cluster
+	// Check if IPv6 egress support is enabled in IPv4 cluster.
 	ipv6EgressEnabled := utils.GetBoolAsStringEnvVar(envEgressV6, defaultEnableIPv6Egress)
 	if enableIPv6 || ipv6EgressEnabled {
 		entry := "net/ipv6/conf/all/forwarding"

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -75,6 +75,7 @@ const (
 	defaultPluginLogLevel        = "Debug"
 	defaultEnableIPv6            = false
 	defaultEnableIPv6Egress      = false
+	defaultEnableIPv4Egress      = true
 	defaultRandomizeSNAT         = "prng"
 	awsConflistFile              = "/10-aws.conflist"
 	vpcCniInitDonePath           = "/vpc-cni-init/done"
@@ -100,6 +101,7 @@ const (
 	envEnBandwidthPlugin     = "ENABLE_BANDWIDTH_PLUGIN"
 	envEnIPv6                = "ENABLE_IPv6"
 	envEnIPv6Egress          = "ENABLE_V6_EGRESS"
+	envEnIPv4Egress          = "ENABLE_V4_EGRESS"
 	envRandomizeSNAT         = "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 	envDisablePodV6          = "DISABLE_POD_V6"
@@ -249,7 +251,8 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		egressIPAMSubnet = egressPluginIpamSubnetV4
 		egressIPAMDst = egressPluginIpamDstV4
 		egressIPAMDataDir = egressPluginIpamDataDirV4
-		egressEnabled = true // enable IPv4 egress by default of IPv6 cluster
+		// Enable IPv4 egress when "ENABLE_V4_EGRESS" is "true" (default)
+		egressEnabled = utils.GetBoolAsStringEnvVar(envEnIPv4Egress, defaultEnableIPv4Egress)
 		egressPluginLogFile = utils.GetEnv(envEgressV4PluginLogFile, defaultEgressV4PluginLogFile)
 		nodeIP, err = getPrimaryIP(true)
 		// Node should have a IPv4 address even in IPv6 cluster


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/aws-network-policy-agent/issues/55

**What does this PR do / Why do we need it**:
This PR adds a new environment variable, `ENABLE_V4_EGRESS`, which controls whether the `egress-cni` chained plugin is enabled for IPv6 clusters. The value is enabled by default, preserving the existing IPv6 default. When disabled, an IPv4 interface will not be created in IPv6 pods, blocking those pods from reaching IPv4 endpoints.

The primary motivation for this PR is to address https://github.com/aws/aws-network-policy-agent/issues/55, where the concern is network policies in IPv6 clusters not applying to IPv4 traffic.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that chained plugin is enabled or disabled based on env var.

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Introduce ENABLE_V4_EGRESS, which controls whether egress-cni plugin is enabled in IPv6 clusters.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
