### PR TITLE
VPC CNI initialization changes for SGPP IPv6 Support

### DIFF
--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1933,7 +1933,7 @@ func TestIPAMContext_setupENIwithPDenabled(t *testing.T) {
 	assert.Equal(t, 1, len(mockContext.primaryIP))
 }
 
-func TestIPAMContext_askForTrunkENIIfNeeded(t *testing.T) {
+func TestIPAMContext_enableSecurityGroupsForPods(t *testing.T) {
 	m := setup(t)
 	defer m.ctrl.Finish()
 	ctx := context.Background()
@@ -1966,10 +1966,10 @@ func TestIPAMContext_askForTrunkENIIfNeeded(t *testing.T) {
 
 	_ = mockContext.dataStore.AddENI("eni-1", 1, true, false, false)
 	// If ENABLE_POD_ENI is not set, nothing happens
-	mockContext.askForTrunkENIIfNeeded(ctx)
+	mockContext.enableSecurityGroupsForPods(ctx)
 
 	mockContext.enablePodENI = true
-	mockContext.askForTrunkENIIfNeeded(ctx)
+	mockContext.enableSecurityGroupsForPods(ctx)
 	var notUpdatedNode corev1.Node
 	NodeKey := types.NamespacedName{
 		Namespace: "",
@@ -1987,12 +1987,12 @@ func TestIPAMContext_askForTrunkENIIfNeeded(t *testing.T) {
 	contained := lo.ContainsBy(cniNode.Spec.Features, func(addedFeature rcscheme.Feature) bool {
 		return rcscheme.SecurityGroupsForPods == addedFeature.Name && addedFeature.Value == ""
 	})
-	assert.False(t, contained, "the node's CNINode shouldn't be updated for trunk when there is no room")
-	assert.Equal(t, 0, len(cniNode.Spec.Features))
+	assert.True(t, contained, "CNINode should be updated regardless of whether there is room for trunk ENI")
+	assert.Equal(t, 1, len(cniNode.Spec.Features))
 
+	// Make room for trunk ENI
 	mockContext.maxENI = 4
-	// Now there is room!
-	mockContext.askForTrunkENIIfNeeded(ctx)
+	mockContext.enableSecurityGroupsForPods(ctx)
 
 	err = mockContext.k8sClient.Get(ctx, types.NamespacedName{
 		Name: fakeNode.Name,
@@ -2002,7 +2002,7 @@ func TestIPAMContext_askForTrunkENIIfNeeded(t *testing.T) {
 	contained = lo.ContainsBy(cniNode.Spec.Features, func(addedFeature rcscheme.Feature) bool {
 		return rcscheme.SecurityGroupsForPods == addedFeature.Name && addedFeature.Value == ""
 	})
-	assert.True(t, contained, "the node's CNINode should be updated for trunk when there is some room")
+	assert.True(t, contained, "CNINode should be updated regardless of whether there is room for trunk ENI")
 	assert.Equal(t, 1, len(cniNode.Spec.Features))
 }
 
@@ -2092,7 +2092,7 @@ func TestIsConfigValid(t *testing.T) {
 				podENIEnabled:           true,
 				isNitroInstance:         true,
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "ppsg enabled in v4 mode",
@@ -2112,7 +2112,7 @@ func TestIsConfigValid(t *testing.T) {
 			m := setup(t)
 			defer m.ctrl.Finish()
 
-			if tt.fields.prefixDelegationEnabled && !(tt.fields.podENIEnabled && tt.fields.ipV6Enabled) {
+			if tt.fields.prefixDelegationEnabled {
 				if tt.fields.isNitroInstance {
 					m.awsutils.EXPECT().IsPrefixDelegationSupported().Return(true)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR modifies the VPC CNI initialization logic to patch the CNINode CRD for Security Groups for Pods when IPv6 is enabled.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually validated change against IPv6 cluster

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
