### PR TITLE
Added description to list of metrics reported by cni-metrics-helper

### DIFF
--- a/cmd/cni-metrics-helper/README.md
+++ b/cmd/cni-metrics-helper/README.md
@@ -15,24 +15,33 @@ The following diagram shows how `cni-metrics-helper` works in a cluster:
 As you can see in the diagram, the `cni-metrics-helper` connects to the API Server over https (`tcp/443`), and another connection is created from the API Server to the worker node over http (`tcp/61678`). If you deploy Amazon EKS with the recommended security groups from [Restricting cluster traffic](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#security-group-restricting-cluster-traffic), then make sure that a security group is in place that allows the inbound connection from the API Server to the worker nodes over `tcp/61678`.
 
 Adding the CNI metrics helper will publish the following metrics to CloudWatch:
-```
-"addReqCount",
-"assignIPAddresses",
-"awsAPIErr",
-"awsAPILatency",
-"awsUtilErr",
-"delReqCount",
-"eniAllocated",
-"eniMaxAvailable",
-"ipamdActionInProgress",
-"ipamdErr",
-"maxIPAddresses",
-"podENIErr",
-"reconcileCount",
-"totalIPAddresses",
-"totalIPv4Prefixes",
-"totalAssignedIPv4sPerCidr"
-```
+
+| Metric | Description | Statistic[^1] |
+| ------ | ----------- | ------------- |
+| addReqCount | The number of CNI ADD requests that require an IP address | Sum |
+| assignIPAddresses |  The number of IP addresses assigned to pods | Sum |
+| awsAPIErr | The number of times AWS API returns an error | Sum |
+| awsAPILatency | AWS API call latency in ms | Max |
+| awsUtilErr | The number of errors not handled in awsutils library | Sum |
+| delReqCount | The number of CNI DEL requests | Sum |
+| eniAllocated | The number of ENIs allocated | Sum |
+| eniMaxAvailable | The maximum number of ENIs that can be attached to this instance, accounting for unmanaged ENIs | Sum |
+| ipamdActionInProgress | The number of ipamd actions in progress | Sum |
+| ipamdErr | The number of errors encountered in ipamd | Sum |
+| maxIPAddresses | The maximum number of IP addresses that can be allocated to the instance | Sum | 
+| podENIErr | The number of errors encountered while managing ENIs for pods | Sum |
+| reconcileCount | The number of times ipamd reconciles on ENIs and IP/Prefix addresses | Sum |
+| totalIPAddresses | The number of IPs allocated for pods | Sum |
+| totalIPv4Prefixes | The total number of IPv4 prefixes | Sum |
+| totalAssignedIPv4sPerCidr | The total number of IP addresses assigned per cidr | Sum |
+| forceRemoveENI | The number of ENIs force removed while they had assigned pods | Sum |
+| forceRemoveIPs | The number of IPs force removed while they had assigned pods | Sum |
+| ec2ApiReqCount | The number of requests made to EC2 APIs by CNI | Sum |
+| ec2ApiErrCount | The number of failed EC2 API requests | Sum |
+
+[^1]: This column indicates how the metric has been aggregated across all nodes
+  Sum: For datapoints from all nodes, this is the summation of those datapoints
+  Max: For datapoints from all nodes, this is the maximum value of those datapoints
 
 ## Using IRSA
 As per [AWS EKS Security Best Practice](https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html), if you are using IRSA for pods then following requirements must be satisfied to succesfully publish metrics to CloudWatch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
documentation

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2421

**What does this PR do / Why do we need it**:
This PR provides a description of each metric reported by `cni-metrics-helper`. It consolidates both the metric name and metric description into a table.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
