### PR TITLE
Run Release Test for Updating KubeConfig.

### DIFF
--- a/scripts/lib/set_kubeconfig.sh
+++ b/scripts/lib/set_kubeconfig.sh
@@ -2,6 +2,6 @@
 
 # This script sets the KUBECONFIG environment variable based on KUBE_CONFIG_PATH if not already set.
 
-if [ -n "$KUBE_CONFIG_PATH" ] && [ -z "$KUBECONFIG" ]; then
+if [ -n "${KUBE_CONFIG_PATH:-}" ] && [ -z "$KUBECONFIG" ]; then
   export KUBECONFIG=$KUBE_CONFIG_PATH
 fi


### PR DESCRIPTION
Run Release Test for Updating KubeConfig.

This is to fix the integration test issue from
https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/11283474280/job/31382962702

```
Run ./scripts/run-integration-tests.sh
  ./scripts/run-integration-tests.sh
  shell: /usr/bin/bash -e {0}
  env:
    AWS_DEFAULT_REGION: ***
    AWS_REGION: ***
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
    DISABLE_PROMPT: true
    ROLE_CREATE: false
    ROLE_ARN: ***
    RUN_CONFORMANCE: true
/home/runner/work/amazon-vpc-cni-k8s/amazon-vpc-cni-k8s/scripts/lib/set_kubeconfig.sh: line 5: KUBE_CONFIG_PATH: unbound variable
```