### PR TITLE
Publish AZ Metrics from Canary Tests.

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -652,7 +652,11 @@ func (c *IPAMContext) updateIPPoolIfRequired(ctx context.Context) {
 	log.Debugf("IP stats - total IPs: %d, assigned IPs: %d, cooldown IPs: %d", stats.TotalIPs, stats.AssignedIPs, stats.CooldownIPs)
 
 	if datastorePoolTooLow {
-		c.increaseDatastorePool(ctx)
+		// Allow for rapid scale up to decrease time it takes for pod to retrieve an ip
+		// but conservative scale down to account for pod churn
+		for datastorePoolStillTooLow := datastorePoolTooLow; datastorePoolStillTooLow; datastorePoolStillTooLow, _ = c.isDatastorePoolTooLow() {
+			c.increaseDatastorePool(ctx)
+		}
 	} else if c.isDatastorePoolTooHigh(stats) {
 		c.decreaseDatastorePool(decreaseIPPoolInterval)
 	}

--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -29,6 +29,7 @@ function run_ginkgo_test() {
       --ng-name-label-key="kubernetes.io/os" \
       --ng-name-label-val="linux" \
       --test-image-registry=$TEST_IMAGE_REGISTRY \
+      --publish-cw-metrics=true \
       $ENDPOINT_OPTION)
 }
 

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -48,7 +48,7 @@ type Options struct {
 	PublicRouteTableID string
 	NgK8SVersion       string
 	TestImageRegistry  string
-	PublicCWMetrics    bool
+	PublishCWMetrics   bool
 }
 
 func (options *Options) BindFlags() {
@@ -73,7 +73,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.PublicRouteTableID, "public-route-table-id", "", "Public route table ID (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
 	flag.StringVar(&options.NgK8SVersion, "ng-kubernetes-version", "1.25", `Kubernetes version for self-managed node groups (optional, default is "1.25")`)
 	flag.StringVar(&options.TestImageRegistry, "test-image-registry", "617930562442.dkr.ecr.us-west-2.amazonaws.com", `AWS registry where the e2e test images are stored`)
-	flag.BoolVar(&options.PublicCWMetrics, "publish-cw-metrics", false, "Option to publish cloudwatch metrics from the test.")
+	flag.BoolVar(&options.PublishCWMetrics, "publish-cw-metrics", false, "Option to publish cloudwatch metrics from the test.")
 }
 
 func (options *Options) Validate() error {

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	PublicRouteTableID string
 	NgK8SVersion       string
 	TestImageRegistry  string
+	PublicCWMetrics    bool
 }
 
 func (options *Options) BindFlags() {
@@ -72,6 +73,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.PublicRouteTableID, "public-route-table-id", "", "Public route table ID (optional, if specified you must specify all of public/private-subnets, public-route-table-id, and availability-zones)")
 	flag.StringVar(&options.NgK8SVersion, "ng-kubernetes-version", "1.25", `Kubernetes version for self-managed node groups (optional, default is "1.25")`)
 	flag.StringVar(&options.TestImageRegistry, "test-image-registry", "617930562442.dkr.ecr.us-west-2.amazonaws.com", `AWS registry where the e2e test images are stored`)
+	flag.BoolVar(&options.PublicCWMetrics, "publish-cw-metrics", false, "Option to publish cloudwatch metrics from the test.")
 }
 
 func (options *Options) Validate() error {

--- a/test/framework/resources/aws/services/cloudwatch.go
+++ b/test/framework/resources/aws/services/cloudwatch.go
@@ -21,6 +21,7 @@ import (
 
 type CloudWatch interface {
 	GetMetricStatistics(getMetricStatisticsInput *cloudwatch.GetMetricStatisticsInput) (*cloudwatch.GetMetricStatisticsOutput, error)
+	PutMetricData(input *cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error)
 }
 
 type defaultCloudWatch struct {
@@ -35,4 +36,8 @@ func NewCloudWatch(session *session.Session) CloudWatch {
 
 func (d *defaultCloudWatch) GetMetricStatistics(getMetricStatisticsInput *cloudwatch.GetMetricStatisticsInput) (*cloudwatch.GetMetricStatisticsOutput, error) {
 	return d.CloudWatchAPI.GetMetricStatistics(getMetricStatisticsInput)
+}
+
+func (d *defaultCloudWatch) PutMetricData(input *cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error) {
+	return d.CloudWatchAPI.PutMetricData(input)
 }

--- a/test/framework/resources/aws/services/ec2.go
+++ b/test/framework/resources/aws/services/ec2.go
@@ -47,6 +47,8 @@ type EC2 interface {
 	DeleteKey(keyName string) error
 	DescribeKey(keyName string) (*ec2.DescribeKeyPairsOutput, error)
 	ModifyNetworkInterfaceSecurityGroups(securityGroupIds []*string, networkInterfaceId *string) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
+
+	DescribeAvailabilityZones() (*ec2.DescribeAvailabilityZonesOutput, error)
 }
 
 type defaultEC2 struct {
@@ -65,6 +67,11 @@ func (d *defaultEC2) DescribeInstanceType(instanceType string) ([]*ec2.InstanceT
 		return nil, fmt.Errorf("no instance type found in the output %s", instanceType)
 	}
 	return describeInstanceOp.InstanceTypes, nil
+}
+
+func (d *defaultEC2) DescribeAvailabilityZones() (*ec2.DescribeAvailabilityZonesOutput, error) {
+	describeAvailabilityZonesInput := &ec2.DescribeAvailabilityZonesInput{}
+	return d.EC2API.DescribeAvailabilityZones(describeAvailabilityZonesInput)
 }
 
 func (d *defaultEC2) ModifyNetworkInterfaceSecurityGroups(securityGroupIds []*string, networkInterfaceId *string) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -2,6 +2,8 @@ package cni
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"strconv"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
@@ -18,6 +20,8 @@ import (
 var (
 	retries = 3
 )
+
+const MetricNamespace = "NetworkingAZConnectivity"
 
 // Tests pod networking across AZs. It similar to pod connectivity test, but launches a daemonset, so that
 // there is a pod on each node across AZs. It then tests connectivity between pods on different nodes across AZs.
@@ -50,6 +54,9 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 
 		// Map of AZ name, string to pod of testDaemonSet
 		azToTestPod map[string]coreV1.Pod
+
+		// Map of AZ name, string to AZ ID for the account.
+		azToazID map[string]string
 	)
 
 	JustBeforeEach(func() {
@@ -88,7 +95,7 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 
 		Expect(err).ToNot(HaveOccurred())
 
-		azToTestPod = GetAZtoPod(nodes)
+		azToTestPod, azToazID = GetAZMappings(nodes)
 	})
 
 	JustAfterEach(func() {
@@ -128,14 +135,26 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 		})
 
 		It("Should allow TCP traffic across AZs.", func() {
-			CheckConnectivityBetweenPods(azToTestPod, serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
+			CheckConnectivityBetweenPods(azToTestPod, azToazID, serverPort, testerExpectedStdOut, testerExpectedStdErr, testConnectionCommandFunc)
 		})
 	})
 })
 
-func GetAZtoPod(nodes coreV1.NodeList) map[string]coreV1.Pod {
+// Functio to Az to Pod mapping and Az to AZ ID mapping
+func GetAZMappings(nodes coreV1.NodeList) (map[string]coreV1.Pod, map[string]string) {
 	// Map of AZ name to Pod from Daemonset running on nodes
 	azToPod := make(map[string]coreV1.Pod)
+	// Map of AZ name to AZ ID
+	azToazID := make(map[string]string)
+
+	describeAZOutput, err := f.CloudServices.EC2().DescribeAvailabilityZones()
+
+	if err != nil {
+		// Don't fail the test if we can't describe AZs. The failure will be caught by the test
+		// We use describe AZs to get the AZ ID for metrics.
+		fmt.Println("Error while describing AZs", err)
+	}
+
 	for i := range nodes.Items {
 		// node label key "topology.kubernetes.io/zone" is well known label populated by cloud controller manager
 		// guaranteed to be present and represent the AZ name
@@ -149,18 +168,21 @@ func GetAZtoPod(nodes coreV1.NodeList) map[string]coreV1.Pod {
 		if len(interfaceToPodList.PodsOnPrimaryENI) > 0 {
 			azToPod[azName] = interfaceToPodList.PodsOnPrimaryENI[0]
 		}
+
+		azToazID[azName] = *describeAZOutput.AvailabilityZones[i].ZoneId
 	}
-	return azToPod
+	return azToPod, azToazID
 }
 
-var _ = Describe("[STATIC_CANARY2] API Server Connectivity from AZs", FlakeAttempts(retries), func() {
+var _ = Describe("[STATIC_CANARY] API Server Connectivity from AZs", FlakeAttempts(retries), func() {
 
 	var (
 		err           error
 		testDaemonSet *v1.DaemonSet
 
 		// Map of AZ name to Pod of testDaemonSet running on nodes
-		azToPod map[string]coreV1.Pod
+		azToPod  map[string]coreV1.Pod
+		azToazID map[string]string
 	)
 
 	JustBeforeEach(func() {
@@ -190,7 +212,8 @@ var _ = Describe("[STATIC_CANARY2] API Server Connectivity from AZs", FlakeAttem
 		nodes, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 		Expect(err).ToNot(HaveOccurred())
 
-		azToPod = GetAZtoPod(nodes)
+		azToPod, azToazID = GetAZMappings(nodes)
+
 	})
 
 	JustAfterEach(func() {
@@ -208,21 +231,22 @@ var _ = Describe("[STATIC_CANARY2] API Server Connectivity from AZs", FlakeAttem
 			APIServerNLBEndpoint := fmt.Sprintf("%s/api", *describeClusterOutput.Cluster.Endpoint)
 			APIServerInternalEndpoint := "https://kubernetes.default.svc/api"
 
-			CheckAPIServerConnectivityFromPods(azToPod, APIServerInternalEndpoint)
+			CheckAPIServerConnectivityFromPods(azToPod, azToazID, APIServerInternalEndpoint)
 
-			CheckAPIServerConnectivityFromPods(azToPod, APIServerNLBEndpoint)
+			CheckAPIServerConnectivityFromPods(azToPod, azToazID, APIServerNLBEndpoint)
 		})
 
 	})
 })
 
-func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, api_server_url string) {
+func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, azToazId map[string]string, api_server_url string) {
 	// Standard paths for SA token, CA cert and API Server URL
 	token_path := "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	cacert := "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	const MetricName = "APIServerConnectivity"
 
 	for az := range azToPod {
-		fmt.Printf("Testing API Server %s Connectivity from AZ %s \n", api_server_url, az)
+		fmt.Printf("Testing API Server %s Connectivity from AZ %s  AZID %s \n", api_server_url, az, azToazId[az])
 		sa_token := []string{"cat", token_path}
 		token_value, _, err := RunCommandOnPod(azToPod[az], sa_token)
 
@@ -240,19 +264,59 @@ func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, api_serve
 		Expect(api_server_stdout).ToNot(BeEmpty())
 		Expect(api_server_stdout).To(ContainSubstring("APIVersions"))
 		fmt.Printf("API Server %s Connectivity from AZ %s was successful.\n", api_server_url, az)
+
+		putmetricData := cloudwatch.PutMetricDataInput{
+			Namespace: aws.String(MetricNamespace),
+			MetricData: []*cloudwatch.MetricDatum{
+				{
+					MetricName: aws.String(MetricName),
+					Unit:       aws.String("Count"),
+					Value:      aws.Float64(1),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("AZID"),
+							Value: aws.String(azToazId[az]),
+						},
+					},
+				},
+			},
+		}
+
+		_, err = f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", az))
 	}
 }
 
-func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, port int, testerExpectedStdOut string, testerExpectedStdErr string, getTestCommandFunc func(serverPod coreV1.Pod, port int) []string) {
+func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, azToazId map[string]string, port int, testerExpectedStdOut string, testerExpectedStdErr string, getTestCommandFunc func(serverPod coreV1.Pod, port int) []string) {
+	const MetricName = "InterAZConnectivity"
 
 	By("checking connection on same node, primary to primary")
 
 	for az1 := range azToPod {
 		for az2 := range azToPod {
 			if az1 != az2 {
-				fmt.Printf("Testing Connectivity from Pod IP1 %s (%s) to Pod IP2 %s (%s) \n",
-					azToPod[az1].Status.PodIP, az1, azToPod[az2].Status.PodIP, az2)
+				fmt.Printf("Testing Connectivity from Pod IP1 %s (%s, %s) to Pod IP2 %s (%s, %s) \n",
+					azToPod[az1].Status.PodIP, az1, azToazId[az1], azToPod[az2].Status.PodIP, az2, azToazId[az2])
 				testConnectivity(azToPod[az1], azToPod[az2], testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
+
+				putmetricData := cloudwatch.PutMetricDataInput{
+					Namespace: aws.String(MetricNamespace),
+					MetricData: []*cloudwatch.MetricDatum{
+						{
+							MetricName: aws.String(MetricName),
+							Unit:       aws.String("Count"),
+							Value:      aws.Float64(1),
+							Dimensions: []*cloudwatch.Dimension{
+								{
+									Name:  aws.String("AZID"),
+									Value: aws.String(azToazId[az1]),
+								},
+							},
+						},
+					},
+				}
+				_, err := f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
+				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", azToazId[az1]))
 			}
 		}
 	}

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -2,9 +2,10 @@ package cni
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"strconv"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -266,7 +266,7 @@ func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, azToazId 
 		Expect(api_server_stdout).To(ContainSubstring("APIVersions"))
 		fmt.Printf("API Server %s Connectivity from AZ %s was successful.\n", api_server_url, az)
 
-		if f.Options.PublicCWMetrics {
+		if f.Options.PublishCWMetrics {
 			putmetricData := cloudwatch.PutMetricDataInput{
 				Namespace: aws.String(MetricNamespace),
 				MetricData: []*cloudwatch.MetricDatum{
@@ -302,7 +302,7 @@ func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, azToazId map[st
 					azToPod[az1].Status.PodIP, az1, azToazId[az1], azToPod[az2].Status.PodIP, az2, azToazId[az2])
 				testConnectivity(azToPod[az1], azToPod[az2], testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
 
-				if f.Options.PublicCWMetrics {
+				if f.Options.PublishCWMetrics {
 					putmetricData := cloudwatch.PutMetricDataInput{
 						Namespace: aws.String(MetricNamespace),
 						MetricData: []*cloudwatch.MetricDatum{

--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -266,25 +266,27 @@ func CheckAPIServerConnectivityFromPods(azToPod map[string]coreV1.Pod, azToazId 
 		Expect(api_server_stdout).To(ContainSubstring("APIVersions"))
 		fmt.Printf("API Server %s Connectivity from AZ %s was successful.\n", api_server_url, az)
 
-		putmetricData := cloudwatch.PutMetricDataInput{
-			Namespace: aws.String(MetricNamespace),
-			MetricData: []*cloudwatch.MetricDatum{
-				{
-					MetricName: aws.String(MetricName),
-					Unit:       aws.String("Count"),
-					Value:      aws.Float64(1),
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("AZID"),
-							Value: aws.String(azToazId[az]),
+		if f.Options.PublicCWMetrics {
+			putmetricData := cloudwatch.PutMetricDataInput{
+				Namespace: aws.String(MetricNamespace),
+				MetricData: []*cloudwatch.MetricDatum{
+					{
+						MetricName: aws.String(MetricName),
+						Unit:       aws.String("Count"),
+						Value:      aws.Float64(1),
+						Dimensions: []*cloudwatch.Dimension{
+							{
+								Name:  aws.String("AZID"),
+								Value: aws.String(azToazId[az]),
+							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		_, err = f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", az))
+			_, err = f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
+			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", az))
+		}
 	}
 }
 
@@ -300,24 +302,26 @@ func CheckConnectivityBetweenPods(azToPod map[string]coreV1.Pod, azToazId map[st
 					azToPod[az1].Status.PodIP, az1, azToazId[az1], azToPod[az2].Status.PodIP, az2, azToazId[az2])
 				testConnectivity(azToPod[az1], azToPod[az2], testerExpectedStdOut, testerExpectedStdErr, port, getTestCommandFunc)
 
-				putmetricData := cloudwatch.PutMetricDataInput{
-					Namespace: aws.String(MetricNamespace),
-					MetricData: []*cloudwatch.MetricDatum{
-						{
-							MetricName: aws.String(MetricName),
-							Unit:       aws.String("Count"),
-							Value:      aws.Float64(1),
-							Dimensions: []*cloudwatch.Dimension{
-								{
-									Name:  aws.String("AZID"),
-									Value: aws.String(azToazId[az1]),
+				if f.Options.PublicCWMetrics {
+					putmetricData := cloudwatch.PutMetricDataInput{
+						Namespace: aws.String(MetricNamespace),
+						MetricData: []*cloudwatch.MetricDatum{
+							{
+								MetricName: aws.String(MetricName),
+								Unit:       aws.String("Count"),
+								Value:      aws.Float64(1),
+								Dimensions: []*cloudwatch.Dimension{
+									{
+										Name:  aws.String("AZID"),
+										Value: aws.String(azToazId[az1]),
+									},
 								},
 							},
 						},
-					},
+					}
+					_, err := f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
+					Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", azToazId[az1]))
 				}
-				_, err := f.CloudServices.CloudWatch().PutMetricData(&putmetricData)
-				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error while putting metric data for API Server Connectivity from %s", azToazId[az1]))
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

Canary Tests exercise API Server Connectivity and Inter AZ communication from pods from various AZs.  We want to capture the AZ Metrics from various AZs.

*This is test only metrics and local only to the tests* There is no user impact with this change. This publishes AZ level metrics from the test.  The metrics will use AZ_ID to publish the connectivity Result. There will be two MetricNames  `"APIServerConnectivity"`, and `"InterAZConnectivity"` published in the namespace - `"NetworkingAZConnectivity"`

**Testing done on this change**:

![2024-01-15_17-22](https://github.com/aws/amazon-vpc-cni-k8s/assets/332330/bc129f73-ee1b-42ac-bfcf-d5daf2dea9c7)

```
Will run 2 of 17 specs
------------------------------
[BeforeSuite]
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_networking_suite_test.go:47
  STEP: creating test namespace @ 01/15/24 17:09:22.389
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 01/15/24 17:09:22.489
  STEP: verifying more than 1 nodes are present for the test @ 01/15/24 17:09:22.642
  STEP: getting the instance type from node label beta.kubernetes.io/instance-type @ 01/15/24 17:09:22.997
  STEP: getting the network interface details from ec2 @ 01/15/24 17:09:22.997
  STEP: describing the VPC to get the VPC CIDRs @ 01/15/24 17:09:23.062
  STEP: setting the environment variables on the ds to map[WARM_ENI_TARGET:0 WARM_IP_TARGET:3] @ 01/15/24 17:09:23.131
  STEP: getting the aws-node daemon set in namespace kube-system @ 01/15/24 17:09:23.131
  STEP: updating the daemon set with new environment variable @ 01/15/24 17:09:23.266
[BeforeSuite] PASSED [12.956 seconds]
------------------------------
SSS
------------------------------
[STATIC_CANARY] API Server Connectivity from AZs While testing API Server Connectivity Should connect to the API Server
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:228
  STEP: creating a server DaemonSet on primary node @ 01/15/24 17:09:33.383
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 01/15/24 17:09:35.442
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c  AZID usw2-az3
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a  AZID usw2-az2
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b  AZID usw2-az1
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2c  AZID usw2-az3
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2c was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2a  AZID usw2-az2
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2b  AZID usw2-az1
API Server https://757CBE67CE5FA5DC0BEA97AF921AADAE.gr7.us-west-2.eks.amazonaws.com/api Connectivity from AZ us-west-2b was successful.
  STEP: Deleting the Daemonset. @ 01/15/24 17:09:41.801
• [10.475 seconds]
------------------------------
SSSSS
------------------------------
[STATIC_CANARY] test pod networking While testing connectivity across AZ Should allow TCP traffic across AZs.
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_traffic_across_az_test.go:137
  STEP: authorizing security group ingress on instance security group @ 01/15/24 17:09:43.858
  STEP: authorizing security group egress on instance security group @ 01/15/24 17:09:44.129
  STEP: creating a server DaemonSet on primary node @ 01/15/24 17:09:44.38
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 01/15/24 17:09:46.428
  STEP: checking connection on same node, primary to primary @ 01/15/24 17:09:46.966
Testing Connectivity from Pod IP1 192.168.55.37 (us-west-2b, usw2-az1) to Pod IP2 192.168.4.74 (us-west-2a, usw2-az2)
  verifying connectivity from pod netcat-daemonset-ktf8l on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.55.37 to pod netcat-daemonset-zjx6z on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.4.74
  stdout:  and stderr: Connection to 192.168.4.74 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.55.37 (us-west-2b, usw2-az1) to Pod IP2 192.168.95.123 (us-west-2c, usw2-az3)
  verifying connectivity from pod netcat-daemonset-ktf8l on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.55.37 to pod netcat-daemonset-2zjqv on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.95.123
  stdout:  and stderr: Connection to 192.168.95.123 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.95.123 (us-west-2c, usw2-az3) to Pod IP2 192.168.4.74 (us-west-2a, usw2-az2)
  verifying connectivity from pod netcat-daemonset-2zjqv on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.95.123 to pod netcat-daemonset-zjx6z on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.4.74
  stdout:  and stderr: Connection to 192.168.4.74 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.95.123 (us-west-2c, usw2-az3) to Pod IP2 192.168.55.37 (us-west-2b, usw2-az1)
  verifying connectivity from pod netcat-daemonset-2zjqv on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.95.123 to pod netcat-daemonset-ktf8l on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.55.37
  stdout:  and stderr: Connection to 192.168.55.37 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.4.74 (us-west-2a, usw2-az2) to Pod IP2 192.168.55.37 (us-west-2b, usw2-az1)
  verifying connectivity from pod netcat-daemonset-zjx6z on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.4.74 to pod netcat-daemonset-ktf8l on node ip-192-168-33-162.us-west-2.compute.internal with IP 192.168.55.37
  stdout:  and stderr: Connection to 192.168.55.37 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.4.74 (us-west-2a, usw2-az2) to Pod IP2 192.168.95.123 (us-west-2c, usw2-az3)
  verifying connectivity from pod netcat-daemonset-zjx6z on node ip-192-168-20-49.us-west-2.compute.internal with IP 192.168.4.74 to pod netcat-daemonset-2zjqv on node ip-192-168-88-55.us-west-2.compute.internal with IP 192.168.95.123
  stdout:  and stderr: Connection to 192.168.95.123 2273 port [tcp/*] succeeded!

  STEP: revoking security group ingress on instance security group @ 01/15/24 17:10:01.454
  STEP: revoking security group egress on instance security group @ 01/15/24 17:10:01.74
  STEP: deleting the Daemonset. @ 01/15/24 17:10:02.033
• [18.237 seconds]
------------------------------
SSSSSSS
------------------------------
[AfterSuite]
/Users/senthilx/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_networking_suite_test.go:111
  STEP: deleting test namespace @ 01/15/24 17:10:02.096
  STEP: update environment variables map[AWS_VPC_ENI_MTU:9001 AWS_VPC_K8S_CNI_VETHPREFIX:eni], remove map[IP_COOLDOWN_PERIOD:{} WARM_ENI_TARGET:{} WARM_IP_TARGET:{}] @ 01/15/24 17:10:08.261
  STEP: getting the aws-node daemon set in namespace kube-system @ 01/15/24 17:10:08.261
  STEP: updating the daemon set with new environment variable @ 01/15/24 17:10:08.261
[AfterSuite] PASSED [18.547 seconds]
------------------------------

Ran 2 of 17 Specs in 60.216 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 15 Skipped
PASS
```