### PR TITLE
Add correct labels to CNI metrics chart.

### DIFF
--- a/charts/cni-metrics-helper/templates/deployment.yaml
+++ b/charts/cni-metrics-helper/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       {{- end }}
       {{- end }}
       labels:
+        app.kubernetes.io/name: {{ include "cni-metrics-helper.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         k8s-app: cni-metrics-helper
     spec:
       containers:


### PR DESCRIPTION
Continuing from the conversation here

https://github.com/aws/amazon-vpc-cni-k8s/pull/2874#discussion_r1571602390


**What type of PR is this?**

Cleanup

**What does this PR do / Why do we need it?**:

Without this change, this command will not work

``` 
kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=cni-metrics-helper,app.kubernetes.io/instance=cni-metrics-helper"
```

**Testing done on this change**:

With this change

```
$ helm install cni-metrics-helper --namespace kube-system ./charts/cni-metrics-helper
NAME: cni-metrics-helper
LAST DEPLOYED: Fri Apr 19 18:19:46 2024
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
cni-metrics-helper has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=cni-metrics-helper,app.kubernetes.io/instance=cni-metrics-helper"

$ kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=cni-metrics-helper,app.kubernetes.io/instance=cni-metrics-helper"
NAME                                 READY   STATUS    RESTARTS   AGE
cni-metrics-helper-9b68b89c8-lpvd4   1/1     Running   0          15s
```

**Will this PR introduce any new dependencies?**:
```release-note

```