### PR TITLE
Fix Charts Release 1.18 Branch.

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -65,6 +65,7 @@ image:
 # See https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables
 env:
   ADDITIONAL_ENI_TAGS: "{}"
+  ANNOTATE_POD_IP: "false"
   AWS_VPC_CNI_NODE_PORT_SUPPORT: "true"
   AWS_VPC_ENI_MTU: "9001"
   AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "false"


### PR DESCRIPTION
Looks like `ANNOTATE_POD_IP` wasn't present in charts in release 1.18 branch. It is present in default addons manifest and in master.