### PR TITLE
Migrate scripts/gen_vpc_ip_limits.go to SDK V2

### DIFF
--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -18,12 +18,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"os"
 	"reflect"
 	"sort"
 	"strconv"
 	"text/template"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 

--- a/scripts/gen_vpc_ip_limits.go
+++ b/scripts/gen_vpc_ip_limits.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -23,13 +24,12 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/vpc"
 
-	"github.com/aws/aws-sdk-go/aws"
-
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
 const ipLimitFileName = "pkg/vpc/vpc_ip_resource_limit.go"
@@ -103,19 +103,25 @@ func main() {
 // Helper function to call the EC2 DescribeRegions API, returning sorted region names
 // Note that the credentials being used may not be opted-in to all regions
 func describeRegions() []string {
-	// Get session
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
-	_, err := sess.Config.Credentials.Get()
+	// Create context
+	ctx := context.Background()
+
+	// Load AWS configuration
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get session credentials: %v", err)
+		log.Fatalf("Failed to load configuration: %v", err)
 	}
-	svc := ec2.New(sess)
-	output, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
+
+	// Create EC2 client
+	client := ec2.NewFromConfig(cfg)
+
+	// Call DescribeRegions
+	output, err := client.DescribeRegions(ctx, &ec2.DescribeRegionsInput{})
 	if err != nil {
 		log.Fatalf("Failed to call EC2 DescribeRegions: %v", err)
 	}
+
+	// Extract and sort region names
 	var regionNames []string
 	for _, region := range output.Regions {
 		regionNames = append(regionNames, *region.RegionName)
@@ -128,64 +134,75 @@ func describeRegions() []string {
 func describeInstanceTypes(region string, eniLimitMap map[string]vpc.InstanceTypeLimits) {
 	log.Infof("Describing instance types in region=%s", region)
 
-	// Get session
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-		Config:            *aws.NewConfig().WithRegion(region),
-	}))
-	_, err := sess.Config.Credentials.Get()
-	if err != nil {
-		log.Fatalf("Failed to get session credentials: %v", err)
-	}
-	svc := ec2.New(sess)
-	describeInstanceTypesInput := &ec2.DescribeInstanceTypesInput{}
+	// Create context
+	ctx := context.Background()
 
-	for {
-		output, err := svc.DescribeInstanceTypes(describeInstanceTypesInput)
+	// Load AWS configuration with specific region
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+	)
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Create EC2 client
+	client := ec2.NewFromConfig(cfg)
+
+	paginator := ec2.NewDescribeInstanceTypesPaginator(client, &ec2.DescribeInstanceTypesInput{})
+
+	// Iterate through all pages
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
 		if err != nil {
 			log.Fatalf("Failed to call EC2 DescribeInstanceTypes: %v", err)
 		}
+
 		// We just want the type name, ENI and IP limits
 		for _, info := range output.InstanceTypes {
 			// Ignore any missing values
-			instanceType := aws.StringValue(info.InstanceType)
+			instanceType := string(info.InstanceType)
+
 			// only one network card is supported, so use the MaximumNetworkInterfaces from the default card if more than one are present
 			var eniLimit int
 			if len(info.NetworkInfo.NetworkCards) > 1 {
-				eniLimit = int(aws.Int64Value(info.NetworkInfo.NetworkCards[*info.NetworkInfo.DefaultNetworkCardIndex].MaximumNetworkInterfaces))
+				eniLimit = int(*info.NetworkInfo.NetworkCards[*info.NetworkInfo.DefaultNetworkCardIndex].MaximumNetworkInterfaces)
 			} else {
-				eniLimit = int(aws.Int64Value(info.NetworkInfo.MaximumNetworkInterfaces))
+				eniLimit = int(*info.NetworkInfo.MaximumNetworkInterfaces)
 			}
-			ipv4Limit := int(aws.Int64Value(info.NetworkInfo.Ipv4AddressesPerInterface))
-			isBareMetalInstance := aws.BoolValue(info.BareMetal)
-			hypervisorType := aws.StringValue(info.Hypervisor)
+
+			ipv4Limit := int(*info.NetworkInfo.Ipv4AddressesPerInterface)
+			isBareMetalInstance := *info.BareMetal
+			hypervisorType := string(info.Hypervisor)
 			if hypervisorType == "" {
 				hypervisorType = "unknown"
 			}
-			networkCards := make([]vpc.NetworkCard, aws.Int64Value(info.NetworkInfo.MaximumNetworkCards))
-			defaultNetworkCardIndex := int(aws.Int64Value(info.NetworkInfo.DefaultNetworkCardIndex))
-			for idx := 0; idx < len(networkCards); idx += 1 {
+
+			networkCards := make([]vpc.NetworkCard, *info.NetworkInfo.MaximumNetworkCards)
+			defaultNetworkCardIndex := int(*info.NetworkInfo.DefaultNetworkCardIndex)
+
+			for idx := 0; idx < len(networkCards); idx++ {
 				networkCards[idx] = vpc.NetworkCard{
-					MaximumNetworkInterfaces: *info.NetworkInfo.NetworkCards[idx].MaximumNetworkInterfaces,
-					NetworkCardIndex:         *info.NetworkInfo.NetworkCards[idx].NetworkCardIndex,
+					MaximumNetworkInterfaces: int64(*info.NetworkInfo.NetworkCards[idx].MaximumNetworkInterfaces),
+					NetworkCardIndex:         int64(*info.NetworkInfo.NetworkCards[idx].NetworkCardIndex),
 				}
 			}
+
 			if instanceType != "" && eniLimit > 0 && ipv4Limit > 0 {
-				limits := vpc.InstanceTypeLimits{ENILimit: eniLimit, IPv4Limit: ipv4Limit, NetworkCards: networkCards, HypervisorType: strconv.Quote(hypervisorType),
-					IsBareMetal: isBareMetalInstance, DefaultNetworkCardIndex: defaultNetworkCardIndex}
+				limits := vpc.InstanceTypeLimits{
+					ENILimit:                eniLimit,
+					IPv4Limit:               ipv4Limit,
+					NetworkCards:            networkCards,
+					HypervisorType:          strconv.Quote(hypervisorType),
+					IsBareMetal:             isBareMetalInstance,
+					DefaultNetworkCardIndex: defaultNetworkCardIndex,
+				}
+
 				if existingLimits, contains := eniLimitMap[instanceType]; contains && !reflect.DeepEqual(existingLimits, limits) {
 					// this should never happen
 					log.Fatalf("A previous region has different limits for instanceType=%s than region=%s", instanceType, region)
 				}
 				eniLimitMap[instanceType] = limits
 			}
-		}
-		// Paginate to the next request
-		if output.NextToken == nil {
-			break
-		}
-		describeInstanceTypesInput = &ec2.DescribeInstanceTypesInput{
-			NextToken: output.NextToken,
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

- Feature

*Migrate scripts/gen_vpc_ip_limits.go to SDK V2*

For - Update AWS SDK Go dependency in amazon-vpc-cni-k8s to SDK V2 #3116
https://github.com/aws/amazon-vpc-cni-k8s/issues/3116


**Output of the Test Run**


```
]$ make generate-limits
go run  scripts/gen_vpc_ip_limits.go
{"level":"info","ts":"2024-11-19T21:55:29.774Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-northeast-1"}
{"level":"info","ts":"2024-11-19T21:55:32.335Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-northeast-2"}
{"level":"info","ts":"2024-11-19T21:55:34.512Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-northeast-3"}
{"level":"info","ts":"2024-11-19T21:55:35.581Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-south-1"}
{"level":"info","ts":"2024-11-19T21:55:39.282Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-southeast-1"}
{"level":"info","ts":"2024-11-19T21:55:42.678Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ap-southeast-2"}
{"level":"info","ts":"2024-11-19T21:55:45.690Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=ca-central-1"}
{"level":"info","ts":"2024-11-19T21:55:47.048Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=eu-central-1"}
{"level":"info","ts":"2024-11-19T21:55:50.356Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=eu-north-1"}
{"level":"info","ts":"2024-11-19T21:55:52.799Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=eu-west-1"}
{"level":"info","ts":"2024-11-19T21:55:55.828Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=eu-west-2"}
{"level":"info","ts":"2024-11-19T21:55:58.099Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=eu-west-3"}
{"level":"info","ts":"2024-11-19T21:56:00.123Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=sa-east-1"}
{"level":"info","ts":"2024-11-19T21:56:03.192Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=us-east-1"}
{"level":"info","ts":"2024-11-19T21:56:05.469Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=us-east-2"}
{"level":"info","ts":"2024-11-19T21:56:07.255Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=us-west-1"}
{"level":"info","ts":"2024-11-19T21:56:08.126Z","caller":"/home/ec2-user/git/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:51","msg":"Describing instance types in region=us-west-2"}
Adding "cr1.8xlarge": {8 30 0 [] "unknown" false} since it is missing from the API
Adding "u-12tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
Adding "c5a.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "p4de.24xlarge": {15 50 0 [] "nitro" false} since it is missing from the API
Adding "bmn-sf1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "hs1.8xlarge": {8 30 0 [] "unknown" false} since it is missing from the API
Adding "u-18tb1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "u-24tb1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "u-6tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
Adding "u-9tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
Adding "c5ad.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Replacing API value {15 50 0 [{15 0 }] "unknown" true} with override {15 50 0 [] "nitro" true} for "c7g.metal"
{"level":"info","ts":"2024-11-19T21:56:09.049Z","caller":"/home/ec2-user/.linuxbrew/Cellar/go/1.22.5/libexec/src/runtime/proc.go:271","msg":"Generated pkg/vpc/vpc_ip_resource_limit.go"}
{"level":"info","ts":"2024-11-19T21:56:09.053Z","caller":"/home/ec2-user/.linuxbrew/Cellar/go/1.22.5/libexec/src/runtime/proc.go:271","msg":"Generated misc/eni-max-pods.txt"}

```

