### PR TITLE
Update golang to go1.22.3

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up tools
         run: |
           # Install ginkgo version from go.mod

--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up tools
         run: |
           # Install ginkgo version from go.mod

--- a/.github/workflows/pr-automated-tests.yaml
+++ b/.github/workflows/pr-automated-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up tools
         run: |
           go install golang.org/x/lint/golint@latest
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Build CNI images
         run: make multi-arch-cni-build
       - name: Build CNI Init images

--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up tools
         run: |
           # Install ginkgo version from go.mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Generate CNI YAML
         run: make generate-cni-yaml
       - name: Create eks-charts PR

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up tools
         run: |
           # Install ginkgo version from go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-cni-k8s
 
-go 1.21
+go 1.22.3
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/test/agent/go.mod
+++ b/test/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-cni-k8s/test/agent
 
-go 1.21
+go 1.22.3
 
 require (
 	github.com/coreos/go-iptables v0.7.0


### PR DESCRIPTION
Update golang to go1.22.3

Go 1.22,  each iteration of the for loop creates new variables, and avoids accidental sharing bugs. https://go.dev/blog/loopvar-preview

In unit-tests we were relying on this "accidental sharing" to assert the mock expect outside of the scope of the for loop, so as soon as we updated go from 1.21 to 1.22 (https://github.com/aws/amazon-vpc-cni-k8s/pull/2921/files) our bug in unit-tests were revealed! It was strange to see mock tests failing https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/9204241312/job/25317363552?pr=2921

Another change which was required was moving the `gomock.NewController(t)` to the for loop so that each test will have it's own controller and own set of mocks.
