### PR TITLE
Fix Github Nightly Tests. Ensure Nodes are spread across AZs.

### DIFF
--- a/scripts/test/config/test-cluster.yaml
+++ b/scripts/test/config/test-cluster.yaml
@@ -30,3 +30,8 @@ managedNodeGroups:
     releaseVersion: ""
     tags:
       group: amazon-vpc-cni-k8s-x86
+availabilityZones:
+  - us-west-2a
+  - us-west-2b
+  - us-west-2c
+  - us-west-2d


### PR DESCRIPTION
[Github Nightly tests](https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/7794059935/job/21254782034#step:8:586) were failing on Node AZ presence test introduced recently for static canary.  One way to ignore these tests in Github runs. However, just adding AZ subnet requirements will spread the nodes across AZs and can satisfy the test requirements.

This will modify the test cluster used nightly runs and ensure nodes are present across AZs.

