### PR TITLE
Remove self-managed node group from custom-networking suite

### DIFF
--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -297,8 +297,8 @@ func GetClusterVPCConfig(f *framework.Framework) (*ClusterVPCConfig, error) {
 	return clusterConfig, nil
 }
 
-func TerminateInstances(f *framework.Framework, ngLabelKey string, ngLabelVal string) error {
-	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(ngLabelKey, ngLabelVal)
+func TerminateInstances(f *framework.Framework) error {
+	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 	if err != nil {
 		return fmt.Errorf("failed to get list of nodes created: %v", err)
 	}
@@ -314,6 +314,6 @@ func TerminateInstances(f *framework.Framework, ngLabelKey string, ngLabelVal st
 	}
 
 	// Wait for instances to be replaced
-	time.Sleep(time.Second * 450)
+	time.Sleep(time.Minute * 8)
 	return nil
 }

--- a/test/integration/custom-networking/custom_networking_test.go
+++ b/test/integration/custom-networking/custom_networking_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	awsUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
@@ -51,16 +52,20 @@ var _ = Describe("Custom Networking Test", func() {
 				Args([]string{"-k", "-l", strconv.Itoa(port)}).
 				Build()
 
-			deployment = manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+			deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Container(container).
 				Replicas(replicaCount).
-				NodeSelector(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal).
 				PodLabel(podLabelKey, podLabelVal).
 				Build()
 
+			var err error
 			deployment, err = f.K8sResourceManagers.DeploymentManager().
-				CreateAndWaitTillDeploymentIsReady(deployment, utils.DefaultDeploymentReadyTimeout)
+				CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for deployment to settle, as if any pods restart, their pod IP will change between
+			// the GET and the validation.
+			time.Sleep(5)
 
 			podList, err = f.K8sResourceManagers.PodManager().
 				GetPodsWithLabelSelector(podLabelKey, podLabelVal)
@@ -100,14 +105,14 @@ var _ = Describe("Custom Networking Test", func() {
 		})
 
 		JustAfterEach(func() {
-			err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+			err := f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("when connecting to reachable port", func() {
 			BeforeEach(func() {
 				port = customNetworkingSGOpenPort
-				replicaCount = 16
+				replicaCount = 10
 				shouldConnect = true
 			})
 			It("should connect", func() {})
@@ -127,7 +132,7 @@ var _ = Describe("Custom Networking Test", func() {
 		JustBeforeEach(func() {
 			By("deleting ENIConfig for all availability zones")
 			for _, eniConfig := range eniConfigList {
-				err = f.K8sResourceManagers.CustomResourceManager().DeleteResource(eniConfig)
+				err := f.K8sResourceManagers.CustomResourceManager().DeleteResource(eniConfig)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
@@ -135,21 +140,20 @@ var _ = Describe("Custom Networking Test", func() {
 		JustAfterEach(func() {
 			By("re-creating ENIConfig for all availability zones")
 			for _, eniConfig := range eniConfigList {
-				err = f.K8sResourceManagers.CustomResourceManager().CreateResource(eniConfig)
+				err := f.K8sResourceManagers.CustomResourceManager().CreateResource(eniConfig)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
 
 		It("deployment should not become ready", func() {
 			By("terminating instances")
-			err := awsUtils.TerminateInstances(f, nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal)
+			err := awsUtils.TerminateInstances(f)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Nodes should be stuck in NotReady state since no ENIs could be attached and no pod
 			// IP addresses are available.
 			deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Replicas(2).
-				NodeSelector(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal).
 				Build()
 
 			By("verifying deployment should not succeed")
@@ -168,7 +172,7 @@ var _ = Describe("Custom Networking Test", func() {
 		JustBeforeEach(func() {
 			By("deleting ENIConfig for each availability zone")
 			for _, eniConfig := range eniConfigList {
-				err = f.K8sResourceManagers.CustomResourceManager().DeleteResource(eniConfig)
+				err := f.K8sResourceManagers.CustomResourceManager().DeleteResource(eniConfig)
 				Expect(err).ToNot(HaveOccurred())
 			}
 			By("re-creating ENIConfigs with no security group")
@@ -185,12 +189,11 @@ var _ = Describe("Custom Networking Test", func() {
 
 		It("deployment should become ready", func() {
 			By("terminating instances")
-			err := awsUtils.TerminateInstances(f, nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal)
+			err := awsUtils.TerminateInstances(f)
 			Expect(err).ToNot(HaveOccurred())
 
 			deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Replicas(2).
-				NodeSelector(nodeGroupProperties.NgLabelKey, nodeGroupProperties.NgLabelVal).
 				Build()
 
 			By("verifying deployment succeeds")

--- a/test/integration/custom-networking/custom_networking_test.go
+++ b/test/integration/custom-networking/custom_networking_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Custom Networking Test", func() {
 
 			// Wait for deployment to settle, as if any pods restart, their pod IP will change between
 			// the GET and the validation.
-			time.Sleep(5)
+			time.Sleep(5 * time.Second)
 
 			podList, err = f.K8sResourceManagers.PodManager().
 				GetPodsWithLabelSelector(podLabelKey, podLabelVal)

--- a/test/integration/pod-eni/security_group_per_pod_suite_test.go
+++ b/test/integration/pod-eni/security_group_per_pod_suite_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 		})
 
 	By("terminating instances")
-	err = awsUtils.TerminateInstances(f, f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+	err = awsUtils.TerminateInstances(f)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("getting target node")
@@ -122,7 +122,7 @@ var _ = AfterSuite(func() {
 		})
 
 	By("terminating instances")
-	err := awsUtils.TerminateInstances(f, f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+	err := awsUtils.TerminateInstances(f)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("deleting the security group")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
testing
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR removes the creation of a self-managed node group for the `custom-networking` integration suite. This removal makes the test more flexible and decreases its complexity. It also removes the flakiness that was present in the test, as not all jobs had the proper node selectors.

It is unfortunate that this test suite has so much waiting time. The time spent waiting for instance termination cannot be avoided, nor can the ENI cooldown time. It would be nice to eliminate some of the other waits, though.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually verified that integration suite passes following change

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
