### PR TITLE
Add vpc-id to leaked eni filters

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1886,6 +1886,12 @@ func (cache *EC2InstanceMetadataCache) getLeakedENIs() ([]*ec2.NetworkInterface,
 				aws.String(ec2.NetworkInterfaceStatusAvailable),
 			},
 		},
+		{
+			Name: aws.String("vpc-id"),
+			Values: []*string{
+				aws.String(cache.vpcID),
+			},
+		},
 	}
 	if cache.clusterName != "" {
 		leakedENIFilters = append(leakedENIFilters, &ec2.Filter{

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -1261,6 +1261,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
 								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
+								},
 							},
 							MaxResults: aws.Int64(1000),
 						},
@@ -1289,6 +1293,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 								{
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
 								},
 							},
 							MaxResults: aws.Int64(1000),
@@ -1351,6 +1359,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
 								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
+								},
 							},
 							MaxResults: aws.Int64(1000),
 						},
@@ -1395,6 +1407,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 								{
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
 								},
 							},
 							MaxResults: aws.Int64(1000),
@@ -1441,6 +1457,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
 								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
+								},
 							},
 							MaxResults: aws.Int64(1000),
 						},
@@ -1469,6 +1489,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 								{
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
 								},
 								{
 									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
@@ -1544,6 +1568,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 									Values: []*string{aws.String("available")},
 								},
 								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
+								},
+								{
 									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
 									Values: []*string{aws.String("awesome-cluster")},
 								},
@@ -1595,6 +1623,10 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 								{
 									Name:   aws.String("status"),
 									Values: []*string{aws.String("available")},
+								},
+								{
+									Name:   aws.String("vpc-id"),
+									Values: []*string{aws.String(vpcID)},
 								},
 								{
 									Name:   aws.String("tag:cluster.k8s.amazonaws.com/name"),
@@ -1653,7 +1685,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 						return nil
 					})
 			}
-			cache := &EC2InstanceMetadataCache{ec2SVC: mockEC2, clusterName: tt.fields.clusterName}
+			cache := &EC2InstanceMetadataCache{ec2SVC: mockEC2, clusterName: tt.fields.clusterName, vpcID: vpcID}
 			got, err := cache.getLeakedENIs()
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
N/A

**What does this PR do / Why do we need it?**:
Adds a VPC-ID filter when checking for leaked ENIs for better filtering.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
Verified that (for testing purposes changed the loop to check every minute rather than hour during testing: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/awsutils/awsutils.go#L390)

- CNI tagged ENIs are cleaned up properly after manually adding them through EC2 console. 
  - Tagged with `node.k8s.amazonaws.com/createdAt`: <time_stamp>
  - Tagged with `node.k8s.amazonaws.com/instance_id`: <instance_id>
  -  Tagged with `cluster.k8s.amazonaws.com/name`: <cluster_name>
  -  Description starts with `aws-K8S-`
-  Untagged ENIs are not cleaned up.
- CNI tagged ENIs on a different VPC are not cleaned up.
- Verified VPC ID is populated in the `DescribeNetworkInterface` call
  - `Request:{method:DescribeUserInterfaces, request-id:<request-id>, request:{\"InterfaceIds\":null, \"SubnetIds\":null, \"SecurityGroupIds\":null, \"PrivateAddresses\":null, \"InstanceIds\":null, \"PrivateDnsNames\":null, \"InstancePrivateDnsNames\":null, \"MacAddresses\":null, \"VpcId\":\"<vpc-id>\", [...]`


<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
