### PR TITLE
Simplify IPv6 Gateway Calculation

### DIFF
--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1877,7 +1877,7 @@ func TestIPAMContext_setupENI(t *testing.T) {
 
 	newENIMetadata := getSecondaryENIMetadata()
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet).Return(nil, errors.New("not able to set route 0.0.0.0/0 via 10.10.10.1 table 2"))
+	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet).Return(errors.New("not able to set route 0.0.0.0/0 via 10.10.10.1 table 2"))
 
 	err = mockContext.setupENI(newENIMetadata.ENIID, newENIMetadata, false, false)
 	assert.Error(t, err)
@@ -1923,7 +1923,7 @@ func TestIPAMContext_setupENIwithPDenabled(t *testing.T) {
 
 	newENIMetadata := getSecondaryENIMetadata()
 	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid)
-	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet).Return(nil, errors.New("not able to set route 0.0.0.0/0 via 10.10.10.1 table 2"))
+	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet).Return(errors.New("not able to set route 0.0.0.0/0 via 10.10.10.1 table 2"))
 
 	err = mockContext.setupENI(newENIMetadata.ENIID, newENIMetadata, false, false)
 	assert.Error(t, err)

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -142,7 +142,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 					// For IPv6, the gateway is derived from the RA route on the primary ENI. The primary ENI is always in the same subnet as the trunk and branch ENI.
 					// For IPv4, the gateway is always the .1 address for the subnet CIDR.
 					if s.ipamContext.enableIPv6 {
-						gw = s.ipamContext.v6Gateway
+						gw = networkutils.GetIPv6Gateway()
 					} else {
 						gw = networkutils.GetIPv4Gateway(subnetCIDR)
 					}

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -124,12 +124,11 @@ func (mr *MockNetworkAPIsMockRecorder) GetRuleListBySrc(arg0, arg1 interface{}) 
 }
 
 // SetupENINetwork mocks base method.
-func (m *MockNetworkAPIs) SetupENINetwork(arg0, arg1 string, arg2 int, arg3 string) (net.IP, error) {
+func (m *MockNetworkAPIs) SetupENINetwork(arg0, arg1 string, arg2 int, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetupENINetwork", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(net.IP)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SetupENINetwork indicates an expected call of SetupENINetwork.
@@ -178,20 +177,6 @@ func (m *MockNetworkAPIs) UpdateHostIptablesRules(arg0 []string, arg1 string, ar
 func (mr *MockNetworkAPIsMockRecorder) UpdateHostIptablesRules(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostIptablesRules", reflect.TypeOf((*MockNetworkAPIs)(nil).UpdateHostIptablesRules), arg0, arg1, arg2, arg3, arg4)
-}
-
-// UpdateIPv6GatewayRule mocks base method.
-func (m *MockNetworkAPIs) UpdateIPv6GatewayRule(arg0 *net.IP) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIPv6GatewayRule", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateIPv6GatewayRule indicates an expected call of UpdateIPv6GatewayRule.
-func (mr *MockNetworkAPIsMockRecorder) UpdateIPv6GatewayRule(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIPv6GatewayRule", reflect.TypeOf((*MockNetworkAPIs)(nil).UpdateIPv6GatewayRule), arg0)
 }
 
 // UpdateRuleListBySrc mocks base method.

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -122,7 +122,7 @@ func TestSetupENINetwork(t *testing.T) {
 
 	mockNetLink.EXPECT().RouteDel(gomock.Any()).Return(nil)
 
-	_, err = setupENINetwork(testEniIP, testMAC2, testTable, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
+	err = setupENINetwork(testEniIP, testMAC2, testTable, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
 	assert.NoError(t, err)
 }
 
@@ -171,7 +171,7 @@ func TestSetupENIV6Network(t *testing.T) {
 	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
 	mockNetLink.EXPECT().RouteDel(gomock.Any()).Return(nil)
 
-	_, err = setupENINetwork(testEniIP6, testMAC2, testTable, testEniV6Subnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
+	err = setupENINetwork(testEniIP6, testMAC2, testTable, testEniV6Subnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
 	assert.NoError(t, err)
 }
 
@@ -185,7 +185,7 @@ func TestSetupENINetworkMACFail(t *testing.T) {
 		mockNetLink.EXPECT().LinkList().Return(nil, fmt.Errorf("simulated failure"))
 	}
 
-	_, err := setupENINetwork(testEniIP, testMAC2, testTable, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
+	err := setupENINetwork(testEniIP, testMAC2, testTable, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
 	assert.Errorf(t, err, "simulated failure")
 }
 
@@ -193,7 +193,7 @@ func TestSetupENINetworkErrorOnPrimaryENI(t *testing.T) {
 	ctrl, mockNetLink, _, _, _ := setup(t)
 	defer ctrl.Finish()
 	deviceNumber := 0
-	_, err := setupENINetwork(testEniIP, testMAC2, deviceNumber, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
+	err := setupENINetwork(testEniIP, testMAC2, deviceNumber, testEniSubnet, mockNetLink, 0*time.Second, 0*time.Second, testMTU)
 	assert.Error(t, err)
 }
 
@@ -218,7 +218,7 @@ func TestUpdateIPv6GatewayRule(t *testing.T) {
 	mockNetLink.EXPECT().NewRule().Return(&icmpRule)
 	mockNetLink.EXPECT().RuleAdd(&icmpRule)
 
-	err := ln.UpdateIPv6GatewayRule(&testEniV6GatewayNet)
+	err := ln.createIPv6GatewayRule()
 	assert.NoError(t, err)
 
 	// Validate rule del in non-strict mode
@@ -226,7 +226,7 @@ func TestUpdateIPv6GatewayRule(t *testing.T) {
 	mockNetLink.EXPECT().NewRule().Return(&icmpRule)
 	mockNetLink.EXPECT().RuleDel(&icmpRule)
 
-	err = ln.UpdateIPv6GatewayRule(&testEniV6GatewayNet)
+	err = ln.createIPv6GatewayRule()
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR takes the finding in https://github.com/aws/amazon-vpc-cni-k8s/pull/2700 and applies it to simplify IPv6 gateway calculation for IPv6 Security Groups for Pods support. The IPv6 gateway for a subnet can always be reached from the node via `fe80:ec2::1`.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that all integration tests pass against an IPv6 cluster, including the `pod-eni` test suite.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
