### PR TITLE
Remove unused code in vpc cni init and vpc cni binary.

### DIFF
--- a/cmd/aws-vpc-cni-init/main.go
+++ b/cmd/aws-vpc-cni-init/main.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	defaultHostCNIBinPath           = "/host/opt/cni/bin"
-	vpcCniInitDonePath              = "/vpc-cni-init/done"
 	metadataLocalIP                 = "local-ipv4"
 	metadataMAC                     = "mac"
 	defaultDisableIPv4TcpEarlyDemux = false
@@ -181,17 +180,7 @@ func _main() int {
 		return 1
 	}
 
-	// TODO: In order to speed up pod launch time, VPC CNI init container is not a Kubernetes init container.
-	// The VPC CNI container blocks on the existence of vpcCniInitDonePath
-	//err = cp.TouchFile(vpcCniInitDonePath)
-	//if err != nil {
-	//	log.WithError(err).Errorf("Failed to set VPC CNI init done")
-	//	return 1
-	//}
-
 	log.Infof("CNI init container done")
 
-	// TODO: Since VPC CNI init container is a real container, it never exits
-	// time.Sleep(time.Duration(1<<63 - 1))
 	return 0
 }


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix?**:


**What does this PR do / Why do we need it?**:


**Testing done on this change**:

[AfterSuite] PASSED [34.238 seconds]
------------------------------

$ ginkgo -vv --focus=CANARY --skip=STATIC

```
Ran 6 of 19 Specs in 1066.914 seconds
SUCCESS! -- 6 Passed | 0 Failed | 1 Flaked | 0 Pending | 13 Skipped
PASS

Ginkgo ran 1 suite in 18m18.846463429s
Test Suite Passed
```
