### PR TITLE
Revert #2744 to prevent livelock when attempting to increase datastore pool

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -660,11 +660,7 @@ func (c *IPAMContext) updateIPPoolIfRequired(ctx context.Context) {
 	log.Debugf("IP stats - total IPs: %d, assigned IPs: %d, cooldown IPs: %d", stats.TotalIPs, stats.AssignedIPs, stats.CooldownIPs)
 
 	if datastorePoolTooLow {
-		// Allow for rapid scale up to decrease time it takes for pod to retrieve an ip
-		// but conservative scale down to account for pod churn
-		for datastorePoolStillTooLow := datastorePoolTooLow; datastorePoolStillTooLow; datastorePoolStillTooLow, _ = c.isDatastorePoolTooLow() {
-			c.increaseDatastorePool(ctx)
-		}
+		c.increaseDatastorePool(ctx)
 	} else if c.isDatastorePoolTooHigh(stats) {
 		c.decreaseDatastorePool(decreaseIPPoolInterval)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/2807

**What does this PR do / Why do we need it**:
This PR fixes a livelock condition that was reported in https://github.com/aws/amazon-vpc-cni-k8s/issues/2807. When the datastore pool is too low, we try to aggressively scale up to the desired state, hence the for loop. Under certain conditions, the datastore pool could return "too low" for a prolonged period of time (or indefinitely).

The change here is to revert https://github.com/aws/amazon-vpc-cni-k8s/pull/2744 so that only one scale up attempt happens during each iteration of the activity loop.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
N/A

**Testing done on this change**:
Ran all integration tests to ensure that they passed.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Fix potential livelock while trying to increase the size of the datastore pool
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
