### PR TITLE
Fix the AZ name to AZ ID mapping in tests.

### DIFF
--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -141,7 +141,7 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	})
 })
 
-// Functio to Az to Pod mapping and Az to AZ ID mapping
+// Function for AZ to Pod mapping and AZ to AZ ID mapping
 func GetAZMappings(nodes coreV1.NodeList) (map[string]coreV1.Pod, map[string]string) {
 	// Map of AZ name to Pod from Daemonset running on nodes
 	azToPod := make(map[string]coreV1.Pod)
@@ -149,6 +149,11 @@ func GetAZMappings(nodes coreV1.NodeList) (map[string]coreV1.Pod, map[string]str
 	azToazID := make(map[string]string)
 
 	describeAZOutput, err := f.CloudServices.EC2().DescribeAvailabilityZones()
+
+	// iterate describe AZ output and populate AZ name to AZ ID mapping
+	for _, az := range describeAZOutput.AvailabilityZones {
+		azToazID[*az.ZoneName] = *az.ZoneId
+	}
 
 	if err != nil {
 		// Don't fail the test if we can't describe AZs. The failure will be caught by the test
@@ -170,7 +175,6 @@ func GetAZMappings(nodes coreV1.NodeList) (map[string]coreV1.Pod, map[string]str
 			azToPod[azName] = interfaceToPodList.PodsOnPrimaryENI[0]
 		}
 
-		azToazID[azName] = *describeAZOutput.AvailabilityZones[i].ZoneId
 	}
 	return azToPod, azToazID
 }


### PR DESCRIPTION
Fix the AZ name to AZ ID mapping in tests.

* Don't rely on node index, which is an independent entity.


There is a mistake in the code, which node index to get the AZ name to AZ ID mapping. This works only by accident.

If we have 3+ nodes in a cluster in us-west-1 region, this will fail as the us-west-1 has only two default AZs.

```
$ aws ec2 describe-availability-zones --region us-west-1
{
    "AvailabilityZones": [
        {
            "State": "available",
            "OptInStatus": "opt-in-not-required",
            "Messages": [],
            "RegionName": "us-west-1",
            "ZoneName": "us-west-1a",
            "ZoneId": "usw1-az1",
            "GroupName": "us-west-1",
            "NetworkBorderGroup": "us-west-1",
            "ZoneType": "availability-zone"
        },
        {
            "State": "available",
            "OptInStatus": "opt-in-not-required",
            "Messages": [],
            "RegionName": "us-west-1",
            "ZoneName": "us-west-1c",
            "ZoneId": "usw1-az3",
            "GroupName": "us-west-1",
            "NetworkBorderGroup": "us-west-1",
            "ZoneType": "availability-zone"
        }
    ]
}
```

This failure was observed in internal tests, and PR fixes this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
