### PR TITLE
Increase time for service readiness in integration test

### DIFF
--- a/test/integration/cni/service_connectivity_test.go
+++ b/test/integration/cni/service_connectivity_test.go
@@ -99,7 +99,7 @@ var _ = Describe("[CANARY] test service connectivity", func() {
 		fmt.Fprintf(GinkgoWriter, "created service\n: %+v\n", service.Status)
 
 		By("sleeping for some time to allow service to become ready")
-		time.Sleep(utils.PollIntervalLong)
+		time.Sleep(3 * utils.PollIntervalLong)
 
 		testerContainer = manifest.NewBusyBoxContainerBuilder(f.Options.TestImageRegistry).
 			Command([]string{"wget"}).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
testing
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
The `cni` service connectivity integration test was occasionally failing as 20 seconds is not enough time for a Classic Load Balancer to become ready. This PR increases the time to one minute as a temporary solution to resolve the flakiness. Long-term, we need to make an EC2 API call to ensure that the load balancer is ready.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
None

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
None

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
