### PR TITLE
Fix test run scripts.

### DIFF
--- a/scripts/lib/canary.sh
+++ b/scripts/lib/canary.sh
@@ -4,9 +4,7 @@
 
 SECONDS=0
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "$SCRIPT_DIR"/set_kubeconfig.sh
-
+source "$SCRIPT_DIR"/lib/set_kubeconfig.sh
 
 echo "Running tests for amazon-vpc-cni-k8s with the following variables
 KUBECONFIG:  $KUBECONFIG

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "$SCRIPT_DIR"/set_kubeconfig.sh
-
+source "$SCRIPT_DIR"/lib/set_kubeconfig.sh
 
 function load_cluster_details() {
   echo "loading cluster details $CLUSTER_NAME"

--- a/scripts/lib/performance_tests.sh
+++ b/scripts/lib/performance_tests.sh
@@ -43,7 +43,7 @@ function check_for_slow_performance() {
 
     # Divided by 3 to get current average, multiply past averages by 5/4 to get 25% window
     # Checks if current average is greater than or equal to 15 seconds to avoid failing due to fast previous runs
-    if [[$((CURRENT_DURATION_UP_SUM / 3)) -ge 15] && [ $((CURRENT_DURATION_UP_SUM / 3)) -gt $((PAST_PERFORMANCE_UP_AVERAGE * 5 / 4)) ]]; then
+    if [[ $((CURRENT_DURATION_UP_SUM / 3)) -ge 15 ]] && [[ $((CURRENT_DURATION_UP_SUM / 3)) -gt $((PAST_PERFORMANCE_UP_AVERAGE * 5 / 4)) ]]; then
         echo "FAILURE! Performance test pod UPPING took >25% longer than the past three tests"
         echo "This tests time: $((CURRENT_DURATION_UP_SUM / 3))"
         echo "Previous tests' time: ${PAST_PERFORMANCE_UP_AVERAGE}"


### PR DESCRIPTION
This change
> SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

introduced recently was mutating the SCRIPT_DIR (with `cd`), either had to be reverted or fixed.
