### PR TITLE
Enhance subnet selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,15 @@ You can use the below command to enable `DISABLE_TCP_EARLY_DEMUX` to `true` -
 kubectl patch daemonset aws-node -n kube-system -p '{"spec": {"template": {"spec": {"initContainers": [{"env":[{"name":"DISABLE_TCP_EARLY_DEMUX","value":"true"}],"name":"aws-vpc-cni-init"}]}}}}'
 ```
 
+#### `ENABLE_SUBNET_DISCOVERY` (v1.18.0+)
+
+Type: Boolean as a String
+
+Default: `true`
+
+Subnet discovery is enabled by default. VPC-CNI will pick the subnet with the most number of free IPs from the nodes' VPC/AZ to create the secondary ENIs. The subnets considered are the subnet the node is created in and subnets tagged with `kubernetes.io/role/cni`.
+If `ENABLE_SUBNET_DISCOVERY` is set to `false` or if DescribeSubnets fails due to IAM permissions, all secondary ENIs will be created in the subnet the node is created in.
+
 #### `ENABLE_PREFIX_DELEGATION` (v1.9.0+)
 
 Type: Boolean as a String
@@ -733,6 +742,7 @@ Note that if you set this while using Multus, you must ensure that any chained p
 This plugin interacts with the following tags on ENIs:
 
 * `cluster.k8s.amazonaws.com/name`
+* `kubernetes.io/role/cni`
 * `node.k8s.amazonaws.com/instance_id`
 * `node.k8s.amazonaws.com/no_manage`
 
@@ -740,6 +750,17 @@ This plugin interacts with the following tags on ENIs:
 
 The tag `cluster.k8s.amazonaws.com/name` will be set to the cluster name of the
 aws-node daemonset which created the ENI.
+
+#### CNI role tag
+
+The tag `kubernetes.io/role/cni` is read by the aws-node daemonset to determine
+if a secondary subnet can be used for creating secondary ENIs.
+
+This tag is not set by the cni plugin itself, but rather must be set by a user
+to indicate that a subnet can be used for secondary ENIs. Secondary subnets
+to be used must have this tag. The primary subnet (node's subnet) is not
+required to be tagged.
+
 
 #### Instance ID tag
 

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -84,6 +84,7 @@ env:
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
   VPC_CNI_VERSION: "v1.16.4"
+  ENABLE_SUBNET_DISCOVERY: "true"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -466,6 +466,8 @@ spec:
               value: "false"
             - name: VPC_CNI_VERSION
               value: "v1.16.4"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -466,6 +466,8 @@ spec:
               value: "false"
             - name: VPC_CNI_VERSION
               value: "v1.16.4"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -466,6 +466,8 @@ spec:
               value: "false"
             - name: VPC_CNI_VERSION
               value: "v1.16.4"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -466,6 +466,8 @@ spec:
               value: "false"
             - name: VPC_CNI_VERSION
               value: "v1.16.4"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -46,6 +46,7 @@ const (
 	metadataInstanceType = "instance-type"
 	metadataSGs          = "/security-group-ids"
 	metadataSubnetID     = "/subnet-id"
+	metadataVpcID        = "/vpc-id"
 	metadataVPCcidrs     = "/vpc-ipv4-cidr-blocks"
 	metadataDeviceNum    = "/device-number"
 	metadataInterface    = "/interface-id"
@@ -65,6 +66,7 @@ const (
 	sgs                  = sg1 + " " + sg2
 	subnetID             = "subnet-6b245523"
 	subnetCIDR           = "10.0.1.0/24"
+	vpcID                = "vpc-3c133421"
 	primaryeniID         = "eni-00000000"
 	eniID                = primaryeniID
 	eniAttachID          = "eni-attach-beb21856"
@@ -93,6 +95,7 @@ func testMetadata(overrides map[string]interface{}) FakeIMDS {
 		metadataMACPath + primaryMAC + metadataSGs:        sgs,
 		metadataMACPath + primaryMAC + metadataIPv4s:      eni1PrivateIP,
 		metadataMACPath + primaryMAC + metadataSubnetID:   subnetID,
+		metadataMACPath + primaryMAC + metadataVpcID:      vpcID,
 		metadataMACPath + primaryMAC + metadataSubnetCIDR: subnetCIDR,
 		metadataMACPath + primaryMAC + metadataVPCcidrs:   metadataVPCIPv4CIDRs,
 	}
@@ -118,6 +121,7 @@ func testMetadataWithPrefixes(overrides map[string]interface{}) FakeIMDS {
 		metadataMACPath + primaryMAC + metadataIPv4s:        eni1PrivateIP,
 		metadataMACPath + primaryMAC + metadataIPv4Prefixes: eni1Prefix,
 		metadataMACPath + primaryMAC + metadataSubnetID:     subnetID,
+		metadataMACPath + primaryMAC + metadataVpcID:        vpcID,
 		metadataMACPath + primaryMAC + metadataSubnetCIDR:   subnetCIDR,
 		metadataMACPath + primaryMAC + metadataVPCcidrs:     metadataVPCIPv4CIDRs,
 	}
@@ -167,7 +171,7 @@ func TestInitWithEC2metadata(t *testing.T) {
 		assert.Equal(t, cache.instanceID, instanceID)
 		assert.Equal(t, cache.primaryENImac, primaryMAC)
 		assert.Equal(t, cache.primaryENI, primaryeniID)
-		assert.Equal(t, subnetID, cache.subnetID)
+		assert.Equal(t, cache.vpcID, vpcID)
 	}
 }
 
@@ -376,6 +380,21 @@ func TestAllocENI(t *testing.T) {
 
 	mockMetadata := testMetadata(nil)
 
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: aws.Int64(ipAddressCount),
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
+
 	cureniID := eniID
 	eni := ec2.CreateNetworkInterfaceOutput{NetworkInterface: &ec2.NetworkInterface{NetworkInterfaceId: &cureniID}}
 	mockEC2.EXPECT().CreateNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&eni, nil)
@@ -401,9 +420,10 @@ func TestAllocENI(t *testing.T) {
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	cache := &EC2InstanceMetadataCache{
-		ec2SVC:       mockEC2,
-		imds:         TypedIMDS{mockMetadata},
-		instanceType: "c5n.18xlarge",
+		ec2SVC:             mockEC2,
+		imds:               TypedIMDS{mockMetadata},
+		instanceType:       "c5n.18xlarge",
+		useSubnetDiscovery: true,
 	}
 
 	_, err := cache.AllocENI(false, nil, "", 5)
@@ -415,6 +435,21 @@ func TestAllocENINoFreeDevice(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockMetadata := testMetadata(nil)
+
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
 
 	cureniID := eniID
 	eni := ec2.CreateNetworkInterfaceOutput{NetworkInterface: &ec2.NetworkInterface{NetworkInterfaceId: &cureniID}}
@@ -436,9 +471,10 @@ func TestAllocENINoFreeDevice(t *testing.T) {
 	mockEC2.EXPECT().DeleteNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	cache := &EC2InstanceMetadataCache{
-		ec2SVC:       mockEC2,
-		imds:         TypedIMDS{mockMetadata},
-		instanceType: "c5n.18xlarge",
+		ec2SVC:             mockEC2,
+		imds:               TypedIMDS{mockMetadata},
+		instanceType:       "c5n.18xlarge",
+		useSubnetDiscovery: true,
 	}
 
 	_, err := cache.AllocENI(false, nil, "", 5)
@@ -450,6 +486,21 @@ func TestAllocENIMaxReached(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockMetadata := testMetadata(nil)
+
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
 
 	cureniID := eniID
 	eni := ec2.CreateNetworkInterfaceOutput{NetworkInterface: &ec2.NetworkInterface{NetworkInterfaceId: &cureniID}}
@@ -473,9 +524,10 @@ func TestAllocENIMaxReached(t *testing.T) {
 	mockEC2.EXPECT().DeleteNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	cache := &EC2InstanceMetadataCache{
-		ec2SVC:       mockEC2,
-		imds:         TypedIMDS{mockMetadata},
-		instanceType: "c5n.18xlarge",
+		ec2SVC:             mockEC2,
+		imds:               TypedIMDS{mockMetadata},
+		instanceType:       "c5n.18xlarge",
+		useSubnetDiscovery: true,
 	}
 
 	_, err := cache.AllocENI(false, nil, "", 5)
@@ -485,6 +537,21 @@ func TestAllocENIMaxReached(t *testing.T) {
 func TestAllocENIWithIPAddresses(t *testing.T) {
 	ctrl, mockEC2 := setup(t)
 	defer ctrl.Finish()
+
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
 
 	// when required IP numbers(5) is below ENI's limit(30)
 	currentEniID := eniID
@@ -509,16 +576,17 @@ func TestAllocENIWithIPAddresses(t *testing.T) {
 	mockEC2.EXPECT().AttachNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
-	cache := &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "c5n.18xlarge"}
+	cache := &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "c5n.18xlarge", useSubnetDiscovery: true}
 	_, err := cache.AllocENI(false, nil, subnetID, 5)
 	assert.NoError(t, err)
 
 	// when required IP numbers(50) is higher than ENI's limit(49)
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
 	mockEC2.EXPECT().CreateNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&eni, nil)
 	mockEC2.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	mockEC2.EXPECT().AttachNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttributeWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	cache = &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "c5n.18xlarge"}
+	cache = &EC2InstanceMetadataCache{ec2SVC: mockEC2, instanceType: "c5n.18xlarge", useSubnetDiscovery: true}
 	_, err = cache.AllocENI(false, nil, subnetID, 49)
 	assert.NoError(t, err)
 }
@@ -529,13 +597,29 @@ func TestAllocENIWithIPAddressesAlreadyFull(t *testing.T) {
 
 	mockMetadata := testMetadata(nil)
 
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
+
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().CreateNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, retErr)
 
 	cache := &EC2InstanceMetadataCache{
-		ec2SVC:       mockEC2,
-		imds:         TypedIMDS{mockMetadata},
-		instanceType: "t3.xlarge",
+		ec2SVC:             mockEC2,
+		imds:               TypedIMDS{mockMetadata},
+		instanceType:       "t3.xlarge",
+		useSubnetDiscovery: true,
 	}
 	_, err := cache.AllocENI(true, nil, "", 14)
 	assert.Error(t, err)
@@ -546,6 +630,21 @@ func TestAllocENIWithPrefixAddresses(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockMetadata := testMetadata(nil)
+
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
 
 	currentEniID := eniID
 	eni := ec2.CreateNetworkInterfaceOutput{NetworkInterface: &ec2.NetworkInterface{NetworkInterfaceId: &currentEniID}}
@@ -574,6 +673,7 @@ func TestAllocENIWithPrefixAddresses(t *testing.T) {
 		imds:                   TypedIMDS{mockMetadata},
 		instanceType:           "c5n.18xlarge",
 		enablePrefixDelegation: true,
+		useSubnetDiscovery:     true,
 	}
 	_, err := cache.AllocENI(false, nil, subnetID, 1)
 	assert.NoError(t, err)
@@ -585,6 +685,21 @@ func TestAllocENIWithPrefixesAlreadyFull(t *testing.T) {
 
 	mockMetadata := testMetadata(nil)
 
+	ipAddressCount := int64(100)
+	subnetResult := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{{
+			AvailableIpAddressCount: &ipAddressCount,
+			SubnetId:                aws.String(subnetID),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("1"),
+				},
+			},
+		}},
+	}
+	mockEC2.EXPECT().DescribeSubnetsWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(subnetResult, nil)
+
 	retErr := awserr.New("PrivateIpAddressLimitExceeded", "Too many IPs already allocated", nil)
 	mockEC2.EXPECT().CreateNetworkInterfaceWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, retErr)
 
@@ -593,6 +708,7 @@ func TestAllocENIWithPrefixesAlreadyFull(t *testing.T) {
 		imds:                   TypedIMDS{mockMetadata},
 		instanceType:           "c5n.18xlarge",
 		enablePrefixDelegation: true,
+		useSubnetDiscovery:     true,
 	}
 	_, err := cache.AllocENI(true, nil, "", 1)
 	assert.Error(t, err)

--- a/pkg/awsutils/imds.go
+++ b/pkg/awsutils/imds.go
@@ -186,6 +186,19 @@ func (imds TypedIMDS) GetSubnetID(ctx context.Context, mac string) (string, erro
 	return subnetID, err
 }
 
+func (imds TypedIMDS) GetVpcID(ctx context.Context, mac string) (string, error) {
+	key := fmt.Sprintf("network/interfaces/macs/%s/vpc-id", mac)
+	vpcID, err := imds.GetMetadataWithContext(ctx, key)
+	if err != nil {
+		if imdsErr, ok := err.(*imdsRequestError); ok {
+			log.Warnf("%v", err)
+			return vpcID, imdsErr.err
+		}
+		return "", err
+	}
+	return vpcID, err
+}
+
 // GetSecurityGroupIDs returns the IDs of the security groups to which the network interface belongs.
 func (imds TypedIMDS) GetSecurityGroupIDs(ctx context.Context, mac string) ([]string, error) {
 	key := fmt.Sprintf("network/interfaces/macs/%s/security-group-ids", mac)

--- a/pkg/awsutils/imds_test.go
+++ b/pkg/awsutils/imds_test.go
@@ -126,6 +126,17 @@ func TestGetSubnetID(t *testing.T) {
 	}
 }
 
+func TestGetVpcID(t *testing.T) {
+	f := TypedIMDS{FakeIMDS(map[string]interface{}{
+		"network/interfaces/macs/02:c5:f8:3e:6b:27/vpc-id": "vpc-0afaed81bf542db37",
+	})}
+
+	id, err := f.GetVpcID(context.TODO(), "02:c5:f8:3e:6b:27")
+	if assert.NoError(t, err) {
+		assert.Equal(t, id, "vpc-0afaed81bf542db37")
+	}
+}
+
 func TestGetSecurityGroupIDs(t *testing.T) {
 	f := TypedIMDS{FakeIMDS(map[string]interface{}{
 		"network/interfaces/macs/02:c5:f8:3e:6b:27/security-group-ids": "sg-00581e028df71bda8",

--- a/pkg/ec2wrapper/client.go
+++ b/pkg/ec2wrapper/client.go
@@ -36,6 +36,7 @@ type EC2 interface {
 	ModifyNetworkInterfaceAttributeWithContext(ctx aws.Context, input *ec2svc.ModifyNetworkInterfaceAttributeInput, opts ...request.Option) (*ec2svc.ModifyNetworkInterfaceAttributeOutput, error)
 	CreateTagsWithContext(ctx aws.Context, input *ec2svc.CreateTagsInput, opts ...request.Option) (*ec2svc.CreateTagsOutput, error)
 	DescribeNetworkInterfacesPagesWithContext(ctx aws.Context, input *ec2svc.DescribeNetworkInterfacesInput, fn func(*ec2svc.DescribeNetworkInterfacesOutput, bool) bool, opts ...request.Option) error
+	DescribeSubnetsWithContext(ctx aws.Context, input *ec2svc.DescribeSubnetsInput, opts ...request.Option) (*ec2svc.DescribeSubnetsOutput, error)
 }
 
 // New creates a new EC2 wrapper

--- a/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
+++ b/pkg/ec2wrapper/mocks/ec2wrapper_mocks.go
@@ -249,6 +249,26 @@ func (mr *MockEC2MockRecorder) DescribeNetworkInterfacesWithContext(arg0, arg1 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeNetworkInterfacesWithContext), varargs...)
 }
 
+// DescribeSubnetsWithContext mocks base method.
+func (m *MockEC2) DescribeSubnetsWithContext(arg0 context.Context, arg1 *ec2.DescribeSubnetsInput, arg2 ...request.Option) (*ec2.DescribeSubnetsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeSubnetsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSubnetsWithContext indicates an expected call of DescribeSubnetsWithContext.
+func (mr *MockEC2MockRecorder) DescribeSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnetsWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeSubnetsWithContext), varargs...)
+}
+
 // DetachNetworkInterfaceWithContext mocks base method.
 func (m *MockEC2) DetachNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.DetachNetworkInterfaceInput, arg2 ...request.Option) (*ec2.DetachNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()

--- a/test/framework/resources/aws/services/ec2.go
+++ b/test/framework/resources/aws/services/ec2.go
@@ -47,8 +47,9 @@ type EC2 interface {
 	DeleteKey(keyName string) error
 	DescribeKey(keyName string) (*ec2.DescribeKeyPairsOutput, error)
 	ModifyNetworkInterfaceSecurityGroups(securityGroupIds []*string, networkInterfaceId *string) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
-
 	DescribeAvailabilityZones() (*ec2.DescribeAvailabilityZonesOutput, error)
+	CreateTags(resourceIds []string, tags []*ec2.Tag) (*ec2.CreateTagsOutput, error)
+	DeleteTags(resourceIds []string, tags []*ec2.Tag) (*ec2.DeleteTagsOutput, error)
 }
 
 type defaultEC2 struct {
@@ -392,6 +393,22 @@ func (d *defaultEC2) DescribeVPC(vpcID string) (*ec2.DescribeVpcsOutput, error) 
 		VpcIds: aws.StringSlice([]string{vpcID}),
 	}
 	return d.EC2API.DescribeVpcs(describeVPCInput)
+}
+
+func (d *defaultEC2) CreateTags(resourceIds []string, tags []*ec2.Tag) (*ec2.CreateTagsOutput, error) {
+	input := &ec2.CreateTagsInput{
+		Resources: aws.StringSlice(resourceIds),
+		Tags:      tags,
+	}
+	return d.EC2API.CreateTags(input)
+}
+
+func (d *defaultEC2) DeleteTags(resourceIds []string, tags []*ec2.Tag) (*ec2.DeleteTagsOutput, error) {
+	input := &ec2.DeleteTagsInput{
+		Resources: aws.StringSlice(resourceIds),
+		Tags:      tags,
+	}
+	return d.EC2API.DeleteTags(input)
 }
 
 func NewEC2(session *session.Session) EC2 {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -81,6 +81,13 @@ Custom networking tests validate use of the `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG`
 Test info:
   - Pass `custom-networking-cidr-range` flag with *allowed* VPC CIDR that does not conflict with an existing one. So if existing VPC CIDR is `192.168.0.0/16`, you can use `custom-networking-cidr-range=100.64.0.0/16`. You can go to your cluster VPC to check existing/allowed CIDRs.
 
+### ENI Subnet Discovery (eni_subnet_discovery)
+
+The ENI Subnet Discovery test suite validates ENI allocation by making sure the tagged subnet with the largest number of free IPs is selected.
+
+Test info:
+	- Pass `secondary-cidr-range` flag with *allowed* VPC CIDR that does not conflict with an existing one. So if existing VPC CIDR is `192.168.0.0/16`, you can use `secondary-cidr-range=100.64.0.0/16`. You can go to your cluster VPC to check existing/allowed CIDRs.
+
 ### SNAT tests (snat)
 
 SNAT tests cover pod source NAT behavior with various deployment scenarios.

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -1,0 +1,142 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eni_subnet_discovery
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	awsUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws/utils"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCustomNetworking(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CNI ENI Subnet Selection Test Suite")
+}
+
+var (
+	f                      *framework.Framework
+	clusterVPCConfig       *awsUtils.ClusterVPCConfig
+	cidrRangeString        string
+	cidrRange              *net.IPNet
+	cidrBlockAssociationID string
+	createdSubnet          string
+	primaryInstance        *ec2.Instance
+)
+
+// Parse test specific variable from flag
+func init() {
+	flag.StringVar(&cidrRangeString, "secondary-cidr-range", "100.64.0.0/16", "second cidr range to be associated with the VPC")
+}
+
+var _ = BeforeSuite(func() {
+	f = framework.New(framework.GlobalOptions)
+
+	nodeList, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey,
+		f.Options.NgNameLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+	numOfNodes := len(nodeList.Items)
+	Expect(numOfNodes).Should(BeNumerically(">", 1))
+
+	// Nominate the first untainted node as the one to run deployment against
+	By("finding the first untainted node for the deployment")
+	var primaryNode *corev1.Node
+	for _, n := range nodeList.Items {
+		if len(n.Spec.Taints) == 0 {
+			primaryNode = &n
+			break
+		}
+	}
+	Expect(primaryNode).To(Not(BeNil()), "expected to find a non-tainted node")
+
+	instanceID := k8sUtils.GetInstanceIDFromNode(*primaryNode)
+	primaryInstance, err = f.CloudServices.EC2().DescribeInstance(instanceID)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, cidrRange, err = net.ParseCIDR(cidrRangeString)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("creating test namespace")
+	f.K8sResourceManagers.NamespaceManager().CreateNamespace(utils.DefaultTestNamespace)
+
+	By("getting the cluster VPC Config")
+	clusterVPCConfig, err = awsUtils.GetClusterVPCConfig(f)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("associating cidr range to the VPC")
+	association, err := f.CloudServices.EC2().AssociateVPCCIDRBlock(f.Options.AWSVPCID, cidrRange.String())
+	Expect(err).ToNot(HaveOccurred())
+	cidrBlockAssociationID = *association.CidrBlockAssociation.AssociationId
+
+	By(fmt.Sprintf("creating the subnet in %s", *primaryInstance.Placement.AvailabilityZone))
+
+	// Subnet must be greater than /19
+	subnetCidr, err := cidr.Subnet(cidrRange, 2, 0)
+	Expect(err).ToNot(HaveOccurred())
+
+	createSubnetOutput, err := f.CloudServices.EC2().
+		CreateSubnet(subnetCidr.String(), f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
+	Expect(err).ToNot(HaveOccurred())
+
+	subnetID := *createSubnetOutput.Subnet.SubnetId
+
+	By("associating the route table with the newly created subnet")
+	err = f.CloudServices.EC2().AssociateRouteTableToSubnet(clusterVPCConfig.PublicRouteTableID, subnetID)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("try detaching all ENIs by setting WARM_ENI_TARGET to 0")
+	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+		utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
+
+	By("sleeping to allow CNI Plugin to delete unused ENIs")
+	time.Sleep(time.Second * 90)
+
+	createdSubnet = subnetID
+})
+
+var _ = AfterSuite(func() {
+	By("deleting test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
+
+	var errs prometheus.MultiError
+
+	By("sleeping to allow CNI Plugin to delete unused ENIs")
+	time.Sleep(time.Second * 90)
+
+	By(fmt.Sprintf("deleting the subnet %s", createdSubnet))
+	errs.Append(f.CloudServices.EC2().DeleteSubnet(createdSubnet))
+
+	By("disassociating the CIDR range to the VPC")
+	errs.Append(f.CloudServices.EC2().DisAssociateVPCCIDRBlock(cidrBlockAssociationID))
+
+	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred())
+
+	By("by setting WARM_ENI_TARGET to 1")
+	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+		utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "1"})
+})

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
@@ -1,0 +1,331 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eni_subnet_discovery
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
+	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+)
+
+const (
+	podLabelKey     = "role"
+	podLabelVal     = "eni-subnet-discovery-test"
+	AwsNodeLabelKey = "k8s-app"
+	EKSCNIPolicyARN = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+	EKSCNIPolicyV4  = "/testdata/amazon-eks-cni-policy-v4.json"
+)
+
+var err error
+var newEniSubnetIds []string
+
+var _ = Describe("ENI Subnet Selection Test", func() {
+	var (
+		deployment *v1.Deployment
+	)
+
+	Context("when creating deployment", func() {
+		JustBeforeEach(func() {
+			By("creating deployment")
+			container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+				Command([]string{"sleep"}).
+				Args([]string{"3600"}).
+				Build()
+
+			deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+				Container(container).
+				Replicas(50).
+				PodLabel(podLabelKey, podLabelVal).
+				NodeName(*primaryInstance.PrivateDnsName).
+				Build()
+
+			deployment, err = f.K8sResourceManagers.DeploymentManager().
+				CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for deployment to settle, as if any pods restart, their pod IP will change between
+			// the GET and the validation.
+			time.Sleep(5 * time.Second)
+		})
+
+		JustAfterEach(func() {
+			By("deleting deployment")
+			err := f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("sleeping to allow CNI Plugin to delete unused ENIs")
+			time.Sleep(time.Second * 90)
+
+			newEniSubnetIds = nil
+		})
+
+		Context("when subnet discovery is enabled", func() {
+			BeforeEach(func() {
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+					"ENABLE_SUBNET_DISCOVERY": "true",
+				})
+				// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the latest VETH prefix and MTU.
+				// Otherwise, the stale value can cause failures in future test cases.
+				time.Sleep(utils.PollIntervalMedium)
+			})
+			Context("using a subnet tagged with kubernetes.io/role/cni", func() {
+				BeforeEach(func() {
+					By("Tagging kubernetes.io/role/cni to subnet")
+					_, err = f.CloudServices.EC2().
+						CreateTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cni"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					By("Untagging kubernetes.io/role/cni from subnet")
+					_, err = f.CloudServices.EC2().
+						DeleteTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cni"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It(fmt.Sprintf("should have subnet in CIDR range %s", cidrRangeString), func() {
+					checkSecondaryENISubnets(true)
+				})
+
+				Context("missing ec2:DescribeSubnets permission,", func() {
+					var role string
+					var EKSCNIPolicyV4ARN string
+					BeforeEach(func() {
+						By("getting the iam role")
+						podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
+						Expect(err).ToNot(HaveOccurred())
+						for _, env := range podList.Items[0].Spec.Containers[0].Env {
+							if env.Name == "AWS_ROLE_ARN" {
+								role = strings.Split(env.Value, "/")[1]
+							}
+						}
+						if role == "" { // get the node instance role
+							By("getting the node instance role")
+							instanceProfileRoleName := strings.Split(*primaryInstance.IamInstanceProfile.Arn, "instance-profile/")[1]
+							instanceProfileOutput, err := f.CloudServices.IAM().GetInstanceProfile(instanceProfileRoleName)
+							Expect(err).ToNot(HaveOccurred())
+							role = *instanceProfileOutput.InstanceProfile.Roles[0].RoleName
+						}
+						err = f.CloudServices.IAM().DetachRolePolicy(EKSCNIPolicyARN, role)
+						Expect(err).ToNot(HaveOccurred())
+
+						eksCNIPolicyV4Path := utils.GetProjectRoot() + EKSCNIPolicyV4
+						eksCNIPolicyV4Bytes, err := os.ReadFile(eksCNIPolicyV4Path)
+						Expect(err).ToNot(HaveOccurred())
+
+						eksCNIPolicyV4Data := string(eksCNIPolicyV4Bytes)
+
+						By("Creating and attaching policy AmazonEKS_CNI_Policy_V4")
+						output, err := f.CloudServices.IAM().CreatePolicy("AmazonEKS_CNI_Policy_V4", eksCNIPolicyV4Data)
+						Expect(err).ToNot(HaveOccurred())
+						EKSCNIPolicyV4ARN = *output.Policy.Arn
+						err = f.CloudServices.IAM().AttachRolePolicy(EKSCNIPolicyV4ARN, role)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Sleep to allow time for CNI policy reattachment
+						time.Sleep(10 * time.Second)
+
+						RestartAwsNodePods()
+					})
+
+					AfterEach(func() {
+						By("attaching VPC_CNI policy")
+						err = f.CloudServices.IAM().AttachRolePolicy(EKSCNIPolicyARN, role)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Detaching and deleting policy AmazonEKS_CNI_Policy_V4")
+						err = f.CloudServices.IAM().DetachRolePolicy(EKSCNIPolicyV4ARN, role)
+						Expect(err).ToNot(HaveOccurred())
+
+						err = f.CloudServices.IAM().DeletePolicy(EKSCNIPolicyV4ARN)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Sleep to allow time for CNI policy detachment
+						time.Sleep(10 * time.Second)
+
+						RestartAwsNodePods()
+					})
+					It("should have same subnet as primary ENI", func() {
+						checkSecondaryENISubnets(false)
+					})
+				})
+			})
+			Context("using a subnet tagged with kubernetes.io/role/cn", func() {
+				BeforeEach(func() {
+					By("Tagging kubernetes.io/role/cn to subnet")
+					_, err = f.CloudServices.EC2().
+						CreateTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cn"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					By("Untagging kubernetes.io/role/cn from subnet")
+					_, err = f.CloudServices.EC2().
+						DeleteTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cn"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should have same subnet as primary ENI", func() {
+					checkSecondaryENISubnets(false)
+				})
+			})
+		})
+
+		Context("when subnet discovery is disabled", func() {
+			BeforeEach(func() {
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+					"ENABLE_SUBNET_DISCOVERY": "false",
+				})
+				// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the latest VETH prefix and MTU.
+				// Otherwise, the stale value can cause failures in future test cases.
+				time.Sleep(utils.PollIntervalMedium)
+			})
+			AfterEach(func() {
+				// Set ENABLE_SUBNET_DISCOVERY back to true as this is the default behavior going forward.
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+					"ENABLE_SUBNET_DISCOVERY": "true",
+				})
+				// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the latest VETH prefix and MTU.
+				// Otherwise, the stale value can cause failures in future test cases.
+				time.Sleep(utils.PollIntervalMedium)
+			})
+			Context("using a subnet tagged with kubernetes.io/role/cni", func() {
+				BeforeEach(func() {
+					By("Tagging kubernetes.io/role/cni to subnet")
+					_, err = f.CloudServices.EC2().
+						CreateTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cni"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					By("Untagging kubernetes.io/role/cni from subnet")
+					_, err = f.CloudServices.EC2().
+						DeleteTags(
+							[]string{createdSubnet},
+							[]*ec2.Tag{
+								{
+									Key:   aws.String("kubernetes.io/role/cni"),
+									Value: aws.String("1"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should have the same subnets as the primary ENI", func() {
+					checkSecondaryENISubnets(false)
+				})
+			})
+		})
+	})
+})
+
+func checkSecondaryENISubnets(expectNewCidr bool) {
+	instance, err := f.CloudServices.EC2().DescribeInstance(*primaryInstance.InstanceId)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("retrieving secondary ENIs")
+	for _, nwInterface := range instance.NetworkInterfaces {
+		primaryENI := common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress)
+		if !primaryENI {
+			newEniSubnetIds = append(newEniSubnetIds, *nwInterface.SubnetId)
+		}
+	}
+
+	By("verifying at least one new Secondary ENI is created")
+	Expect(len(newEniSubnetIds)).Should(BeNumerically(">", 0))
+
+	vpcOutput, err := f.CloudServices.EC2().DescribeVPC(*primaryInstance.VpcId)
+	Expect(err).ToNot(HaveOccurred())
+
+	expectedCidrRangeString := *vpcOutput.Vpcs[0].CidrBlock
+	expectedCidrSplit := strings.Split(*vpcOutput.Vpcs[0].CidrBlock, "/")
+	expectedSuffix, _ := strconv.Atoi(expectedCidrSplit[1])
+	_, expectedCIDR, _ := net.ParseCIDR(*vpcOutput.Vpcs[0].CidrBlock)
+
+	if expectNewCidr {
+		expectedCidrRangeString = cidrRangeString
+		expectedCidrSplit = strings.Split(cidrRangeString, "/")
+		expectedSuffix, _ = strconv.Atoi(expectedCidrSplit[1])
+		_, expectedCIDR, _ = net.ParseCIDR(cidrRangeString)
+	}
+
+	By(fmt.Sprintf("checking the secondary ENI subnets are in the CIDR %s", expectedCidrRangeString))
+	for _, subnetID := range newEniSubnetIds {
+		subnetOutput, err := f.CloudServices.EC2().DescribeSubnet(subnetID)
+		Expect(err).ToNot(HaveOccurred())
+		cidrSplit := strings.Split(*subnetOutput.Subnets[0].CidrBlock, "/")
+		actualSubnetIp, _, _ := net.ParseCIDR(*subnetOutput.Subnets[0].CidrBlock)
+		Expect(expectedCIDR.Contains(actualSubnetIp))
+		suffix, _ := strconv.Atoi(cidrSplit[1])
+		Expect(suffix).Should(BeNumerically(">=", expectedSuffix))
+	}
+}
+
+func RestartAwsNodePods() {
+	By("Restarting aws-node pods")
+	podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
+	Expect(err).ToNot(HaveOccurred())
+	for _, pod := range podList.Items {
+		f.K8sResourceManagers.PodManager().DeleteAndWaitTillPodDeleted(&pod)
+	}
+}

--- a/testdata/amazon-eks-cni-policy-v4.json
+++ b/testdata/amazon-eks-cni-policy-v4.json
@@ -1,0 +1,31 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:AttachNetworkInterface",
+                "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DescribeInstances",
+                "ec2:DescribeTags",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DetachNetworkInterface",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:UnassignPrivateIpAddresses"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:network-interface/*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
IP exhaustion in IPv4 is a prevalent issue. This PR helps with this by creating ENIs using all subnets in the VPC with the correct tags.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
**Integration**
- CNI: Passing
<img width="408" alt="Screenshot 2024-03-01 at 11 43 18 AM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/8fee7365-3a07-4368-b416-f450f7b64555">

- IPAMD: Passing
<img width="405" alt="Screenshot 2023-12-14 at 2 42 01 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/c633cde3-4d53-47c3-83b3-99b764259a7d">

- Custom Networking: Passing
<img width="394" alt="Screenshot 2023-12-14 at 3 10 57 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/4efc3b26-f409-4859-a4ad-0a8b82790aa1">

- IPv6: Passing
<img width="396" alt="Screenshot 2023-12-15 at 12 17 10 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/948c8a8c-5303-4284-9e02-2df9e512d55b">

- ENI Subnet Selection (New Suite): Passing
<img width="397" alt="Screenshot 2024-03-13 at 4 10 02 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/e6b8abd8-5bae-445b-81a0-54d813a56a54">



**Upgrade/Downgrade**

- Upgrading and downgrading won't break `aws-node` pod
- Older cni version can delete ENIs created from the newer version

**Performance Test**
- 130 Pods
<img width="590" alt="enhanced-subnet-selection-130" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/b180ecec-c3ea-477d-8443-72d5c3078360">

- 730 pods
<img width="580" alt="enhanced-subnet-selection-730" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/cd2ba743-efe3-46f9-a0fc-ad6bc94c6388">

- 5000 pods
<img width="575" alt="enhanced-subnet-selection-5000" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/703b933b-8e3d-49c3-9859-930d3e735671">


**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

Yes

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
All subnets tagged with `kubernetes.io*` or `*cluster-name` will be considered for eni allocation.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
