### PR TITLE
bugfix: templating broken on helm when cniconfig is enabled

### DIFF
--- a/charts/aws-vpc-cni/templates/configmap.yaml
+++ b/charts/aws-vpc-cni/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
 binaryData:
   10-aws.conflist: {{ .Values.cniConfig.fileContents | b64enc }}
-{{- end -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
This fixes a templating bug where when cniConfig is enabled, whitespace after the base64 encoded value gets stripped due to the use of `{{ - end - }}` instead of `{{ - end }}`.

#### Expectation:
```
---
# Source: aws-vpc-cni/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-node
  labels:
    app.kubernetes.io/name: aws-node
    helm.sh/chart: aws-vpc-cni-1.18.2
    app.kubernetes.io/instance: aws-cni-node
    k8s-app: aws-node
    app.kubernetes.io/version: "v1.18.2"
    app.kubernetes.io/managed-by: Helm
binaryData:
  10-aws.conflist: e30=
---
# Source: aws-vpc-cni/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: amazon-vpc-cni
  namespace: default
  labels:
    app.kubernetes.io/name: aws-node
    helm.sh/chart: aws-vpc-cni-1.18.2
    app.kubernetes.io/instance: aws-cni-node
    k8s-app: aws-node
    app.kubernetes.io/version: "v1.18.2"
    app.kubernetes.io/managed-by: Helm
data:
  enable-windows-ipam: "false"
  enable-network-policy-controller: "false"
  enable-windows-prefix-delegation: "false"
  warm-prefix-target: "0"
  warm-ip-target: "1"
  minimum-ip-target: "3"
  branch-eni-cooldown: "60"
---
```

#### Actual:
```
---
# Source: aws-vpc-cni/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-node
  labels:
    app.kubernetes.io/name: aws-node
    helm.sh/chart: aws-vpc-cni-1.18.2
    app.kubernetes.io/instance: aws-cni-node
    k8s-app: aws-node
    app.kubernetes.io/version: "v1.18.2"
    app.kubernetes.io/managed-by: Helm
binaryData:
  10-aws.conflist: e30=---
apiVersion: v1
kind: ConfigMap
metadata:
  name: amazon-vpc-cni
  namespace: default
  labels:
    app.kubernetes.io/name: aws-node
    helm.sh/chart: aws-vpc-cni-1.18.2
    app.kubernetes.io/instance: aws-cni-node
    k8s-app: aws-node
    app.kubernetes.io/version: "v1.18.2"
    app.kubernetes.io/managed-by: Helm
data:
  enable-windows-ipam: "false"
  enable-network-policy-controller: "false"
  enable-windows-prefix-delegation: "false"
  warm-prefix-target: "0"
  warm-ip-target: "1"
  minimum-ip-target: "3"
  branch-eni-cooldown: "60"
---
```

**Will this PR introduce any new dependencies?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
no

**Does this PR introduce any user-facing change?**:
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
