### PR TITLE
log for DelNetworkReply now differentiates between IPv4 and IPv6 addr…

### DIFF
--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -229,7 +229,7 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 		ParentIfIndex:   int32(trunkENILinkIndex),
 	}
 
-	log.Infof("Send AddNetworkReply: IPv4Addr %s, IPv6Addr: %s, DeviceNumber: %d, err: %v", ipv4Addr, ipv6Addr, deviceNumber, err)
+	log.Infof("Send AddNetworkReply: IPv4Addr: %s, IPv6Addr: %s, DeviceNumber: %d, err: %v", ipv4Addr, ipv6Addr, deviceNumber, err)
 	return &resp, nil
 }
 
@@ -314,7 +314,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 		}
 	}
 
-	log.Infof("Send DelNetworkReply: IPv4Addr %s, DeviceNumber: %d, err: %v", ip, deviceNumber, err)
+	log.Infof("Send DelNetworkReply: IPv4Addr: %s, IPv6Addr: %s, DeviceNumber: %d, err: %v", ipv4Addr, ipv6Addr, deviceNumber, err)
 
 	return &rpc.DelNetworkReply{Success: err == nil, IPv4Addr: ipv4Addr, IPv6Addr: ipv6Addr, DeviceNumber: int32(deviceNumber)}, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2741

**What does this PR do / Why do we need it**:
Fixes log statement for `DelNetworkReply` to differentiate between `IPv4` and `IPv6` addresses. Also added punctuation to `AddNetworkReply` log statement so that both logging statements follow a similar format

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Below are `ipamd.log` logs showing the modified log statements
```
{"level":"debug","ts":"2024-01-04T23:57:49.484Z","caller":"rpc/rpc.pb.go:713","msg":"VPC V6 CIDR 2600:1f14:324e:1700::/56"}
{"level":"info","ts":"2024-01-04T23:57:49.484Z","caller":"rpc/rpc.pb.go:713","msg":"Send AddNetworkReply: IPv4Addr: , IPv6Addr: 2600:1f14:324e:1700:22df::1, DeviceNumber: 0, err: <nil>"}
{"level":"info","ts":"2024-01-04T23:57:58.316Z","caller":"rpc/rpc.pb.go:731","msg":"Received DelNetwork for Sandbox 65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448"}
{"level":"debug","ts":"2024-01-04T23:57:58.316Z","caller":"rpc/rpc.pb.go:731","msg":"DelNetworkRequest: K8S_POD_NAME:\"nginx-deployment-cd5968d5b-cq8vq\" K8S_POD_NAMESPACE:\"default\" K8S_POD_INFRA_CONTAINER_ID:\"65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448\" Reason:\"PodDeleted\" ContainerID:\"65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448\" IfName:\"eth0\" NetworkName:\"aws-cni\""}
{"level":"debug","ts":"2024-01-04T23:57:58.316Z","caller":"ipamd/rpc_handler.go:260","msg":"UnassignPodIPAddress: IP address pool stats: total 281474976710656, assigned 2, sandbox aws-cni/65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448/eth0"}
{"level":"info","ts":"2024-01-04T23:57:58.316Z","caller":"datastore/data_store.go:1111","msg":"unassignPodIPAddressUnsafe: Unassign IP 2600:1f14:324e:1700:22df::1 from sandbox aws-cni/65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448/eth0"}{"level":"info","ts":"2024-01-04T23:57:58.317Z","caller":"ipamd/rpc_handler.go:260","msg":"UnassignPodIPAddress: sandbox aws-cni/65edae24ac84421bf117c5d1138b62b758c66b2d606da033caf60ca3c880d448/eth0's ipAddr 2600:1f14:324e:1700:22df::1, DeviceNumber 0"}
{"level":"info","ts":"2024-01-04T23:57:58.317Z","caller":"rpc/rpc.pb.go:731","msg":"Send DelNetworkReply: IPv4Addr: , IPv6Addr: 2600:1f14:324e:1700:22df::1, DeviceNumber: 0, err: <nil>"}
```

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
