### PR TITLE
feat(chart): Made node agent optional

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -60,8 +60,10 @@ The following table lists the configurable parameters for this chart and their d
 | `init.image.override`   | A custom docker image to use                            | `nil`                               |
 | `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
+| `init.resources`        | Init container resources, will defualt to .Values.resources if not set | `{}`                 |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
+| `nodeAgent.enabled`     | If the Node Agent container should be created           | `true`                              |
 | `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.4`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
@@ -74,6 +76,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
 | `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
 | `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
+| `nodeAgent.resources`   | Node Agent resources, will defualt to .Values.resources if not set | `{}`                     |
 | `extraVolumes`          | Array to add extra volumes                              | `[]`                                |
 | `extraVolumeMounts`     | Array to add extra mount                                | `[]`                                |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -48,8 +48,10 @@ spec:
 {{- end }}
         securityContext:
           {{- toYaml .Values.init.securityContext | nindent 12 }}
+        {{- with default .Values.resources .Values.init.resources }}
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -91,8 +93,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
@@ -116,6 +120,7 @@ spec:
           {{- with .Values.extraVolumeMounts  }}
           {{- toYaml .| nindent 10 }}
           {{- end }}
+        {{- if .Values.nodeAgent.enabled }}
         - name: aws-eks-nodeagent
           image: {{ include "aws-vpc-cni.nodeAgentImage" . }}
           env:
@@ -131,8 +136,10 @@ spec:
             - --enable-policy-event-logs={{ .Values.nodeAgent.enablePolicyEventLogs }}
             - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
             - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
+          {{- with default .Values.resources .Values.nodeAgent.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.nodeAgent.securityContext | nindent 12 }}
           volumeMounts:
@@ -144,10 +151,13 @@ spec:
             name: log-dir
           - mountPath: /var/run/aws-node
             name: run-dir
+      {{- end }}
       volumes:
+      {{- if .Values.nodeAgent.enabled }}
       - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
+      {{- end }}
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -22,8 +22,10 @@ init:
     ENABLE_IPv6: "false"
   securityContext:
     privileged: true
+  resources: {}
 
 nodeAgent:
+  enabled: true
   image:
     tag: v1.0.4
     domain: amazonaws.com
@@ -44,6 +46,7 @@ nodeAgent:
   enableIpv6: "false"
   metricsBindAddr: "8162"
   healthProbeBindAddr: "8163"
+  resources: {}
 
 image:
   tag: v1.15.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:

- Fixes #2524

**What does this PR do / Why do we need it**:
This PR updates the Helm chart to makes the node agent container optional (defaults to present) and allows for custom resource specification for the init container and the node agent. These changes should be a no-op unless someone makes use of the new chart inputs.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

n/a

**Testing done on this change**:
I've templated the Helm chart and these changes are a no-op. The new chart values work as expected.

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:

No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:
 No

**Does this PR introduce any user-facing change?**:
 
Yes

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
