### PR TITLE
Run Kops Test Separately to triage failures.

### DIFF
--- a/.github/workflows/kops-test.yaml
+++ b/.github/workflows/kops-test.yaml
@@ -1,16 +1,16 @@
-name: Weekly Cron tests
+name: Kops tests
 
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 16 * * 3" # every Wednesday
+    - cron: "0 15 * * *" # every day
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  weekly-cron:
+  daily-kops:
     if: github.repository == 'aws/amazon-vpc-cni-k8s'
     runs-on: ubuntu-latest
     steps:
@@ -36,24 +36,16 @@ jobs:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 28800 # 8 hours
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Run perf tests
+      - name: Run kops tests
         env:
           DISABLE_PROMPT: true
           ROLE_CREATE: false
           ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
           RUN_CNI_INTEGRATION_TESTS: false
-          PERFORMANCE_TEST_S3_BUCKET_NAME: cni-performance-tests
-          RUN_PERFORMANCE_TESTS: true
-        run: |
-          ./scripts/run-integration-tests.sh
-        if: always()
-      - name: Run bottlerocket tests
-        env:
-          DISABLE_PROMPT: true
-          ROLE_CREATE: false
-          ROLE_ARN: ${{ secrets.EKS_CLUSTER_ROLE_ARN }}
-          RUN_CNI_INTEGRATION_TESTS: false
-          RUN_BOTTLEROCKET_TEST: true
+          RUN_KOPS_TEST: true
+          K8S_VERSION: 1.30.0-beta.0
+          KOPS_VERSION: v1.29.0
+          KOPS_RUN_TOO_NEW_VERSION: 1
         run: |
           ./scripts/run-integration-tests.sh
         if: always()

--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.image.pullPolicy` | Container pull policy                              | `IfNotPresent`                      |
 | `nodeAgent.securityContext`  | Node Agent container Security context              | `capabilities: add: - "NET_ADMIN" privileged: true` |
 | `nodeAgent.enableCloudWatchLogs`  | Enable CW logging for Node Agent              | `false`                             |
+ `nodeAgent.networkPolicyAgentLogFileLocation`  | Log File location of Network Policy Agent | `/var/log/aws-routed-eni/network-policy-agent.log` |
 | `nodeAgent.enablePolicyEventLogs` | Enable policy decision logs for Node Agent    | `false`                             |
 | `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
 | `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |


### PR DESCRIPTION
Weekly Tests have been failing at the Kops Cluster create stage for a long time - https://github.com/aws/amazon-vpc-cni-k8s/actions/workflows/weekly-cron-tests.yaml

I verified locally that cluster create was successful for the Kops cluster.

Running the kops test separately will

a) Ensure bring the healthy status of weekly test.
b) By running kops test daily against the updated KOPS version, we can detect the failure and incorporate the fix back into weekly test.

```
Using cluster from kubectl context: kops-cni-test-cluster-1717198338.k8s.local

+ [[ ! -n Your cluster kops-cni-test-cluster-1717198338.k8s.local is ready ]]
+ export KUBECONFIG=/Users/senthilx/.kube/config
+ KUBECONFIG=/Users/senthilx/.kube/config
+ kubectl delete daemonset ebs-csi-node -n kube-system
daemonset.apps "ebs-csi-node" deleted
+ kubectl delete deployment coredns-autoscaler -n kube-system
deployment.apps "coredns-autoscaler" deleted
+ kubectl delete deployment aws-node-termination-handler -n kube-system --wait=true
deployment.apps "aws-node-termination-handler" deleted
+ kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.1/config/master/cni-metrics-helper.yaml
serviceaccount/cni-metrics-helper created
clusterrole.rbac.authorization.k8s.io/cni-metrics-helper created
clusterrolebinding.rbac.authorization.k8s.io/cni-metrics-helper created
deployment.apps/cni-metrics-helper created

(base) [senthilx@88665a371033:~/weekly-cron]$ kubectl get pods -A
NAMESPACE     NAME                                          READY   STATUS    RESTARTS        AGE
kube-system   aws-cloud-controller-manager-ssbvl            1/1     Running   1 (14m ago)     19m
kube-system   aws-node-66x5q                                1/1     Running   0               19m
kube-system   aws-node-n5hph                                1/1     Running   1 (14m ago)     19m
kube-system   aws-node-q928h                                1/1     Running   0               19m
kube-system   cni-metrics-helper-76b7f6dcf7-s7klb           1/1     Running   6 (4m12s ago)   18m
kube-system   coredns-6dd4f8d684-4fvdf                      1/1     Running   0               19m
kube-system   coredns-6dd4f8d684-52qdx                      1/1     Running   0               19m
kube-system   dns-controller-d78c47db6-vztrw                1/1     Running   1 (14m ago)     19m
kube-system   ebs-csi-controller-c95fd4f86-8gb6n            5/5     Running   5 (14m ago)     19m
kube-system   etcd-manager-events-i-02107542987d93f36       1/1     Running   1 (14m ago)     19m
kube-system   etcd-manager-main-i-02107542987d93f36         1/1     Running   1 (14m ago)     19m
kube-system   kops-controller-79dk9                         1/1     Running   1 (14m ago)     19m
kube-system   kube-apiserver-i-02107542987d93f36            2/2     Running   4 (14m ago)     19m
kube-system   kube-controller-manager-i-02107542987d93f36   1/1     Running   5 (14m ago)     20m
kube-system   kube-proxy-i-007f559b388064d7b                1/1     Running   0               19m
kube-system   kube-proxy-i-02107542987d93f36                1/1     Running   1 (14m ago)     19m
kube-system   kube-proxy-i-05825e7507931f244                1/1     Running   0               18m
kube-system   kube-scheduler-i-02107542987d93f36            1/1     Running   1 (14m ago)     18m
```
