### PR TITLE
Fix issues with handling unmanaged ENIs with IPv6 only

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -610,7 +610,9 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 		awsAPIErrInc("GetMACImdsFields", err)
 		return ENIMetadata{}, err
 	}
-	ipInfoAvailable := false
+
+	ipv4Available := false
+	ipv6Available := false
 	// Efa-only interfaces do not have any ipv4s or ipv6s associated with it. If we don't find any local-ipv4 or ipv6 info in imds we assume it to be efa-only interface and validate this later via ec2 call
 	for _, field := range macImdsFields {
 		if field == "local-ipv4s" {
@@ -620,7 +622,7 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 				return ENIMetadata{}, err
 			}
 			if len(imdsIPv4s) > 0 {
-				ipInfoAvailable = true
+				ipv4Available = true
 				log.Debugf("Found IPv4 addresses associated with interface. This is not efa-only interface")
 				break
 			}
@@ -630,14 +632,14 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 			if err != nil {
 				awsAPIErrInc("GetIPv6s", err)
 			} else if len(imdsIPv6s) > 0 {
-				ipInfoAvailable = true
+				ipv6Available = true
 				log.Debugf("Found IPv6 addresses associated with interface. This is not efa-only interface")
 				break
 			}
 		}
 	}
 
-	if !ipInfoAvailable {
+	if !ipv4Available && !ipv6Available {
 		return ENIMetadata{
 			ENIID:          eniID,
 			MAC:            eniMAC,
@@ -652,23 +654,29 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 	}
 
 	// Get IPv4 and IPv6 addresses assigned to interface
-	cidr, err := cache.imds.GetSubnetIPv4CIDRBlock(ctx, eniMAC)
-	if err != nil {
-		awsAPIErrInc("GetSubnetIPv4CIDRBlock", err)
-		return ENIMetadata{}, err
-	}
+	var ec2ip4s []*ec2.NetworkInterfacePrivateIpAddress
+	var subnetV4Cidr string
+	if ipv4Available {
+		cidr, err := cache.imds.GetSubnetIPv4CIDRBlock(ctx, eniMAC)
+		if err != nil {
+			awsAPIErrInc("GetSubnetIPv4CIDRBlock", err)
+			return ENIMetadata{}, err
+		}
 
-	imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
-	if err != nil {
-		awsAPIErrInc("GetLocalIPv4s", err)
-		return ENIMetadata{}, err
-	}
+		subnetV4Cidr = cidr.String()
 
-	ec2ip4s := make([]*ec2.NetworkInterfacePrivateIpAddress, len(imdsIPv4s))
-	for i, ip4 := range imdsIPv4s {
-		ec2ip4s[i] = &ec2.NetworkInterfacePrivateIpAddress{
-			Primary:          aws.Bool(i == 0),
-			PrivateIpAddress: aws.String(ip4.String()),
+		imdsIPv4s, err := cache.imds.GetLocalIPv4s(ctx, eniMAC)
+		if err != nil {
+			awsAPIErrInc("GetLocalIPv4s", err)
+			return ENIMetadata{}, err
+		}
+
+		ec2ip4s = make([]*ec2.NetworkInterfacePrivateIpAddress, len(imdsIPv4s))
+		for i, ip4 := range imdsIPv4s {
+			ec2ip4s[i] = &ec2.NetworkInterfacePrivateIpAddress{
+				Primary:          aws.Bool(i == 0),
+				PrivateIpAddress: aws.String(ip4.String()),
+			}
 		}
 	}
 
@@ -732,7 +740,7 @@ func (cache *EC2InstanceMetadataCache) getENIMetadata(eniMAC string) (ENIMetadat
 		ENIID:          eniID,
 		MAC:            eniMAC,
 		DeviceNumber:   deviceNum,
-		SubnetIPv4CIDR: cidr.String(),
+		SubnetIPv4CIDR: subnetV4Cidr,
 		IPv4Addresses:  ec2ip4s,
 		IPv4Prefixes:   ec2ipv4Prefixes,
 		SubnetIPv6CIDR: subnetV6Cidr,
@@ -1407,14 +1415,17 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs() (DescribeAllENIsResult,
 			efaENIs[eniID] = true
 		}
 		if interfaceType != "efa-only" {
-			if len(eniMetadata.IPv4Addresses) == 0 {
+			if len(eniMetadata.IPv4Addresses) == 0 && len(eniMetadata.IPv6Addresses) == 0 {
 				log.Errorf("Missing IP addresses from IMDS. Non efa-only interface should have IP address associated with it %s", eniID)
-				outOfSyncErr := errors.New("DescribeAllENIs: No IPv4 address found")
+				outOfSyncErr := errors.New("DescribeAllENIs: No IPv4 and IPv6 addresses found")
 				return DescribeAllENIsResult{}, outOfSyncErr
 			}
 		}
+
 		// Check IPv4 addresses
-		logOutOfSyncState(eniID, eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
+		if len(eniMetadata.IPv4Addresses) > 0 {
+			logOutOfSyncState(eniID, eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
+		}
 		tagMap[eniMetadata.ENIID] = convertSDKTagsToTags(ec2res.TagSet)
 	}
 	return DescribeAllENIsResult{

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -56,6 +56,7 @@ const (
 	metadataSubnetCIDR   = "/subnet-ipv4-cidr-block"
 	metadataIPv4s        = "/local-ipv4s"
 	metadataIPv4Prefixes = "/ipv4-prefix"
+	metadataIPv6s        = "/ipv6s"
 	metadataIPv6Prefixes = "/ipv6-prefix"
 
 	az                   = "us-east-1a"
@@ -79,12 +80,14 @@ const (
 	eni2Device           = "1"
 	eni2PrivateIP        = "10.0.0.2"
 	eni2Prefix           = "10.0.2.0/28"
+	eni2v6IP             = "2001:db8:8:4::2"
 	eni2v6Prefix         = "2001:db8::/64"
 	eni2ID               = "eni-12341234"
 	metadataVPCIPv4CIDRs = "192.168.0.0/16	100.66.0.0/1"
 	myNodeName           = "testNodeName"
 	imdsMACFields        = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv4-cidr-block local-ipv4s ipv4-prefix ipv6-prefix"
 	imdsMACFieldsEfaOnly = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv4-cidr-block ipv4-prefix ipv6-prefix"
+	imdsMACFieldsV6Only  = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv6-cidr-blocks ipv6s ipv6-prefix"
 )
 
 func testMetadata(overrides map[string]interface{}) FakeIMDS {
@@ -232,6 +235,23 @@ func TestGetAttachedENIsWithEfaOnly(t *testing.T) {
 		metadataMACPath + eni2MAC + metadataDeviceNum:  eni2Device,
 		metadataMACPath + eni2MAC + metadataInterface:  eni2ID,
 		metadataMACPath + eni2MAC + metadataSubnetCIDR: subnetCIDR,
+	})
+
+	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}}
+	ens, err := cache.GetAttachedENIs()
+	if assert.NoError(t, err) {
+		assert.Equal(t, len(ens), 2)
+	}
+}
+
+func TestGetAttachedENIsWithIPv6Only(t *testing.T) {
+	mockMetadata := testMetadata(map[string]interface{}{
+		metadataMACPath:                                  primaryMAC + " " + eni2MAC,
+		metadataMACPath + eni2MAC:                        imdsMACFieldsV6Only,
+		metadataMACPath + eni2MAC + metadataDeviceNum:    eni2Device,
+		metadataMACPath + eni2MAC + metadataInterface:    eni2ID,
+		metadataMACPath + eni2MAC + metadataIPv6s:        eni2v6IP,
+		metadataMACPath + eni2MAC + metadataIPv6Prefixes: eni2v6Prefix,
 	})
 
 	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}}


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:

We have unmanaged trunk ENIs attached to our worker nodes which are designed for ipv6 only networks. These ENIs are tagged with `node.k8s.amazonaws.com/no_manage`, however the listing of attached ENIs happens before the IPAMD process filters those ENIs. As such, the metadata retrieval process fails when looking up the ipv4 address details for these ENIs, and causes the `aws-k8s-agent` process to exit with an initialization failure.

In this log, `eni-084b51xxxxxx` / `0e:7c:f9:xx:xx:xx` is the aws-vpc-cni managed ENI, and `eni-0b2cf8b6xxxxxx` / `0e:f3:73:xx:xx:xx` is our managed eni:

```
{"level":"debug","ts":"2024-11-22T16:49:26.314Z","caller":"awsutils/awsutils.go:1317","msg":"Total number of interfaces found: 2 "}
{"level":"debug","ts":"2024-11-22T16:49:26.314Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI MAC address: 0e:7c:f9:xx:xx:xx"}
{"level":"debug","ts":"2024-11-22T16:49:26.316Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI: eni-084b51xxxxxx, MAC 0e:7c:f9:xx:xx:xx, device 0"}
{"level":"debug","ts":"2024-11-22T16:49:26.318Z","caller":"awsutils/awsutils.go:567","msg":"Found IPv6 addresses associated with interface. This is not efa-only interface"}
{"level":"debug","ts":"2024-11-22T16:49:26.322Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI MAC address: 0e:f3:73:xx:xx:xx"}
{"level":"debug","ts":"2024-11-22T16:49:26.324Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI: eni-0b2cf8b6xxxxxx, MAC 0e:f3:73:xx:xx:xx, device 1"}
{"level":"debug","ts":"2024-11-22T16:49:26.326Z","caller":"awsutils/awsutils.go:567","msg":"Found IPv6 addresses associated with interface. This is not efa-only interface"}
{"level":"warn","ts":"2024-11-22T16:49:26.327Z","caller":"awsutils/imds.go:376","msg":"failed to retrieve network/interfaces/macs/0e:f3:73:xx:xx:xx/subnet-ipv4-cidr-block from instance metadata EC2MetadataError: failed to make EC2Metadata request\n<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>404 - Not Found</title>\n </head>\n <body>\n  <h1>404 - Not Found</h1>\n </body>\n</html>\n\n\tstatus code: 404, request id: "}
{"level":"error","ts":"2024-11-22T16:49:26.327Z","caller":"aws-k8s-agent/main.go:42","msg":"Initialization failure: ipamd init: failed to retrieve attached ENIs info: DescribeAllENIs: failed to get local ENI metadata: get attached ENIs: failed to retrieve ENI metadata for ENI: 0e:f3:73:xx:xx:xx: EC2MetadataError: failed to make EC2Metadata request\n<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>404 - Not Found</title>\n </head>\n <body>\n  <h1>404 - Not Found</h1>\n </body>\n</html>\n\n\tstatus code: 404, request id: "}
```

**What does this PR do / Why do we need it?**:

This PR better handles missing IPv4 information for ENIs which are IPv6 only (using same pattern that the IPv6 IPs lookup uses)

**Testing done on this change**:

Added unit tests to cover the new paths. Running in our EKS cluster the ENIs are now retrieved successfully (In this log, `eni-084b51xxxxxx` / `0e:7c:f9:xx:xx:xx` is the aws-vpc-cni managed ENI, and `eni-0b2cf8b6xxxxxx` / `0e:f3:73:xx:xx:xx` is our managed eni):

```
{"level":"debug","ts":"2024-11-22T17:45:13.815Z","caller":"awsutils/awsutils.go:1325","msg":"Total number of interfaces found: 2 "}
{"level":"debug","ts":"2024-11-22T17:45:13.815Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI MAC address: 0e:7c:f9:8b:06:fd"}
{"level":"debug","ts":"2024-11-22T17:45:13.817Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI: eni-084b51xxxxxx, MAC 0e:7c:f9:xx:xx:xx, device 0"}
{"level":"debug","ts":"2024-11-22T17:45:13.818Z","caller":"awsutils/awsutils.go:567","msg":"Found IPv6 addresses associated with interface. This is not efa-only interface"}
{"level":"debug","ts":"2024-11-22T17:45:13.819Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI MAC address: 0e:f3:73:xx:xx:xx"}
{"level":"debug","ts":"2024-11-22T17:45:13.821Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI: eni-0b2cf8b6xxxxxx, MAC 0e:f3:73:xx:xx:xx, device 1"}
{"level":"debug","ts":"2024-11-22T17:45:13.822Z","caller":"awsutils/awsutils.go:567","msg":"Found IPv6 addresses associated with interface. This is not efa-only interface"}
{"level":"info","ts":"2024-11-22T17:45:14.003Z","caller":"ipamd/ipamd.go:424","msg":"Got network card index 0 for ENI eni-084b51xxxxxx"}
{"level":"info","ts":"2024-11-22T17:45:14.004Z","caller":"ipamd/ipamd.go:424","msg":"eni-084b51xxxxxx is of type: interface"}
{"level":"info","ts":"2024-11-22T17:45:14.004Z","caller":"ipamd/ipamd.go:424","msg":"Got network card index 0 for ENI eni-0b2cf8b6xxxxxx"}
{"level":"info","ts":"2024-11-22T17:45:14.004Z","caller":"ipamd/ipamd.go:424","msg":"eni-0b2cf8b6xxxxxx is of type: trunk"}
{"level":"debug","ts":"2024-11-22T17:45:14.004Z","caller":"ipamd/ipamd.go:385","msg":"DescribeAllENIs success: ENIs: 2, tagged: 2"}
```

**Will this PR introduce any new dependencies?**:
n/a

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Tested with upgrading inplace without issues

**Does this change require updates to the CNI daemonset config files to work?**:
n/a

**Does this PR introduce any user-facing change?**:
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
