### PR TITLE
Cherry-pick : Add byobject filter on nodes (#2888)

### DIFF
--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -37,7 +37,11 @@ func getIPAMDCacheFilters() map[client.Object]cache.ByObject {
 		return map[client.Object]cache.ByObject{
 			&corev1.Pod{}: {
 				Field: fields.Set{"spec.nodeName": nodeName}.AsSelector(),
-			}}
+			},
+			&corev1.Node{}: {
+				Field: fields.Set{"metadata.name": nodeName}.AsSelector(),
+			},
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
* Add byobject filter on nodes

```
$ git cherry-pick 0703d03dec8afb8f83a7ff0c9d5eb5cc3363026e
[cherry_pick_optimization 4aebcacd] Add byobject filter on nodes (#2888)
 Author: Garvin Pang <garvinpang@protonmail.com>
 Date: Tue Oct 22 18:15:07 2024 -0700
 1 file changed, 5 insertions(+), 1 deletion(-)
```