### PR TITLE
Quote images in chart

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: {{ include "aws-vpc-cni.initImage" . }}
+        image: "{{ include "aws-vpc-cni.initImage" . }}"
         env:
 {{- range $key, $value := .Values.init.env }}
           - name: {{ $key }}
@@ -66,7 +66,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: aws-node
-          image: {{ include "aws-vpc-cni.image" . }}
+          image: "{{ include "aws-vpc-cni.image" . }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -117,7 +117,7 @@ spec:
           {{- toYaml .| nindent 10 }}
           {{- end }}
         - name: aws-eks-nodeagent
-          image: {{ include "aws-vpc-cni.nodeAgentImage" . }}
+          image: "{{ include "aws-vpc-cni.nodeAgentImage" . }}"
           env:
             - name: MY_NODE_NAME
               valueFrom:


### PR DESCRIPTION
This is necessary to ensure that YAML doesn't confuse the leading account as a number. That won't happen with the default account from values.yaml, since that's set as a string, but it can happen when users pass in their own values.

Fixes #2594

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2594

**What does this PR do / Why do we need it**:
Fixes a regression in the chart that broke existing users.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**: n/a


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
✅ `helm template . --set 'init.image.account=602401143452,image.account=602401143452,nodeAgent.account=602401143452'` generates correct YAML. 

✅ `helm template .` generates correct YAML

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: n/a


**Does this change require updates to the CNI daemonset config files to work?**: no
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
