### PR TITLE
Upgrade to latest versions of GitHub actions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
         with:
           show-progress: false
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # refs/tags/v4.3.3
   govulncheck:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
         with:
           show-progress: false
       - name: Setup Go Version

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -31,7 +31,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 14400 # 4 hours

--- a/.github/workflows/issue-closed-message.yaml
+++ b/.github/workflows/issue-closed-message.yaml
@@ -10,7 +10,7 @@ jobs:
   auto_comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/closed-issue-message@v1
+      - uses: aws-actions/closed-issue-message@3c30436c76e381c567524ba630f169f2fc0d175a # refs/tags/v1
         with:
           # These inputs are both required
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/issue-stale-pr.yaml
+++ b/.github/workflows/issue-stale-pr.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@main
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # refs/tags/v9.0.0
         id: stale
         with:
           ascending: true

--- a/.github/workflows/kops-test.yaml
+++ b/.github/workflows/kops-test.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -31,7 +31,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 28800 # 8 hours

--- a/.github/workflows/nightly-cron-tests.yaml
+++ b/.github/workflows/nightly-cron-tests.yaml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -30,7 +30,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 14400 # 4 hours

--- a/.github/workflows/pr-automated-tests.yaml
+++ b/.github/workflows/pr-automated-tests.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -36,19 +36,19 @@ jobs:
       - name: Unit test
         run: make unit-test
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3 # refs/tags/v4.5.0
   docker-build:
     name: Build Docker images
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Build CNI images

--- a/.github/workflows/pr-manual-tests.yaml
+++ b/.github/workflows/pr-manual-tests.yaml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
         with:
           ref: "refs/pull/${{ github.event.inputs.pull_request_number }}/merge"
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -37,7 +37,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 14400 # 4 hours

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
         with:
           ref: "refs/tags/${{ github.event.release.tag_name }}"
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Generate CNI YAML

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,32 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2024
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+name: Scheduled Update Versions
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
+      - uses: technote-space/create-pr-action@91114507cf92349bec0a9a501c2edf1635427bc5 # refs/tags/v2.1.4
+        with:
+          EXECUTE_COMMANDS: |
+            gh_actions=$(grep -r "uses: [a-z\-]*/[\_a-z\-]*@" .github/workflows/ | sed 's/@.*//' | awk -F ': ' '{ print $3 }' | sort | uniq)
+            for action in $gh_actions; do
+                commit_hash=$(git ls-remote --tags "https://github.com/$action" | grep 'refs/tags/v[0-9][0-9\.]*$' | awk '{ print $NF,$0 }' | sort -k1,1 -V | cut -f2- -d' ' | grep -oh '.*refs/tags/[v0-9\.]*$' | tail -1 | awk '{ printf "%s # %s\n",$1,$2 }')
+                grep -ElRZ "uses: $action@" .github/workflows/ | xargs -0 -l sed -i -e "s|uses: $action@.*|uses: $action@$commit_hash|g"
+            done
+          COMMIT_MESSAGE: 'Upgrade versions GitHub actions'
+          COMMIT_NAME: 'updater bot'
+          PR_BRANCH_NAME: "versions-update-${PR_ID}"
+          PR_TITLE: 'chore: update gh versions'

--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit in the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
       - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # refs/tags/v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # refs/tags/v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # refs/tags/v5.0.1
         with:
           go-version: "1.22"
       - name: Set up tools
@@ -31,7 +31,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
         with:
           role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
           role-duration-seconds: 28800 # 8 hours


### PR DESCRIPTION
**What type of PR is this?**
dependency update

**Which issue does this PR fix?**:
NA

**What does this PR do / Why do we need it?**:
It seems like `dependabot` is not detecting the latest versions released by the GitHub actions used by this project. This change upgrades to the latest stable versions, resulting in fixing issues and vulneratibilties on the CI jobs.

**Testing done on this change**:
This testing has to be performed on the CI, which limits the possibility to run local tests.

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
