### PR TITLE
Ginkgo Test to exercise cross AZ testing, to be run on static canaries.

### DIFF
--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# The script runs amazon-vpc-cni Canary tests on the default
-# addon version and then runs smoke test on the latest addon version.
+# The script runs amazon-vpc-cni static canary tests
+# The tests in this suite are designed to exercise AZ failure scenarios.
 
 set -e
 
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
 # TEST_IMAGE_REGISTRY is the registry in test-infra-* accounts where e2e test images are stored
 TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-"617930562442.dkr.ecr.us-west-2.amazonaws.com"}
-ADC_REGIONS="us-iso-east-1 us-isob-east-1 us-iso-west-1"
 
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/canary.sh
@@ -17,7 +16,15 @@ source "$SCRIPT_DIR"/lib/canary.sh
 function run_ginkgo_test() {
   local focus=$1
   echo "Running ginkgo tests with focus: $focus"
-  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 30m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux" --test-image-registry=$TEST_IMAGE_REGISTRY)
+
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 30m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- \
+      --cluster-kubeconfig="$KUBE_CONFIG_PATH" \
+      --cluster-name="$CLUSTER_NAME" \
+      --aws-region="$REGION" \
+      --aws-vpc-id="$VPC_ID" \
+      --ng-name-label-key="kubernetes.io/os" \
+      --ng-name-label-val="linux" \
+      --test-image-registry=$TEST_IMAGE_REGISTRY)
 }
 
 load_cluster_details

--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# The script runs amazon-vpc-cni Canary tests on the default
+# addon version and then runs smoke test on the latest addon version.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
+# TEST_IMAGE_REGISTRY is the registry in test-infra-* accounts where e2e test images are stored
+TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-"617930562442.dkr.ecr.us-west-2.amazonaws.com"}
+ADC_REGIONS="us-iso-east-1 us-isob-east-1 us-iso-west-1"
+
+source "$SCRIPT_DIR"/lib/cluster.sh
+source "$SCRIPT_DIR"/lib/canary.sh
+
+function run_ginkgo_test() {
+  local focus=$1
+  echo "Running ginkgo tests with focus: $focus"
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 30m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- --cluster-kubeconfig="$KUBE_CONFIG_PATH" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux" --test-image-registry=$TEST_IMAGE_REGISTRY)
+}
+
+load_cluster_details
+
+run_ginkgo_test "STATIC_CANARY"
+
+echo "all tests ran successfully in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/test/framework/resources/k8s/manifest/container.go
+++ b/test/framework/resources/k8s/manifest/container.go
@@ -28,6 +28,7 @@ type Container struct {
 	probe           *v1.Probe
 	ports           []v1.ContainerPort
 	securityContext *v1.SecurityContext
+	Env             []v1.EnvVar
 }
 
 func NewBusyBoxContainerBuilder(testImageRegistry string) *Container {
@@ -101,6 +102,11 @@ func (w *Container) Command(cmd []string) *Container {
 	return w
 }
 
+func (w *Container) EnvVar(env []v1.EnvVar) *Container {
+	w.Env = env
+	return w
+}
+
 func (w *Container) Args(arg []string) *Container {
 	w.args = arg
 	return w
@@ -126,5 +132,6 @@ func (w *Container) Build() v1.Container {
 		LivenessProbe:   w.probe,
 		Ports:           w.ports,
 		SecurityContext: w.securityContext,
+		Env:             w.Env,
 	}
 }

--- a/test/framework/resources/k8s/manifest/daemonset.go
+++ b/test/framework/resources/k8s/manifest/daemonset.go
@@ -1,0 +1,155 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package manifest
+
+import (
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/aws-sdk-go/aws"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DaemonsetBuilder struct {
+	namespace              string
+	name                   string
+	replicas               int
+	container              corev1.Container
+	labels                 map[string]string
+	nodeSelector           map[string]string
+	terminationGracePeriod int
+	nodeName               string
+	hostNetwork            bool
+	volume                 []corev1.Volume
+	volumeMount            []corev1.VolumeMount
+}
+
+func NewBusyBoxDaemonsetBuilder(testImageRegistry string) *DaemonsetBuilder {
+	return &DaemonsetBuilder{
+		namespace:              utils.DefaultTestNamespace,
+		name:                   "deployment-test",
+		replicas:               10,
+		container:              NewBusyBoxContainerBuilder(testImageRegistry).Build(),
+		labels:                 map[string]string{"role": "test"},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
+		terminationGracePeriod: 1,
+	}
+}
+
+func NewDefaultDaemonsetBuilder() *DaemonsetBuilder {
+	return &DaemonsetBuilder{
+		namespace:              utils.DefaultTestNamespace,
+		terminationGracePeriod: 1,
+		labels:                 map[string]string{"role": "test"},
+		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
+	}
+}
+
+func NewCalicoStarDaemonsetBuilder() *DaemonsetBuilder {
+	return &DaemonsetBuilder{
+		labels:       map[string]string{},
+		nodeSelector: map[string]string{},
+	}
+}
+
+func (d *DaemonsetBuilder) Labels(labels map[string]string) *DaemonsetBuilder {
+	d.labels = labels
+	return d
+}
+
+func (d *DaemonsetBuilder) NodeSelector(labelKey string, labelVal string) *DaemonsetBuilder {
+	if labelKey != "" {
+		d.nodeSelector[labelKey] = labelVal
+	}
+	return d
+}
+
+func (d *DaemonsetBuilder) Namespace(namespace string) *DaemonsetBuilder {
+	d.namespace = namespace
+	return d
+}
+
+func (d *DaemonsetBuilder) TerminationGracePeriod(tg int) *DaemonsetBuilder {
+	d.terminationGracePeriod = tg
+	return d
+}
+
+func (d *DaemonsetBuilder) Name(name string) *DaemonsetBuilder {
+	d.name = name
+	return d
+}
+
+func (d *DaemonsetBuilder) NodeName(nodeName string) *DaemonsetBuilder {
+	d.nodeName = nodeName
+	return d
+}
+
+func (d *DaemonsetBuilder) Replicas(replicas int) *DaemonsetBuilder {
+	d.replicas = replicas
+	return d
+}
+
+func (d *DaemonsetBuilder) Container(container corev1.Container) *DaemonsetBuilder {
+	d.container = container
+	return d
+}
+
+func (d *DaemonsetBuilder) PodLabel(labelKey string, labelValue string) *DaemonsetBuilder {
+	d.labels[labelKey] = labelValue
+	return d
+}
+
+func (d *DaemonsetBuilder) HostNetwork(hostNetwork bool) *DaemonsetBuilder {
+	d.hostNetwork = hostNetwork
+	return d
+}
+
+func (d *DaemonsetBuilder) MountVolume(volume []corev1.Volume, volumeMount []corev1.VolumeMount) *DaemonsetBuilder {
+	d.volume = volume
+	d.volumeMount = volumeMount
+	return d
+}
+
+func (d *DaemonsetBuilder) Build() *v1.DaemonSet {
+	deploymentSpec := &v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      d.name,
+			Namespace: d.namespace,
+			Labels:    d.labels,
+		},
+		Spec: v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: d.labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: d.labels,
+				},
+				Spec: corev1.PodSpec{
+					HostNetwork:                   d.hostNetwork,
+					NodeSelector:                  d.nodeSelector,
+					Containers:                    []corev1.Container{d.container},
+					TerminationGracePeriodSeconds: aws.Int64(int64(d.terminationGracePeriod)),
+					NodeName:                      d.nodeName,
+				},
+			},
+		},
+	}
+
+	if len(d.volume) > 0 && len(d.volumeMount) > 0 {
+		deploymentSpec.Spec.Template.Spec.Volumes = d.volume
+		deploymentSpec.Spec.Template.Spec.Containers[0].VolumeMounts = d.volumeMount
+	}
+	return deploymentSpec
+}

--- a/test/framework/resources/k8s/manifest/daemonset.go
+++ b/test/framework/resources/k8s/manifest/daemonset.go
@@ -24,27 +24,13 @@ import (
 type DaemonsetBuilder struct {
 	namespace              string
 	name                   string
-	replicas               int
 	container              corev1.Container
 	labels                 map[string]string
 	nodeSelector           map[string]string
 	terminationGracePeriod int
-	nodeName               string
 	hostNetwork            bool
 	volume                 []corev1.Volume
 	volumeMount            []corev1.VolumeMount
-}
-
-func NewBusyBoxDaemonsetBuilder(testImageRegistry string) *DaemonsetBuilder {
-	return &DaemonsetBuilder{
-		namespace:              utils.DefaultTestNamespace,
-		name:                   "deployment-test",
-		replicas:               10,
-		container:              NewBusyBoxContainerBuilder(testImageRegistry).Build(),
-		labels:                 map[string]string{"role": "test"},
-		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
-		terminationGracePeriod: 1,
-	}
 }
 
 func NewDefaultDaemonsetBuilder() *DaemonsetBuilder {
@@ -53,13 +39,6 @@ func NewDefaultDaemonsetBuilder() *DaemonsetBuilder {
 		terminationGracePeriod: 1,
 		labels:                 map[string]string{"role": "test"},
 		nodeSelector:           map[string]string{"kubernetes.io/os": "linux"},
-	}
-}
-
-func NewCalicoStarDaemonsetBuilder() *DaemonsetBuilder {
-	return &DaemonsetBuilder{
-		labels:       map[string]string{},
-		nodeSelector: map[string]string{},
 	}
 }
 
@@ -87,16 +66,6 @@ func (d *DaemonsetBuilder) TerminationGracePeriod(tg int) *DaemonsetBuilder {
 
 func (d *DaemonsetBuilder) Name(name string) *DaemonsetBuilder {
 	d.name = name
-	return d
-}
-
-func (d *DaemonsetBuilder) NodeName(nodeName string) *DaemonsetBuilder {
-	d.nodeName = nodeName
-	return d
-}
-
-func (d *DaemonsetBuilder) Replicas(replicas int) *DaemonsetBuilder {
-	d.replicas = replicas
 	return d
 }
 
@@ -141,7 +110,6 @@ func (d *DaemonsetBuilder) Build() *v1.DaemonSet {
 					NodeSelector:                  d.nodeSelector,
 					Containers:                    []corev1.Container{d.container},
 					TerminationGracePeriodSeconds: aws.Int64(int64(d.terminationGracePeriod)),
-					NodeName:                      d.nodeName,
 				},
 			},
 		},

--- a/test/framework/resources/k8s/resources/daemonset.go
+++ b/test/framework/resources/k8s/resources/daemonset.go
@@ -121,9 +121,7 @@ func (d *defaultDaemonSetManager) CheckIfDaemonSetIsReady(namespace string, name
 func (d *defaultDaemonSetManager) DeleteAndWaitTillDaemonSetDeleted(daemonSet *v1.DaemonSet, timeout time.Duration) error {
 	ctx := context.Background()
 
-	err := d.k8sClient.Delete(ctx, daemonSet)
-
-	if err != nil {
+	if err := d.k8sClient.Delete(ctx, daemonSet); err != nil {
 		return err
 	}
 

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -103,7 +103,7 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 		Expect(err).ToNot(HaveOccurred())
 
 		By("deleting the Daemonset.")
-		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetIsDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -195,7 +195,7 @@ var _ = Describe("[STATIC_CANARY2] API Server Connectivity from AZs", FlakeAttem
 
 	JustAfterEach(func() {
 		By("Deleting the Daemonset.")
-		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetIsDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -239,6 +239,7 @@ func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, api_serve
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while connecting to API Server from %s", az))
 		Expect(api_server_stdout).ToNot(BeEmpty())
 		Expect(api_server_stdout).To(ContainSubstring("APIVersions"))
+		fmt.Printf("API Server %s Connectivity from AZ %s was successful.\n", api_server_url, az)
 	}
 }
 

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -239,7 +239,6 @@ func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, port int, teste
 }
 
 func RunCommandOnPod(receiverPod coreV1.Pod, command []string) (string, string, error) {
-	stdout, stderr, err := f.K8sResourceManagers.PodManager().
+	return f.K8sResourceManagers.PodManager().
 		PodExec(receiverPod.Namespace, receiverPod.Name, command)
-	return stdout, stderr, err
 }

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -2,12 +2,13 @@ package cni
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	coreV1 "k8s.io/api/core/v1"
-	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -1,0 +1,304 @@
+package cni
+
+import (
+	"fmt"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	coreV1 "k8s.io/api/core/v1"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+)
+
+// Tests pod networking across AZs. It similar to pod connectivity test, but launches a daemonset, so that
+// there is a pod on each node across AZs. It then tests connectivity between pods on different nodes across AZs.
+var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(3), func() {
+
+	var (
+		err        error
+		serverPort int
+		protocol   string
+
+		// The command to run on server pods, to allow incoming
+		// connections for different traffic type
+		serverListenCmd []string
+		// Arguments to the server listen command
+		serverListenCmdArgs []string
+
+		// The function that generates command which will be sent from
+		// tester pod to receiver pod
+		testConnectionCommandFunc func(serverPod coreV1.Pod, port int) []string
+
+		// The functions re-inforces that the positive test is working as
+		// expected by creating a negative test command that should fail
+		testFailedConnectionCommandFunc func(serverPod coreV1.Pod, port int) []string
+
+		// Expected stdout from the exec command on testing connection
+		// from tester to server
+		testerExpectedStdOut string
+		// Expected stderr from the exec command on testing connection
+		// from tester to server
+		testerExpectedStdErr string
+
+		// Daemonset to run on node
+		testDaemonSet *v1.DaemonSet
+
+		// Map of Pods placed on the node
+		interfaceToPodList common.InterfaceTypeToPodList
+
+		// Map of AZ name, string to pod IP, string
+		azName    string
+		azToPodIP map[string]string
+		azToPod   map[string]coreV1.Pod
+	)
+
+	JustBeforeEach(func() {
+		By("authorizing security group ingress on instance security group")
+		err = f.CloudServices.EC2().
+			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("authorizing security group egress on instance security group")
+		err = f.CloudServices.EC2().
+			AuthorizeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		netcatContainer := manifest.
+			NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+			Command(serverListenCmd).
+			Args(serverListenCmdArgs).
+			Build()
+
+		By("creating a server DaemonSet on primary node")
+
+		testDaemonSet = manifest.
+			NewDefaultDaemonsetBuilder().
+			Container(netcatContainer).
+			PodLabel("role", "az-test").
+			Name("netcat-daemonset").
+			Build()
+
+		_, err = f.K8sResourceManagers.DaemonSetManager().CreateAndWaitTillDaemonSetIsReady(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("getting the node with the node label key %s and value %s",
+			f.Options.NgNameLabelKey, f.Options.NgNameLabelVal))
+
+		nodes, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		azToPodIP = make(map[string]string)
+		azToPod = make(map[string]coreV1.Pod)
+
+		for i := range nodes.Items {
+			// node label key "topology.kubernetes.io/zone" is well known label populated by cloud controller manager
+			// guaranteed to be present and represent the AZ name
+			// Ref https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone
+			azName = nodes.Items[i].ObjectMeta.Labels["topology.kubernetes.io/zone"]
+			interfaceToPodList = common.GetPodsOnPrimaryAndSecondaryInterface(nodes.Items[i], "role", "az-test", f)
+			// It doesn't matter which ENI the pod is on, as long as it is on the node
+			if len(interfaceToPodList.PodsOnSecondaryENI) > 0 {
+				azToPodIP[azName] = interfaceToPodList.PodsOnSecondaryENI[0].Status.PodIP
+				azToPod[azName] = interfaceToPodList.PodsOnSecondaryENI[0]
+			}
+			if len(interfaceToPodList.PodsOnPrimaryENI) > 0 {
+				azToPodIP[azName] = interfaceToPodList.PodsOnPrimaryENI[0].Status.PodIP
+				azToPod[azName] = interfaceToPodList.PodsOnPrimaryENI[0]
+			}
+		}
+	})
+
+	JustAfterEach(func() {
+		By("revoking security group ingress on instance security group")
+		err = f.CloudServices.EC2().
+			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("revoking security group egress on instance security group")
+		err = f.CloudServices.EC2().
+			RevokeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("deleting the Daemonset.")
+		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("While testing connectivity across AZ", func() {
+
+		BeforeEach(func() {
+			serverPort = 2273
+			protocol = ec2.ProtocolTcp
+			// Test tcp connection using netcat
+			serverListenCmd = []string{"nc"}
+			// The nc flag "-l" for listen mode, "-k" to keep server up and not close
+			// connection after each connection
+			serverListenCmdArgs = []string{"-k", "-l", strconv.Itoa(serverPort)}
+			// netcat verbose output is being redirected to stderr instead of stdout
+			testerExpectedStdErr = "succeeded!"
+			testerExpectedStdOut = ""
+
+			// The nc flag "-v" for verbose output and "-wn" for timing out in n seconds
+			testConnectionCommandFunc = func(receiverPod coreV1.Pod, port int) []string {
+				return []string{"nc", "-v", "-w2", receiverPod.Status.PodIP, strconv.Itoa(port)}
+			}
+
+			// Create a negative test case with the wrong port number. This is to reinforce the
+			// positive test case work by verifying negative cases do throw error
+			testFailedConnectionCommandFunc = func(receiverPod coreV1.Pod, port int) []string {
+				return []string{"nc", "-u", "-v", "-w2", receiverPod.Status.PodIP, strconv.Itoa(port + 1)}
+			}
+		})
+
+		It("Should allow TCP traffic across AZs.", func() {
+			CheckConnectivityBetweenPods(azToPod, serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
+			VerifyConnectivityForNegativeCase(azToPod, serverPort, testFailedConnectionCommandFunc)
+		})
+	})
+})
+
+var _ = Describe("[STATIC_CANARY] API Server Connectivity from AZs", FlakeAttempts(3), func() {
+
+	var (
+		err           error
+		testDaemonSet *v1.DaemonSet
+
+		// Map of Pods placed on primary/secondary ENI IP
+		interfaceToPodList common.InterfaceTypeToPodList
+
+		azName string
+
+		// Map of AZ name to Pod
+		azToPod map[string]coreV1.Pod
+	)
+
+	JustBeforeEach(func() {
+		serverContainer := manifest.
+			NewCurlContainer().
+			Command([]string{
+				"sleep",
+				"3600",
+			}).
+			Build()
+
+		By("creating a server DaemonSet on primary node")
+
+		testDaemonSet = manifest.
+			NewDefaultDaemonsetBuilder().
+			Container(serverContainer).
+			PodLabel("role", "az-test").
+			Name("api-server-connectivity-daemonset").
+			Build()
+
+		_, err = f.K8sResourceManagers.DaemonSetManager().CreateAndWaitTillDaemonSetIsReady(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("getting the node with the node label key %s and value %s",
+			f.Options.NgNameLabelKey, f.Options.NgNameLabelVal))
+
+		nodes, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+		Expect(err).ToNot(HaveOccurred())
+
+		azToPod = make(map[string]coreV1.Pod)
+
+		for i := range nodes.Items {
+			// node label key "topology.kubernetes.io/zone" is well known label populated by cloud controller manager
+			// guaranteed to be present and represent the AZ name
+			// Ref https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone
+			azName = nodes.Items[i].ObjectMeta.Labels["topology.kubernetes.io/zone"]
+			interfaceToPodList = common.GetPodsOnPrimaryAndSecondaryInterface(nodes.Items[i], "role", "az-test", f)
+			if len(interfaceToPodList.PodsOnSecondaryENI) > 0 {
+				azToPod[azName] = interfaceToPodList.PodsOnSecondaryENI[0]
+			}
+			if len(interfaceToPodList.PodsOnPrimaryENI) > 0 {
+				azToPod[azName] = interfaceToPodList.PodsOnPrimaryENI[0]
+			}
+		}
+	})
+
+	JustAfterEach(func() {
+		By("Deleting the Daemonset.")
+		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	Context("While testing API Server Connectivity", func() {
+		It("Should connect to the API Server", func() {
+			// Standard paths for SA token, CA cert and API Server URL
+			token_path := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+			cacert := "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+			api_server_url := "https://kubernetes.default.svc/api"
+
+			for az := range azToPod {
+				fmt.Printf("Testing API Server Connectivity from AZ %s \n", az)
+				sa_token := []string{"cat", token_path}
+				token_value, _, err := RunCommandOnPod(azToPod[az], sa_token)
+				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get SA token for pod in %s", az))
+				bearer := fmt.Sprintf("Authorization: Bearer %s", token_value)
+				test_api_server_connectivity := []string{"curl", "--cacert", cacert, "--header", bearer, "-X", "GET",
+					api_server_url,
+				}
+
+				api_server_stdout, _, err := RunCommandOnPod(azToPod[az], test_api_server_connectivity)
+				// Descriptive error message on failure to connect to API Server from particular AZ.
+				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while connecting to API Server from %s", az))
+				Expect(api_server_stdout).ToNot(BeEmpty())
+				Expect(api_server_stdout).To(ContainSubstring("APIVersions"))
+			}
+		})
+	})
+})
+
+func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, port int, testerExpectedStdOut string, testerExpectedStdErr string, getTestCommandFunc func(serverPod coreV1.Pod, port int) []string) {
+
+	By("checking connection on same node, primary to primary")
+
+	for az1 := range azToPod {
+		for az2 := range azToPod {
+			if az1 != az2 {
+				fmt.Printf("Testing Connectivity from Pod IP1 %s (%s) to Pod IP2 %s (%s) \n",
+					azToPod[az1].Status.PodIP, az1, azToPod[az2].Status.PodIP, az2)
+				testConnectivity(azToPod[az1], azToPod[az2], testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+			}
+		}
+	}
+}
+
+func RunCommandOnPod(receiverPod coreV1.Pod, command []string) (string, string, error) {
+	stdout, stderr, err := f.K8sResourceManagers.PodManager().
+		PodExec(receiverPod.Namespace, receiverPod.Name, command)
+	return stdout, stderr, err
+}
+
+func VerifyConnectivityForNegativeCase(azToPod map[string]coreV1.Pod, port int,
+	getTestCommandFunc func(receiverPod coreV1.Pod, port int) []string) {
+
+	for az1 := range azToPod {
+		for az2 := range azToPod {
+			if az1 != az2 {
+				fmt.Printf("Testing Connectivity from Pod IP1 %s (%s) to Pod IP2 %s (%s) \n",
+					azToPod[az1].Status.PodIP, az1, azToPod[az2].Status.PodIP, az2)
+
+				senderPod := azToPod[az1]
+				receiverPod := azToPod[az2]
+				testerCommand := getTestCommandFunc(receiverPod, port)
+
+				GinkgoWriter.Printf("verifying connectivity fails from pod %s on node %s with IP %s to pod"+
+					" %s on node %s with IP %s\n", senderPod.Name, senderPod.Spec.NodeName, senderPod.Status.PodIP,
+					receiverPod.Name, receiverPod.Spec.NodeName, receiverPod.Status.PodIP)
+
+				_, _, err := f.K8sResourceManagers.PodManager().
+					PodExec(senderPod.Namespace, senderPod.Name, testerCommand)
+				Expect(err).To(HaveOccurred())
+				// Negative test for single scenario is fine!
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
This brings in two tests.

* Test Pod Connectivity Across AZs, to exercise CNI and pod connectivity upon AZ failures.

* Test API Server Connectivity from various AZs to ensure that Service Discovery (kube-proxy) and Service Name look up (Coredns) remain functional during AZ failures.

**What type of PR is this?**

Test Coverage

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Test Coverage to run on Static Canaries.


I have been testing this in internal clusters, and they have been consistently successful with no flakes. (Cluster create failures aren't part of this test suite).

![2023-11-29_13-50](https://github.com/aws/amazon-vpc-cni-k8s/assets/332330/4d3e5422-e083-4c65-8a3c-382f16ed6740)

---- 

Success Outputs

```
[STATIC_CANARY] test pod networking While testing connectivity across AZ Should allow TCP traffic across AZs.
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:130
  STEP: authorizing security group ingress on instance security group @ 12/10/23 15:29:26.498
  STEP: authorizing security group egress on instance security group @ 12/10/23 15:29:26.731
  STEP: creating a server DaemonSet on primary node @ 12/10/23 15:29:26.97
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 12/10/23 15:29:29.029
  STEP: checking connection on same node, primary to primary @ 12/10/23 15:29:30.672
Testing Connectivity from Pod IP1 192.168.21.36 (us-west-2a) to Pod IP2 192.168.54.126 (us-west-2b)
  verifying connectivity from pod netcat-daemonset-gfk5h on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.21.36 to pod netcat-daemonset-72pkq on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.54.126
  stdout:  and stderr: Connection to 192.168.54.126 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.21.36 (us-west-2a) to Pod IP2 192.168.66.142 (us-west-2c)
  verifying connectivity from pod netcat-daemonset-gfk5h on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.21.36 to pod netcat-daemonset-phfgj on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.66.142
  stdout:  and stderr: Connection to 192.168.66.142 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.54.126 (us-west-2b) to Pod IP2 192.168.66.142 (us-west-2c)
  verifying connectivity from pod netcat-daemonset-72pkq on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.54.126 to pod netcat-daemonset-phfgj on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.66.142
  stdout:  and stderr: Connection to 192.168.66.142 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.54.126 (us-west-2b) to Pod IP2 192.168.21.36 (us-west-2a)
  verifying connectivity from pod netcat-daemonset-72pkq on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.54.126 to pod netcat-daemonset-gfk5h on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.21.36
  stdout:  and stderr: Connection to 192.168.21.36 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.66.142 (us-west-2c) to Pod IP2 192.168.21.36 (us-west-2a)
  verifying connectivity from pod netcat-daemonset-phfgj on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.66.142 to pod netcat-daemonset-gfk5h on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.21.36
  stdout:  and stderr: Connection to 192.168.21.36 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.66.142 (us-west-2c) to Pod IP2 192.168.54.126 (us-west-2b)
  verifying connectivity from pod netcat-daemonset-phfgj on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.66.142 to pod netcat-daemonset-72pkq on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.54.126
  stdout:  and stderr: Connection to 192.168.54.126 2273 port [tcp/*] succeeded!

  STEP: revoking security group ingress on instance security group @ 12/10/23 15:29:45.679
  STEP: revoking security group egress on instance security group @ 12/10/23 15:29:45.896
  STEP: deleting the Daemonset. @ 12/10/23 15:29:46.126
• [21.685 seconds]
```

* API Server Connectivity test will succeed for us-west-2a, us-west-2b and us-west-2c

```
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2a
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2b
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2c
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2c was successful.
  STEP: Deleting the Daemonset. @ 12/10/23 16:00:29.501

```

Failure ouput

**Simulating a test failure in us-west-2c**

* Across AZs test will fail for us-west-2c and succeed for us-west-2a and us-west-2b
* 3 Attempts before declaring failure.

```
Testing Connectivity from Pod IP1 192.168.15.137 (us-west-2a) to Pod IP2 192.168.43.120 (us-west-2b)
  verifying connectivity from pod netcat-daemonset-2bnpt on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.15.137 to pod netcat-daemonset-sfpmk on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.43.120
  stdout:  and stderr: Connection to 192.168.43.120 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.15.137 (us-west-2a) to Pod IP2 192.168.65.235 (us-west-2c)
  verifying connectivity from pod netcat-daemonset-2bnpt on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.15.137 to pod netcat-daemonset-rz6g9 on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.65.235
  [FAILED] in [It] - /Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_test.go:339 @ 12/10/23 15:49:53.296
  STEP: revoking security group ingress on instance security group @ 12/10/23 15:49:53.296
  STEP: revoking security group egress on instance security group @ 12/10/23 15:49:53.522
  STEP: deleting the Daemonset. @ 12/10/23 15:49:53.737

  Attempt #1 Failed.  Retrying ↺ @ 12/10/23 15:49:53.792

  STEP: authorizing security group ingress on instance security group @ 12/10/23 15:49:53.792
  STEP: authorizing security group egress on instance security group @ 12/10/23 15:49:54.036
  STEP: creating a server DaemonSet on primary node @ 12/10/23 15:49:54.291
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 12/10/23 15:49:56.342
  STEP: checking connection on same node, primary to primary @ 12/10/23 15:49:56.809
Testing Connectivity from Pod IP1 192.168.69.61 (us-west-2c) to Pod IP2 192.168.8.192 (us-west-2a)
  verifying connectivity from pod netcat-daemonset-w928w on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.69.61 to pod netcat-daemonset-485gj on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.8.192
  stdout:  and stderr: Connection to 192.168.8.192 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.69.61 (us-west-2c) to Pod IP2 192.168.53.170 (us-west-2b)
  verifying connectivity from pod netcat-daemonset-w928w on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.69.61 to pod netcat-daemonset-2qd4h on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.53.170
  stdout:  and stderr: Connection to 192.168.53.170 2273 port [tcp/*] succeeded!

...

• [FAILED] [27.798 seconds]
[STATIC_CANARY] test pod networking While testing connectivity across AZ [It] Should allow TCP traffic across AZs.
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:130

  [FAILED] Unexpected error:
      <exec.CodeExitError>:
      command terminated with exit code 1
      {
          Err: <*errors.errorString | 0xc0006685d0>{
              s: "command terminated with exit code 1",
          },
          Code: 1,
      }
  occurred


```

* API Server Connectivity test will fail for us-west-2c and succeed for us-west-2a and us-west-2b


```
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c
  [FAILED] in [It] - /Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:245 @ 12/10/23 15:58:18.002
  STEP: Deleting the Daemonset. @ 12/10/23 15:58:18.002
• [FAILED] [37.652 seconds]
[STATIC_CANARY2] API Server Connectivity from AZs While testing API Server Connectivity [It] Should connect to the API Server
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:205

  [FAILED] Expected
```
