### PR TITLE
Refactor static canary tests.

### DIFF
--- a/scripts/run-static-canary.sh
+++ b/scripts/run-static-canary.sh
@@ -21,7 +21,7 @@ function run_ginkgo_test() {
   local focus=$1
   echo "Running ginkgo tests with focus: $focus"
 
-  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 10m --fail-on-pending $GINKGO_TEST_BUILD/cni.test -- \
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --no-color --focus="$focus" -v --timeout 10m --fail-on-pending $GINKGO_TEST_BUILD/az-traffic.test -- \
       --cluster-kubeconfig="$KUBE_CONFIG_PATH" \
       --cluster-name="$CLUSTER_NAME" \
       --aws-region="$REGION" \

--- a/test/integration/az-traffic/pod_az_traffic_suite_test.go
+++ b/test/integration/az-traffic/pod_az_traffic_suite_test.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package az_traffic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAZConnectivity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CNI AZ Traffic Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	f = framework.New(framework.GlobalOptions)
+
+	By("creating test namespace")
+	f.K8sResourceManagers.NamespaceManager().CreateNamespace(utils.DefaultTestNamespace)
+
+	By(fmt.Sprintf("getting the node with the node label key %s and value %s",
+		f.Options.NgNameLabelKey, f.Options.NgNameLabelVal))
+	_, err := f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+})
+
+var _ = AfterSuite(func() {
+	By("deleting test namespace")
+	f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
+})

--- a/test/integration/az-traffic/pod_traffic_across_az_test.go
+++ b/test/integration/az-traffic/pod_traffic_across_az_test.go
@@ -1,4 +1,4 @@
-package cni
+package az_traffic
 
 import (
 	"fmt"
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	coreV1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,6 +23,8 @@ var (
 )
 
 const MetricNamespace = "NetworkingAZConnectivity"
+
+var f *framework.Framework
 
 var _ = Describe("[STATIC_CANARY] AZ Node Presence", FlakeAttempts(retries), func() {
 
@@ -69,7 +71,6 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	var (
 		err        error
 		serverPort int
-		protocol   string
 
 		// The command to run on server pods, to allow incoming
 		// connections for different traffic type
@@ -99,16 +100,6 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	)
 
 	JustBeforeEach(func() {
-		By("authorizing security group ingress on instance security group")
-		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("authorizing security group egress on instance security group")
-		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
-		Expect(err).ToNot(HaveOccurred())
-
 		netcatContainer := manifest.
 			NewNetCatAlpineContainer(f.Options.TestImageRegistry).
 			Command(serverListenCmd).
@@ -138,16 +129,6 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 	})
 
 	JustAfterEach(func() {
-		By("revoking security group ingress on instance security group")
-		err = f.CloudServices.EC2().
-			RevokeSecurityGroupIngress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("revoking security group egress on instance security group")
-		err = f.CloudServices.EC2().
-			RevokeSecurityGroupEgress(instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0")
-		Expect(err).ToNot(HaveOccurred())
-
 		By("deleting the Daemonset.")
 		err = f.K8sResourceManagers.DaemonSetManager().DeleteAndWaitTillDaemonSetIsDeleted(testDaemonSet, utils.DefaultDeploymentReadyTimeout)
 		Expect(err).ToNot(HaveOccurred())
@@ -157,7 +138,6 @@ var _ = Describe("[STATIC_CANARY] test pod networking", FlakeAttempts(retries), 
 
 		BeforeEach(func() {
 			serverPort = 2273
-			protocol = ec2.ProtocolTcp
 			// Test tcp connection using netcat
 			serverListenCmd = []string{"nc"}
 			// The nc flag "-l" for listen mode, "-k" to keep server up and not close
@@ -379,4 +359,24 @@ func RunCommandOnPod(receiverPod coreV1.Pod, command []string) (string, string, 
 			return stdout, stdrr, err
 		}
 	}
+}
+
+// testConnectivity verifies connectivity between tester and server
+func testConnectivity(senderPod coreV1.Pod, receiverPod coreV1.Pod, expectedStdout string,
+	expectedStderr string, port int, getTestCommandFunc func(receiverPod coreV1.Pod, port int) []string) {
+
+	testerCommand := getTestCommandFunc(receiverPod, port)
+
+	fmt.Fprintf(GinkgoWriter, "verifying connectivity from pod %s on node %s with IP %s to pod"+
+		" %s on node %s with IP %s\n", senderPod.Name, senderPod.Spec.NodeName, senderPod.Status.PodIP,
+		receiverPod.Name, receiverPod.Spec.NodeName, receiverPod.Status.PodIP)
+
+	stdOut, stdErr, err := f.K8sResourceManagers.PodManager().
+		PodExec(senderPod.Namespace, senderPod.Name, testerCommand)
+	Expect(err).ToNot(HaveOccurred())
+
+	fmt.Fprintf(GinkgoWriter, "stdout: %s and stderr: %s\n", stdOut, stdErr)
+
+	Expect(stdErr).To(ContainSubstring(expectedStderr))
+	Expect(stdOut).To(ContainSubstring(expectedStdout))
 }


### PR DESCRIPTION
- Remove any config changes to aws-node pod in BeforeSuite, by moving this into a separate package.
- Remove dependency on multiple EC2 apis.

**What type of PR is this?**

* cleanup
* dependency update
* improvement
* testing

## Testing Output

```
Will run 3 of 3 specs
------------------------------
[BeforeSuite]
/repository/vpc-cni/test/integration/az-traffic/pod_az_traffic_suite_test.go:32
  STEP: creating test namespace @ 06/21/24 14:52:40.003
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 06/21/24 14:52:40.027
[BeforeSuite] PASSED [0.893 seconds]
------------------------------
[STATIC_CANARY] AZ Node Presence While testing AZ availability Ensure nodes are present across AZs and returned by the k8s client.
/repository/vpc-cni/test/integration/az-traffic/pod_traffic_across_az_test.go:32
• [0.099 seconds]
------------------------------
[STATIC_CANARY] API Server Connectivity from AZs While testing API Server Connectivity Should connect to the API Server
/repository/vpc-cni/test/integration/az-traffic/pod_traffic_across_az_test.go:251
  STEP: creating a server DaemonSet on primary node @ 06/21/24 14:52:40.232
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 06/21/24 14:53:00.348
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c  AZID usw2-az3
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2c was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2d  AZID usw2-az4
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2d was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b  AZID usw2-az1
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a  AZID usw2-az2
API Server https://kubernetes.default.svc/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2d  AZID usw2-az4
API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2d was successful.
Testing API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2b  AZID usw2-az1
API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2b was successful.
Testing API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2a  AZID usw2-az2
API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2a was successful.
Testing API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2c  AZID usw2-az3
API Server https://6054439DAEF26D9867AF21C57A00977E.yl4.beta.us-west-2.clusters.wesley.amazonaws.com/api Connectivity from AZ us-west-2c was successful.
  STEP: Deleting the Daemonset. @ 06/21/24 14:53:02.202
• [23.988 seconds]
------------------------------
[STATIC_CANARY] test pod networking While testing connectivity across AZ Should allow TCP traffic across AZs.
/repository/vpc-cni/test/integration/az-traffic/pod_traffic_across_az_test.go:156
  STEP: creating a server DaemonSet on primary node @ 06/21/24 14:53:04.22
  STEP: getting the node with the node label key kubernetes.io/os and value linux @ 06/21/24 14:53:24.24
  STEP: checking connection on same node, primary to primary @ 06/21/24 14:53:24.786
Testing Connectivity from Pod IP1 192.168.79.253 (us-west-2c, usw2-az3) to Pod IP2 192.168.7.183 (us-west-2a, usw2-az2)
  verifying connectivity from pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253 to pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183
  stdout:  and stderr: Connection to 192.168.7.183 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.79.253 (us-west-2c, usw2-az3) to Pod IP2 192.168.197.78 (us-west-2d, usw2-az4)
  verifying connectivity from pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253 to pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78
  stdout:  and stderr: Connection to 192.168.197.78 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.79.253 (us-west-2c, usw2-az3) to Pod IP2 192.168.61.3 (us-west-2b, usw2-az1)
  verifying connectivity from pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253 to pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3
  stdout:  and stderr: Connection to 192.168.61.3 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.197.78 (us-west-2d, usw2-az4) to Pod IP2 192.168.79.253 (us-west-2c, usw2-az3)
  verifying connectivity from pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78 to pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253
  stdout:  and stderr: Connection to 192.168.79.253 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.197.78 (us-west-2d, usw2-az4) to Pod IP2 192.168.61.3 (us-west-2b, usw2-az1)
  verifying connectivity from pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78 to pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3
  stdout:  and stderr: Connection to 192.168.61.3 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.197.78 (us-west-2d, usw2-az4) to Pod IP2 192.168.7.183 (us-west-2a, usw2-az2)
  verifying connectivity from pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78 to pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183
  stdout:  and stderr: Connection to 192.168.7.183 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.61.3 (us-west-2b, usw2-az1) to Pod IP2 192.168.79.253 (us-west-2c, usw2-az3)
  verifying connectivity from pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3 to pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253
  stdout:  and stderr: Connection to 192.168.79.253 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.61.3 (us-west-2b, usw2-az1) to Pod IP2 192.168.197.78 (us-west-2d, usw2-az4)
  verifying connectivity from pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3 to pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78
  stdout:  and stderr: Connection to 192.168.197.78 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.61.3 (us-west-2b, usw2-az1) to Pod IP2 192.168.7.183 (us-west-2a, usw2-az2)
  verifying connectivity from pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3 to pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183
  stdout:  and stderr: Connection to 192.168.7.183 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.7.183 (us-west-2a, usw2-az2) to Pod IP2 192.168.79.253 (us-west-2c, usw2-az3)
  verifying connectivity from pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183 to pod netcat-daemonset-mdctg on node ip-192-168-86-69.us-west-2.compute.internal with IP 192.168.79.253
  stdout:  and stderr: Connection to 192.168.79.253 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.7.183 (us-west-2a, usw2-az2) to Pod IP2 192.168.197.78 (us-west-2d, usw2-az4)
  verifying connectivity from pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183 to pod netcat-daemonset-7cr7f on node ip-192-168-210-98.us-west-2.compute.internal with IP 192.168.197.78
  stdout:  and stderr: Connection to 192.168.197.78 2273 port [tcp/*] succeeded!

Testing Connectivity from Pod IP1 192.168.7.183 (us-west-2a, usw2-az2) to Pod IP2 192.168.61.3 (us-west-2b, usw2-az1)
  verifying connectivity from pod netcat-daemonset-l24xq on node ip-192-168-8-92.us-west-2.compute.internal with IP 192.168.7.183 to pod netcat-daemonset-l7vfm on node ip-192-168-63-220.us-west-2.compute.internal with IP 192.168.61.3
  stdout:  and stderr: Connection to 192.168.61.3 2273 port [tcp/*] succeeded!

  STEP: deleting the Daemonset. @ 06/21/24 14:53:49.458
• [47.247 seconds]
------------------------------
[AfterSuite]
/repository/vpc-cni/test/integration/az-traffic/pod_az_traffic_suite_test.go:45
  STEP: deleting test namespace @ 06/21/24 14:53:51.468
[AfterSuite] PASSED [6.110 seconds]
------------------------------

Ran 3 of 3 Specs in 78.338 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 1m18.370438004s
Test Suite Passed
all tests ran successfully in 3 minutes and 56 seconds

```