### PR TITLE
Fix the Charts Version for v1.18.2

### DIFF
--- a/charts/aws-vpc-cni/Chart.yaml
+++ b/charts/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.18.1
+version: 1.18.2
 appVersion: "v1.18.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/cni-metrics-helper/Chart.yaml
+++ b/charts/cni-metrics-helper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.18.1
+version: 1.18.2
 appVersion: v1.18.2
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
Helm Charts are fixed in eks-charts.

https://github.com/aws/eks-charts/pull/1115
https://github.com/aws/eks-charts/pull/1116