### PR TITLE
Remove hard-coded comment for primary intf

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -399,7 +399,7 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	}
 	log.Debugf("Found availability zone: %s ", cache.availabilityZone)
 
-	// retrieve eth0 local-ipv4
+	// retrieve primary interface local-ipv4
 	cache.localIPv4, err = cache.imds.GetLocalIPv4(ctx)
 	if err != nil {
 		awsAPIErrInc("GetLocalIPv4", err)

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -291,13 +291,12 @@ func (n *linuxNetwork) SetupHostNetwork(vpcv4CIDRs []string, primaryMAC string, 
 	v4Enabled bool, v6Enabled bool) error {
 	log.Info("Setting up host network... ")
 
-	primaryIntf := "eth0"
 	link, err := linkByMac(primaryMAC, n.netLink, retryLinkByMacInterval)
 	if err != nil {
 		return errors.Wrapf(err, "setupHostNetwork: failed to find the link primary ENI with MAC address %s", primaryMAC)
 	}
 	if err = n.netLink.LinkSetMTU(link, n.mtu); err != nil {
-		return errors.Wrapf(err, "setupHostNetwork: failed to set MTU to %d for %s", n.mtu, primaryIntf)
+		return errors.Wrapf(err, "setupHostNetwork: failed to set primary interface MTU to %d", n.mtu)
 	}
 
 	ipFamily := unix.AF_INET


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
The primary interface is not necessarily named `eth0`. The name depends on the base operating system. This PR removes the hard-coded use of `eth0`, which was only used in a comment. The logic was still getting the primary interface name from IMDS, which is always correct.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that integration tests pass.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Update comment for host-networking setup
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
