### PR TITLE
Updating cache sync interval for daemonset from 5 secs to 20 secs in tests

### DIFF
--- a/test/framework/resources/k8s/resources/daemonset.go
+++ b/test/framework/resources/k8s/resources/daemonset.go
@@ -52,7 +52,7 @@ func (d *defaultDaemonSetManager) CreateAndWaitTillDaemonSetIsReady(daemonSet *v
 	}
 
 	// Allow for the cache to sync
-	time.Sleep(utils.PollIntervalShort)
+	time.Sleep(utils.PollIntervalLong)
 
 	err = d.CheckIfDaemonSetIsReady(daemonSet.Namespace, daemonSet.Name)
 	if err != nil {


### PR DESCRIPTION
* Updating cache sync interval for daemonset from 5 secs to 20 secs in tests

In certain test runs, I observed that the test had failed with daemonset not completely ready. (1 out of 10, depending on the region).

```
/repository/vpc-cni/test/integration/cni/pod_traffic_across_az_test.go:229

  [FAILED] failed to get SA token for pod in us-west-2b
  Unexpected error:
      <*errors.errorString | 0xc000e2df70>:
      unable to upgrade connection: container not found ("curl")
      {
          s: "unable to upgrade connection: container not found (\"curl\")",
      }
  occurred
  In [It] at: /repository/vpc-cni/test/integration/cni/pod_traffic_across_az_test.go:254 @ 01/22/24 15:40:17.41
```

* Modifying wait go 20 secs; so that cache is synced.

* I wanted to modify the polling period from Medium to Long, but prefer making one change a a time for sync intervals.
* 

**What type of PR is this?**

test fixes.

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:

* Ran tests with the change continuously and did not notice any errors. 