### PR TITLE
Update prefix-and-ip-target.md

### DIFF
--- a/docs/prefix-and-ip-target.md
+++ b/docs/prefix-and-ip-target.md
@@ -11,7 +11,7 @@ When a new ENI is allocated, IPAMD will determine the number of prefixes needed 
 This table demonstrates how prefixes and ENIs will be allocated and use as pods will be created and scheduled to an instance. When reading this table, please keep in mind the following:
 
 * Every instance type has different limits of ENI pre instance type, and secondary IPv4 addresses per ENI. This information is available on our [EC2 Docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI).  
-In the example below, `t3.small` was chosen to demonstrate how additional ENIs will be created, since `t3.small` have a maximum of 3 ENIs and 4 IPv4 addresses per ENI. This result in a maximum of 11 available prefixes (3 * 4 minus the primary IPv4 address used by the instance)
+In the example below, `t3.small` was chosen to demonstrate how additional ENIs will be created, since `t3.small` have a maximum of 3 ENIs and 4 IPv4 addresses per ENI. This result in a maximum of 9 available prefixes (3 ENIs * (4 IPv4s minus the primary IPv4 address used by the ENI))
 
 * When using prefixes or IPv4 assignment, if the value of `MINIMUM_IP_TARGET` is bigger than N*16, it's equivalent to setting it to (N+1)*16.  
 The reason for this is because prefixes are allocated as /28 CIDR block or 16 consecutive IP addresses, so asking for minimum of 20 IPv4 addresses is equally as asking 32 IPv4 addresses
@@ -19,9 +19,10 @@ The reason for this is because prefixes are allocated as /28 CIDR block or 16 co
 | Instance type | `WARM_PREFIX_TARGET` | `WARM_IP_TARGET` | `MINIMUM_IP_TARGET` | Pods | ENIs | Pod per ENIs | Attached Prefixes | Pod per Prefixes | Unused Prefixes | Prefixes per ENI | Unused IPs |
 |---------------|:--------------------:|:----------------:|:-------------------:|:----:|:----:|:------------:|:-----------------:|------------------|:---------------:|:----------------:|:----------:|
 | t3.small      | 1                    | -                | -                   | 0    | 1    | 0            | 1                 | 0                | 1               | 1                | 16         |
-| t3.small      | 1                    | -                | -                   | 5    | 1    | 5            | 2                 | 5                | 1               | 2                | 27         |
-| t3.small      | 1                    | -                | -                   | 17   | 1    | 17           | 3                 | 16,1             | 1               | 3                | 31         |
-| t3.small      | 1                    | -                | -                   | 58   | 2    | 48,10         | 5                 | 16,16,16,10,0    | 1               | 3,2              | 22         |
+| t3.small      | 1                    | -                | -                   | 5    | 1    | 5            | 2                 | 5,0              | 1               | 2                | 27         |
+| t3.small      | 1                    | -                | -                   | 16   | 1    | 16           | 2                 | 16,0             | 1               | 2                | 16         |
+| t3.small      | 1                    | -                | -                   | 17   | 1    | 17           | 3                 | 16,1,0           | 1               | 3                | 31         |
+| t3.small      | 1                    | -                | -                   | 58   | 2    | 48,10        | 5                 | 16,16,16,10,0    | 1               | 3,2              | 22         |
 |               |                      |                  |                     |      |      |              |                   |                  |                 |                  |            |
 | t3.small      | -                    | 1                | 1                   | 0    | 1    | 0            | 1                 | 0                | 1               | 1                | 16         |
 | t3.small      | -                    | 1                | 1                   | 5    | 1    | 5            | 1                 | 5                | 0               | 1                | 11         |


### PR DESCRIPTION
Corrected a few examples with `WARM_PREFIX_TARGET=1` and added another example to the list. Small correction of the text clarifying that a t3.small instance has a maximum of 144 IP addresses in prefix mode, and not 176.

---

I'm only somewhat confident of these corrections, the motivation/reasoning that lead me to this change is as follows.

The metric `awscni_ip_max` shows 144 (9\*16) IPs for a t3.small instance, not 176 (11\*16) as would have been the case if 11 prefixes had been available. I've had a hard time finding the exact documentation for IP address assignment to ENIs. The first ENI attached to an instance is always assigned the primary IP of the instance, but additional ENIs apparently also have a preallocated IP, thus reducing the number of avalable prefixes to N-1, where N is the number of IPv4 adresses available in the ENI. 

If my reasoning above is wrong, then the metric `awscni_ip_max` is reporting incorrectly low values.

The table with examples was inconsistent with adding zeroes in the 'Pod per Prefixes' column to show that there is always one entire empty prefix allocated. Additionally I've added another example (with 16 pods) to emphasize this behavior. Please do correct me if I'm wrong in this understanding of `WARM_PREFIX_TARGET=1`

**What type of PR is this?**
documentation

**Which issue does this PR fix**:
No issue created

**What does this PR do / Why do we need it**:
It fixes incorrect documentation

**If an issue \# is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
-

**Testing done on this change**:
None

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
