### PR TITLE
Added information on the build troubleshooting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [here](./docs/iam-policy.md) for required IAM policies.
 * `unit-test`, `format`,`lint` and `vet` provide ways to run the respective tests/tools and should be run before submitting a PR.
 * `make docker` will create a docker container using `docker buildx` that contains the finished binaries, with a tag of `amazon/amazon-k8s-cni:latest`
 * `make docker-unit-tests` uses a docker container to run all unit tests.
-* builds for all build and test actions run in docker containers based on `golang:1.21.5-6-gcc-al2` unless a different `GOLANG_IMAGE` tag is passed in.
+* Builds for all build and test actions run in docker containers based on `.go-version` unless a different `GOLANG_IMAGE` tag is passed in.
 
 ## Components
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -253,3 +253,11 @@ The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-no
 
 See the [cni-metrics-helper README](../cmd/cni-metrics-helper/README.md).
 
+
+## Build Troubleshooting
+
+If you encouter build issues while building vpc cni, ensure you are logged into a docker registry.
+For e.g.
+
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+~


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix?**:

Added information on the build troubleshooting.


**What does this PR do / Why do we need it?**:

If we run into authentication issues (404) when running `make docker`, this will help address that

```
 make docker
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.22.2-gcc-al2" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2" --network=host  \
        -f scripts/dockerfiles/Dockerfile.release \
        -t "amazon/amazon-k8s-cni:v1.12.0-333-g19d59c1b" \
        .
[+] Building 0.2s (5/5) FINISHED                                                                                                                                                      
 => [internal] load build definition from Dockerfile.release                                                                                                                     0.0s
 => => transferring dockerfile: 958B                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                 
```


**Testing done on this change**:

`make docker` is successful
