### PR TITLE
Subnet Discovery - Unfilled ENI fix

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -973,8 +973,9 @@ func (e *ENI) hasPods() bool {
 	return e.AssignedIPv4Addresses() != 0
 }
 
-// GetENINeedsIP finds an ENI in the datastore that needs more IP addresses allocated
-func (ds *DataStore) GetENINeedsIP(maxIPperENI int, skipPrimary bool) *ENI {
+// GetAllocatableENIs finds ENIs in the datastore that needs more IP addresses allocated
+func (ds *DataStore) GetAllocatableENIs(maxIPperENI int, skipPrimary bool) []*ENI {
+	var enis []*ENI
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 	for _, eni := range ds.eniPool {
@@ -985,10 +986,10 @@ func (ds *DataStore) GetENINeedsIP(maxIPperENI int, skipPrimary bool) *ENI {
 		if len(eni.AvailableIPv4Cidrs) < maxIPperENI {
 			ds.log.Debugf("Found ENI %s that has less than the maximum number of IP/Prefixes addresses allocated: cur=%d, max=%d",
 				eni.ID, len(eni.AvailableIPv4Cidrs), maxIPperENI)
-			return eni
+			enis = append(enis, eni)
 		}
 	}
-	return nil
+	return enis
 }
 
 // RemoveUnusedENIFromStore removes a deletable ENI from the data store.

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
@@ -468,13 +469,18 @@ func getDummyENIMetadataWithV6Prefix() awsutils.ENIMetadata {
 
 func TestIncreaseIPPoolDefault(t *testing.T) {
 	_ = os.Unsetenv(envCustomNetworkCfg)
-	testIncreaseIPPool(t, false, false)
+	testIncreaseIPPool(t, false, false, false)
+}
+
+func TestIncreaseIPPoolSubnetDiscoveryUnfilledENI(t *testing.T) {
+	_ = os.Unsetenv(envCustomNetworkCfg)
+	testIncreaseIPPool(t, false, false, true)
 }
 
 func TestIncreaseIPPoolCustomENI(t *testing.T) {
 	_ = os.Setenv(envCustomNetworkCfg, "true")
 	_ = os.Setenv("MY_NODE_NAME", myNodeName)
-	testIncreaseIPPool(t, true, false)
+	testIncreaseIPPool(t, true, false, false)
 }
 
 // Testing that the ENI will be allocated on non schedulable node when the AWS_MANAGE_ENIS_NON_SCHEDULABLE is set to `true`
@@ -482,7 +488,7 @@ func TestIncreaseIPPoolCustomENIOnNonSchedulableNode(t *testing.T) {
 	_ = os.Setenv(envCustomNetworkCfg, "true")
 	_ = os.Setenv(envManageENIsNonSchedulable, "true")
 	_ = os.Setenv("MY_NODE_NAME", myNodeName)
-	testIncreaseIPPool(t, true, true)
+	testIncreaseIPPool(t, true, true, false)
 }
 
 // Testing that the ENI will NOT be allocated on non schedulable node when the AWS_MANAGE_ENIS_NON_SCHEDULABLE is not set
@@ -490,10 +496,10 @@ func TestIncreaseIPPoolCustomENIOnNonSchedulableNodeDefault(t *testing.T) {
 	_ = os.Unsetenv(envManageENIsNonSchedulable)
 	_ = os.Setenv(envCustomNetworkCfg, "true")
 	_ = os.Setenv("MY_NODE_NAME", myNodeName)
-	testIncreaseIPPool(t, true, true)
+	testIncreaseIPPool(t, true, true, false)
 }
 
-func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool) {
+func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool, subnetDiscovery bool) {
 	m := setup(t)
 	defer m.ctrl.Finish()
 	ctx := context.Background()
@@ -506,11 +512,15 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool) 
 		warmENITarget:             1,
 		networkClient:             m.network,
 		useCustomNetworking:       UseCustomNetworkCfg(),
+		useSubnetDiscovery:        UseSubnetDiscovery(),
 		manageENIsNonScheduleable: ManageENIsOnNonSchedulableNode(),
 		primaryIP:                 make(map[string]string),
 		terminating:               int32(0),
 	}
 	mockContext.dataStore = testDatastore()
+	if subnetDiscovery {
+		mockContext.dataStore.AddENI(primaryENIid, primaryDevice, true, false, false)
+	}
 
 	primary := true
 	notPrimary := false
@@ -564,13 +574,14 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool) 
 	if unschedulabeNode {
 		val, exist := os.LookupEnv(envManageENIsNonSchedulable)
 		if exist && val == "true" {
-			assertAllocationExternalCalls(true, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata)
+			assertAllocationExternalCalls(true, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata, false)
 		} else {
-			assertAllocationExternalCalls(false, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata)
+			assertAllocationExternalCalls(false, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata, false)
 		}
-
+	} else if subnetDiscovery {
+		assertAllocationExternalCalls(true, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata, true)
 	} else {
-		assertAllocationExternalCalls(true, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata)
+		assertAllocationExternalCalls(true, useENIConfig, m, sg, podENIConfig, eni2, eniMetadata, false)
 	}
 
 	if mockContext.useCustomNetworking {
@@ -609,7 +620,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool) 
 	mockContext.increaseDatastorePool(ctx)
 }
 
-func assertAllocationExternalCalls(shouldCall bool, useENIConfig bool, m *testMocks, sg []*string, podENIConfig *eniconfigscheme.ENIConfigSpec, eni2 string, eniMetadata []awsutils.ENIMetadata) {
+func assertAllocationExternalCalls(shouldCall bool, useENIConfig bool, m *testMocks, sg []*string, podENIConfig *eniconfigscheme.ENIConfigSpec, eni2 string, eniMetadata []awsutils.ENIMetadata, subnetDiscovery bool) {
 	callCount := 0
 	if shouldCall {
 		callCount = 1
@@ -617,6 +628,10 @@ func assertAllocationExternalCalls(shouldCall bool, useENIConfig bool, m *testMo
 
 	if useENIConfig {
 		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet, 14).Times(callCount).Return(eni2, nil)
+	} else if subnetDiscovery {
+		m.awsutils.EXPECT().AllocIPAddresses(primaryENIid, 14).Times(callCount).Return(nil, awserr.New("InsufficientFreeAddressesInSubnet", "", errors.New("err")))
+		m.awsutils.EXPECT().AllocIPAddresses(primaryENIid, 1).Times(callCount).Return(nil, awserr.New("InsufficientFreeAddressesInSubnet", "", errors.New("err")))
+		m.awsutils.EXPECT().AllocENI(false, nil, "", 14).Times(callCount).Return(eni2, nil)
 	} else {
 		m.awsutils.EXPECT().AllocENI(false, nil, "", 14).Times(callCount).Return(eni2, nil)
 	}
@@ -627,15 +642,20 @@ func assertAllocationExternalCalls(shouldCall bool, useENIConfig bool, m *testMo
 
 func TestIncreasePrefixPoolDefault(t *testing.T) {
 	_ = os.Unsetenv(envCustomNetworkCfg)
-	testIncreasePrefixPool(t, false)
+	testIncreasePrefixPool(t, false, false)
+}
+
+func TestIncreasePrefixPoolSubnetDiscoveryUnfilledENI(t *testing.T) {
+	_ = os.Unsetenv(envCustomNetworkCfg)
+	testIncreasePrefixPool(t, false, true)
 }
 
 func TestIncreasePrefixPoolCustomENI(t *testing.T) {
 	_ = os.Setenv(envCustomNetworkCfg, "true")
-	testIncreasePrefixPool(t, true)
+	testIncreasePrefixPool(t, true, false)
 }
 
-func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
+func testIncreasePrefixPool(t *testing.T, useENIConfig, subnetDiscovery bool) {
 	m := setup(t)
 	defer m.ctrl.Finish()
 	ctx := context.Background()
@@ -650,6 +670,7 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
 		warmPrefixTarget:          1,
 		networkClient:             m.network,
 		useCustomNetworking:       UseCustomNetworkCfg(),
+		useSubnetDiscovery:        UseSubnetDiscovery(),
 		manageENIsNonScheduleable: ManageENIsOnNonSchedulableNode(),
 		primaryIP:                 make(map[string]string),
 		terminating:               int32(0),
@@ -657,6 +678,9 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
 	}
 
 	mockContext.dataStore = testDatastorewithPrefix()
+	if subnetDiscovery {
+		mockContext.dataStore.AddENI(primaryENIid, primaryDevice, true, false, false)
+	}
 
 	primary := true
 	testAddr1 := ipaddr01
@@ -677,6 +701,10 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig bool) {
 
 	if useENIConfig {
 		m.awsutils.EXPECT().AllocENI(true, sg, podENIConfig.Subnet, 1).Return(eni2, nil)
+	} else if subnetDiscovery {
+		m.awsutils.EXPECT().AllocIPAddresses(primaryENIid, 1).Return(nil, awserr.New("InsufficientFreeAddressesInSubnet", "", errors.New("err")))
+		m.awsutils.EXPECT().AllocIPAddresses(primaryENIid, 1).Return(nil, awserr.New("InsufficientFreeAddressesInSubnet", "", errors.New("err")))
+		m.awsutils.EXPECT().AllocENI(false, nil, "", 1).Return(eni2, nil)
 	} else {
 		m.awsutils.EXPECT().AllocENI(false, nil, "", 1).Return(eni2, nil)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
#2908 

**What does this PR do / Why do we need it?**:
If subnet discovery is on, we will proceed to create a new ENI if existing ENI is unfilled but the subnet is out of IPs.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
Manual Testing: Will be pasted offline
Integration: CNI, IPAMD, Custom Networking

- <img width="405" alt="Screenshot 2024-06-19 at 2 42 46 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/75ec37cb-0c53-411b-be32-24e6e31f600a">
- <img width="405" alt="Screenshot 2024-06-19 at 3 15 30 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/4607f1c5-44cf-4188-9db4-9d32cb71d4bf">
- <img width="392" alt="Screenshot 2024-06-19 at 4 32 15 PM" src="https://github.com/aws/amazon-vpc-cni-k8s/assets/76720045/b2fb0830-9693-413e-a6b5-793c45ff1de4">




<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, Yes

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
