### PR TITLE
Fix enabling of Metrics and Introspection Endpoint

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -33,6 +33,9 @@ const (
 
 	// Environment variable to disable the metrics endpoint on 61678
 	envDisableMetrics = "DISABLE_METRICS"
+
+	// Environment variable to disable the IPAMD introspection endpoint on 61679
+	envDisableIntrospection = "DISABLE_INTROSPECTION"
 )
 
 func main() {
@@ -74,13 +77,15 @@ func _main() int {
 	// Pool manager
 	go ipamContext.StartNodeIPPoolManager()
 
-	if utils.GetBoolAsStringEnvVar(envDisableMetrics, false) {
+	if !utils.GetBoolAsStringEnvVar(envDisableMetrics, false) {
 		// Prometheus metrics
 		go metrics.ServeMetrics(metricsPort)
 	}
 
 	// CNI introspection endpoints
-	go ipamContext.ServeIntrospection()
+	if !utils.GetBoolAsStringEnvVar(envDisableIntrospection, false) {
+		go ipamContext.ServeIntrospection()
+	}
 
 	// Start the RPC listener
 	err = ipamContext.RunRPCHandler(version.Version)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
integration test failures

**What does this PR do / Why do we need it**:
This PR fixes two bugs introduced by https://github.com/aws/amazon-vpc-cni-k8s/pull/2603:
1. The environment variable used to disable the IPAMD introspection endpoint was unintentionally changed
2. The default for enabling the IPAMD metrics endpoint was changed.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Manually verified that IPAMD metrics and introspection tests now pass.

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
