### PR TITLE
Ignore non-zero cards

### DIFF
--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -252,7 +252,7 @@ func TestAWSGetFreeDeviceNumberNoDevice(t *testing.T) {
 	for i := 0; i < maxENIs; i++ {
 		var deviceNums [maxENIs]int64
 		deviceNums[i] = int64(i)
-		ec2ENI := &ec2.InstanceNetworkInterface{Attachment: &ec2.InstanceNetworkInterfaceAttachment{DeviceIndex: &deviceNums[i]}}
+		ec2ENI := &ec2.InstanceNetworkInterface{Attachment: &ec2.InstanceNetworkInterfaceAttachment{DeviceIndex: &deviceNums[i], NetworkCardIndex: aws.Int64(0)}}
 		ec2ENIs = append(ec2ENIs, ec2ENI)
 	}
 	result := &ec2.DescribeInstancesOutput{
@@ -426,7 +426,7 @@ func TestAllocENINoFreeDevice(t *testing.T) {
 	for i := 0; i < maxENIs; i++ {
 		var deviceNums [maxENIs]int64
 		deviceNums[i] = int64(i)
-		ec2ENI := &ec2.InstanceNetworkInterface{Attachment: &ec2.InstanceNetworkInterfaceAttachment{DeviceIndex: &deviceNums[i]}}
+		ec2ENI := &ec2.InstanceNetworkInterface{Attachment: &ec2.InstanceNetworkInterfaceAttachment{DeviceIndex: &deviceNums[i], NetworkCardIndex: aws.Int64(0)}}
 		ec2ENIs = append(ec2ENIs, ec2ENI)
 	}
 	result := &ec2.DescribeInstancesOutput{

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -23,6 +23,7 @@ import (
 	reflect "reflect"
 
 	awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
+	vpc "github.com/aws/amazon-vpc-cni-k8s/pkg/vpc"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -324,6 +325,20 @@ func (mr *MockAPIsMockRecorder) GetLocalIPv4() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalIPv4", reflect.TypeOf((*MockAPIs)(nil).GetLocalIPv4))
 }
 
+// GetNetworkCards mocks base method.
+func (m *MockAPIs) GetNetworkCards() []vpc.NetworkCard {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkCards")
+	ret0, _ := ret[0].([]vpc.NetworkCard)
+	return ret0
+}
+
+// GetNetworkCards indicates an expected call of GetNetworkCards.
+func (mr *MockAPIsMockRecorder) GetNetworkCards() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkCards", reflect.TypeOf((*MockAPIs)(nil).GetNetworkCards))
+}
+
 // GetPrimaryENI mocks base method.
 func (m *MockAPIs) GetPrimaryENI() string {
 	m.ctrl.T.Helper()
@@ -394,18 +409,18 @@ func (mr *MockAPIsMockRecorder) InitCachedPrefixDelegation(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitCachedPrefixDelegation", reflect.TypeOf((*MockAPIs)(nil).InitCachedPrefixDelegation), arg0)
 }
 
-// IsCNIUnmanagedENI mocks base method.
-func (m *MockAPIs) IsCNIUnmanagedENI(arg0 string) bool {
+// IsMultiCardENI mocks base method.
+func (m *MockAPIs) IsMultiCardENI(arg0 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsCNIUnmanagedENI", arg0)
+	ret := m.ctrl.Call(m, "IsMultiCardENI", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsCNIUnmanagedENI indicates an expected call of IsCNIUnmanagedENI.
-func (mr *MockAPIsMockRecorder) IsCNIUnmanagedENI(arg0 interface{}) *gomock.Call {
+// IsMultiCardENI indicates an expected call of IsMultiCardENI.
+func (mr *MockAPIsMockRecorder) IsMultiCardENI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCNIUnmanagedENI", reflect.TypeOf((*MockAPIs)(nil).IsCNIUnmanagedENI), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMultiCardENI", reflect.TypeOf((*MockAPIs)(nil).IsMultiCardENI), arg0)
 }
 
 // IsPrefixDelegationSupported mocks base method.
@@ -464,18 +479,18 @@ func (mr *MockAPIsMockRecorder) RefreshSGIDs(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSGIDs", reflect.TypeOf((*MockAPIs)(nil).RefreshSGIDs), arg0)
 }
 
-// SetCNIUnmanagedENIs mocks base method.
-func (m *MockAPIs) SetCNIUnmanagedENIs(arg0 []string) error {
+// SetMultiCardENIs mocks base method.
+func (m *MockAPIs) SetMultiCardENIs(arg0 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCNIUnmanagedENIs", arg0)
+	ret := m.ctrl.Call(m, "SetMultiCardENIs", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetCNIUnmanagedENIs indicates an expected call of SetCNIUnmanagedENIs.
-func (mr *MockAPIsMockRecorder) SetCNIUnmanagedENIs(arg0 interface{}) *gomock.Call {
+// SetMultiCardENIs indicates an expected call of SetMultiCardENIs.
+func (mr *MockAPIsMockRecorder) SetMultiCardENIs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCNIUnmanagedENIs", reflect.TypeOf((*MockAPIs)(nil).SetCNIUnmanagedENIs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultiCardENIs", reflect.TypeOf((*MockAPIs)(nil).SetMultiCardENIs), arg0)
 }
 
 // SetUnmanagedENIs mocks base method.

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -144,8 +144,8 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().IsUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eni1.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eni2.ENIID).Return(false).AnyTimes()
 
 	primaryIP := net.ParseIP(ipaddr01)
 	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs, nil)
@@ -166,7 +166,7 @@ func TestNodeInit(t *testing.T) {
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp.MultiCardENIIDs).AnyTimes()
 	m.awsutils.EXPECT().GetLocalIPv4().Return(primaryIP)
 
 	var rules []netlink.Rule
@@ -234,8 +234,8 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().IsUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni2.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eni1.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eni2.ENIID).Return(false).AnyTimes()
 
 	primaryIP := net.ParseIP(ipaddr01)
 	m.awsutils.EXPECT().GetVPCIPv4CIDRs().AnyTimes().Return(cidrs, nil)
@@ -256,7 +256,7 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, secSubnet)
 
 	m.awsutils.EXPECT().GetLocalIPv4().Return(primaryIP)
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp.MultiCardENIIDs).AnyTimes()
 
 	var rules []netlink.Rule
 	m.network.EXPECT().GetRuleList().Return(rules, nil)
@@ -317,7 +317,7 @@ func TestNodeInitwithPDenabledIPv6Mode(t *testing.T) {
 	var cidrs []string
 	m.awsutils.EXPECT().IsUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
 	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eni1.ENIID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eni1.ENIID).Return(false).AnyTimes()
 
 	primaryIP := net.ParseIP(ipaddr01)
 	m.network.EXPECT().SetupHostNetwork(cidrs, eni1.MAC, &primaryIP, false, false, true).Return(nil)
@@ -336,7 +336,7 @@ func TestNodeInitwithPDenabledIPv6Mode(t *testing.T) {
 	}
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 	m.awsutils.EXPECT().GetLocalIPv4().Return(primaryIP)
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp.MultiCardENIIDs).AnyTimes()
 
 	fakeNode := v1.Node{
 		TypeMeta:   metav1.TypeMeta{Kind: "Node"},
@@ -902,7 +902,7 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	// Always the primary ENI
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
 	m.awsutils.EXPECT().IsUnmanagedENI(primaryENIid).AnyTimes().Return(false)
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(primaryENIid).AnyTimes().Return(false)
+	m.awsutils.EXPECT().IsMultiCardENI(primaryENIid).AnyTimes().Return(false)
 	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
@@ -915,7 +915,7 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	}
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp.MultiCardENIIDs).AnyTimes()
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 
 	curENIs := mockContext.dataStore.GetENIInfos()
@@ -952,7 +952,7 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	// Two ENIs found
 	m.awsutils.EXPECT().GetAttachedENIs().Return(twoENIs, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(secENIid).Times(2).Return(false)
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(secENIid).Times(2).Return(false)
+	m.awsutils.EXPECT().IsMultiCardENI(secENIid).Times(2).Return(false)
 	resp2 := awsutils.DescribeAllENIsResult{
 		ENIMetadata:     twoENIs,
 		TagMap:          map[string]awsutils.TagMap{},
@@ -962,7 +962,7 @@ func TestNodeIPPoolReconcile(t *testing.T) {
 	}
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp2, nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet)
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp2.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp2.MultiCardENIIDs).AnyTimes()
 
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 
@@ -1002,7 +1002,7 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 	// Always the primary ENI
 	m.awsutils.EXPECT().GetPrimaryENI().AnyTimes().Return(primaryENIid)
 	m.awsutils.EXPECT().IsUnmanagedENI(primaryENIid).AnyTimes().Return(false)
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(primaryENIid).AnyTimes().Return(false)
+	m.awsutils.EXPECT().IsMultiCardENI(primaryENIid).AnyTimes().Return(false)
 	m.awsutils.EXPECT().TagENI(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
@@ -1014,7 +1014,7 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 	}
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp, nil)
 
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp.MultiCardENIIDs).AnyTimes()
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 
 	curENIs := mockContext.dataStore.GetENIInfos()
@@ -1054,7 +1054,7 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 	// Two ENIs found
 	m.awsutils.EXPECT().GetAttachedENIs().Return(twoENIs, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(secENIid).Times(2).Return(false)
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(secENIid).Times(2).Return(false)
+	m.awsutils.EXPECT().IsMultiCardENI(secENIid).Times(2).Return(false)
 	resp2 := awsutils.DescribeAllENIsResult{
 		ENIMetadata: twoENIs,
 		TagMap:      map[string]awsutils.TagMap{},
@@ -1063,7 +1063,7 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 	}
 	m.awsutils.EXPECT().DescribeAllENIs().Return(resp2, nil)
 	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, secDevice, primarySubnet)
-	m.awsutils.EXPECT().SetCNIUnmanagedENIs(resp2.MultiCardENIIDs).AnyTimes()
+	m.awsutils.EXPECT().SetMultiCardENIs(resp2.MultiCardENIIDs).AnyTimes()
 
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 
@@ -1465,7 +1465,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 
 				}).AnyTimes()
 
-			mockAWSUtils.EXPECT().IsCNIUnmanagedENI(gomock.Any()).DoAndReturn(
+			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
 
@@ -1550,7 +1550,7 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 
 				}).AnyTimes()
 
-			mockAWSUtils.EXPECT().IsCNIUnmanagedENI(gomock.Any()).DoAndReturn(
+			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
 
@@ -1616,7 +1616,7 @@ func TestNodeIPPoolReconcileBadIMDSData(t *testing.T) {
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eniID).Return(false).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eniID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eniID).Return(false).AnyTimes()
 
 	// First reconcile, IMDS returns correct IPs so no change needed
 	mockContext.nodeIPPoolReconcile(ctx, 0)
@@ -1702,7 +1702,7 @@ func TestNodePrefixPoolReconcileBadIMDSData(t *testing.T) {
 	eniMetadataList := []awsutils.ENIMetadata{primaryENIMetadata}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(eniMetadataList, nil)
 	m.awsutils.EXPECT().IsUnmanagedENI(eniID).Return(false).AnyTimes()
-	m.awsutils.EXPECT().IsCNIUnmanagedENI(eniID).Return(false).AnyTimes()
+	m.awsutils.EXPECT().IsMultiCardENI(eniID).Return(false).AnyTimes()
 
 	// First reconcile, IMDS returns correct IPs so no change needed
 	mockContext.nodeIPPoolReconcile(ctx, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
The previous logic `c.dataStore.GetENIs() < (c.maxENI - c.unmanagedENI - trunkEni)` would return negative for multicard instance types that had EFA devices installed on non-zero cards. This adds another value to the inequality to negate ENIs on non-zero cards as CNI does not support multi-card yet.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
CNI and IPAMD suites look good

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
