### PR TITLE
Use the correct git tag version when building from master branch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@
 
 # VERSION is the source revision that executables and images are built from.
 VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
+
+# if the branch is master, use the version as master-<commit-hash>
+ifeq ($(shell git rev-parse --abbrev-ref HEAD),master)
+	VERSION = master-$(shell git rev-parse --short HEAD)
+endif
+
 GOLANG_VERSION ?= $(shell cat .go-version)
 # GOLANG_IMAGE is the building golang container image used.
 GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->

The master branch pointed to a old tag, so all the latest commits were pushed to these tags `v1.12.0-418-g612e8177` with prefix v1.12.0-


```
commit 612e81771c5641b0a58b37d9727526721f01e21a (HEAD -> master, origin/master, origin/HEAD, ref)
Author: Senthil Kumaran <senthilx@amazon.com>
Date:   Fri Oct 18 12:06:51 2024 -0700

    Update Limits and Add New Instance Types. (#3077)
[ec2-user@ip-172-32-32-162 amazon-vpc-cni-k8s]$ git describe --tags --always --dirty
v1.12.0-418-g612e8177
```

It will be better to use the master as prefix, with this change the tag will now look like

`amazon/amazon-k8s-cni:master-612e8177`

### Testing

```
[ec2-user@ip-172-32-32-162 amazon-vpc-cni-k8s]$ make docker
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2" --network=host  \
        -f scripts/dockerfiles/Dockerfile.release \
        -t "amazon/amazon-k8s-cni:master-612e8177" \
```