### PR TITLE
Add watch permission for CNINode resource

### DIFF
--- a/charts/aws-vpc-cni/templates/clusterrole.yaml
+++ b/charts/aws-vpc-cni/templates/clusterrole.yaml
@@ -45,4 +45,4 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "patch"]

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -327,7 +327,7 @@ rules:
       - vpcresources.k8s.aws
     resources:
       - cninodes
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -96,6 +96,7 @@ func CreateKubeClient(appName string) (client.Client, error) {
 	vpcCniScheme := runtime.NewScheme()
 	corev1.AddToScheme(vpcCniScheme)
 	eniconfigscheme.AddToScheme(vpcCniScheme)
+	rcscheme.AddToScheme(vpcCniScheme)
 
 	var filterMap map[client.Object]cache.ByObject
 	if appName == awsNode {
@@ -110,9 +111,7 @@ func CreateKubeClient(appName string) (client.Client, error) {
 	// Start cache and wait for initial sync
 	StartKubeClientCache(cacheReader)
 
-	// The cache will start a WATCH for all GVKs in the scheme. CNINode objects should not
-	// be cached, so their GVK is added only for the client.
-	rcscheme.AddToScheme(vpcCniScheme)
+	// The cache will start a WATCH for all GVKs in the scheme.
 	k8sClient, err := client.New(restCfg, client.Options{
 		Cache: &client.CacheOptions{
 			Reader: cacheReader,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2680
https://github.com/aws/amazon-vpc-cni-k8s/issues/2589

**What does this PR do / Why do we need it**:
https://github.com/aws/amazon-vpc-cni-k8s/pull/2570 was not a complete fix to stop WATCH from being issued for CNINode resource. While we could create an entirely new scheme for the cache vs the client, it is easier to add the `watch` permission for CNINode resource. Though the IPAM daemon does not need to cache this resource, doing so does not require enough additional memory to be concerned.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
All unit tests and integration tests pass.

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
Add watch permission for CNINode resource
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
