### PR TITLE
Fix VPC CNI weekly tests for Bottlerocket and kops

### DIFF
--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -44,7 +44,6 @@ jobs:
           RUN_CNI_INTEGRATION_TESTS: false
           PERFORMANCE_TEST_S3_BUCKET_NAME: cni-performance-tests
           RUN_PERFORMANCE_TESTS: true
-          RUN_TESTER_LB_ADDONS: true
         run: |
           ./scripts/run-integration-tests.sh
       - name: Run kops tests
@@ -54,9 +53,8 @@ jobs:
           ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_CNI_INTEGRATION_TESTS: false
           RUN_KOPS_TEST: true
-          RUN_TESTER_LB_ADDONS: true
-          K8S_VERSION: 1.29.0-alpha.2
-          KOPS_VERSION: v1.29.0-alpha.2
+          K8S_VERSION: 1.29.0-alpha.3
+          KOPS_VERSION: v1.29.0-alpha.3
         run: |
           ./scripts/run-integration-tests.sh
         if: always()
@@ -67,7 +65,6 @@ jobs:
           ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_CNI_INTEGRATION_TESTS: false
           RUN_BOTTLEROCKET_TEST: true
-          RUN_TESTER_LB_ADDONS: true
         run: |
           ./scripts/run-integration-tests.sh
         if: always()

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -12,7 +12,7 @@ function load_deveks_cluster_details() {
   echo "loading cluster details $CLUSTER_NAME"
   PROVIDER_ID=$(kubectl get nodes --kubeconfig $KUBE_CONFIG_PATH -ojson | jq -r '.items[0].spec.providerID')
   INSTANCE_ID=${PROVIDER_ID##*/}
-  VPC_ID=$(aws ec2 describe-instances --instance-ids ${INSTANCE_ID} --no-cli-pager | jq -r '.Reservations[].Instances[].VpcId')
+  VPC_ID=$(aws ec2 describe-instances --instance-ids ${INSTANCE_ID} | jq -r '.Reservations[].Instances[].VpcId')
 }
 
 function down-test-cluster() {
@@ -92,7 +92,6 @@ function up-kops-cluster {
     --cloud aws \
     --zones ${AWS_DEFAULT_REGION}a,${AWS_DEFAULT_REGION}b \
     --networking amazonvpc \
-    --container-runtime containerd \
     --node-count 2 \
     --node-size c5.xlarge \
     --ssh-public-key=~/.ssh/devopsinuse.pub \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
test fixes
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This PR resolves failures in the weekly Bottlerocket and kops tests.
- Bottlerocket - tests were failing on cluster deletion, as `eksctl` was trying to drain nodes before deleting them. Nodes could not successfully drain due to the Coredns Pod Disruption Budget. The fix is to pass `--disable-nodegroup-eviction` on cluster deletion.
- kops - integration tests were failing. The combination of updating the kops version and removing bad/unnecessary CLI flags resolved these failures.  

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
Manually ran tests and validated that they passed.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
