### PR TITLE
Do not patch CNINode for custom networking unless SGPP is enabled

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -560,14 +560,16 @@ func (c *IPAMContext) nodeInit() error {
 
 		eniConfigName, err := eniconfig.GetNodeSpecificENIConfigName(node)
 		if err == nil && eniConfigName != "default" {
-			// Add the feature name to CNINode of this node
-			err := c.AddFeatureToCNINode(ctx, rcv1alpha1.CustomNetworking, eniConfigName)
-			if err != nil {
-				log.Errorf("Failed to add feature custom networking into CNINode", err)
-				podENIErrInc("nodeInit")
-				return err
+			// If Security Groups for Pods is enabled, the VPC Resource Controller must also know that Custom Networking is enabled
+			if c.enablePodENI {
+				err := c.AddFeatureToCNINode(ctx, rcv1alpha1.CustomNetworking, eniConfigName)
+				if err != nil {
+					log.Errorf("Failed to add feature custom networking into CNINode", err)
+					podENIErrInc("nodeInit")
+					return err
+				}
+				log.Infof("Enabled feature %s in CNINode for node %s if not existing", rcv1alpha1.CustomNetworking, c.myNodeName)
 			}
-			log.Infof("Enabled feature %s in CNINode for node %s if not existing", rcv1alpha1.CustomNetworking, c.myNodeName)
 		} else {
 			log.Errorf("No ENIConfig could be found for this node", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2584

**What does this PR do / Why do we need it**:
When Custom Networking is enabled, IPAMD patches the `CNINode` resource for this node by default, when it only needs to patch it when Security Groups for Pods is also enabled. Patching by default leads to an issue if the VPC Resource Controller is not running, as that `CNINode` resource will not exist.

This PR avoids patching the `CNINode` resource when unless a VPC Resource Controller feature is enabled. This is done so that customers can run the VPC CNI and configure certain features without needing the controller.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually verified the fix.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
Patch CNINode only when Security Groups for Pods is enabled
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
