### PR TITLE
Update the APISpec Schema definition for ENIConfig.

### DIFF
--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -43,7 +43,6 @@ spec:
                 subnet:
                   type: string
               required:
-              - securityGroups
               - subnet
               type: object
             status:

--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -14,6 +14,41 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
+          description: ENIConfig is the Schema for the eniconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ENIConfigSpec defines the desired state of ENIConfig
+              properties:
+                securityGroups:
+                  items:
+                    type: string
+                  type: array
+                subnet:
+                  type: string
+              required:
+              - securityGroups
+              - subnet
+              type: object
+            status:
+              description: ENIConfigStatus defines the observed state of ENIConfig
+              type: object
   names:
     plural: eniconfigs
     singular: eniconfig


### PR DESCRIPTION
**What type of PR is this?**

Addresses the issue raised in https://github.com/aws/amazon-vpc-cni-k8s/issues/2963
Installer / Config Manager Terraform wasn't gracefully creating ENIConfig without this Schema Spec.


**Which issue does this PR fix?**:

https://github.com/aws/amazon-vpc-cni-k8s/issues/2963


**This was auto generated**


```
kubebuilder create api --group webapp --version v1 --kind ENIConfig
```

Copied the existing type from https://github.com/aws/amazon-vpc-cni-k8s/blob/189f00f64f3e0b0bd0f3b8eff070aed3f0ba32b6/pkg/apis/crd/v1alpha1/eniconfig_types.go

```
make manifests
```

**Will this PR introduce any new dependencies?**:

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:

No

**Does this PR introduce any user-facing change?**:

SchemaSpec API docs will have information.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
