### PR TITLE
Migrate Routed eni cni plugin to AWS SDK V2.

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	current "github.com/containernetworking/cni/pkg/types/100"
 
 	"github.com/containernetworking/cni/pkg/skel"


### PR DESCRIPTION
Migrate Routed eni cni plugin to AWS SDK V2.

- No other dependency on SDK V1.
- The only method dependency was on `aws.Int` which is same as V1 and V2.


Addressing - Update AWS SDK Go dependency in amazon-vpc-cni-k8s to SDK V2 https://github.com/aws/amazon-vpc-cni-k8s/issues/3116