### PR TITLE
Pod MTU

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,15 @@ Default: empty
 Specify a comma-separated list of IPv4 CIDRs to exclude from SNAT. For every item in the list an `iptables` rule and off\-VPC
 IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`.
 
+#### `POD_MTU` (v1.x.x+)
+
+Type: Integer as a String
+
+*Note*: The default value is set to AWS_VPC_ENI_MTU, which defaults to 9001 if unset.
+Default: 9001
+
+Used to configure the MTU size for pod virtual interfaces. The valid range is from `576` to `9001`.
+
 #### `WARM_ENI_TARGET`
 
 Type: Integer as a String

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -88,6 +88,7 @@ const (
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
 	envVethPrefix            = "AWS_VPC_K8S_CNI_VETHPREFIX"
 	envEniMTU                = "AWS_VPC_ENI_MTU"
+	envPodMTU                = "POD_MTU"
 	envEnablePodEni          = "ENABLE_POD_ENI"
 	envPodSGEnforcingMode    = "POD_SECURITY_GROUP_ENFORCING_MODE"
 	envPluginLogFile         = "AWS_VPC_K8S_PLUGIN_LOG_FILE"
@@ -278,7 +279,10 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		}
 	}
 	vethPrefix := utils.GetEnv(envVethPrefix, defaultVethPrefix)
-	mtu := utils.GetEnv(envEniMTU, defaultMTU)
+	// Derive pod MTU from ENI MTU by default
+	eniMTU := utils.GetEnv(envEniMTU, defaultMTU)
+	// If pod MTU environment variable is set, overwrite ENI MTU.
+	podMTU := utils.GetEnv(envPodMTU, eniMTU)
 	podSGEnforcingMode := utils.GetEnv(envPodSGEnforcingMode, defaultPodSGEnforcingMode)
 	pluginLogFile := utils.GetEnv(envPluginLogFile, defaultPluginLogFile)
 	pluginLogLevel := utils.GetEnv(envPluginLogLevel, defaultPluginLogLevel)
@@ -286,7 +290,7 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 
 	netconf := string(byteValue)
 	netconf = strings.Replace(netconf, "__VETHPREFIX__", vethPrefix, -1)
-	netconf = strings.Replace(netconf, "__MTU__", mtu, -1)
+	netconf = strings.Replace(netconf, "__MTU__", podMTU, -1)
 	netconf = strings.Replace(netconf, "__PODSGENFORCINGMODE__", podSGEnforcingMode, -1)
 	netconf = strings.Replace(netconf, "__PLUGINLOGFILE__", pluginLogFile, -1)
 	netconf = strings.Replace(netconf, "__PLUGINLOGLEVEL__", pluginLogLevel, -1)

--- a/test/integration/cni/host_networking_test.go
+++ b/test/integration/cni/host_networking_test.go
@@ -17,12 +17,11 @@ import (
 	"strconv"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
+	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,13 +30,15 @@ import (
 // TODO: Instead of passing the list of pods to the test helper, have the test helper get the pod on node
 const (
 	NEW_MTU_VAL     = 1300
+	NEW_POD_MTU     = 1280
 	NEW_VETH_PREFIX = "veth"
+	podLabelKey     = "app"
+	podLabelVal     = "host-networking-test"
 )
 
+var err error
+
 var _ = Describe("test host networking", func() {
-	var err error
-	var podLabelKey = "app"
-	var podLabelVal = "host-networking-test"
 
 	// For host networking tests, increase WARM_IP_TARGET to prevent long IPAMD warmup.
 	BeforeEach(func() {
@@ -57,6 +58,10 @@ var _ = Describe("test host networking", func() {
 				"AWS_VPC_ENI_MTU":            DEFAULT_MTU_VAL,
 				"AWS_VPC_K8S_CNI_VETHPREFIX": DEFAULT_VETH_PREFIX,
 			})
+			k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName,
+				utils.AwsNodeNamespace, utils.AwsNodeName, map[string]struct{}{
+					"POD_MTU": {},
+				})
 			// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the latest VETH prefix and MTU.
 			// Otherwise, the stale value can cause failures in future test cases.
 			time.Sleep(utils.PollIntervalMedium)
@@ -104,51 +109,13 @@ var _ = Describe("test host networking", func() {
 			common.ValidateHostNetworking(common.NetworkingTearDownSucceeds, input, primaryNode.Name, f)
 		})
 
-		It("Validate Host Networking setup after changing MTU and Veth Prefix", func() {
-			deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
-				Replicas(maxIPPerInterface*2).
-				PodLabel(podLabelKey, podLabelVal).
-				NodeName(primaryNode.Name).
-				Build()
-
-			By("Configuring Veth Prefix and MTU value on aws-node daemonset")
-			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
-				"AWS_VPC_ENI_MTU":            strconv.Itoa(NEW_MTU_VAL),
-				"AWS_VPC_K8S_CNI_VETHPREFIX": NEW_VETH_PREFIX,
+		Context("Validate Host Networking setup after changing Veth Prefix and", func() {
+			It("ENI MTU", func() {
+				mtuValidationTest(false, NEW_MTU_VAL)
 			})
-			// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the new VETH prefix and MTU.
-			time.Sleep(utils.PollIntervalMedium)
-
-			By("creating a deployment to launch pods")
-			deployment, err = f.K8sResourceManagers.DeploymentManager().
-				CreateAndWaitTillDeploymentIsReady(deployment, utils.DefaultDeploymentReadyTimeout)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("getting the list of pods using IP from primary and secondary ENI")
-			interfaceTypeToPodList :=
-				common.GetPodsOnPrimaryAndSecondaryInterface(primaryNode, podLabelKey, podLabelVal, f)
-
-			By("generating the pod networking validation input to be passed to tester")
-			podNetworkingValidationInput := common.GetPodNetworkingValidationInput(interfaceTypeToPodList, vpcCIDRs)
-			podNetworkingValidationInput.VethPrefix = NEW_VETH_PREFIX
-			podNetworkingValidationInput.ValidateMTU = true
-			podNetworkingValidationInput.MTU = NEW_MTU_VAL
-			input, err := podNetworkingValidationInput.Serialize()
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating host networking setup is setup correctly with MTU check as well")
-			common.ValidateHostNetworking(common.NetworkingSetupSucceeds, input, primaryNode.Name, f)
-
-			By("deleting the deployment to test teardown")
-			err = f.K8sResourceManagers.DeploymentManager().
-				DeleteAndWaitTillDeploymentIsDeleted(deployment)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("waiting to allow CNI to tear down networking for terminated pods")
-			time.Sleep(time.Second * 60)
-
-			By("validating host networking is teared down correctly")
-			common.ValidateHostNetworking(common.NetworkingTearDownSucceeds, input, primaryNode.Name, f)
+			It("POD MTU", func() {
+				mtuValidationTest(true, NEW_POD_MTU)
+			})
 		})
 	})
 
@@ -205,3 +172,59 @@ var _ = Describe("test host networking", func() {
 		})
 	})
 })
+
+func mtuValidationTest(usePodMTU bool, mtuVal int) {
+	deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+		Replicas(maxIPPerInterface*2).
+		PodLabel(podLabelKey, podLabelVal).
+		NodeName(primaryNode.Name).
+		Build()
+
+	if usePodMTU {
+		By("Configuring Veth Prefix and Pod MTU value on aws-node daemonset")
+		k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+			"AWS_VPC_ENI_MTU":            strconv.Itoa(NEW_MTU_VAL),
+			"POD_MTU":                    strconv.Itoa(NEW_POD_MTU),
+			"AWS_VPC_K8S_CNI_VETHPREFIX": NEW_VETH_PREFIX,
+		})
+	} else {
+		By("Configuring Veth Prefix and ENI MTU value on aws-node daemonset")
+		k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+			"AWS_VPC_ENI_MTU":            strconv.Itoa(NEW_MTU_VAL),
+			"AWS_VPC_K8S_CNI_VETHPREFIX": NEW_VETH_PREFIX,
+		})
+	}
+	// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the new VETH prefix and MTU.
+	time.Sleep(utils.PollIntervalMedium)
+
+	By("creating a deployment to launch pods")
+	deployment, err = f.K8sResourceManagers.DeploymentManager().
+		CreateAndWaitTillDeploymentIsReady(deployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("getting the list of pods using IP from primary and secondary ENI")
+	interfaceTypeToPodList :=
+		common.GetPodsOnPrimaryAndSecondaryInterface(primaryNode, podLabelKey, podLabelVal, f)
+
+	By("generating the pod networking validation input to be passed to tester")
+	podNetworkingValidationInput := common.GetPodNetworkingValidationInput(interfaceTypeToPodList, vpcCIDRs)
+	podNetworkingValidationInput.VethPrefix = NEW_VETH_PREFIX
+	podNetworkingValidationInput.ValidateMTU = true
+	podNetworkingValidationInput.MTU = mtuVal
+	input, err := podNetworkingValidationInput.Serialize()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("validating host networking setup is setup correctly with MTU check as well")
+	common.ValidateHostNetworking(common.NetworkingSetupSucceeds, input, primaryNode.Name, f)
+
+	By("deleting the deployment to test teardown")
+	err = f.K8sResourceManagers.DeploymentManager().
+		DeleteAndWaitTillDeploymentIsDeleted(deployment)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("waiting to allow CNI to tear down networking for terminated pods")
+	time.Sleep(time.Second * 60)
+
+	By("validating host networking is teared down correctly")
+	common.ValidateHostNetworking(common.NetworkingTearDownSucceeds, input, primaryNode.Name, f)
+}

--- a/test/integration/ipv6/ipv6_host_networking_test.go
+++ b/test/integration/ipv6/ipv6_host_networking_test.go
@@ -41,16 +41,19 @@ const (
 const (
 	AWS_VPC_ENI_MTU            = "AWS_VPC_ENI_MTU"
 	AWS_VPC_K8S_CNI_VETHPREFIX = "AWS_VPC_K8S_CNI_VETHPREFIX"
+	POD_MTU                    = "POD_MTU"
 	NEW_MTU_VAL                = 1300
+	NEW_POD_MTU                = 1280
 	NEW_VETH_PREFIX            = "veth"
 	DEFAULT_MTU_VAL            = "9001"
 	DEFAULT_VETH_PREFIX        = "eni"
+	podLabelKey                = "app"
+	podLabelVal                = "host-networking-test"
 )
 
+var err error
+
 var _ = Describe("[CANARY] test ipv6 host netns setup", func() {
-	var err error
-	var podLabelKey = "app"
-	var podLabelVal = "host-networking-test"
 
 	Context("when pods using IP from primary ENI are created", func() {
 		AfterEach(func() {
@@ -58,6 +61,10 @@ var _ = Describe("[CANARY] test ipv6 host netns setup", func() {
 				AWS_VPC_ENI_MTU:            DEFAULT_MTU_VAL,
 				AWS_VPC_K8S_CNI_VETHPREFIX: DEFAULT_VETH_PREFIX,
 			})
+			k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName,
+				utils.AwsNodeNamespace, utils.AwsNodeName, map[string]struct{}{
+					"POD_MTU": {},
+				})
 			// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the latest VETH prefix and MTU.
 			// Otherwise, the stale value can cause failures in future test cases.
 			time.Sleep(utils.PollIntervalMedium)
@@ -98,51 +105,13 @@ var _ = Describe("[CANARY] test ipv6 host netns setup", func() {
 			ValidateHostNetworking(NetworkingTearDownSucceeds, input)
 		})
 
-		It("Validate host netns setup after changing MTU and Veth Prefix", func() {
-			deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
-				Replicas(2).
-				PodLabel(podLabelKey, podLabelVal).
-				NodeName(primaryNode.Name).
-				Build()
-
-			By("Configuring Veth Prefix and MTU value on aws-node daemonset")
-			k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
-				AWS_VPC_ENI_MTU:            strconv.Itoa(NEW_MTU_VAL),
-				AWS_VPC_K8S_CNI_VETHPREFIX: NEW_VETH_PREFIX,
+		Context("Validate Host Networking setup after changing Veth Prefix and", func() {
+			It("ENI MTU", func() {
+				mtuValidationTest(false, NEW_MTU_VAL)
 			})
-			// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the new VETH prefix and MTU.
-			time.Sleep(utils.PollIntervalMedium)
-
-			By("creating a deployment to launch pods")
-			deployment, err = f.K8sResourceManagers.DeploymentManager().
-				CreateAndWaitTillDeploymentIsReady(deployment, utils.DefaultDeploymentReadyTimeout)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("getting the list of pods using IP from primary and secondary ENI")
-			interfaceTypeToPodList :=
-				GetIPv6Pods(podLabelKey, podLabelVal)
-
-			By("generating the pod networking validation input to be passed to tester")
-			podNetworkingValidationInput := GetIPv6PodNetworkingValidationInput(interfaceTypeToPodList)
-			podNetworkingValidationInput.VethPrefix = NEW_VETH_PREFIX
-			podNetworkingValidationInput.ValidateMTU = true
-			podNetworkingValidationInput.MTU = NEW_MTU_VAL
-			input, err := podNetworkingValidationInput.Serialize()
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating host networking setup is setup correctly with MTU check as well")
-			ValidateHostNetworking(NetworkingSetupSucceeds, input)
-
-			By("deleting the deployment to test teardown")
-			err = f.K8sResourceManagers.DeploymentManager().
-				DeleteAndWaitTillDeploymentIsDeleted(deployment)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("waiting to allow CNI to tear down networking for terminated pods")
-			time.Sleep(time.Second * 60)
-
-			By("validating host networking is teared down correctly")
-			ValidateHostNetworking(NetworkingTearDownSucceeds, input)
+			It("POD MTU", func() {
+				mtuValidationTest(true, NEW_POD_MTU)
+			})
 		})
 	})
 
@@ -276,4 +245,60 @@ func GetIPv6PodNetworkingValidationInput(podList v1.PodList) input.PodNetworking
 		})
 	}
 	return ip
+}
+
+func mtuValidationTest(usePodMTU bool, mtuVal int) {
+	deployment := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+		Replicas(2).
+		PodLabel(podLabelKey, podLabelVal).
+		NodeName(primaryNode.Name).
+		Build()
+
+	if usePodMTU {
+		By("Configuring Veth Prefix and Pod MTU value on aws-node daemonset")
+		k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+			AWS_VPC_ENI_MTU:            strconv.Itoa(NEW_MTU_VAL),
+			POD_MTU:                    strconv.Itoa(NEW_POD_MTU),
+			AWS_VPC_K8S_CNI_VETHPREFIX: NEW_VETH_PREFIX,
+		})
+	} else {
+		By("Configuring Veth Prefix and ENI MTU value on aws-node daemonset")
+		k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace, utils.AwsNodeName, map[string]string{
+			AWS_VPC_ENI_MTU:            strconv.Itoa(NEW_MTU_VAL),
+			AWS_VPC_K8S_CNI_VETHPREFIX: NEW_VETH_PREFIX,
+		})
+	}
+	// After updating daemonset pod, we must wait until conflist is updated so that container-runtime calls CNI ADD with the new VETH prefix and MTU.
+	time.Sleep(utils.PollIntervalMedium)
+
+	By("creating a deployment to launch pods")
+	deployment, err = f.K8sResourceManagers.DeploymentManager().
+		CreateAndWaitTillDeploymentIsReady(deployment, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("getting the list of pods using IP from primary and secondary ENI")
+	interfaceTypeToPodList :=
+		GetIPv6Pods(podLabelKey, podLabelVal)
+
+	By("generating the pod networking validation input to be passed to tester")
+	podNetworkingValidationInput := GetIPv6PodNetworkingValidationInput(interfaceTypeToPodList)
+	podNetworkingValidationInput.VethPrefix = NEW_VETH_PREFIX
+	podNetworkingValidationInput.ValidateMTU = true
+	podNetworkingValidationInput.MTU = mtuVal
+	input, err := podNetworkingValidationInput.Serialize()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("validating host networking setup is setup correctly with MTU check as well")
+	ValidateHostNetworking(NetworkingSetupSucceeds, input)
+
+	By("deleting the deployment to test teardown")
+	err = f.K8sResourceManagers.DeploymentManager().
+		DeleteAndWaitTillDeploymentIsDeleted(deployment)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("waiting to allow CNI to tear down networking for terminated pods")
+	time.Sleep(time.Second * 60)
+
+	By("validating host networking is teared down correctly")
+	ValidateHostNetworking(NetworkingTearDownSucceeds, input)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

feature

**Which issue does this PR fix**:
#2606 

**What does this PR do / Why do we need it**:
Implements a new env var `POD_MTU` that sets the pod MTU. This will default to `AWS_VPC_ENI_MTU` value if not set.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran CNI, IPAMD, and IPv6 test suites.

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

```release-note
By setting `POD_MTU`, you can have different MTU values for the pod and ENI.

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
