### PR TITLE
use __MTU__ variable for IPv4 egress-cni too

### DIFF
--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -15,7 +15,7 @@
     {
       "name": "egress-cni",
       "type": "egress-cni",
-      "mtu": "9001",
+      "mtu": "__MTU__",
       "enabled": "__EGRESSPLUGINENABLED__",
       "randomizeSNAT": "__RANDOMIZESNAT__",
       "nodeIP": "__NODEIP__",


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
fixes #2949 

**What does this PR do / Why do we need it?**:

When setting `AWS_VPC_ENI_MTU` and/or `POD_MTU` to `"1500"` before, the network interfaces in a pod look like this:
```
$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
3: eth0@if17: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether ae:97:27:f0:0e:2a brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 2600:<snip>::1/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::ac97:27ff:fef0:e2a/64 scope link
       valid_lft forever preferred_lft forever
4: v4if0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP group default
    link/ether b2:7c:f4:d2:81:7c brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 169.254.172.9/22 brd 169.254.175.255 scope global v4if0
       valid_lft forever preferred_lft forever
    inet6 fe80::b07c:f4ff:fed2:817c/64 scope link
       valid_lft forever preferred_lft forever
```
after this change, the interfaces correctly show 1500 for both:
```
$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
3: eth0@if17: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether ae:97:27:f0:0e:2a brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 2600:<snip>::1/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::ac97:27ff:fef0:e2a/64 scope link
       valid_lft forever preferred_lft forever
4: v4if0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether b2:7c:f4:d2:81:7c brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 169.254.172.9/22 brd 169.254.175.255 scope global v4if0
       valid_lft forever preferred_lft forever
    inet6 fe80::b07c:f4ff:fed2:817c/64 scope link
       valid_lft forever preferred_lft forever
```

**Testing done on this change**:
It runs in our test environments and a single production region for ~8h. This is roughly 100 nodes.

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
People having set something else than MTU 9001 will also get the new MTU for the IPv4 interface.

**Does this change require updates to the CNI daemonset config files to work?**:
Not sure, we rebuild the container and init container and deployed them at once.

**Does this PR introduce any user-facing change?**:
People having set something else than MTU 9001 will also get the new MTU for the IPv4 interface.

```release-note
- fix MTU setting for the egress-cni: egress-cni is now also picking up on a custom `AWS_VPC_ENI_MTU` setting
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
