### PR TITLE
Reduce the default timeout for static canary tests.

### DIFF
--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -21,7 +21,7 @@ function run_ginkgo_test() {
   local focus=$1
   echo "Running ginkgo tests with focus: $focus"
 
-  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 30m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- \
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 10m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- \
       --cluster-kubeconfig="$KUBE_CONFIG_PATH" \
       --cluster-name="$CLUSTER_NAME" \
       --aws-region="$REGION" \


### PR DESCRIPTION
**What type of PR is this?**

During a AZ failure testing where in fault induction done at ingress, test failure was significantly delayed, and thus it delayed the alarm too.

Since the static canary tests run within 5 minutes in all regions, it is best to keep the global timeout to much lower value like 10m instead of 30m.
