### PR TITLE
Revert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -24,13 +24,13 @@ import (
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/aws/smithy-go"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/golang/mock/gomock"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	mock_ec2wrapper "github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper/mocks"
@@ -307,7 +307,8 @@ func TestAWSGetFreeDeviceNumberNoDevice(t *testing.T) {
 	result := &ec2.DescribeInstancesOutput{Reservations: []ec2types.Reservation{{
 		Instances: []ec2types.Instance{{
 			NetworkInterfaces: ec2ENIs,
-		}}}}}
+		}},
+	}}}
 
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 
@@ -473,12 +474,14 @@ func TestAllocENI(t *testing.T) {
 	ec2ENIs = append(ec2ENIs, ec2ENI)
 
 	result := &ec2.DescribeInstancesOutput{
-		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}}}
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}},
+	}
 
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	attachmentID := "eni-attach-58ddda9d"
 	attachResult := &ec2.AttachNetworkInterfaceOutput{
-		AttachmentId: &attachmentID}
+		AttachmentId: &attachmentID,
+	}
 	mockEC2.EXPECT().AttachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
@@ -527,7 +530,8 @@ func TestAllocENINoFreeDevice(t *testing.T) {
 		ec2ENIs = append(ec2ENIs, ec2ENI)
 	}
 	result := &ec2.DescribeInstancesOutput{
-		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}}}
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}},
+	}
 
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	mockEC2.EXPECT().DeleteNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -579,7 +583,8 @@ func TestAllocENIMaxReached(t *testing.T) {
 	ec2ENIs = append(ec2ENIs, ec2ENI)
 
 	result := &ec2.DescribeInstancesOutput{
-		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}}}
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}},
+	}
 
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	mockEC2.EXPECT().AttachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("AttachmentLimitExceeded"))
@@ -630,11 +635,13 @@ func TestAllocENIWithIPAddresses(t *testing.T) {
 	ec2ENIs = append(ec2ENIs, ec2ENI)
 
 	result := &ec2.DescribeInstancesOutput{
-		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}}}
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}},
+	}
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	attachmentID := "eni-attach-58ddda9d"
 	attachResult := &ec2.AttachNetworkInterfaceOutput{
-		AttachmentId: &attachmentID}
+		AttachmentId: &attachmentID,
+	}
 	mockEC2.EXPECT().AttachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
@@ -722,11 +729,13 @@ func TestAllocENIWithPrefixAddresses(t *testing.T) {
 	ec2ENIs = append(ec2ENIs, ec2ENI)
 
 	result := &ec2.DescribeInstancesOutput{
-		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}}}
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{NetworkInterfaces: ec2ENIs}}}},
+	}
 	mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	attachmentID := "eni-attach-58ddda9d"
 	attachResult := &ec2.AttachNetworkInterfaceOutput{
-		AttachmentId: &attachmentID}
+		AttachmentId: &attachmentID,
+	}
 	mockEC2.EXPECT().AttachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(attachResult, nil)
 	mockEC2.EXPECT().ModifyNetworkInterfaceAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
@@ -783,7 +792,8 @@ func TestFreeENI(t *testing.T) {
 	attachmentID := eniAttachID
 	attachment := &ec2types.NetworkInterfaceAttachment{AttachmentId: &attachmentID}
 	result := &ec2.DescribeNetworkInterfacesOutput{
-		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}}}
+		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}},
+	}
 	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	mockEC2.EXPECT().DetachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockEC2.EXPECT().DeleteNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -803,7 +813,8 @@ func TestFreeENIRetry(t *testing.T) {
 	attachmentID := eniAttachID
 	attachment := &ec2types.NetworkInterfaceAttachment{AttachmentId: &attachmentID}
 	result := &ec2.DescribeNetworkInterfacesOutput{
-		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}}}
+		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}},
+	}
 	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 
 	// retry 2 times
@@ -857,7 +868,8 @@ func TestFreeENIRetryMax(t *testing.T) {
 	attachmentID := eniAttachID
 	attachment := &ec2types.NetworkInterfaceAttachment{AttachmentId: &attachmentID}
 	result := &ec2.DescribeNetworkInterfacesOutput{
-		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}}}
+		NetworkInterfaces: []ec2types.NetworkInterface{{Attachment: attachment}},
+	}
 	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
 	mockEC2.EXPECT().DetachNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 
@@ -892,9 +904,11 @@ func TestDescribeInstanceTypes(t *testing.T) {
 	defer ctrl.Finish()
 	mockEC2.EXPECT().DescribeInstanceTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ec2.DescribeInstanceTypesOutput{
 		InstanceTypes: []ec2types.InstanceTypeInfo{
-			{InstanceType: "not-there", NetworkInfo: &ec2types.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int32(9),
-				Ipv4AddressesPerInterface: aws.Int32(99)},
+			{
+				InstanceType: "not-there", NetworkInfo: &ec2types.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int32(9),
+					Ipv4AddressesPerInterface: aws.Int32(99),
+				},
 			},
 		},
 		NextToken: nil,
@@ -989,7 +1003,7 @@ func TestAllocPrefixAddresses(t *testing.T) {
 	ctrl, mockEC2 := setup(t)
 	defer ctrl.Finish()
 
-	//Allocate 1 prefix for the ENI
+	// Allocate 1 prefix for the ENI
 	input := &ec2.AssignPrivateIpAddressesInput{
 		NetworkInterfaceId: aws.String(eniID),
 		Ipv4PrefixCount:    aws.Int32(1),
@@ -1203,8 +1217,10 @@ func TestEC2InstanceMetadataCache_waitForENIAndPrefixesAttached(t *testing.T) {
 				metadataMACPath + eni2MAC + metadataIPv4s:      eniIPs,
 				metadataMACPath + eni2MAC + metaDataPrefixPath: eniPrefixes,
 			})
-			cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2,
-				enablePrefixDelegation: true, v4Enabled: tt.args.v4Enabled, v6Enabled: tt.args.v6Enabled}
+			cache := &EC2InstanceMetadataCache{
+				imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2,
+				enablePrefixDelegation: true, v4Enabled: tt.args.v4Enabled, v6Enabled: tt.args.v6Enabled,
+			}
 			gotEniMetadata, err := cache.waitForENIAndIPsAttached(tt.args.eni, tt.args.wantedSecondaryIPs, tt.args.maxBackoffDelay)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("waitForENIAndIPsAttached() error = %v, wantErr %v", err, tt.wantErr)
@@ -1250,7 +1266,8 @@ func TestEC2InstanceMetadataCache_cleanUpLeakedENIsInternal(t *testing.T) {
 }
 
 func setupDescribeNetworkInterfacesPagesWithContextMock(
-	t *testing.T, mockEC2 *mock_ec2wrapper.MockEC2, interfaces []ec2types.NetworkInterface, err error, times int) {
+	t *testing.T, mockEC2 *mock_ec2wrapper.MockEC2, interfaces []ec2types.NetworkInterface, err error, times int,
+) {
 	mockEC2.EXPECT().
 		DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(times).

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -49,10 +49,7 @@ import (
 	mock_eniconfig "github.com/aws/amazon-vpc-cni-k8s/pkg/eniconfig/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	mock_networkutils "github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
 	rcscheme "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 const (
@@ -594,7 +591,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool, 
 		labels := map[string]string{
 			"k8s.amazonaws.com/eniConfig": "az1",
 		}
-		// Create a Fake Node
+		//Create a Fake Node
 		fakeNode := v1.Node{
 			TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 			ObjectMeta: metav1.ObjectMeta{Name: myNodeName, Labels: labels},
@@ -778,7 +775,7 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig, subnetDiscovery bool) {
 		labels := map[string]string{
 			"k8s.amazonaws.com/eniConfig": "az1",
 		}
-		// Create a Fake Node
+		//Create a Fake Node
 		fakeNode := v1.Node{
 			TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 			ObjectMeta: metav1.ObjectMeta{Name: myNodeName, Labels: labels},
@@ -787,7 +784,7 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig, subnetDiscovery bool) {
 		}
 		m.k8sClient.Create(ctx, &fakeNode)
 
-		// Create a dummy ENIConfig
+		//Create a dummy ENIConfig
 		fakeENIConfig := v1alpha1.ENIConfig{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "az1"},
@@ -849,7 +846,7 @@ func TestDecreaseIPPool(t *testing.T) {
 	assert.Equal(t, 0, over)       // after the above deallocation this should be zero
 	assert.Equal(t, true, enabled) // there is warm ip target enabled with the value of 1
 
-	// make another call just to ensure that more deallocations do not happen
+	//make another call just to ensure that more deallocations do not happen
 	mockContext.decreaseDatastorePool(10 * time.Second)
 
 	short, over, enabled = mockContext.datastoreTargetState(nil)
@@ -923,7 +920,7 @@ func TestTryAddIPToENI(t *testing.T) {
 
 	mockContext.myNodeName = myNodeName
 
-	// Create a Fake Node
+	//Create a Fake Node
 	fakeNode := v1.Node{
 		TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 		ObjectMeta: metav1.ObjectMeta{Name: myNodeName},
@@ -1085,13 +1082,13 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 					PrivateIpAddress: &testAddr1, Primary: &primary,
 				},
 			},
-			// IPv4Prefixes: make([]*ec2.Ipv4PrefixSpecification, 0),
+			//IPv4Prefixes: make([]*ec2.Ipv4PrefixSpecification, 0),
 			IPv4Prefixes: nil,
 		},
 	}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(oneIPUnassigned, nil)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Prefixes, nil)
-	// m.awsutils.EXPECT().GetIPv4sFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Addresses, nil)
+	//m.awsutils.EXPECT().GetIPv4sFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Addresses, nil)
 
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 	curENIs = mockContext.dataStore.GetENIInfos()
@@ -1456,20 +1453,16 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test3TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
 	Test4TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	tests := []struct {
 		name                       string
@@ -1496,8 +1489,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 
 			c := &IPAMContext{
 				awsClient:                mockAWSUtils,
-				enableManageUntaggedMode: true,
-			}
+				enableManageUntaggedMode: true}
 
 			mockAWSUtils.EXPECT().SetUnmanagedENIs(gomock.Any()).
 				Do(func(args []string) {
@@ -1524,11 +1516,13 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 						}
 					}
 					return false
+
 				}).AnyTimes()
 
 			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
+
 				}).AnyTimes()
 
 			if got := c.filterUnmanagedENIs(tt.enis); !reflect.DeepEqual(got, tt.want) {
@@ -1539,6 +1533,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 }
 
 func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T) {
+
 	eni1, eni2, eni3 := getDummyENIMetadata()
 	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
 	primaryENIonly := []awsutils.ENIMetadata{eni1}
@@ -1546,20 +1541,16 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test3TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
 	Test4TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	tests := []struct {
 		name                       string
@@ -1587,8 +1578,7 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 
 			c := &IPAMContext{
 				awsClient:                mockAWSUtils,
-				enableManageUntaggedMode: false,
-			}
+				enableManageUntaggedMode: false}
 
 			mockAWSUtils.EXPECT().GetPrimaryENI().Times(tt.expectedGetPrimaryENICalls).Return(eni1.ENIID)
 			mockAWSUtils.EXPECT().GetInstanceID().Times(tt.expectedGetInstanceIDCalls).Return(instanceID)
@@ -1617,11 +1607,13 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 						}
 					}
 					return false
+
 				}).AnyTimes()
 
 			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
+
 				}).AnyTimes()
 
 			if got := c.filterUnmanagedENIs(tt.enis); !reflect.DeepEqual(got, tt.want) {
@@ -1827,7 +1819,6 @@ func TestNodePrefixPoolReconcileBadIMDSData(t *testing.T) {
 	assert.Equal(t, 1, len(curENIs.ENIs))
 	assert.Equal(t, 16, curENIs.TotalIPs)
 }
-
 func getPrimaryENIMetadata() awsutils.ENIMetadata {
 	primary := true
 	notPrimary := false
@@ -1935,7 +1926,7 @@ func TestIPAMContext_setupENI(t *testing.T) {
 		primaryIP:     make(map[string]string),
 		terminating:   int32(0),
 	}
-	// mockContext.primaryIP[]
+	//mockContext.primaryIP[]
 
 	mockContext.dataStore = testDatastore()
 	primary := true
@@ -1981,7 +1972,7 @@ func TestIPAMContext_setupENIwithPDenabled(t *testing.T) {
 		primaryIP:     make(map[string]string),
 		terminating:   int32(0),
 	}
-	// mockContext.primaryIP[]
+	//mockContext.primaryIP[]
 
 	mockContext.dataStore = testDatastorewithPrefix()
 	primary := true
@@ -2223,6 +2214,7 @@ func TestIsConfigValid(t *testing.T) {
 			assert.Equal(t, tt.want, resp)
 		})
 	}
+
 }
 
 func TestAnnotatePod(t *testing.T) {
@@ -2418,74 +2410,4 @@ func TestAddFeatureToCNINode(t *testing.T) {
 			assert.True(t, containedCN == tt.customNet)
 		})
 	}
-}
-
-func TestPodENIErrInc(t *testing.T) {
-	// Reset metrics before test
-	prometheusmetrics.PodENIErr.Reset()
-
-	m := setup(t)
-	defer m.ctrl.Finish()
-	ctx := context.Background()
-
-	mockContext := &IPAMContext{
-		awsClient:     m.awsutils,
-		k8sClient:     m.k8sClient,
-		networkClient: m.network,
-		primaryIP:     make(map[string]string),
-		terminating:   int32(0),
-		dataStore:     testDatastore(),
-		enableIPv4:    true,
-		enableIPv6:    false,
-		enablePodENI:  true,
-	}
-
-	// Create a test pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "test-namespace",
-		},
-	}
-	err := mockContext.k8sClient.Create(ctx, pod)
-	assert.NoError(t, err)
-
-	// Mock AWS API error
-	m.awsutils.EXPECT().AllocENI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errors.New("API error")).Times(2) // Expect 2 calls
-
-	// Test case 1: First error
-	err = mockContext.tryAssignPodENI(ctx, pod, "test-function")
-	assert.Error(t, err)
-
-	// Verify metric was incremented
-	count := testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "test-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to be 1 for test-function")
-
-	// Test case 2: Second error with different function
-	err = mockContext.tryAssignPodENI(ctx, pod, "another-function")
-	assert.Error(t, err)
-
-	// Verify counts for both functions
-	count = testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "another-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to be 1 for another-function")
-
-	count = testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "test-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to remain 1 for test-function")
-}
-
-func (c *IPAMContext) tryAssignPodENI(ctx context.Context, pod *corev1.Pod, fnName string) error {
-	// Mock implementation for the test
-	_, err := c.awsClient.AllocENI(false, nil, "", 0)
-	if err != nil {
-		prometheusmetrics.PodENIErr.With(prometheus.Labels{"fn": fnName}).Inc()
-		return err
-	}
-	return nil
 }

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -22,9 +22,6 @@ import (
 
 	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
 
-	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -241,12 +238,6 @@ func TestServer_AddNetwork(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Reset the counter for each test case
-			prometheusmetrics.AddIPCnt = prometheus.NewCounter(prometheus.CounterOpts{
-				Name: "awscni_add_ip_req_count",
-				Help: "Number of add IP address requests",
-			})
-
 			m := setup(t)
 			defer m.ctrl.Finish()
 
@@ -311,10 +302,6 @@ func TestServer_AddNetwork(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, resp)
 			}
-
-			// Add more detailed assertion messages
-			assert.Equal(t, float64(1), testutil.ToFloat64(prometheusmetrics.AddIPCnt),
-				"AddIPCnt should be incremented exactly once for test case: %s", tt.name)
 		})
 	}
 }

--- a/utils/prometheusmetrics/prometheusmetrics.go
+++ b/utils/prometheusmetrics/prometheusmetrics.go
@@ -61,8 +61,8 @@ var (
 		},
 		[]string{"fn"},
 	)
-	AddIPCnt = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	AddIPCnt = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_add_ip_req_count",
 			Help: "The number of add IP address requests",
 		},
@@ -74,8 +74,8 @@ var (
 		},
 		[]string{"reason"},
 	)
-	PodENIErr = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	PodENIErr = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "awscni_pod_eni_error_count",
 			Help: "The number of errors encountered for pod ENIs",
 		},
@@ -88,8 +88,8 @@ var (
 		},
 		[]string{"api", "error", "status"},
 	)
-	AwsAPIErr = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	AwsAPIErr = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "awscni_aws_api_error_count",
 			Help: "The number of times AWS API returns an error",
 		},
@@ -134,14 +134,14 @@ var (
 			Help: "The number of IP addresses assigned to pods",
 		},
 	)
-	ForceRemovedENIs = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	ForceRemovedENIs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_force_removed_enis",
 			Help: "The number of ENIs force removed while they had assigned pods",
 		},
 	)
-	ForceRemovedIPs = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	ForceRemovedIPs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_force_removed_ips",
 			Help: "The number of IPs force removed while they had assigned pods",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
