### PR TITLE
CHANGELOG, chart, and manifest updates following VPC CNI v1.16.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.16.4
+
+* Bug - [Revert #2744 to prevent livelock when attempting to increase datastore pool](https://github.com/aws/amazon-vpc-cni-k8s/pull/2810) (@jdn5126 )
+* Bug - [Do not allocate IPs or prefixes to trunk ENIs; enable Custom Networking before Security Groups for Pods](https://github.com/aws/amazon-vpc-cni-k8s/pull/2801) (@jdn5126 )
+* Bug - [Ignore non-zero cards](https://github.com/aws/amazon-vpc-cni-k8s/pull/2784) (@jchen6585 )
+* Documentation - [Added description to list of metrics reported by cni-metrics-helper](https://github.com/aws/amazon-vpc-cni-k8s/pull/2786) (@zachdorame )
+* Enhancement - [Bump helm.sh/helm/v3 from 3.14.1 to 3.14.2](https://github.com/aws/amazon-vpc-cni-k8s/pull/2806) (@dependabot )
+* Enhancement - [Add validation for MTU, update ANNOTATE_POD_IP README](https://github.com/aws/amazon-vpc-cni-k8s/pull/2798) (@jdn5126 )
+* Enhancement - [Update Golang version to 1.21.7; update aws-vpc-cni chart README](https://github.com/aws/amazon-vpc-cni-k8s/pull/2795) (@jdn5126 )
+* Enhancement - [Bump helm.sh/helm/v3 from 3.14.0 to 3.14.1](https://github.com/aws/amazon-vpc-cni-k8s/pull/2794) (@jdn5126 )
+* Feature - [Pod MTU](https://github.com/aws/amazon-vpc-cni-k8s/pull/2791) (@jchen6585 )
+
 ## v1.16.3
 
 * Dependency - [Dependabot updates](https://github.com/aws/amazon-vpc-cni-k8s/pull/2775) (@jdn5126 )

--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.16.3
-appVersion: "v1.16.3"
+version: 1.16.4
+appVersion: "v1.16.4"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters for this chart and their d
 | `minimumWindowsIPTarget`| Minimum IP target value for Windows prefix delegation   | `3`                                 |
 | `branchENICooldown`     | Number of seconds that branch ENIs remain in cooldown   | `60`                                |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.16.3`                           |
+| `image.tag`             | Image tag                                               | `v1.16.4`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -56,7 +56,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.16.3`                           |
+| `init.image.tag`        | Image tag                                               | `v1.16.4`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.16.3
+    tag: v1.16.4
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -50,7 +50,7 @@ nodeAgent:
   resources: {}
 
 image:
-  tag: v1.16.3
+  tag: v1.16.4
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
@@ -83,7 +83,7 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
-  VPC_CNI_VERSION: "v1.16.3"
+  VPC_CNI_VERSION: "v1.16.4"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.16.3
-appVersion: v1.16.3
+version: 1.16.4
+appVersion: v1.16.4
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/charts/cni-metrics-helper/README.md
+++ b/charts/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.16.3            |
+| image.tag                    | Image tag                                                     | v1.16.4            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/charts/cni-metrics-helper/values.yaml
+++ b/charts/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.16.3
+  tag: v1.16.4
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -297,7 +297,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -343,7 +343,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -363,7 +363,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -384,7 +384,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.16.3
+        image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.16.4
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -405,7 +405,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.16.3
+          image: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.16.4
           ports:
             - containerPort: 61678
               name: metrics
@@ -465,7 +465,7 @@ spec:
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
             - name: VPC_CNI_VERSION
-              value: "v1.16.3"
+              value: "v1.16.4"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -297,7 +297,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -343,7 +343,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -363,7 +363,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -384,7 +384,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.16.3
+        image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni-init:v1.16.4
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -405,7 +405,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.16.3
+          image: 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon-k8s-cni:v1.16.4
           ports:
             - containerPort: 61678
               name: metrics
@@ -465,7 +465,7 @@ spec:
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
             - name: VPC_CNI_VERSION
-              value: "v1.16.3"
+              value: "v1.16.4"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -297,7 +297,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -343,7 +343,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -363,7 +363,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -384,7 +384,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.16.3
+        image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni-init:v1.16.4
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -405,7 +405,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.16.3
+          image: 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon-k8s-cni:v1.16.4
           ports:
             - containerPort: 61678
               name: metrics
@@ -465,7 +465,7 @@ spec:
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
             - name: VPC_CNI_VERSION
-              value: "v1.16.3"
+              value: "v1.16.4"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -266,7 +266,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -297,7 +297,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -343,7 +343,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -363,7 +363,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -384,7 +384,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.4
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -405,7 +405,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.3
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.4
           ports:
             - containerPort: 61678
               name: metrics
@@ -465,7 +465,7 @@ spec:
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
             - name: VPC_CNI_VERSION
-              value: "v1.16.3"
+              value: "v1.16.4"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/cni-metrics-helper-cn.yaml
+++ b/config/master/cni-metrics-helper-cn.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -69,5 +69,5 @@ spec:
         - name: USE_PROMETHEUS
           value: "false"
         name: cni-metrics-helper
-        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.16.3"
+        image: "961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/cni-metrics-helper:v1.16.4"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-east-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-east-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -69,5 +69,5 @@ spec:
         - name: USE_PROMETHEUS
           value: "false"
         name: cni-metrics-helper
-        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.16.3"
+        image: "151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/cni-metrics-helper:v1.16.4"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper-us-gov-west-1.yaml
+++ b/config/master/cni-metrics-helper-us-gov-west-1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -69,5 +69,5 @@ spec:
         - name: USE_PROMETHEUS
           value: "false"
         name: cni-metrics-helper
-        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.16.3"
+        image: "013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/cni-metrics-helper:v1.16.4"
       serviceAccountName: cni-metrics-helper

--- a/config/master/cni-metrics-helper.yaml
+++ b/config/master/cni-metrics-helper.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 ---
 # Source: cni-metrics-helper/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cni-metrics-helper
     app.kubernetes.io/instance: cni-metrics-helper
-    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/version: "v1.16.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -69,5 +69,5 @@ spec:
         - name: USE_PROMETHEUS
           value: "false"
         name: cni-metrics-helper
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.3"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.4"
       serviceAccountName: cni-metrics-helper

--- a/scripts/generate-cni-yaml.sh
+++ b/scripts/generate-cni-yaml.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
-HELM_VERSION="3.14.1"
+HELM_VERSION="3.14.2"
 NAMESPACE="kube-system"
 
 MAKEFILEPATH=$SCRIPTPATH/../Makefile
-VPC_CNI_VERSION="v1.16.3"
+VPC_CNI_VERSION="v1.16.4"
 NODE_AGENT_VERSION="v1.0.8"
 BUILD_DIR=$SCRIPTPATH/../build/cni-rel-yamls/$VPC_CNI_VERSION
 

--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -10,7 +10,7 @@
 # NG_LABEL_KEY: nodegroup label key, default "kubernetes.io/os"
 # NG_LABEL_VAL: nodegroup label val, default "linux"
 # RUN_DEVEKS_TEST: Set this variable for tests to run on a deveks cluster
-# CNI_METRICS_HELPER: cni metrics helper image tag, default "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.3"
+# CNI_METRICS_HELPER: cni metrics helper image tag, default "602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.4"
 # TEST_IMAGE_REGISTRY: the registry in test-infra-* accounts where e2e test images are stored
 set -e
 
@@ -37,9 +37,9 @@ function run_integration_test() {
   echo "cni test took $((SECONDS - START)) seconds."
 
   if [[ ! -z $PROD_IMAGE_REGISTRY ]]; then
-    CNI_METRICS_HELPER="$PROD_IMAGE_REGISTRY/cni-metrics-helper:v1.16.3"
+    CNI_METRICS_HELPER="$PROD_IMAGE_REGISTRY/cni-metrics-helper:v1.16.4"
   else
-    CNI_METRICS_HELPER="${CNI_METRICS_HELPER:=602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.3}"
+    CNI_METRICS_HELPER="${CNI_METRICS_HELPER:=602401143452.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:v1.16.4}"
   fi
 
   REPO_NAME=$(echo $CNI_METRICS_HELPER | cut -d ":" -f 1)

--- a/test/integration/cni/host_networking_test.go
+++ b/test/integration/cni/host_networking_test.go
@@ -114,7 +114,6 @@ var _ = Describe("test host networking", func() {
 				mtuValidationTest(false, NEW_MTU_VAL)
 			})
 			It("POD MTU", func() {
-				Skip("Skip this test until v1.16.4 is released")
 				mtuValidationTest(true, NEW_POD_MTU)
 			})
 		})

--- a/test/integration/ipv6/ipv6_host_networking_test.go
+++ b/test/integration/ipv6/ipv6_host_networking_test.go
@@ -110,7 +110,6 @@ var _ = Describe("[CANARY] test ipv6 host netns setup", func() {
 				mtuValidationTest(false, NEW_MTU_VAL)
 			})
 			It("POD MTU", func() {
-				Skip("Skip this test until v1.16.4 is released")
 				mtuValidationTest(true, NEW_POD_MTU)
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
release workflow
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
N/A

**What does this PR do / Why do we need it?**:
This PR contains CHANGELOG, chart, and manifest updates following the VPC CNI v1.16.4 release. It also enables the `POD_MTU` integration tests now that the feature is released.

**Testing done on this change**:
Release testing was already performed for this release.
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
Yes
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
