### PR TITLE
No need to set accept_ra or accept_redirects for non-primary interfaces

### DIFF
--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -117,35 +117,13 @@ func configureIPv6Settings(procSys procsyswrapper.ProcSys, primaryIF string) err
 	// Check if IPv6 egress support is enabled in IPv4 cluster.
 	ipv6EgressEnabled := utils.GetBoolAsStringEnvVar(envEgressV6, defaultEnableIPv6Egress)
 	if enableIPv6 || ipv6EgressEnabled {
-		// For IPv6, the following sysctls are set:
-		// 1. forwarding defaults to 1
-		// 2. accept_ra defaults to 2
-		// 3. accept_redirects defaults to 1
+		// Enable IPv6 forwarding on all interfaces by default
 		entry := "net/ipv6/conf/all/forwarding"
 		err = procSys.Set(entry, "1")
 		if err != nil {
 			return errors.Wrap(err, "Failed to enable IPv6 forwarding")
 		}
 		val, _ := procSys.Get(entry)
-		log.Infof("Updated %s to %s", entry, val)
-
-		// accept_ra must be set to 2 so that RA routes are installed by the kernel on secondary ENIs
-		// For IPv6, this setting must be inherited by the trunk ENI. It must be set here as IPAMD does
-		// not have permission to set sysctl values.
-		entry = "net/ipv6/conf/default/accept_ra"
-		err = procSys.Set(entry, "2")
-		if err != nil {
-			return errors.Wrap(err, "Failed to set IPv6 accept Router Advertisements to 2")
-		}
-		val, _ = procSys.Get(entry)
-		log.Infof("Updated %s to %s", entry, val)
-
-		entry = "net/ipv6/conf/default/accept_redirects"
-		err = procSys.Set(entry, "1")
-		if err != nil {
-			return errors.Wrap(err, "Failed to enable IPv6 accept redirects")
-		}
-		val, _ = procSys.Get(entry)
 		log.Infof("Updated %s to %s", entry, val)
 
 		// For the primary ENI in IPv6, sysctls are set to:

--- a/test/framework/resources/agent/traffic_tester.go
+++ b/test/framework/resources/agent/traffic_tester.go
@@ -128,7 +128,7 @@ func (t *TrafficTest) TestTraffic() (float64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("pod list %v validation failed %v", podList, err)
 		}
-		fmt.Fprintln(GinkgoWriter, "successfully validated the server pod list")
+		fmt.Fprintln(GinkgoWriter, "successfully validated the client pod list")
 	}
 
 	metricServerIP := metricServerPod.Status.PodIP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR removes the IPv6 sysctl setup done in the VPC CNI init container for `accept_ra` and `accept_redirects`. Our IPv6 implementation does not rely on RA for non-primary interfaces, so these sysctls do not need to be set.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Verified that the `pod-eni` integration test suite passes with and without these sysctls. Also verified that the RA route getting installed for the trunk ENI has no impact.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
