### PR TITLE
Filter for interfaces with no ip info

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -603,14 +603,15 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 	}
 
 	log.Debugf("Found ENI: %s, MAC %s, device %d", eniID, eniMAC, deviceNum)
+
 	// Get IMDS fields for the interface
 	macImdsFields, err := cache.imds.GetMACImdsFields(ctx, eniMAC)
 	if err != nil {
 		awsAPIErrInc("GetMACImdsFields", err)
 		return ENIMetadata{}, err
 	}
-	isEFAOnlyInterface := true
-	// Efa-only interfaces do not have any ipv4s or ipv6s associated with it. If we don't find any local-ipv4 or ipv6 info in imds we assume it to be efa-only interface and validate this later via ec2 call n
+	ipInfoAvailable := false
+	// Efa-only interfaces do not have any ipv4s or ipv6s associated with it. If we don't find any local-ipv4 or ipv6 info in imds we assume it to be efa-only interface and validate this later via ec2 call
 	for _, field := range macImdsFields {
 		if field == "local-ipv4s" {
 			imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
@@ -619,7 +620,7 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 				return ENIMetadata{}, err
 			}
 			if len(imdsIPv4s) > 0 {
-				isEFAOnlyInterface = false
+				ipInfoAvailable = true
 				log.Debugf("Found IPv4 addresses associated with interface. This is not efa-only interface")
 				break
 			}
@@ -629,104 +630,109 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 			if err != nil {
 				awsAPIErrInc("GetIPv6s", err)
 			} else if len(imdsIPv6s) > 0 {
-				isEFAOnlyInterface = false
+				ipInfoAvailable = true
 				log.Debugf("Found IPv6 addresses associated with interface. This is not efa-only interface")
 				break
 			}
 		}
 	}
 
-	var subnetV4Cidr string
-	var ec2ip4s []*ec2.NetworkInterfacePrivateIpAddress
+	if !ipInfoAvailable {
+		return ENIMetadata{
+			ENIID:          eniID,
+			MAC:            eniMAC,
+			DeviceNumber:   deviceNum,
+			SubnetIPv4CIDR: "",
+			IPv4Addresses:  make([]*ec2.NetworkInterfacePrivateIpAddress, 0),
+			IPv4Prefixes:   make([]*ec2.Ipv4PrefixSpecification, 0),
+			SubnetIPv6CIDR: "",
+			IPv6Addresses:  make([]*ec2.NetworkInterfaceIpv6Address, 0),
+			IPv6Prefixes:   make([]*ec2.Ipv6PrefixSpecification, 0),
+		}, nil
+	}
+
+	// Get IPv4 and IPv6 addresses assigned to interface
+	cidr, err := cache.imds.GetSubnetIPv4CIDRBlock(ctx, eniMAC)
+	if err != nil {
+		awsAPIErrInc("GetSubnetIPv4CIDRBlock", err)
+		return ENIMetadata{}, err
+	}
+
+	imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
+	if err != nil {
+		awsAPIErrInc("GetLocalIPv4s", err)
+		return ENIMetadata{}, err
+	}
+
+	ec2ip4s := make([]*ec2.NetworkInterfacePrivateIpAddress, len(imdsIPv4s))
+	for i, ip4 := range imdsIPv4s {
+		ec2ip4s[i] = &ec2.NetworkInterfacePrivateIpAddress{
+			Primary:          aws.Bool(i == 0),
+			PrivateIpAddress: aws.String(ip4.String()),
+		}
+	}
+
 	var ec2ip6s []*ec2.NetworkInterfaceIpv6Address
 	var subnetV6Cidr string
-	var ec2ipv4Prefixes []*ec2.Ipv4PrefixSpecification
-	var ec2ipv6Prefixes []*ec2.Ipv6PrefixSpecification
-
-	// Do no fetch ip related info for Efa-only interfaces
-	if !isEFAOnlyInterface {
-		// Get IPv4 and IPv6 addresses assigned to interface
-		cidr, err := cache.imds.GetSubnetIPv4CIDRBlock(ctx, eniMAC)
+	if cache.v6Enabled {
+		// For IPv6 ENIs, do not error on missing IPv6 information
+		v6cidr, err := cache.imds.GetSubnetIPv6CIDRBlocks(ctx, eniMAC)
 		if err != nil {
-			awsAPIErrInc("GetSubnetIPv4CIDRBlock", err)
-			return ENIMetadata{}, err
+			awsAPIErrInc("GetSubnetIPv6CIDRBlocks", err)
 		} else {
-			subnetV4Cidr = cidr.String()
+			subnetV6Cidr = v6cidr.String()
 		}
 
-		imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
+		imdsIPv6s, err := cache.imds.GetIPv6s(ctx, eniMAC)
 		if err != nil {
-			awsAPIErrInc("GetLocalIPv4s", err)
-			return ENIMetadata{}, err
-		}
-
-		ec2ip4s = make([]*ec2.NetworkInterfacePrivateIpAddress, len(imdsIPv4s))
-		for i, ip4 := range imdsIPv4s {
-			ec2ip4s[i] = &ec2.NetworkInterfacePrivateIpAddress{
-				Primary:          aws.Bool(i == 0),
-				PrivateIpAddress: aws.String(ip4.String()),
-			}
-		}
-
-		if cache.v6Enabled {
-			// For IPv6 ENIs, do not error on missing IPv6 information
-			v6cidr, err := cache.imds.GetSubnetIPv6CIDRBlocks(ctx, eniMAC)
-			if err != nil {
-				awsAPIErrInc("GetSubnetIPv6CIDRBlocks", err)
-			} else {
-				subnetV6Cidr = v6cidr.String()
-			}
-
-			imdsIPv6s, err := cache.imds.GetIPv6s(ctx, eniMAC)
-			if err != nil {
-				awsAPIErrInc("GetIPv6s", err)
-			} else {
-				ec2ip6s = make([]*ec2.NetworkInterfaceIpv6Address, len(imdsIPv6s))
-				for i, ip6 := range imdsIPv6s {
-					ec2ip6s[i] = &ec2.NetworkInterfaceIpv6Address{
-						Ipv6Address: aws.String(ip6.String()),
-					}
+			awsAPIErrInc("GetIPv6s", err)
+		} else {
+			ec2ip6s = make([]*ec2.NetworkInterfaceIpv6Address, len(imdsIPv6s))
+			for i, ip6 := range imdsIPv6s {
+				ec2ip6s[i] = &ec2.NetworkInterfaceIpv6Address{
+					Ipv6Address: aws.String(ip6.String()),
 				}
 			}
 		}
+	}
 
-		// If IPv6 is enabled, get attached v6 prefixes.
-		if cache.v6Enabled {
-			imdsIPv6Prefixes, err := cache.imds.GetIPv6Prefixes(ctx, eniMAC)
-			if err != nil {
-				awsAPIErrInc("GetIPv6Prefixes", err)
-				return ENIMetadata{}, err
-			}
-			for _, ipv6prefix := range imdsIPv6Prefixes {
-				ec2ipv6Prefixes = append(ec2ipv6Prefixes, &ec2.Ipv6PrefixSpecification{
-					Ipv6Prefix: aws.String(ipv6prefix.String()),
-				})
-			}
-		} else if cache.v4Enabled && ((eniMAC == primaryMAC && !cache.useCustomNetworking) || (eniMAC != primaryMAC)) {
-			// Get prefix on primary ENI when custom networking is enabled is not needed.
-			// If primary ENI has prefixes attached and then we move to custom networking, we don't need to fetch
-			// the prefix since recommendation is to terminate the nodes and that would have deleted the prefix on the
-			// primary ENI.
-			imdsIPv4Prefixes, err := cache.imds.GetIPv4Prefixes(ctx, eniMAC)
-			if err != nil {
-				awsAPIErrInc("GetIPv4Prefixes", err)
-				return ENIMetadata{}, err
-			}
-			for _, ipv4prefix := range imdsIPv4Prefixes {
-				ec2ipv4Prefixes = append(ec2ipv4Prefixes, &ec2.Ipv4PrefixSpecification{
-					Ipv4Prefix: aws.String(ipv4prefix.String()),
-				})
-			}
+	var ec2ipv4Prefixes []*ec2.Ipv4PrefixSpecification
+	var ec2ipv6Prefixes []*ec2.Ipv6PrefixSpecification
+
+	// If IPv6 is enabled, get attached v6 prefixes.
+	if cache.v6Enabled {
+		imdsIPv6Prefixes, err := cache.imds.GetIPv6Prefixes(ctx, eniMAC)
+		if err != nil {
+			awsAPIErrInc("GetIPv6Prefixes", err)
+			return ENIMetadata{}, err
 		}
-	} else {
-		log.Debugf("No ipv4 or ipv6 info associated with this interface. This might be efa-only interface")
+		for _, ipv6prefix := range imdsIPv6Prefixes {
+			ec2ipv6Prefixes = append(ec2ipv6Prefixes, &ec2.Ipv6PrefixSpecification{
+				Ipv6Prefix: aws.String(ipv6prefix.String()),
+			})
+		}
+	} else if cache.v4Enabled && ((eniMAC == primaryMAC && !cache.useCustomNetworking) || (eniMAC != primaryMAC)) {
+		// Get prefix on primary ENI when custom networking is enabled is not needed.
+		// If primary ENI has prefixes attached and then we move to custom networking, we don't need to fetch
+		// the prefix since recommendation is to terminate the nodes and that would have deleted the prefix on the
+		// primary ENI.
+		imdsIPv4Prefixes, err := cache.imds.GetIPv4Prefixes(ctx, eniMAC)
+		if err != nil {
+			awsAPIErrInc("GetIPv4Prefixes", err)
+			return ENIMetadata{}, err
+		}
+		for _, ipv4prefix := range imdsIPv4Prefixes {
+			ec2ipv4Prefixes = append(ec2ipv4Prefixes, &ec2.Ipv4PrefixSpecification{
+				Ipv4Prefix: aws.String(ipv4prefix.String()),
+			})
+		}
 	}
 
 	return ENIMetadata{
 		ENIID:          eniID,
 		MAC:            eniMAC,
 		DeviceNumber:   deviceNum,
-		SubnetIPv4CIDR: subnetV4Cidr,
+		SubnetIPv4CIDR: cidr.String(),
 		IPv4Addresses:  ec2ip4s,
 		IPv4Prefixes:   ec2ipv4Prefixes,
 		SubnetIPv6CIDR: subnetV6Cidr,

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1407,9 +1407,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (DescribeAllENIsResult,
 			efaENIs[eniID] = true
 		}
 		if interfaceType != "efa-only" {
-			if len(eniMetadata.IPv4Addresses) == 0 && len(eniMetadata.IPv6Addresses) == 0 {
+			if len(eniMetadata.IPv4Addresses) == 0 {
 				log.Errorf("Missing IP addresses from IMDS. Non efa-only interface should have IP address associated with it %s", eniID)
-				outOfSyncErr := errors.New("DescribeAllENIs: No IP addresses found")
+				outOfSyncErr := errors.New("DescribeAllENIs: No IPv4 address found")
 				return DescribeAllENIsResult{}, outOfSyncErr
 			}
 		}

--- a/pkg/awsutils/imds.go
+++ b/pkg/awsutils/imds.go
@@ -136,6 +136,24 @@ func (imds TypedIMDS) GetMACs(ctx context.Context) ([]string, error) {
 	return list, err
 }
 
+// GetMACImdsFields returns the imds fields present for a MAC
+func (imds TypedIMDS) GetMACImdsFields(ctx context.Context, mac string) ([]string, error) {
+	key := fmt.Sprintf("network/interfaces/macs/%s", mac)
+	list, err := imds.getList(ctx, key)
+	if err != nil {
+		if imdsErr, ok := err.(*imdsRequestError); ok {
+			log.Warnf("%v", err)
+			return nil, imdsErr.err
+		}
+		return nil, err
+	}
+	// Remove trailing /
+	for i, item := range list {
+		list[i] = strings.TrimSuffix(item, "/")
+	}
+	return list, err
+}
+
 // GetInterfaceID returns the ID of the network interface.
 func (imds TypedIMDS) GetInterfaceID(ctx context.Context, mac string) (string, error) {
 	key := fmt.Sprintf("network/interfaces/macs/%s/interface-id", mac)


### PR DESCRIPTION
**What type of PR is this?**
feature support
-->

**Which issue does this PR fix?**:
Do not fetch ip info from imds for interfaces that will not have ip fields

**What does this PR do / Why do we need it?**:


**Testing done on this change**:
Tested with multi card and single card instance by deploying pods

normal interface imds fields 
```
sh-4.2$ curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/0e:bf:84:ab:27:65/
device-number
interface-id
local-hostname
local-ipv4s
mac
network-card
owner-id
security-group-ids
security-groups
subnet-id
subnet-ipv4-cidr-block
vpc-id
vpc-ipv4-cidr-block
vpc-ipv4-cidr-blocks
```

imds fields for interfaces with no ip info 
```
sh-4.2$ curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/0e:46:1b:72:19:89
device-number
interface-id
local-hostname
mac
network-card
owner-id
security-group-ids
security-groups
subnet-id
subnet-ipv4-cidr-block
vpc-id
vpc-ipv4-cidr-block
vpc-ipv4-cidr-blocks
```
**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
