### PR TITLE
Bug fix: Ensure exact IP match between IMDS and local datastore.

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1457,7 +1457,7 @@ func (c *IPAMContext) eniIPPoolReconcile(ipPool []string, attachedENI awsutils.E
 	needEC2Reconcile := true
 	// Here we can't trust attachedENI since the IMDS metadata can be stale. We need to check with EC2 API.
 	// IPsSimilar will exclude primary IP of the ENI that is not added to the ipPool and not available for pods to use.
-	if !cniutils.IPsSimilar(ipPool,attachedENIIPs) {
+	if !cniutils.IPsSimilar(ipPool, attachedENIIPs) {
 		log.Warnf("Instance metadata does not match data store! ipPool: %v, metadata: %v", ipPool, attachedENIIPs)
 		log.Debugf("We need to check the ENI status by calling the EC2 control plane.")
 		// Call EC2 to verify IPs on this ENI

--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/imds"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 const (
@@ -144,4 +145,51 @@ func IsIptableTargetNotExist(err error) bool {
 		return false
 	}
 	return e.IsNotExist()
+}
+
+// PrefixSimilar checks if prefix pool and eni prefix are equivalent.
+func PrefixSimilar(prefixPool []string, eniPrefixes []*ec2.Ipv4PrefixSpecification) bool {
+	if len(prefixPool) != len(eniPrefixes) {
+		return false
+	}
+	
+	prefixPoolSet := make(map[string]struct{}, len(prefixPool))
+	for _, ip := range prefixPool {
+		prefixPoolSet[ip] = struct{}{}
+	}
+	
+	for _, prefix := range eniPrefixes {
+		if prefix == nil || prefix.Ipv4Prefix == nil {
+			return false
+		}
+		if _, exists := prefixPoolSet[*prefix.Ipv4Prefix]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+// IPsSimilar checks if ipPool and eniIPs are equivalent.
+func IPsSimilar(ipPool []string, eniIPs []*ec2.NetworkInterfacePrivateIpAddress) bool {
+	if len(ipPool) != len(eniIPs) {
+		return false
+	}
+	
+	ipPoolSet := make(map[string]struct{}, len(ipPool))
+	for _, ip := range ipPool {
+		ipPoolSet[ip] = struct{}{}
+	}
+	
+	for _, ip := range eniIPs {
+		if ip == nil || ip.PrivateIpAddress == nil || ip.Primary == nil {
+			return false
+		}
+		if *ip.Primary {
+			continue
+		}
+		if _, exists := ipPoolSet[*ip.PrivateIpAddress]; !exists {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -172,7 +172,7 @@ func PrefixSimilar(prefixPool []string, eniPrefixes []*ec2.Ipv4PrefixSpecificati
 // IPsSimilar checks if ipPool and eniIPs are equivalent.
 func IPsSimilar(ipPool []string, eniIPs []*ec2.NetworkInterfacePrivateIpAddress) bool {
 	// Here we do +1 in ipPool because eniIPs will also have primary IP which is not used by pods.
-	if len(ipPool) +1 != len(eniIPs) {
+	if len(ipPool)+1 != len(eniIPs) {
 		return false
 	}
 

--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -152,12 +152,12 @@ func PrefixSimilar(prefixPool []string, eniPrefixes []*ec2.Ipv4PrefixSpecificati
 	if len(prefixPool) != len(eniPrefixes) {
 		return false
 	}
-	
+
 	prefixPoolSet := make(map[string]struct{}, len(prefixPool))
 	for _, ip := range prefixPool {
 		prefixPoolSet[ip] = struct{}{}
 	}
-	
+
 	for _, prefix := range eniPrefixes {
 		if prefix == nil || prefix.Ipv4Prefix == nil {
 			return false
@@ -171,15 +171,16 @@ func PrefixSimilar(prefixPool []string, eniPrefixes []*ec2.Ipv4PrefixSpecificati
 
 // IPsSimilar checks if ipPool and eniIPs are equivalent.
 func IPsSimilar(ipPool []string, eniIPs []*ec2.NetworkInterfacePrivateIpAddress) bool {
-	if len(ipPool) != len(eniIPs) {
+	// Here we do +1 in ipPool because eniIPs will also have primary IP which is not used by pods.
+	if len(ipPool) +1 != len(eniIPs) {
 		return false
 	}
-	
+
 	ipPoolSet := make(map[string]struct{}, len(ipPool))
 	for _, ip := range ipPool {
 		ipPoolSet[ip] = struct{}{}
 	}
-	
+
 	for _, ip := range eniIPs {
 		if ip == nil || ip.PrivateIpAddress == nil || ip.Primary == nil {
 			return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Fixes #3019 


**What does this PR do / Why do we need it?**:
This PR verifies contents of imds ips vs internal state instead of just length of array.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
I have added unit test for functions that test equivalency of array.
<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
