### PR TITLE
Select CNI manifest based on regions

### DIFF
--- a/scripts/update-cni-images.sh
+++ b/scripts/update-cni-images.sh
@@ -9,25 +9,37 @@ set -e
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$SCRIPTS_DIR/lib/k8s.sh"
+: "${REGION=us-west-2}"
 
-AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni.yaml"
+# Select CNI manifest based on regions
+if [[ $REGION == "cn-north-1" || $REGION == "cn-northwest-1" ]]; then
+    AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni-cn.yaml"
+elif [[ $REGION == "us-gov-east-1" ]]; then
+    AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni-us-gov-east-1.yaml"
+elif [[ $REGION == "us-gov-west-1" ]]; then
+    AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni-us-gov-west-1.yaml"
+else
+    AWS_K8S_CNI_MANIFEST="$SCRIPTS_DIR/../config/master/aws-k8s-cni.yaml"
+fi
+
 MANIFEST_IMG_VERSION=`grep "image:" $AWS_K8S_CNI_MANIFEST | cut -d ":" -f3 | cut -d "\"" -f1 | head -1`
+IMAGE_REPOSITORY=`grep "image:" $AWS_K8S_CNI_MANIFEST | cut -d ":" -f2 | cut -d "/" -f1 | head -1`
 
 # Replace the images in aws-k8s-cni.yaml with the tester images when environment variables are set
 if [[ -z $AMAZON_K8S_CNI ]]; then
     echo "Using latest CNI image from aws-k8s-cni manifest"
 else
     echo "Replacing CNI image in aws-k8s-cni manifest with $AMAZON_K8S_CNI"
-    sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI," "$AWS_K8S_CNI_MANIFEST"
+    sed -i'.bak' "s,$IMAGE_REPOSITORY/amazon-k8s-cni:$MANIFEST_IMG_VERSION, $AMAZON_K8S_CNI," "$AWS_K8S_CNI_MANIFEST"
 fi
 if [[ -z $AMAZON_K8S_CNI_INIT ]]; then
     echo "Using latest CNI init image from aws-k8s-cni manifest"
 else
     echo "Replacing CNI init image in aws-k8s-cni manifest with $AMAZON_K8S_CNI_INIT"
-    sed -i'.bak' "s,602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:$MANIFEST_IMG_VERSION,$AMAZON_K8S_CNI_INIT," "$AWS_K8S_CNI_MANIFEST"
+    sed -i'.bak' "s,$IMAGE_REPOSITORY/amazon-k8s-cni-init:$MANIFEST_IMG_VERSION, $AMAZON_K8S_CNI_INIT," "$AWS_K8S_CNI_MANIFEST"
 fi
 
-echo "Applying amazon-vpc-cni-k8s/config/master/aws-k8s-cni.yaml manifest"
+echo "Applying $AWS_K8S_CNI_MANIFEST manifest"
 kubectl apply -f $AWS_K8S_CNI_MANIFEST
 
 check_ds_rollout "aws-node" "kube-system" "10m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
fix

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
The script always uses the commercial region manifest. We run into failures when we run tests in Gov cloud or China region


**What does this PR do / Why do we need it**:
Run canaries in Gov cloud and China region accounts


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
N/A

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
N/A

<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
N/A

<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A


**Does this change require updates to the CNI daemonset config files to work?**:
N/A

<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
N/A

<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
