### PR TITLE
Change pause images to ecr mirror

### DIFF
--- a/testdata/deploy-130-pods.yaml
+++ b/testdata/deploy-130-pods.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: hello
-          image: registry.k8s.io/pause:latest
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.9
           ports:
             - name: http
               containerPort: 80

--- a/testdata/deploy-5000-pods.yaml
+++ b/testdata/deploy-5000-pods.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: hello
-          image: registry.k8s.io/pause:latest
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.9
           ports:
             - name: http
               containerPort: 80

--- a/testdata/deploy-730-pods.yaml
+++ b/testdata/deploy-730-pods.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: hello
-          image: registry.k8s.io/pause:latest
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.9
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

enhancement

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Using the k8s registry will result in throttling when spinning up hundreds of pods. Switching to the ecr mirror will remove this throttling and improve performance test speeds.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Tested 130, 730, and 5000 pods.

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
