### PR TITLE
revert CNI spec to 0.4.0 [master]

### DIFF
--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -1,5 +1,5 @@
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "0.4.0",
   "name": "aws-cni",
   "disableCheck": true,
   "plugins": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
revert
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR reverts the VPC CNI spec to CNI spec 0.4.0. This is done so that the compatibility with older EKS versions can be preserved for longer. There are no backward incompatibility issues with this revert.

This PR copies https://github.com/aws/amazon-vpc-cni-k8s/pull/2757

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Manually verified that integration tests and upgrade/downgrade tests pass.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Set CNI spec back to 0.4.0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
