### PR TITLE
Update README.md to add missing releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ For help, please consider the following venues (in order):
 For all Kubernetes releases, *we recommend installing the latest VPC CNI release*. The following table denotes our *oldest* recommended
 VPC CNI version for each actively supported Kubernetes release.
 
-| Kubernetes Release | 1.29     | 1.28     | 1.27     | 1.26     | 1.25     | 1.24    |
-| ------------------ | -------- | -------- | -------- | -------- | -------- | ------- |
-| VPC CNI Version    | v1.14.1+ | v1.13.4+ | v1.12.5+ | v1.12.0+ | v1.11.4+ | v1.9.3+ |
+| Kubernetes Release | 1.31     | 1.30     | 1.29     | 1.28     | 1.27     | 1.26     | 1.25     | 1.24    |
+| ------------------ | -------- | -------- | -------- | -------- | -------- | -------- | -------- | ------- |
+| VPC CNI Version    | v1.16.4+ | v1.16.0+ | v1.14.1+ | v1.13.4+ | v1.12.5+ | v1.12.0+ | v1.11.4+ | v1.9.3+ |
 
 ## Version Upgrade
 


### PR DESCRIPTION
Add kubernetes release 1.30 and 1.31 with supported CNI versions

**What type of PR is this?**
documentation
**Which issue does this PR fix?**:
#3062

**What does this PR do / Why do we need it?**:
Need current versions of kubernetes as the last two are missing from recommended version table.

**Testing done on this change**:
Doc change. Can be validated by going through `aws eks describe-addon-versions --addon-name vpc-cni`

**Will this PR introduce any new dependencies?**:
No
**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes, it updates the readme to include kubernetes versions 1.30 and 1.31.
```release-note
Add kubernetes version 1.30 and 1.31 to README.md
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
