### PR TITLE
Fix KOps Integration Test

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -96,6 +96,9 @@ function up-kops-cluster {
     --networking amazonvpc \
     --node-count 2 \
     --node-size c5.xlarge \
+    --control-plane-count 3 \
+    --control-plane-size c5.xlarge \
+    --control-plane-zones ${AWS_DEFAULT_REGION}a,${AWS_DEFAULT_REGION}b \
     --ssh-public-key=~/.ssh/devopsinuse.pub \
     --kubernetes-version ${K8S_VERSION} \
     --image ${HOST_IMAGE_SSM_PARAMETER} \

--- a/scripts/lib/integration.sh
+++ b/scripts/lib/integration.sh
@@ -1,32 +1,79 @@
 function run_kops_conformance() {
-    START=$SECONDS
+  START=$SECONDS
 
-    export KUBECONFIG=~/.kube/config
-    kubectl apply -f "$TEST_CONFIG_PATH"
+  export KUBECONFIG=~/.kube/config
+
+  echo "=== Setting up test environment ==="
+  echo "Current directory: $(pwd)"
+  echo "KUBECONFIG path: $KUBECONFIG"
+  echo "K8S_VERSION: $K8S_VERSION"
+
+  # Download e2e test binary
+  echo "=== Downloading e2e test binary ==="
+  wget -qO- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test-linux-amd64.tar.gz | tar -zxvf - --strip-components=3 -C /tmp kubernetes/test/bin/e2e.test
+
+  # Apply CNI config and wait for daemonset
+  echo "=== Applying CNI configuration ==="
+  kubectl apply -f "$TEST_CONFIG_PATH"
+  echo "Waiting for aws-node daemonset to be ready..."
+  sleep 5
+  while [[ $(kubectl describe ds aws-node -n=kube-system | grep "Available Pods: 0") ]]; do
     sleep 5
-    while [[ $(kubectl describe ds aws-node -n=kube-system | grep "Available Pods: 0") ]]
-    do
-        sleep 5
-        echo "Waiting for daemonset update"
-    done
-    echo "Updated!"
+    echo "Still waiting for daemonset update..."
+    kubectl get ds aws-node -n kube-system
+  done
+  echo "CNI DaemonSet is ready!"
 
-    wget -qO- https://dl.k8s.io/v$K8S_VERSION/kubernetes-test-linux-amd64.tar.gz | tar -zxvf - --strip-components=3 -C /tmp  kubernetes/test/bin/e2e.test
+  # Show cluster state before tests
+  echo "=== Cluster State Before Tests ==="
+  echo "Nodes:"
+  kubectl get nodes -o wide
+  echo "Pods in kube-system:"
+  kubectl get pods -n kube-system
+  echo "CNI DaemonSet status:"
+  kubectl describe ds aws-node -n=kube-system
 
-    /tmp/e2e.test --ginkgo.focus="Conformance" --ginkgo.timeout 120m --kubeconfig=$KUBECONFIG --ginkgo.v --ginkgo.fail-fast  --ginkgo.flake-attempts 2 \
-	    --ginkgo.skip="(works for CRD with validation schema)|(ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer)|(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|(Basic StatefulSet functionality [StatefulSetBasic])|\[Slow\]|\[Serial\]"
+  # Run the focused set of tests with detailed logging
+  TEST_START=$SECONDS
+  set -o pipefail # Ensure we catch test failures
 
-    /tmp/e2e.test --ginkgo.focus="\[Serial\].*Conformance" --kubeconfig=$KUBECONFIG --ginkgo.v --ginkgo.fail-fast --ginkgo.flake-attempts 2 \
-	    --ginkgo.skip="(ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer)|(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]"
-    echo "Kops conformance tests ran successfully!"
+  /tmp/e2e.test --ginkgo.focus="Conformance" --ginkgo.timeout=120m --kubeconfig=$KUBECONFIG --ginkgo.v --ginkgo.trace --ginkgo.flake-attempts 8 \
+    --ginkgo.skip="(works for CRD with validation schema)|(ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer)|(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|(Basic StatefulSet functionality [StatefulSetBasic])|\[Slow\]|\[Serial\]"
 
-    KOPS_TEST_DURATION=$((SECONDS - START))
-    echo "TIMELINE: KOPS tests took $KOPS_TEST_DURATION seconds."
+  /tmp/e2e.test --ginkgo.focus="\[Serial\].*Conformance" --ginkgo.timeout=120m --kubeconfig=$KUBECONFIG --ginkgo.v --ginkgo.trace --ginkgo.flake-attempts 8 \
+    --ginkgo.skip="(ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer)|(should support remote command execution over websockets)|(should support retrieving logs from the container over websockets)|\[Slow\]"
+  echo "Kops conformance tests ran successfully!"
 
-    sleep 240 #Workaround to avoid ENI leakage during cluster deletion: https://github.com/aws/amazon-vpc-cni-k8s/issues/1223
+  TEST_EXIT_CODE=$?
+  TEST_DURATION=$((SECONDS - TEST_START))
+
+  echo "=== Test Results ==="
+  echo "Test duration: $TEST_DURATION seconds"
+  echo "Exit code: $TEST_EXIT_CODE"
+
+  # Show cluster state after tests
+  echo "=== Cluster State After Tests ==="
+  echo "Nodes:"
+  kubectl get nodes -o wide
+  echo "Pods in kube-system:"
+  kubectl get pods -n kube-system
+  echo "CNI DaemonSet status:"
+  kubectl describe ds aws-node -n=kube-system
+
+  KOPS_TEST_DURATION=$((SECONDS - START))
+  echo "=== Test Run Complete ==="
+  echo "TIMELINE: KOPS tests took $KOPS_TEST_DURATION seconds"
+
+  # Workaround to avoid ENI leakage during cluster deletion
+  # See: https://github.com/aws/amazon-vpc-cni-k8s/issues/1223
+  echo "Waiting for 240 seconds to avoid ENI leakage..."
+  sleep 240
+
+  # Exit with the test exit code
+  return $TEST_EXIT_CODE
 }
 
-function build_and_push_image(){
+function build_and_push_image() {
   command=$1
   args=$2
   START=$SECONDS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
- Test fix

<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->

- https://github.com/aws/amazon-vpc-cni-k8s/issues/3084

**What does this PR do / Why do we need it?**:

- Our K-Ops integration test has been failing for 7+ months in GitHub actions. This PR fixes it.

Changes made:
- Increased control plane node count for KOps test cluster to mitigate intermittent network issues with the API Server encountered during the test.
- Increased flake attempt/retry count from 2 to 8 to make sure that any test failures are not random.
- Added debug statements and modified Ginkgo flags to help with better debugging output if test fails in future. This test is very large with lots of output therefore debugging can be very challenging.



**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

- Successful test run: https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/12207364801

