### PR TITLE
Enable ENABLE_V6_EGRESS on Clusters with Mixed IPv6/IPv4 Subnets

### DIFF
--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -270,8 +270,8 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		if egressEnabled {
 			nodeIP, err = getPrimaryIP(false)
 			if err != nil {
-				log.Errorf("To support IPv6 egress, node primary ENI must have a global IPv6 address, error: %v", err)
-				return err
+				log.Warnf("To support IPv6 egress, node primary ENI must have a global IPv6 address, error: %v", err)
+				egressEnabled = false
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Today, the inability to enable ENABLE_V6_EGRESS on clusters with both IPv6 and IPv4 subnets is addressed in this PR. This enhancement allows for the coexistence of nodes operating exclusively on IPv6, where pods can utilize IPv6 egress, alongside nodes functioning solely on IPv4 without ENABLE_V6_EGRESS being active. This integration enhances network flexibility and functionality.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

**Will this PR introduce any new dependencies?**:
N/A

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

If this change does not work with a "kubectl patch" of the image tag, please explain why.
No

**Does this PR introduce any user-facing change?**:


```release-note
Enable ENABLE_V6_EGRESS on Clusters with Mixed IPv6/IPv4 Subnets
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
