### PR TITLE
iptables operation add timeout and retry exponentially

### DIFF
--- a/cmd/egress-cni-plugin/egressContext.go
+++ b/cmd/egress-cni-plugin/egressContext.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/hostipamwrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/nswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/procsyswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils"
@@ -82,7 +83,7 @@ func NewEgressAddContext(nsPath, ifName string) egressContext {
 		ArgsIfName: ifName,
 		Veth:       vethwrapper.NewSetupVeth(),
 		IptCreator: func(protocol iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
-			return iptableswrapper.NewIPTables(protocol)
+			return networkutils.NewIPTables(protocol)
 		},
 	}
 }
@@ -95,7 +96,7 @@ func NewEgressDelContext(nsPath string) egressContext {
 		Ns:     nswrapper.NewNS(),
 		NsPath: nsPath,
 		IptCreator: func(protocol iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
-			return iptableswrapper.NewIPTables(protocol)
+			return networkutils.NewIPTables(protocol)
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.1
 	github.com/aws/smithy-go v1.22.1
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containernetworking/cni v1.2.3
 	github.com/containernetworking/plugins v1.5.1
 	github.com/coreos/go-iptables v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -53,10 +53,8 @@ func NewIPTables(protocol iptables.Protocol) (IPTablesIface, error) {
 		return nil, err
 	}
 	return &ipTables{
-		ipt: ipt,
-		backoff: &backoff.ExponentialBackOff{
-			MaxElapsedTime: 0, // Never stop retrying
-		},
+		ipt:     ipt,
+		backoff: backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(0)), // Never stop retrying as backward compatibility
 	}, nil
 }
 

--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -14,7 +14,14 @@
 // Package iptableswrapper is a wrapper interface for the iptables package
 package iptableswrapper
 
-import "github.com/coreos/go-iptables/iptables"
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/coreos/go-iptables/iptables"
+)
 
 // IPTablesIface is an interface created to make code unit testable.
 // Both the iptables package version and mocked version implement the same interface
@@ -35,76 +42,133 @@ type IPTablesIface interface {
 
 // ipTables is a struct that implements IPTablesIface using iptables package.
 type ipTables struct {
-	ipt *iptables.IPTables
+	ipt     *iptables.IPTables
+	backoff *backoff.ExponentialBackOff
 }
 
 // NewIPTables return a ipTables struct that implements IPTablesIface
 func NewIPTables(protocol iptables.Protocol) (IPTablesIface, error) {
-	ipt, err := iptables.NewWithProtocol(protocol)
+	ipt, err := iptables.New(iptables.IPFamily(protocol), iptables.Timeout(1))
 	if err != nil {
 		return nil, err
 	}
 	return &ipTables{
 		ipt: ipt,
+		backoff: &backoff.ExponentialBackOff{
+			MaxElapsedTime: 0, // Never stop retrying
+		},
 	}, nil
 }
 
 // Exists implements IPTablesIface interface by calling iptables package
 func (i ipTables) Exists(table, chain string, rulespec ...string) (bool, error) {
-	return i.ipt.Exists(table, chain, rulespec...)
+	operation := func() (bool, error) {
+		return i.ipt.Exists(table, chain, rulespec...)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return true, err
+	}
+	return result, nil
 }
 
 // Insert implements IPTablesIface interface by calling iptables package
 func (i ipTables) Insert(table, chain string, pos int, rulespec ...string) error {
-	return i.ipt.Insert(table, chain, pos, rulespec...)
+	operation := func() error {
+		return i.ipt.Insert(table, chain, pos, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // Append implements IPTablesIface interface by calling iptables package
 func (i ipTables) Append(table, chain string, rulespec ...string) error {
-	return i.ipt.Append(table, chain, rulespec...)
+	operation := func() error {
+		return i.ipt.Append(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // AppendUnique implements IPTablesIface interface by calling iptables package
 func (i ipTables) AppendUnique(table, chain string, rulespec ...string) error {
-	return i.ipt.AppendUnique(table, chain, rulespec...)
+	operation := func() error {
+		return i.ipt.AppendUnique(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // Delete implements IPTablesIface interface by calling iptables package
 func (i ipTables) Delete(table, chain string, rulespec ...string) error {
-	return i.ipt.Delete(table, chain, rulespec...)
+	operation := func() error {
+		return i.ipt.Delete(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // List implements IPTablesIface interface by calling iptables package
 func (i ipTables) List(table, chain string) ([]string, error) {
-	return i.ipt.List(table, chain)
+	operation := func() ([]string, error) {
+		return i.ipt.List(table, chain)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // NewChain implements IPTablesIface interface by calling iptables package
 func (i ipTables) NewChain(table, chain string) error {
-	return i.ipt.NewChain(table, chain)
+	operation := func() error {
+		return i.ipt.NewChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // ClearChain implements IPTablesIface interface by calling iptables package
 func (i ipTables) ClearChain(table, chain string) error {
-	return i.ipt.ClearChain(table, chain)
+	operation := func() error {
+		return i.ipt.ClearChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // DeleteChain implements IPTablesIface interface by calling iptables package
 func (i ipTables) DeleteChain(table, chain string) error {
-	return i.ipt.DeleteChain(table, chain)
+	operation := func() error {
+		return i.ipt.DeleteChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
 }
 
 // ListChains implements IPTablesIface interface by calling iptables package
 func (i ipTables) ListChains(table string) ([]string, error) {
-	return i.ipt.ListChains(table)
+	operation := func() ([]string, error) {
+		return i.ipt.ListChains(table)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // ChainExists implements IPTablesIface interface by calling iptables package
 func (i ipTables) ChainExists(table, chain string) (bool, error) {
-	return i.ipt.ChainExists(table, chain)
+	operation := func() (bool, error) {
+		return i.ipt.ChainExists(table, chain)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return true, err
+	}
+	return result, nil
 }
 
 // HasRandomFully implements IPTablesIface interface by calling iptables package
 func (i ipTables) HasRandomFully() bool {
 	return i.ipt.HasRandomFully()
+}
+
+func logRetryError(err error, t time.Duration) {
+	log.WithError(err).Errorf("Another app is currently holding the xtables lock. Retrying in %f seconds", t.Seconds())
 }

--- a/pkg/networkutils/iptables.go
+++ b/pkg/networkutils/iptables.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package networkutils is a collection of iptables and netlink functions
+package networkutils
+
+import (
+	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/coreos/go-iptables/iptables"
+)
+
+type ipTables struct {
+	ipt     iptableswrapper.IPTablesIface
+	backoff *backoff.ExponentialBackOff
+}
+
+// NewIPTables return a ipTables struct that implements IPTablesIface
+func NewIPTables(protocol iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
+	ipt, err := iptables.New(iptables.IPFamily(protocol), iptables.Timeout(1))
+	if err != nil {
+		return nil, err
+	}
+	return &ipTables{
+		ipt:     ipt,
+		backoff: backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(0)), // Never stop retrying as backward compatibility
+	}, nil
+}
+
+func (i ipTables) Exists(table, chain string, rulespec ...string) (bool, error) {
+	operation := func() (bool, error) {
+		return i.ipt.Exists(table, chain, rulespec...)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return true, err
+	}
+	return result, nil
+}
+
+func (i ipTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	operation := func() error {
+		return i.ipt.Insert(table, chain, pos, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) Append(table, chain string, rulespec ...string) error {
+	operation := func() error {
+		return i.ipt.Append(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) AppendUnique(table, chain string, rulespec ...string) error {
+	operation := func() error {
+		return i.ipt.AppendUnique(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) Delete(table, chain string, rulespec ...string) error {
+	operation := func() error {
+		return i.ipt.Delete(table, chain, rulespec...)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) List(table, chain string) ([]string, error) {
+	operation := func() ([]string, error) {
+		return i.ipt.List(table, chain)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (i ipTables) NewChain(table, chain string) error {
+	operation := func() error {
+		return i.ipt.NewChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) ClearChain(table, chain string) error {
+	operation := func() error {
+		return i.ipt.ClearChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) DeleteChain(table, chain string) error {
+	operation := func() error {
+		return i.ipt.DeleteChain(table, chain)
+	}
+	return backoff.RetryNotify(operation, i.backoff, logRetryError)
+}
+
+func (i ipTables) ListChains(table string) ([]string, error) {
+	operation := func() ([]string, error) {
+		return i.ipt.ListChains(table)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (i ipTables) ChainExists(table, chain string) (bool, error) {
+	operation := func() (bool, error) {
+		return i.ipt.ChainExists(table, chain)
+	}
+	result, err := backoff.RetryNotifyWithData(operation, i.backoff, logRetryError)
+	if err != nil {
+		return true, err
+	}
+	return result, nil
+}
+
+func (i ipTables) HasRandomFully() bool {
+	return i.ipt.HasRandomFully()
+}
+
+func logRetryError(err error, t time.Duration) {
+	log.Errorf("Another app is currently holding the xtables lock. Retrying in %f seconds", t.Seconds())
+}

--- a/pkg/networkutils/iptables_test.go
+++ b/pkg/networkutils/iptables_test.go
@@ -1,0 +1,228 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package networkutils is a collection of iptables and netlink functions
+package networkutils
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	mock_iptables "github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper/mocks"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	address1 = "203.0.113.1/32"
+	address2 = "203.0.113.2/32"
+	subnet1  = "192.0.2.0/24"
+)
+
+func randChain(t *testing.T) string {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		t.Fatalf("Failed to generate random chain name: %v", err)
+	}
+
+	return "TEST-" + n.String()
+}
+
+func setupIPTTest(t *testing.T) (*gomock.Controller,
+	string,
+	string,
+	*backoff.ExponentialBackOff) {
+	return gomock.NewController(t),
+		"filter",
+		randChain(t),
+		backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(0))
+}
+
+func TestExists(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().Exists(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT").Return(false, nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	exists, _ := ipt.Exists(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT")
+	assert.Equal(t, exists, false)
+}
+
+func TestInsert(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().Insert(table, chain, 2, "-s", subnet1, "-d", address2, "-j", "ACCEPT").Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.Insert(table, chain, 2, "-s", subnet1, "-d", address2, "-j", "ACCEPT")
+	assert.NoError(t, err)
+}
+
+func TestAppend(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().Append(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT").Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.Append(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT")
+	assert.NoError(t, err)
+}
+
+func TestAppendUnique(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().AppendUnique(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT").Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.AppendUnique(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT")
+	assert.NoError(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().Delete(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT").Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.Delete(table, chain, "-s", subnet1, "-d", address2, "-j", "ACCEPT")
+	assert.NoError(t, err)
+}
+
+func TestList(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	expected := []string{
+		"-N " + chain,
+		"-A " + chain + " -s " + address1 + " -d " + subnet1 + " -j ACCEPT",
+		"-A " + chain + " -s " + address2 + " -d " + subnet1 + " -j ACCEPT",
+	}
+
+	mockIptable.EXPECT().List(table, chain).Return(expected, nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	result, _ := ipt.List(table, chain)
+	assert.Equal(t, result, expected)
+}
+
+func TestNewChain(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().NewChain(table, chain).Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.NewChain(table, chain)
+	assert.NoError(t, err)
+}
+
+func TestClearChain(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().ClearChain(table, chain).Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.ClearChain(table, chain)
+	assert.NoError(t, err)
+}
+
+func TestDeleteChain(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().DeleteChain(table, chain).Return(nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	err := ipt.DeleteChain(table, chain)
+	assert.NoError(t, err)
+}
+
+func TestListChains(t *testing.T) {
+	ctrl, table, _, expBackoff := setupIPTTest(t)
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	expected := []string{
+		"filter",
+		"input",
+	}
+
+	mockIptable.EXPECT().ListChains(table).Return(expected, nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	result, _ := ipt.ListChains(table)
+	assert.Equal(t, expected, result)
+}
+
+func TestChainExists(t *testing.T) {
+	ctrl, table, chain, expBackoff := setupIPTTest(t)
+
+	mockIptable := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	mockIptable.EXPECT().ChainExists(table, chain).Return(true, nil)
+
+	ipt := &ipTables{
+		ipt:     mockIptable,
+		backoff: expBackoff,
+	}
+
+	exists, _ := ipt.ChainExists(table, chain)
+	assert.Equal(t, exists, true)
+}

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -204,7 +204,7 @@ func New() NetworkAPIs {
 		netLink: netlinkwrapper.NewNetLink(),
 		ns:      nswrapper.NewNS(),
 		newIptables: func(IPProtocol iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
-			ipt, err := iptables.NewWithProtocol(IPProtocol)
+			ipt, err := iptableswrapper.NewIPTables(IPProtocol)
 			return ipt, err
 		},
 	}

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -204,7 +204,7 @@ func New() NetworkAPIs {
 		netLink: netlinkwrapper.NewNetLink(),
 		ns:      nswrapper.NewNS(),
 		newIptables: func(IPProtocol iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
-			ipt, err := iptableswrapper.NewIPTables(IPProtocol)
+			ipt, err := NewIPTables(IPProtocol)
 			return ipt, err
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
- improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Close #2945 

**What does this PR do / Why do we need it?**:
- iptables operation wait forever without any informative output

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
Yes. retry util library: github.com/cenkalti/backoff/v4

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note
iptables operation add timeout and retry exponentially
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
