### PR TITLE
swicth k8s deprecated method to new method

### DIFF
--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -153,7 +153,7 @@ func CheckAPIServerConnectivity() error {
 	log.Infof("Testing communication with server")
 	// Reconcile the API server query after waiting for a second, as the request
 	// times out in one second if it fails to connect to the server
-	return wait.PollImmediateInfinite(2*time.Second, func() (bool, error) {
+	return wait.PollUntilContextCancel(context.Background(), 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		version, err := clientSet.Discovery().ServerVersion()
 		if err != nil {
 			// When times out return no error, so the PollInfinite will retry with the given interval


### PR DESCRIPTION
The kubernetes method `wait.PollImmediateInfinite` is already deprecated, just switch it to `wait.PollUntilContextCancel`

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
none

**What does this PR do / Why do we need it**:
switch the k8s sdk deprecated method to new method


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
none

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
none

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
none

**Does this change require updates to the CNI daemonset config files to work?**:
none

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
none
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
