### PR TITLE
Refactor AllocENI (#2640)

### DIFF
--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -27,45 +27,45 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockAPIs is a mock of APIs interface
+// MockAPIs is a mock of APIs interface.
 type MockAPIs struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIsMockRecorder
 }
 
-// MockAPIsMockRecorder is the mock recorder for MockAPIs
+// MockAPIsMockRecorder is the mock recorder for MockAPIs.
 type MockAPIsMockRecorder struct {
 	mock *MockAPIs
 }
 
-// NewMockAPIs creates a new mock instance
+// NewMockAPIs creates a new mock instance.
 func NewMockAPIs(ctrl *gomock.Controller) *MockAPIs {
 	mock := &MockAPIs{ctrl: ctrl}
 	mock.recorder = &MockAPIsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPIs) EXPECT() *MockAPIsMockRecorder {
 	return m.recorder
 }
 
-// AllocENI mocks base method
-func (m *MockAPIs) AllocENI(arg0 bool, arg1 []*string, arg2 string) (string, error) {
+// AllocENI mocks base method.
+func (m *MockAPIs) AllocENI(arg0 bool, arg1 []*string, arg2 string, arg3 int) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllocENI", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AllocENI", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AllocENI indicates an expected call of AllocENI
-func (mr *MockAPIsMockRecorder) AllocENI(arg0, arg1, arg2 interface{}) *gomock.Call {
+// AllocENI indicates an expected call of AllocENI.
+func (mr *MockAPIsMockRecorder) AllocENI(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocENI", reflect.TypeOf((*MockAPIs)(nil).AllocENI), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocENI", reflect.TypeOf((*MockAPIs)(nil).AllocENI), arg0, arg1, arg2, arg3)
 }
 
-// AllocIPAddress mocks base method
+// AllocIPAddress mocks base method.
 func (m *MockAPIs) AllocIPAddress(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocIPAddress", arg0)
@@ -73,13 +73,13 @@ func (m *MockAPIs) AllocIPAddress(arg0 string) error {
 	return ret0
 }
 
-// AllocIPAddress indicates an expected call of AllocIPAddress
+// AllocIPAddress indicates an expected call of AllocIPAddress.
 func (mr *MockAPIsMockRecorder) AllocIPAddress(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocIPAddress", reflect.TypeOf((*MockAPIs)(nil).AllocIPAddress), arg0)
 }
 
-// AllocIPAddresses mocks base method
+// AllocIPAddresses mocks base method.
 func (m *MockAPIs) AllocIPAddresses(arg0 string, arg1 int) (*ec2.AssignPrivateIpAddressesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocIPAddresses", arg0, arg1)
@@ -88,13 +88,13 @@ func (m *MockAPIs) AllocIPAddresses(arg0 string, arg1 int) (*ec2.AssignPrivateIp
 	return ret0, ret1
 }
 
-// AllocIPAddresses indicates an expected call of AllocIPAddresses
+// AllocIPAddresses indicates an expected call of AllocIPAddresses.
 func (mr *MockAPIsMockRecorder) AllocIPAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocIPAddresses", reflect.TypeOf((*MockAPIs)(nil).AllocIPAddresses), arg0, arg1)
 }
 
-// AllocIPv6Prefixes mocks base method
+// AllocIPv6Prefixes mocks base method.
 func (m *MockAPIs) AllocIPv6Prefixes(arg0 string) ([]*string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocIPv6Prefixes", arg0)
@@ -103,13 +103,13 @@ func (m *MockAPIs) AllocIPv6Prefixes(arg0 string) ([]*string, error) {
 	return ret0, ret1
 }
 
-// AllocIPv6Prefixes indicates an expected call of AllocIPv6Prefixes
+// AllocIPv6Prefixes indicates an expected call of AllocIPv6Prefixes.
 func (mr *MockAPIsMockRecorder) AllocIPv6Prefixes(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocIPv6Prefixes", reflect.TypeOf((*MockAPIs)(nil).AllocIPv6Prefixes), arg0)
 }
 
-// DeallocIPAddresses mocks base method
+// DeallocIPAddresses mocks base method.
 func (m *MockAPIs) DeallocIPAddresses(arg0 string, arg1 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeallocIPAddresses", arg0, arg1)
@@ -117,13 +117,13 @@ func (m *MockAPIs) DeallocIPAddresses(arg0 string, arg1 []string) error {
 	return ret0
 }
 
-// DeallocIPAddresses indicates an expected call of DeallocIPAddresses
+// DeallocIPAddresses indicates an expected call of DeallocIPAddresses.
 func (mr *MockAPIsMockRecorder) DeallocIPAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeallocIPAddresses", reflect.TypeOf((*MockAPIs)(nil).DeallocIPAddresses), arg0, arg1)
 }
 
-// DeallocPrefixAddresses mocks base method
+// DeallocPrefixAddresses mocks base method.
 func (m *MockAPIs) DeallocPrefixAddresses(arg0 string, arg1 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeallocPrefixAddresses", arg0, arg1)
@@ -131,13 +131,13 @@ func (m *MockAPIs) DeallocPrefixAddresses(arg0 string, arg1 []string) error {
 	return ret0
 }
 
-// DeallocPrefixAddresses indicates an expected call of DeallocPrefixAddresses
+// DeallocPrefixAddresses indicates an expected call of DeallocPrefixAddresses.
 func (mr *MockAPIsMockRecorder) DeallocPrefixAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeallocPrefixAddresses", reflect.TypeOf((*MockAPIs)(nil).DeallocPrefixAddresses), arg0, arg1)
 }
 
-// DescribeAllENIs mocks base method
+// DescribeAllENIs mocks base method.
 func (m *MockAPIs) DescribeAllENIs() (awsutils.DescribeAllENIsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAllENIs")
@@ -146,13 +146,13 @@ func (m *MockAPIs) DescribeAllENIs() (awsutils.DescribeAllENIsResult, error) {
 	return ret0, ret1
 }
 
-// DescribeAllENIs indicates an expected call of DescribeAllENIs
+// DescribeAllENIs indicates an expected call of DescribeAllENIs.
 func (mr *MockAPIsMockRecorder) DescribeAllENIs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAllENIs", reflect.TypeOf((*MockAPIs)(nil).DescribeAllENIs))
 }
 
-// FetchInstanceTypeLimits mocks base method
+// FetchInstanceTypeLimits mocks base method.
 func (m *MockAPIs) FetchInstanceTypeLimits() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchInstanceTypeLimits")
@@ -160,13 +160,13 @@ func (m *MockAPIs) FetchInstanceTypeLimits() error {
 	return ret0
 }
 
-// FetchInstanceTypeLimits indicates an expected call of FetchInstanceTypeLimits
+// FetchInstanceTypeLimits indicates an expected call of FetchInstanceTypeLimits.
 func (mr *MockAPIsMockRecorder) FetchInstanceTypeLimits() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchInstanceTypeLimits", reflect.TypeOf((*MockAPIs)(nil).FetchInstanceTypeLimits))
 }
 
-// FreeENI mocks base method
+// FreeENI mocks base method.
 func (m *MockAPIs) FreeENI(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FreeENI", arg0)
@@ -174,13 +174,13 @@ func (m *MockAPIs) FreeENI(arg0 string) error {
 	return ret0
 }
 
-// FreeENI indicates an expected call of FreeENI
+// FreeENI indicates an expected call of FreeENI.
 func (mr *MockAPIsMockRecorder) FreeENI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FreeENI", reflect.TypeOf((*MockAPIs)(nil).FreeENI), arg0)
 }
 
-// GetAttachedENIs mocks base method
+// GetAttachedENIs mocks base method.
 func (m *MockAPIs) GetAttachedENIs() ([]awsutils.ENIMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttachedENIs")
@@ -189,13 +189,13 @@ func (m *MockAPIs) GetAttachedENIs() ([]awsutils.ENIMetadata, error) {
 	return ret0, ret1
 }
 
-// GetAttachedENIs indicates an expected call of GetAttachedENIs
+// GetAttachedENIs indicates an expected call of GetAttachedENIs.
 func (mr *MockAPIsMockRecorder) GetAttachedENIs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttachedENIs", reflect.TypeOf((*MockAPIs)(nil).GetAttachedENIs))
 }
 
-// GetENIIPv4Limit mocks base method
+// GetENIIPv4Limit mocks base method.
 func (m *MockAPIs) GetENIIPv4Limit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENIIPv4Limit")
@@ -203,13 +203,13 @@ func (m *MockAPIs) GetENIIPv4Limit() int {
 	return ret0
 }
 
-// GetENIIPv4Limit indicates an expected call of GetENIIPv4Limit
+// GetENIIPv4Limit indicates an expected call of GetENIIPv4Limit.
 func (mr *MockAPIsMockRecorder) GetENIIPv4Limit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENIIPv4Limit", reflect.TypeOf((*MockAPIs)(nil).GetENIIPv4Limit))
 }
 
-// GetENILimit mocks base method
+// GetENILimit mocks base method.
 func (m *MockAPIs) GetENILimit() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetENILimit")
@@ -217,13 +217,13 @@ func (m *MockAPIs) GetENILimit() int {
 	return ret0
 }
 
-// GetENILimit indicates an expected call of GetENILimit
+// GetENILimit indicates an expected call of GetENILimit.
 func (mr *MockAPIsMockRecorder) GetENILimit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENILimit", reflect.TypeOf((*MockAPIs)(nil).GetENILimit))
 }
 
-// GetIPv4PrefixesFromEC2 mocks base method
+// GetIPv4PrefixesFromEC2 mocks base method.
 func (m *MockAPIs) GetIPv4PrefixesFromEC2(arg0 string) ([]*ec2.Ipv4PrefixSpecification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIPv4PrefixesFromEC2", arg0)
@@ -232,13 +232,13 @@ func (m *MockAPIs) GetIPv4PrefixesFromEC2(arg0 string) ([]*ec2.Ipv4PrefixSpecifi
 	return ret0, ret1
 }
 
-// GetIPv4PrefixesFromEC2 indicates an expected call of GetIPv4PrefixesFromEC2
+// GetIPv4PrefixesFromEC2 indicates an expected call of GetIPv4PrefixesFromEC2.
 func (mr *MockAPIsMockRecorder) GetIPv4PrefixesFromEC2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv4PrefixesFromEC2", reflect.TypeOf((*MockAPIs)(nil).GetIPv4PrefixesFromEC2), arg0)
 }
 
-// GetIPv4sFromEC2 mocks base method
+// GetIPv4sFromEC2 mocks base method.
 func (m *MockAPIs) GetIPv4sFromEC2(arg0 string) ([]*ec2.NetworkInterfacePrivateIpAddress, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIPv4sFromEC2", arg0)
@@ -247,13 +247,13 @@ func (m *MockAPIs) GetIPv4sFromEC2(arg0 string) ([]*ec2.NetworkInterfacePrivateI
 	return ret0, ret1
 }
 
-// GetIPv4sFromEC2 indicates an expected call of GetIPv4sFromEC2
+// GetIPv4sFromEC2 indicates an expected call of GetIPv4sFromEC2.
 func (mr *MockAPIsMockRecorder) GetIPv4sFromEC2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv4sFromEC2", reflect.TypeOf((*MockAPIs)(nil).GetIPv4sFromEC2), arg0)
 }
 
-// GetIPv6PrefixesFromEC2 mocks base method
+// GetIPv6PrefixesFromEC2 mocks base method.
 func (m *MockAPIs) GetIPv6PrefixesFromEC2(arg0 string) ([]*ec2.Ipv6PrefixSpecification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIPv6PrefixesFromEC2", arg0)
@@ -262,13 +262,13 @@ func (m *MockAPIs) GetIPv6PrefixesFromEC2(arg0 string) ([]*ec2.Ipv6PrefixSpecifi
 	return ret0, ret1
 }
 
-// GetIPv6PrefixesFromEC2 indicates an expected call of GetIPv6PrefixesFromEC2
+// GetIPv6PrefixesFromEC2 indicates an expected call of GetIPv6PrefixesFromEC2.
 func (mr *MockAPIsMockRecorder) GetIPv6PrefixesFromEC2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv6PrefixesFromEC2", reflect.TypeOf((*MockAPIs)(nil).GetIPv6PrefixesFromEC2), arg0)
 }
 
-// GetInstanceHypervisorFamily mocks base method
+// GetInstanceHypervisorFamily mocks base method.
 func (m *MockAPIs) GetInstanceHypervisorFamily() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceHypervisorFamily")
@@ -276,13 +276,13 @@ func (m *MockAPIs) GetInstanceHypervisorFamily() string {
 	return ret0
 }
 
-// GetInstanceHypervisorFamily indicates an expected call of GetInstanceHypervisorFamily
+// GetInstanceHypervisorFamily indicates an expected call of GetInstanceHypervisorFamily.
 func (mr *MockAPIsMockRecorder) GetInstanceHypervisorFamily() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceHypervisorFamily", reflect.TypeOf((*MockAPIs)(nil).GetInstanceHypervisorFamily))
 }
 
-// GetInstanceID mocks base method
+// GetInstanceID mocks base method.
 func (m *MockAPIs) GetInstanceID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceID")
@@ -290,13 +290,13 @@ func (m *MockAPIs) GetInstanceID() string {
 	return ret0
 }
 
-// GetInstanceID indicates an expected call of GetInstanceID
+// GetInstanceID indicates an expected call of GetInstanceID.
 func (mr *MockAPIsMockRecorder) GetInstanceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceID", reflect.TypeOf((*MockAPIs)(nil).GetInstanceID))
 }
 
-// GetInstanceType mocks base method
+// GetInstanceType mocks base method.
 func (m *MockAPIs) GetInstanceType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceType")
@@ -304,13 +304,13 @@ func (m *MockAPIs) GetInstanceType() string {
 	return ret0
 }
 
-// GetInstanceType indicates an expected call of GetInstanceType
+// GetInstanceType indicates an expected call of GetInstanceType.
 func (mr *MockAPIsMockRecorder) GetInstanceType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceType", reflect.TypeOf((*MockAPIs)(nil).GetInstanceType))
 }
 
-// GetLocalIPv4 mocks base method
+// GetLocalIPv4 mocks base method.
 func (m *MockAPIs) GetLocalIPv4() net.IP {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLocalIPv4")
@@ -318,13 +318,13 @@ func (m *MockAPIs) GetLocalIPv4() net.IP {
 	return ret0
 }
 
-// GetLocalIPv4 indicates an expected call of GetLocalIPv4
+// GetLocalIPv4 indicates an expected call of GetLocalIPv4.
 func (mr *MockAPIsMockRecorder) GetLocalIPv4() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalIPv4", reflect.TypeOf((*MockAPIs)(nil).GetLocalIPv4))
 }
 
-// GetPrimaryENI mocks base method
+// GetPrimaryENI mocks base method.
 func (m *MockAPIs) GetPrimaryENI() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrimaryENI")
@@ -332,13 +332,13 @@ func (m *MockAPIs) GetPrimaryENI() string {
 	return ret0
 }
 
-// GetPrimaryENI indicates an expected call of GetPrimaryENI
+// GetPrimaryENI indicates an expected call of GetPrimaryENI.
 func (mr *MockAPIsMockRecorder) GetPrimaryENI() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryENI", reflect.TypeOf((*MockAPIs)(nil).GetPrimaryENI))
 }
 
-// GetPrimaryENImac mocks base method
+// GetPrimaryENImac mocks base method.
 func (m *MockAPIs) GetPrimaryENImac() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrimaryENImac")
@@ -346,13 +346,13 @@ func (m *MockAPIs) GetPrimaryENImac() string {
 	return ret0
 }
 
-// GetPrimaryENImac indicates an expected call of GetPrimaryENImac
+// GetPrimaryENImac indicates an expected call of GetPrimaryENImac.
 func (mr *MockAPIsMockRecorder) GetPrimaryENImac() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryENImac", reflect.TypeOf((*MockAPIs)(nil).GetPrimaryENImac))
 }
 
-// GetVPCIPv4CIDRs mocks base method
+// GetVPCIPv4CIDRs mocks base method.
 func (m *MockAPIs) GetVPCIPv4CIDRs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPCIPv4CIDRs")
@@ -361,13 +361,13 @@ func (m *MockAPIs) GetVPCIPv4CIDRs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetVPCIPv4CIDRs indicates an expected call of GetVPCIPv4CIDRs
+// GetVPCIPv4CIDRs indicates an expected call of GetVPCIPv4CIDRs.
 func (mr *MockAPIsMockRecorder) GetVPCIPv4CIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv4CIDRs", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv4CIDRs))
 }
 
-// GetVPCIPv6CIDRs mocks base method
+// GetVPCIPv6CIDRs mocks base method.
 func (m *MockAPIs) GetVPCIPv6CIDRs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPCIPv6CIDRs")
@@ -376,25 +376,25 @@ func (m *MockAPIs) GetVPCIPv6CIDRs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetVPCIPv6CIDRs indicates an expected call of GetVPCIPv6CIDRs
+// GetVPCIPv6CIDRs indicates an expected call of GetVPCIPv6CIDRs.
 func (mr *MockAPIsMockRecorder) GetVPCIPv6CIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCIPv6CIDRs", reflect.TypeOf((*MockAPIs)(nil).GetVPCIPv6CIDRs))
 }
 
-// InitCachedPrefixDelegation mocks base method
+// InitCachedPrefixDelegation mocks base method.
 func (m *MockAPIs) InitCachedPrefixDelegation(arg0 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InitCachedPrefixDelegation", arg0)
 }
 
-// InitCachedPrefixDelegation indicates an expected call of InitCachedPrefixDelegation
+// InitCachedPrefixDelegation indicates an expected call of InitCachedPrefixDelegation.
 func (mr *MockAPIsMockRecorder) InitCachedPrefixDelegation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitCachedPrefixDelegation", reflect.TypeOf((*MockAPIs)(nil).InitCachedPrefixDelegation), arg0)
 }
 
-// IsCNIUnmanagedENI mocks base method
+// IsCNIUnmanagedENI mocks base method.
 func (m *MockAPIs) IsCNIUnmanagedENI(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsCNIUnmanagedENI", arg0)
@@ -402,13 +402,13 @@ func (m *MockAPIs) IsCNIUnmanagedENI(arg0 string) bool {
 	return ret0
 }
 
-// IsCNIUnmanagedENI indicates an expected call of IsCNIUnmanagedENI
+// IsCNIUnmanagedENI indicates an expected call of IsCNIUnmanagedENI.
 func (mr *MockAPIsMockRecorder) IsCNIUnmanagedENI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCNIUnmanagedENI", reflect.TypeOf((*MockAPIs)(nil).IsCNIUnmanagedENI), arg0)
 }
 
-// IsPrefixDelegationSupported mocks base method
+// IsPrefixDelegationSupported mocks base method.
 func (m *MockAPIs) IsPrefixDelegationSupported() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPrefixDelegationSupported")
@@ -416,13 +416,13 @@ func (m *MockAPIs) IsPrefixDelegationSupported() bool {
 	return ret0
 }
 
-// IsPrefixDelegationSupported indicates an expected call of IsPrefixDelegationSupported
+// IsPrefixDelegationSupported indicates an expected call of IsPrefixDelegationSupported.
 func (mr *MockAPIsMockRecorder) IsPrefixDelegationSupported() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrefixDelegationSupported", reflect.TypeOf((*MockAPIs)(nil).IsPrefixDelegationSupported))
 }
 
-// IsPrimaryENI mocks base method
+// IsPrimaryENI mocks base method.
 func (m *MockAPIs) IsPrimaryENI(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPrimaryENI", arg0)
@@ -430,13 +430,13 @@ func (m *MockAPIs) IsPrimaryENI(arg0 string) bool {
 	return ret0
 }
 
-// IsPrimaryENI indicates an expected call of IsPrimaryENI
+// IsPrimaryENI indicates an expected call of IsPrimaryENI.
 func (mr *MockAPIsMockRecorder) IsPrimaryENI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrimaryENI", reflect.TypeOf((*MockAPIs)(nil).IsPrimaryENI), arg0)
 }
 
-// IsUnmanagedENI mocks base method
+// IsUnmanagedENI mocks base method.
 func (m *MockAPIs) IsUnmanagedENI(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUnmanagedENI", arg0)
@@ -444,13 +444,13 @@ func (m *MockAPIs) IsUnmanagedENI(arg0 string) bool {
 	return ret0
 }
 
-// IsUnmanagedENI indicates an expected call of IsUnmanagedENI
+// IsUnmanagedENI indicates an expected call of IsUnmanagedENI.
 func (mr *MockAPIsMockRecorder) IsUnmanagedENI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnmanagedENI", reflect.TypeOf((*MockAPIs)(nil).IsUnmanagedENI), arg0)
 }
 
-// RefreshSGIDs mocks base method
+// RefreshSGIDs mocks base method.
 func (m *MockAPIs) RefreshSGIDs(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshSGIDs", arg0)
@@ -458,13 +458,13 @@ func (m *MockAPIs) RefreshSGIDs(arg0 string) error {
 	return ret0
 }
 
-// RefreshSGIDs indicates an expected call of RefreshSGIDs
+// RefreshSGIDs indicates an expected call of RefreshSGIDs.
 func (mr *MockAPIsMockRecorder) RefreshSGIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSGIDs", reflect.TypeOf((*MockAPIs)(nil).RefreshSGIDs), arg0)
 }
 
-// SetCNIUnmanagedENIs mocks base method
+// SetCNIUnmanagedENIs mocks base method.
 func (m *MockAPIs) SetCNIUnmanagedENIs(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCNIUnmanagedENIs", arg0)
@@ -472,25 +472,25 @@ func (m *MockAPIs) SetCNIUnmanagedENIs(arg0 []string) error {
 	return ret0
 }
 
-// SetCNIUnmanagedENIs indicates an expected call of SetCNIUnmanagedENIs
+// SetCNIUnmanagedENIs indicates an expected call of SetCNIUnmanagedENIs.
 func (mr *MockAPIsMockRecorder) SetCNIUnmanagedENIs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCNIUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetCNIUnmanagedENIs), arg0)
 }
 
-// SetUnmanagedENIs mocks base method
+// SetUnmanagedENIs mocks base method.
 func (m *MockAPIs) SetUnmanagedENIs(arg0 []string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUnmanagedENIs", arg0)
 }
 
-// SetUnmanagedENIs indicates an expected call of SetUnmanagedENIs
+// SetUnmanagedENIs indicates an expected call of SetUnmanagedENIs.
 func (mr *MockAPIsMockRecorder) SetUnmanagedENIs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetUnmanagedENIs), arg0)
 }
 
-// TagENI mocks base method
+// TagENI mocks base method.
 func (m *MockAPIs) TagENI(arg0 string, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagENI", arg0, arg1)
@@ -498,13 +498,13 @@ func (m *MockAPIs) TagENI(arg0 string, arg1 map[string]string) error {
 	return ret0
 }
 
-// TagENI indicates an expected call of TagENI
+// TagENI indicates an expected call of TagENI.
 func (mr *MockAPIsMockRecorder) TagENI(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagENI", reflect.TypeOf((*MockAPIs)(nil).TagENI), arg0, arg1)
 }
 
-// WaitForENIAndIPsAttached mocks base method
+// WaitForENIAndIPsAttached mocks base method.
 func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENIMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForENIAndIPsAttached", arg0, arg1)
@@ -513,7 +513,7 @@ func (m *MockAPIs) WaitForENIAndIPsAttached(arg0 string, arg1 int) (awsutils.ENI
 	return ret0, ret1
 }
 
-// WaitForENIAndIPsAttached indicates an expected call of WaitForENIAndIPsAttached
+// WaitForENIAndIPsAttached indicates an expected call of WaitForENIAndIPsAttached.
 func (mr *MockAPIsMockRecorder) WaitForENIAndIPsAttached(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForENIAndIPsAttached", reflect.TypeOf((*MockAPIs)(nil).WaitForENIAndIPsAttached), arg0, arg1)

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -603,14 +603,13 @@ func assertAllocationExternalCalls(shouldCall bool, useENIConfig bool, m *testMo
 	}
 
 	if useENIConfig {
-		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet).Times(callCount).Return(eni2, nil)
+		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet, 14).Times(callCount).Return(eni2, nil)
 	} else {
-		m.awsutils.EXPECT().AllocENI(false, nil, "").Times(callCount).Return(eni2, nil)
+		m.awsutils.EXPECT().AllocENI(false, nil, "", 14).Times(callCount).Return(eni2, nil)
 	}
 	m.awsutils.EXPECT().GetPrimaryENI().Times(callCount).Return(primaryENIid)
 	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 14).Times(callCount).Return(eniMetadata[1], nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet).Times(callCount)
-	m.awsutils.EXPECT().AllocIPAddresses(eni2, 14).Times(callCount)
 }
 
 func TestIncreasePrefixPoolDefault(t *testing.T) {
@@ -664,9 +663,9 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
 	}
 
 	if useENIConfig {
-		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet).Return(eni2, nil)
+		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet, 1).Return(eni2, nil)
 	} else {
-		m.awsutils.EXPECT().AllocENI(false, nil, "").Return(eni2, nil)
+		m.awsutils.EXPECT().AllocENI(false, nil, "", 1).Return(eni2, nil)
 	}
 
 	eniMetadata := []awsutils.ENIMetadata{
@@ -707,7 +706,6 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
 	m.awsutils.EXPECT().WaitForENIAndIPsAttached(secENIid, 1).Return(eniMetadata[1], nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
-	m.awsutils.EXPECT().AllocIPAddresses(eni2, 1)
 
 	if mockContext.useCustomNetworking {
 		mockContext.myNodeName = myNodeName
@@ -823,8 +821,7 @@ func TestTryAddIPToENI(t *testing.T) {
 
 	mockContext.dataStore = testDatastore()
 
-	m.awsutils.EXPECT().AllocENI(false, nil, "").Return(secENIid, nil)
-	m.awsutils.EXPECT().AllocIPAddresses(secENIid, warmIPTarget)
+	m.awsutils.EXPECT().AllocENI(false, nil, "", warmIPTarget).Return(secENIid, nil)
 	eniMetadata := []awsutils.ENIMetadata{
 		{
 			ENIID:          primaryENIid,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
enhancement #2640 

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Reduces the number of API calls made when creating an ENI and allocating IP addresses. Combines AllocENI and AllocIpAddresses into one API call.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
#2640 

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
