### PR TITLE
Fix endpoint flag, use $ENDPOINT_OPTION already defined in lib/canary.sh

### DIFF
--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -10,12 +10,9 @@ GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
 # TEST_IMAGE_REGISTRY is the registry in test-infra-* accounts where e2e test images are stored
 TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-"617930562442.dkr.ecr.us-west-2.amazonaws.com"}
 
-# If $ENDPOINT is set, as in it is for beta clusters, then add the --endpoint flag to the ginkgo test command
-ENDPOINT_FLAG=""
-if [ -n "$ENDPOINT" ]; then
-  ENDPOINT_FLAG="--eks-endpoint=$ENDPOINT"
-fi
-
+# If $ENDPOINT is set, as in it is for beta clusters then $ENDPOINT_OPTION,
+# defined in lib/cluster.sh will add --eks-endpoint=$ENDPOINT to the ginkgo
+# test command
 
 source "$SCRIPT_DIR"/lib/cluster.sh
 source "$SCRIPT_DIR"/lib/canary.sh
@@ -32,7 +29,7 @@ function run_ginkgo_test() {
       --ng-name-label-key="kubernetes.io/os" \
       --ng-name-label-val="linux" \
       --test-image-registry=$TEST_IMAGE_REGISTRY \
-      "$ENDPOINT_FLAG")
+      $ENDPOINT_OPTION)
 }
 
 load_cluster_details


### PR DESCRIPTION
**Which issue does this PR fix**:

lib/canary.sh was already defining two variables "ENDPOINT_FLAG" and "ENDPOINT_OPTION" 
and it was confusing another introduction of this flag in this script.

We have to use what is already defined here

https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/lib/canary.sh#L13

Integration test suite uses ENDPOINT_OPTION like this
https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/run-ginkgo-integration-suite.sh#L46



**Testing done on this change**:

- [] Tested in Beta
