### PR TITLE
Helpful Make target to login to public ECR.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,9 @@ cleanup-ec2-sdk-override:
 	    ./scripts/ec2_model_override/cleanup.sh ; \
 	fi
 
+ecr-public-login:
+	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
 ##@ Cleanup
 
 # Clean temporary files and build artifacts from the project.


### PR DESCRIPTION
We often need to login to ECR to do the build. This make target can used to login to public ecr

```
make ecr-public-login
```

Not adding any dependency on purpose as it goal is to use this manually. 