### PR TITLE
Add validation for MTU, update ANNOTATE_POD_IP README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Type: Integer as a String
 
 Default: 9001
 
-Used to configure the MTU size for attached ENIs. The valid range is from `576` to `9001`.
+Used to configure the MTU size for attached ENIs. The valid range for IPv4 is from `576` to `9001`, while the valid range for IPv6 is from `1280` to `9001`.
 
 #### `AWS_VPC_K8S_CNI_EXTERNALSNAT`
 
@@ -267,14 +267,14 @@ Default: empty
 Specify a comma-separated list of IPv4 CIDRs to exclude from SNAT. For every item in the list an `iptables` rule and off\-VPC
 IP rule will be applied. If an item is not a valid ipv4 range it will be skipped. This should be used when `AWS_VPC_K8S_CNI_EXTERNALSNAT=false`.
 
-#### `POD_MTU` (v1.x.x+)
+#### `POD_MTU` (v1.16.4+)
 
 Type: Integer as a String
 
-*Note*: The default value is set to AWS_VPC_ENI_MTU, which defaults to 9001 if unset.
+*Note*: If unset, the default value is derived from `AWS_VPC_ENI_MTU`, which defaults to `9001`.
 Default: 9001
 
-Used to configure the MTU size for pod virtual interfaces. The valid range is from `576` to `9001`.
+Used to configure the MTU size for pod virtual interfaces. The valid range for IPv4 is from `576` to `9001`, while the valid range for IPv6 is from `1280` to `9001`.
 
 #### `WARM_ENI_TARGET`
 
@@ -598,7 +598,7 @@ Setting `ANNOTATE_POD_IP` to `true` will allow IPAMD to add an annotation `vpc.a
 
 There is a known [issue](https://github.com/kubernetes/kubernetes/issues/39113) with kubelet taking time to update `Pod.Status.PodIP` leading to calico being blocked on programming the policy. Setting `ANNOTATE_POD_IP` to `true` will enable AWS VPC CNI plugin to add Pod IP as an annotation to the pod spec to address this race condition.
 
-To annotate the pod with pod IP, you will have to add "patch" permission for pods resource in aws-node clusterrole. You can use the below command -
+To annotate the pod with pod IP, you will have to add `patch` permission for pods resource in aws-node clusterrole. You can use the below command -
 
 ```
 cat << EOF > append.yaml
@@ -614,6 +614,8 @@ EOF
 ```
 kubectl apply -f <(cat <(kubectl get clusterrole aws-node -o yaml) append.yaml)
 ```
+
+NOTE: Adding `patch` permissions to the `aws-node` Daemonset increases the security scope for the plugin, so add this permission only after performing a proper security assessment of the tradeoffs.
 
 #### `ENABLE_IPv4` (v1.10.0+)
 

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -66,7 +66,9 @@ const (
 	defaultAWSconflistFile       = "/app/10-aws.conflist"
 	tmpAWSconflistFile           = "/tmp/10-aws.conflist"
 	defaultVethPrefix            = "eni"
-	defaultMTU                   = "9001"
+	defaultMTU                   = 9001
+	minMTUv4                     = 576
+	minMTUv6                     = 1280
 	defaultEnablePodEni          = false
 	defaultPodSGEnforcingMode    = "strict"
 	defaultPluginLogFile         = "/var/log/aws-routed-eni/plugin.log"
@@ -279,8 +281,8 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		}
 	}
 	vethPrefix := utils.GetEnv(envVethPrefix, defaultVethPrefix)
-	// Derive pod MTU from ENI MTU by default
-	eniMTU := utils.GetEnv(envEniMTU, defaultMTU)
+	// Derive pod MTU from ENI MTU by default (note that values have already been validated)
+	eniMTU := utils.GetEnv(envEniMTU, strconv.Itoa(defaultMTU))
 	// If pod MTU environment variable is set, overwrite ENI MTU.
 	podMTU := utils.GetEnv(envPodMTU, eniMTU)
 	podSGEnforcingMode := utils.GetEnv(envPodSGEnforcingMode, defaultPodSGEnforcingMode)
@@ -389,6 +391,11 @@ func validateEnvVars() bool {
 		return false
 	}
 
+	// Validate MTU value for ENIs and pods
+	if !validateMTU(envEniMTU) || !validateMTU(envPodMTU) {
+		return false
+	}
+
 	prefixDelegationEn := utils.GetBoolAsStringEnvVar(envEnPrefixDelegation, defaultEnPrefixDelegation)
 	warmIPTarget := utils.GetEnv(envWarmIPTarget, "0")
 	warmPrefixTarget := utils.GetEnv(envWarmPrefixTarget, "0")
@@ -398,6 +405,29 @@ func validateEnvVars() bool {
 	if prefixDelegationEn && (warmIPTarget <= "0" && warmPrefixTarget <= "0" && minimumIPTarget <= "0") {
 		log.Errorf("Setting WARM_PREFIX_TARGET = 0 is not supported while WARM_IP_TARGET/MINIMUM_IP_TARGET is not set. Please configure either one of the WARM_{PREFIX/IP}_TARGET or MINIMUM_IP_TARGET env variables")
 		return false
+	}
+	return true
+}
+
+func validateMTU(envVar string) bool {
+	// Validate MTU range based on IP address family
+	enabledIPv6 := utils.GetBoolAsStringEnvVar(envEnIPv6, defaultEnableIPv6)
+
+	mtu, err, input := utils.GetIntFromStringEnvVar(envVar, defaultMTU)
+	if err != nil {
+		log.Errorf("%s MUST be a valid integer. %s is invalid", envVar, input)
+		return false
+	}
+	if enabledIPv6 {
+		if mtu < minMTUv6 || mtu > defaultMTU {
+			log.Errorf("%s cannot be less than 1280 or greater than 9001 in IPv6. %s is invalid", envVar, input)
+			return false
+		}
+	} else {
+		if mtu < minMTUv4 || mtu > defaultMTU {
+			log.Errorf("%s cannot be less than 576 or greater than 9001 in IPv4. %s is invalid", envVar, input)
+			return false
+		}
 	}
 	return true
 }

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -144,7 +144,8 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		return errors.Wrap(err, "add cmd: failed to load k8s config from arg")
 	}
 
-	mtu := networkutils.GetEthernetMTU(conf.MTU)
+	// Derive pod MTU. Note that the value has already been validated.
+	mtu := networkutils.GetPodMTU(conf.MTU)
 	log.Debugf("MTU value set is %d:", mtu)
 
 	// Set up a connection to the ipamD server.

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -419,19 +419,21 @@ func TestSetupHostNetworkNodePortDisabledAndSNATEnabled(t *testing.T) {
 	}, mockIptables.(*mock_iptables.MockIptables).DataplaneState)
 }
 
-func TestLoadMTUFromEnvTooLow(t *testing.T) {
-	os.Setenv(envMTU, "1")
-	assert.Equal(t, GetEthernetMTU(""), minimumMTU)
+func TestGetEthernetMTU(t *testing.T) {
+	assert.Equal(t, GetEthernetMTU(), defaultMTU)
+
+	os.Setenv(envMTU, "5000")
+	assert.Equal(t, GetEthernetMTU(), 5000)
 }
 
-func TestLoadMTUFromEnv1500(t *testing.T) {
-	os.Setenv(envMTU, "1500")
-	assert.Equal(t, GetEthernetMTU(""), 1500)
-}
+func TestGetPodMTU(t *testing.T) {
+	// For any invalid value, return the default MTU
+	assert.Equal(t, GetPodMTU("abc"), defaultMTU)
+	assert.Equal(t, GetPodMTU("500"), defaultMTU)
+	assert.Equal(t, GetPodMTU("10000"), defaultMTU)
 
-func TestLoadMTUFromEnvTooHigh(t *testing.T) {
-	os.Setenv(envMTU, "65536")
-	assert.Equal(t, GetEthernetMTU(""), maximumMTU)
+	// For any valid value, return the value
+	assert.Equal(t, GetPodMTU("8000"), 8000)
 }
 
 func TestLoadExcludeSNATCIDRsFromEnv(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR adds validation for the ENI and Pod MTU during `aws-node` container initialization. The validation is specific to the IP address family.

This PR also updates the documentation for `ANNOTATE_POD_IP` to warn on the increased security scope of adding the `patch` permission.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Added unit test coverage for MTU validation during `aws-node` container initialization. All unit tests pass.

Ran integration test and validated that all pass, including those in the `cni` test suite that cover MTU modification.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
