### PR TITLE
Add 50Mi memory requests for aws-node pod; update chart README

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -158,6 +158,7 @@ readinessProbeTimeoutSeconds: 10
 resources:
   requests:
     cpu: 25m
+    memory: 50Mi
 
 updateStrategy:
   type: RollingUpdate

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -395,6 +395,7 @@ spec:
         resources:
             requests:
               cpu: 25m
+              memory: 50Mi
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -483,6 +484,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:
@@ -518,6 +520,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -395,6 +395,7 @@ spec:
         resources:
             requests:
               cpu: 25m
+              memory: 50Mi
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -483,6 +484,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:
@@ -518,6 +520,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -395,6 +395,7 @@ spec:
         resources:
             requests:
               cpu: 25m
+              memory: 50Mi
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -483,6 +484,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:
@@ -518,6 +520,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -395,6 +395,7 @@ spec:
         resources:
             requests:
               cpu: 25m
+              memory: 50Mi
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -483,6 +484,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:
@@ -518,6 +520,7 @@ spec:
           resources:
             requests:
               cpu: 25m
+              memory: 50Mi
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds a 50Mi memory request field to the `aws-node` pod. Note that this request applies to the init container, main container, and network policy agent container by default.

This change is made for two reasons:
1. It is good practice to specify CPU and memory requests
2. This help node autoscalers like Karpenter avoid selecting instance sizes that are too small for pods to run on.

This PR also updates the README in the `aws-vpc-cni` helm chart to provide instructions on how to set the field manager to helm when installing the chart. Since Kubernetes recommends using server-side apply, the README uses it to apply the rendered helm chart.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Manually verified that the requests apply
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
Yes
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Specify 50Mi memory request for containers in the aws-vpc-cni helm chart.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
