### PR TITLE
Fix coredns failing during custom networking tests

### DIFF
--- a/test/integration/cni/pod_traffic_across_az_test.go
+++ b/test/integration/cni/pod_traffic_across_az_test.go
@@ -101,7 +101,7 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	JustBeforeEach(func() {
 		By("authorizing security group ingress on instance security group")
 		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("authorizing security group egress on instance security group")
@@ -140,7 +140,7 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	JustAfterEach(func() {
 		By("revoking security group ingress on instance security group")
 		err = f.CloudServices.EC2().
-			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("revoking security group egress on instance security group")

--- a/test/integration/cni/pod_traffic_test.go
+++ b/test/integration/cni/pod_traffic_test.go
@@ -72,7 +72,7 @@ var _ = Describe("test pod networking", func() {
 	JustBeforeEach(func() {
 		By("authorizing security group ingress on instance security group")
 		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("authorizing security group egress on instance security group")
@@ -139,7 +139,7 @@ var _ = Describe("test pod networking", func() {
 	JustAfterEach(func() {
 		By("revoking security group ingress on instance security group")
 		err = f.CloudServices.EC2().
-			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
+			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("revoking security group egress on instance security group")

--- a/test/integration/pod-eni/security_group_per_pod_suite_test.go
+++ b/test/integration/pod-eni/security_group_per_pod_suite_test.go
@@ -86,11 +86,11 @@ var _ = BeforeSuite(func() {
 	By("authorizing egress and ingress on security group for client-server communication")
 	if isIPv4Cluster {
 		f.CloudServices.EC2().AuthorizeSecurityGroupEgress(securityGroupId, "tcp", openPort, openPort, v4Zero)
-		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "tcp", openPort, openPort, v4Zero)
+		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "tcp", openPort, openPort, v4Zero, false)
 	} else {
 		f.CloudServices.EC2().AuthorizeSecurityGroupEgress(securityGroupId, "tcp", openPort, openPort, v6Zero)
-		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "tcp", openPort, openPort, v6Zero)
-		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "icmpv6", -1, -1, v6Zero)
+		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "tcp", openPort, openPort, v6Zero, false)
+		f.CloudServices.EC2().AuthorizeSecurityGroupIngress(securityGroupId, "icmpv6", -1, -1, v6Zero, false)
 	}
 
 	By("getting branch ENI limits")

--- a/test/integration/pod-eni/security_group_per_pod_test.go
+++ b/test/integration/pod-eni/security_group_per_pod_test.go
@@ -126,10 +126,10 @@ var _ = Describe("Security Group for Pods Test", func() {
 			// 8080: metric-pod listener port
 			By("Adding an additional Ingress Rule on NodeSecurityGroupID to allow client-to-metric traffic")
 			if isIPv4Cluster {
-				err := f.CloudServices.EC2().AuthorizeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v4Zero)
+				err := f.CloudServices.EC2().AuthorizeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v4Zero, false)
 				Expect(err).ToNot(HaveOccurred())
 			} else {
-				err := f.CloudServices.EC2().AuthorizeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v6Zero)
+				err := f.CloudServices.EC2().AuthorizeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v6Zero, false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
@@ -160,10 +160,10 @@ var _ = Describe("Security Group for Pods Test", func() {
 			// Revoke the Ingress rule for traffic from client pods added to Node Security Group
 			By("Revoking the additional Ingress rule added to allow client-to-metric traffic")
 			if isIPv4Cluster {
-				err := f.CloudServices.EC2().RevokeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v4Zero)
+				err := f.CloudServices.EC2().RevokeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v4Zero, false)
 				Expect(err).ToNot(HaveOccurred())
 			} else {
-				err := f.CloudServices.EC2().RevokeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v6Zero)
+				err := f.CloudServices.EC2().RevokeSecurityGroupIngress(clusterSGID, "TCP", metricsPort, metricsPort, v6Zero, false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
testing

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
N/A

**What does this PR do / Why do we need it?**:
Coredns pods are in a failing state during the custom networking suite due to missing security group rules. This doesn't affect the test result since the tests do not require DNS resolving but is still a good fix.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
Tested Custom Networking suite and tested test cases that use ```AuthorizeSecurityGroupIngress``` and ```RevokeSecurityGroupIngress```.
- Custom Networking
<img width="641" alt="Screenshot 2024-03-12 at 2 57 10 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/4409ac49-66af-43b7-a5f5-617a0dcb4138">
<img width="396" alt="Screenshot 2024-03-12 at 3 06 57 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/8f34aa68-0d4e-49ca-86ca-b206d457c16e">

- Pod ENI
<img width="401" alt="Screenshot 2024-03-12 at 3 36 04 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/336967e3-0a3a-45f3-bbf9-be78fdcc221f">

- CNI (pod traffic test and pod traffic across az test)
<img width="410" alt="Screenshot 2024-03-12 at 3 39 25 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/3fff66ff-4657-49c2-b820-391e6dbf83d0">
<img width="409" alt="Screenshot 2024-03-12 at 3 49 51 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/9e92c1b5-6b34-4d9c-a8b9-2988dae98558">


<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
