### PR TITLE
Fix ENABLE_SUBNET_DISCOVERY ordering

### DIFF
--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -464,12 +464,12 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "v1.18.0"
-            - name: ENABLE_SUBNET_DISCOVERY
-              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -464,12 +464,12 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "v1.18.0"
-            - name: ENABLE_SUBNET_DISCOVERY
-              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -464,12 +464,12 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "v1.18.0"
-            - name: ENABLE_SUBNET_DISCOVERY
-              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -464,12 +464,12 @@ spec:
               value: "false"
             - name: ENABLE_PREFIX_DELEGATION
               value: "false"
+            - name: ENABLE_SUBNET_DISCOVERY
+              value: "true"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "v1.18.0"
-            - name: ENABLE_SUBNET_DISCOVERY
-              value: "true"
             - name: WARM_ENI_TARGET
               value: "1"
             - name: WARM_PREFIX_TARGET


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
Cleanup

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
N/A

**What does this PR do / Why do we need it?**:
Fix the ordering to fix merge conflicts merging master to release-1.18

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
N/A

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
