### PR TITLE
Use AL2023 base images on VPC-CNI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@
 VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 GOLANG_VERSION ?= $(shell cat .go-version)
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 # BASE_IMAGE_CNI is the base layer image for the primary AWS VPC CNI plugin container
-BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 # BASE_IMAGE_CNI_INIT is the base layer image for the AWS VPC CNI init container
-BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 # BASE_IMAGE_CNI_METRICS is the base layer image for the AWS VPC CNI metrics publisher sidecar container
-BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
N/A

**What does this PR do / Why do we need it?**:
We should look to move VPC-CNI images to use the AL2023 base images since those will be patched at a faster rate and have improvements compared to AL2.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

Integration test results. IP family in parenthesis means the IP family the cluster the test ran against had.

**Tests on AL2 nodes**
- CNI (IPv4)
<img width="406" alt="Ran 18 of 19 Specs in 1543 589 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/1f086e9b-3c0e-424c-8869-147afd34d0f4">

- IPAMD (IPv4)
<img width="403" alt="Ran 26 of 26 Specs in 1636 912 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/4be85c18-73de-4a65-8d34-8faa76ec4b2c">

- CNI Metrics (IPv4) (Tested against cni metrics image using the AL2023 image)
<img width="396" alt="Ran 1 of 1 Specs in 447 286 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/4c8ac772-511e-4ca9-9fbe-b5ee6ced0fbd">

- Custom Networking (IPv4)
<img width="399" alt="Ran 4 of 4 Specs in 2394 163 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/08179d3e-f4a7-44db-8f93-fa8d74371195">

- SNAT (IPv4)
<img width="408" alt="Ran 4 of 4 Specs in 517 211 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/b463030c-e42f-4347-b228-d2979c275407">

- Pod ENI (IPv4) 
<img width="395" alt="Ran 6 of 6 Specs in 1812 811 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/eca7edc8-52a8-4445-ae60-e6e1a583f0c2">

- IPv6 (IPv6)
<img width="403" alt="Ran 7 of 8 Specs in 379 563 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/1ddd4c33-e4a5-4db1-ae77-dd1fb7a51d92">

- CNI Egress (IPv6)
<img width="398" alt="Ran 1 of 1 Specs in 40 400 seconds" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/a1046405-c7e9-451b-b4b1-789be8387161">

**Tests on AL2023 nodes**
- CNI (IPv4)
<img width="406" alt="Screenshot 2024-03-04 at 12 14 13 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/7703b8ed-5d6c-42d9-a9ab-9ceb95121795">

- IPAMD (IPv4)
<img width="402" alt="Screenshot 2024-03-04 at 2 04 22 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/8aa9d530-fc50-4b27-8ba7-7f032809da5f">

- SNAT (IPv4)
<img width="394" alt="Screenshot 2024-03-05 at 12 39 46 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/ccde2dbc-d696-4eea-a1a4-6d3dbd1c6fc8">

- Pod ENI (IPv4)
<img width="403" alt="Screenshot 2024-03-05 at 1 10 09 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/ef179909-c024-4d41-bc39-ecf24a67769e">

- IPv6 (IPv6)
<img width="402" alt="Screenshot 2024-03-05 at 2 55 01 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/903d1036-98f4-4425-8bd6-1ee24bdc3833">

- CNI Egress (IPv6)
<img width="407" alt="Screenshot 2024-03-05 at 2 54 56 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/ab942af3-b0be-4d56-920c-ce8a4621d8c1">

- Custom Networking (IPv4)
  - WIP



<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
