### PR TITLE
Fix max eni limit for multicard

### DIFF
--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -59,6 +59,13 @@ func GetENILimit(instanceType string) (int, error) {
 		log.Errorf("%s: %s", instanceType, ErrInstanceTypeNotExist)
 		return -1, ErrInstanceTypeNotExist
 	}
+	if len(instance.NetworkCards) > 1 {
+		eniLimit := 0
+		for _, networkCards := range instance.NetworkCards {
+			eniLimit = eniLimit + int(networkCards.MaximumNetworkInterfaces)
+		}
+		return eniLimit, nil
+	}
 	return instance.ENILimit, nil
 }
 

--- a/pkg/vpc/vpc_test.go
+++ b/pkg/vpc/vpc_test.go
@@ -30,6 +30,10 @@ func TestGetENILimit(t *testing.T) {
 	eniLimit, err = GetENILimit("a1.4xlarge")
 	assert.Equal(t, eniLimit, 8)
 	assert.NoError(t, err)
+
+	eniLimit, err = GetENILimit("p5.48xlarge")
+	assert.Equal(t, eniLimit, 64)
+	assert.NoError(t, err)
 }
 
 func TestGetIPv4Limit(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
When using an instance type with multi-card, CNI will be unable to create new ENIs since our `GetENILimit` function currently only checks the max ENIs for a singular network card.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Only ran units tests

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
