### PR TITLE
cni-metrics-helper add podAnnotation value

### DIFF
--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters for this chart and their d
 | serviceAccount.name          | The name of the ServiceAccount to use                         | nil                |
 | serviceAccount.create        | Specifies whether a ServiceAccount should be created          | true               |
 | serviceAccount.annotations   | Specifies the annotations for ServiceAccount                  | {}                 |
+| podAnnotations               | Specifies the annotations for pods                            | {}                 |
 | revisionHistoryLimit         | The number of revisions to keep                               | 10                 |
 | podSecurityContext           | SecurityContext to set on the pod                             | {}                 |
 | containerSecurityContext     | SecurityContext to set on the container                       | {}                 |

--- a/charts/cni-metrics-helper/templates/deployment.yaml
+++ b/charts/cni-metrics-helper/templates/deployment.yaml
@@ -12,6 +12,12 @@ spec:
       k8s-app: cni-metrics-helper
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         k8s-app: cni-metrics-helper
     spec:

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -34,3 +34,5 @@ revisionHistoryLimit: 10
 podSecurityContext: {}
 
 containerSecurityContext: {}
+
+podAnnotations: {}


### PR DESCRIPTION
**What type of PR is this?**

feature
cni-metrics-helper add deployment.podAnnotation value

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Allows to add arbitrary annotations to pods (eg DataDog requires specific annotation to scrap Prometheus metrics)


**Testing done on this change**:
manual deploy

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
It changes the deployment/daemonset

**Does this PR introduce any user-facing change?**:
It introduces a new parameter in cni-metrics-helper helm chart (with a default value {} )

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
