### PR TITLE
Revert commit d57c4436e868106e3d7fc7e46f84e4e31af2c46e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -29,13 +29,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/golang/mock/gomock"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	mock_ec2wrapper "github.com/aws/amazon-vpc-cni-k8s/pkg/ec2wrapper/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/eventrecorder"
-	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -817,37 +814,6 @@ func TestFreeENIRetry(t *testing.T) {
 
 	err := cache.freeENI("test-eni", time.Millisecond, time.Millisecond)
 	assert.NoError(t, err)
-}
-
-func TestAwsAPIErrInc(t *testing.T) {
-	// Reset metrics before test
-	prometheusmetrics.AwsAPIErr.Reset()
-
-	// Test case 1: AWS error
-	awsErr := &smithy.GenericAPIError{
-		Code:    "InvalidParameterException",
-		Message: "The parameter is invalid",
-		Fault:   smithy.FaultUnknown,
-	}
-	awsAPIErrInc("CreateNetworkInterface", awsErr)
-
-	// Verify metric was incremented with correct labels
-	count := testutil.ToFloat64(prometheusmetrics.AwsAPIErr.With(prometheus.Labels{
-		"api":   "CreateNetworkInterface",
-		"error": "InvalidParameterException",
-	}))
-	assert.Equal(t, float64(1), count)
-
-	// Test case 2: Non-AWS error
-	regularErr := errors.New("some other error")
-	awsAPIErrInc("CreateNetworkInterface", regularErr)
-
-	// Verify metric was not incremented for non-AWS error
-	count = testutil.ToFloat64(prometheusmetrics.AwsAPIErr.With(prometheus.Labels{
-		"api":   "CreateNetworkInterface",
-		"error": "InvalidParameterException",
-	}))
-	assert.Equal(t, float64(1), count)
 }
 
 func TestFreeENIRetryMax(t *testing.T) {

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -49,10 +49,7 @@ import (
 	mock_eniconfig "github.com/aws/amazon-vpc-cni-k8s/pkg/eniconfig/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	mock_networkutils "github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils/mocks"
-	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
 	rcscheme "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 const (
@@ -594,7 +591,7 @@ func testIncreaseIPPool(t *testing.T, useENIConfig bool, unschedulabeNode bool, 
 		labels := map[string]string{
 			"k8s.amazonaws.com/eniConfig": "az1",
 		}
-		// Create a Fake Node
+		//Create a Fake Node
 		fakeNode := v1.Node{
 			TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 			ObjectMeta: metav1.ObjectMeta{Name: myNodeName, Labels: labels},
@@ -778,7 +775,7 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig, subnetDiscovery bool) {
 		labels := map[string]string{
 			"k8s.amazonaws.com/eniConfig": "az1",
 		}
-		// Create a Fake Node
+		//Create a Fake Node
 		fakeNode := v1.Node{
 			TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 			ObjectMeta: metav1.ObjectMeta{Name: myNodeName, Labels: labels},
@@ -787,7 +784,7 @@ func testIncreasePrefixPool(t *testing.T, useENIConfig, subnetDiscovery bool) {
 		}
 		m.k8sClient.Create(ctx, &fakeNode)
 
-		// Create a dummy ENIConfig
+		//Create a dummy ENIConfig
 		fakeENIConfig := v1alpha1.ENIConfig{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "az1"},
@@ -849,7 +846,7 @@ func TestDecreaseIPPool(t *testing.T) {
 	assert.Equal(t, 0, over)       // after the above deallocation this should be zero
 	assert.Equal(t, true, enabled) // there is warm ip target enabled with the value of 1
 
-	// make another call just to ensure that more deallocations do not happen
+	//make another call just to ensure that more deallocations do not happen
 	mockContext.decreaseDatastorePool(10 * time.Second)
 
 	short, over, enabled = mockContext.datastoreTargetState(nil)
@@ -923,7 +920,7 @@ func TestTryAddIPToENI(t *testing.T) {
 
 	mockContext.myNodeName = myNodeName
 
-	// Create a Fake Node
+	//Create a Fake Node
 	fakeNode := v1.Node{
 		TypeMeta:   metav1.TypeMeta{Kind: "Node"},
 		ObjectMeta: metav1.ObjectMeta{Name: myNodeName},
@@ -1085,13 +1082,13 @@ func TestNodePrefixPoolReconcile(t *testing.T) {
 					PrivateIpAddress: &testAddr1, Primary: &primary,
 				},
 			},
-			// IPv4Prefixes: make([]*ec2.Ipv4PrefixSpecification, 0),
+			//IPv4Prefixes: make([]*ec2.Ipv4PrefixSpecification, 0),
 			IPv4Prefixes: nil,
 		},
 	}
 	m.awsutils.EXPECT().GetAttachedENIs().Return(oneIPUnassigned, nil)
 	m.awsutils.EXPECT().GetIPv4PrefixesFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Prefixes, nil)
-	// m.awsutils.EXPECT().GetIPv4sFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Addresses, nil)
+	//m.awsutils.EXPECT().GetIPv4sFromEC2(primaryENIid).Return(oneIPUnassigned[0].IPv4Addresses, nil)
 
 	mockContext.nodeIPPoolReconcile(ctx, 0)
 	curENIs = mockContext.dataStore.GetENIInfos()
@@ -1456,20 +1453,16 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test3TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
 	Test4TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	tests := []struct {
 		name                       string
@@ -1496,8 +1489,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 
 			c := &IPAMContext{
 				awsClient:                mockAWSUtils,
-				enableManageUntaggedMode: true,
-			}
+				enableManageUntaggedMode: true}
 
 			mockAWSUtils.EXPECT().SetUnmanagedENIs(gomock.Any()).
 				Do(func(args []string) {
@@ -1524,11 +1516,13 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 						}
 					}
 					return false
+
 				}).AnyTimes()
 
 			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
+
 				}).AnyTimes()
 
 			if got := c.filterUnmanagedENIs(tt.enis); !reflect.DeepEqual(got, tt.want) {
@@ -1539,6 +1533,7 @@ func TestIPAMContext_filterUnmanagedENIs(t *testing.T) {
 }
 
 func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T) {
+
 	eni1, eni2, eni3 := getDummyENIMetadata()
 	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
 	primaryENIonly := []awsutils.ENIMetadata{eni1}
@@ -1546,20 +1541,16 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 	Test1TagMap := map[string]awsutils.TagMap{eni1.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test2TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "true"}}
 	Test3TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"},
-	}
+		eni3.ENIID: {"hi": "tag", eniNoManageTagKey: "false"}}
 	Test4TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNoManageTagKey: "true"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 	Test5TagMap := map[string]awsutils.TagMap{
 		eni2.ENIID: {"hi": "tag", eniNodeTagKey: "i-abcdabcdabcd"},
-		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID},
-	}
+		eni3.ENIID: {"hi": "tag", eniNodeTagKey: instanceID}}
 
 	tests := []struct {
 		name                       string
@@ -1587,8 +1578,7 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 
 			c := &IPAMContext{
 				awsClient:                mockAWSUtils,
-				enableManageUntaggedMode: false,
-			}
+				enableManageUntaggedMode: false}
 
 			mockAWSUtils.EXPECT().GetPrimaryENI().Times(tt.expectedGetPrimaryENICalls).Return(eni1.ENIID)
 			mockAWSUtils.EXPECT().GetInstanceID().Times(tt.expectedGetInstanceIDCalls).Return(instanceID)
@@ -1617,11 +1607,13 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 						}
 					}
 					return false
+
 				}).AnyTimes()
 
 			mockAWSUtils.EXPECT().IsMultiCardENI(gomock.Any()).DoAndReturn(
 				func(eni string) (unmanaged bool) {
 					return false
+
 				}).AnyTimes()
 
 			if got := c.filterUnmanagedENIs(tt.enis); !reflect.DeepEqual(got, tt.want) {
@@ -1827,7 +1819,6 @@ func TestNodePrefixPoolReconcileBadIMDSData(t *testing.T) {
 	assert.Equal(t, 1, len(curENIs.ENIs))
 	assert.Equal(t, 16, curENIs.TotalIPs)
 }
-
 func getPrimaryENIMetadata() awsutils.ENIMetadata {
 	primary := true
 	notPrimary := false
@@ -1935,7 +1926,7 @@ func TestIPAMContext_setupENI(t *testing.T) {
 		primaryIP:     make(map[string]string),
 		terminating:   int32(0),
 	}
-	// mockContext.primaryIP[]
+	//mockContext.primaryIP[]
 
 	mockContext.dataStore = testDatastore()
 	primary := true
@@ -1981,7 +1972,7 @@ func TestIPAMContext_setupENIwithPDenabled(t *testing.T) {
 		primaryIP:     make(map[string]string),
 		terminating:   int32(0),
 	}
-	// mockContext.primaryIP[]
+	//mockContext.primaryIP[]
 
 	mockContext.dataStore = testDatastorewithPrefix()
 	primary := true
@@ -2223,6 +2214,7 @@ func TestIsConfigValid(t *testing.T) {
 			assert.Equal(t, tt.want, resp)
 		})
 	}
+
 }
 
 func TestAnnotatePod(t *testing.T) {
@@ -2418,74 +2410,4 @@ func TestAddFeatureToCNINode(t *testing.T) {
 			assert.True(t, containedCN == tt.customNet)
 		})
 	}
-}
-
-func TestPodENIErrInc(t *testing.T) {
-	// Reset metrics before test
-	prometheusmetrics.PodENIErr.Reset()
-
-	m := setup(t)
-	defer m.ctrl.Finish()
-	ctx := context.Background()
-
-	mockContext := &IPAMContext{
-		awsClient:     m.awsutils,
-		k8sClient:     m.k8sClient,
-		networkClient: m.network,
-		primaryIP:     make(map[string]string),
-		terminating:   int32(0),
-		dataStore:     testDatastore(),
-		enableIPv4:    true,
-		enableIPv6:    false,
-		enablePodENI:  true,
-	}
-
-	// Create a test pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "test-namespace",
-		},
-	}
-	err := mockContext.k8sClient.Create(ctx, pod)
-	assert.NoError(t, err)
-
-	// Mock AWS API error
-	m.awsutils.EXPECT().AllocENI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errors.New("API error")).Times(2) // Expect 2 calls
-
-	// Test case 1: First error
-	err = mockContext.tryAssignPodENI(ctx, pod, "test-function")
-	assert.Error(t, err)
-
-	// Verify metric was incremented
-	count := testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "test-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to be 1 for test-function")
-
-	// Test case 2: Second error with different function
-	err = mockContext.tryAssignPodENI(ctx, pod, "another-function")
-	assert.Error(t, err)
-
-	// Verify counts for both functions
-	count = testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "another-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to be 1 for another-function")
-
-	count = testutil.ToFloat64(prometheusmetrics.PodENIErr.With(prometheus.Labels{
-		"fn": "test-function",
-	}))
-	assert.Equal(t, float64(1), count, "Expected error count to remain 1 for test-function")
-}
-
-func (c *IPAMContext) tryAssignPodENI(ctx context.Context, pod *corev1.Pod, fnName string) error {
-	// Mock implementation for the test
-	_, err := c.awsClient.AllocENI(false, nil, "", 0)
-	if err != nil {
-		prometheusmetrics.PodENIErr.With(prometheus.Labels{"fn": fnName}).Inc()
-		return err
-	}
-	return nil
 }

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -22,9 +22,6 @@ import (
 
 	pb "github.com/aws/amazon-vpc-cni-k8s/rpc"
 
-	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -241,12 +238,6 @@ func TestServer_AddNetwork(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Reset the counter for each test case
-			prometheusmetrics.AddIPCnt = prometheus.NewCounter(prometheus.CounterOpts{
-				Name: "awscni_add_ip_req_count",
-				Help: "Number of add IP address requests",
-			})
-
 			m := setup(t)
 			defer m.ctrl.Finish()
 
@@ -311,10 +302,6 @@ func TestServer_AddNetwork(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, resp)
 			}
-
-			// Add more detailed assertion messages
-			assert.Equal(t, float64(1), testutil.ToFloat64(prometheusmetrics.AddIPCnt),
-				"AddIPCnt should be incremented exactly once for test case: %s", tt.name)
 		})
 	}
 }

--- a/utils/prometheusmetrics/prometheusmetrics.go
+++ b/utils/prometheusmetrics/prometheusmetrics.go
@@ -61,8 +61,8 @@ var (
 		},
 		[]string{"fn"},
 	)
-	AddIPCnt = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	AddIPCnt = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_add_ip_req_count",
 			Help: "The number of add IP address requests",
 		},
@@ -74,8 +74,8 @@ var (
 		},
 		[]string{"reason"},
 	)
-	PodENIErr = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	PodENIErr = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "awscni_pod_eni_error_count",
 			Help: "The number of errors encountered for pod ENIs",
 		},
@@ -88,8 +88,8 @@ var (
 		},
 		[]string{"api", "error", "status"},
 	)
-	AwsAPIErr = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	AwsAPIErr = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "awscni_aws_api_error_count",
 			Help: "The number of times AWS API returns an error",
 		},
@@ -134,14 +134,14 @@ var (
 			Help: "The number of IP addresses assigned to pods",
 		},
 	)
-	ForceRemovedENIs = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	ForceRemovedENIs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_force_removed_enis",
 			Help: "The number of ENIs force removed while they had assigned pods",
 		},
 	)
-	ForceRemovedIPs = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	ForceRemovedIPs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "awscni_force_removed_ips",
 			Help: "The number of IPs force removed while they had assigned pods",
 		},


### PR DESCRIPTION
Revert commit matches with this:
https://github.com/aws/amazon-vpc-cni-k8s/pull/3147/commits

Testing:
```
go mod tidy # passes

make # passes

make multi-arch-cni-build # passes (logs below)

docker buildx build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2" --network=host  \
		-f scripts/dockerfiles/Dockerfile.release \
		--platform "linux/amd64,linux/arm64"\
		--cache-from=type=gha \
		--cache-to=type=gha,mode=max \
		.
[+] Building 273.3s (24/24) FINISHED                                                                                                                                                                                            docker:desktop-linux
 => [internal] load build definition from Dockerfile.release                                                                                                                                                                                    0.0s
 => => transferring dockerfile: 988B                                                                                                                                                                                                            0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)                                                                                                                                                                  0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG $golang_image results in empty or invalid base image name (line 4)                                                                                                                     0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG $base_image results in empty or invalid base image name (line 15)                                                                                                                      0.0s
 => [linux/arm64 internal] load metadata for public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2                                                                                                                  0.1s
 => [linux/arm64 internal] load metadata for public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2                                                                                                                                      0.1s
 => [linux/amd64 internal] load metadata for public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2                                                                                                                  0.1s
 => [linux/amd64 internal] load metadata for public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2                                                                                                                                      0.1s
 => [internal] load .dockerignore                                                                                                                                                                                                               0.0s
 => => transferring context: 185B                                                                                                                                                                                                               0.0s
 => [linux/amd64 builder 1/4] FROM public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2@sha256:461dff837b3c329347af1eb162acc6d0a0d88794ea2b64db5ab97ab8da640d02                                                                        1.2s
 => => resolve public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2@sha256:461dff837b3c329347af1eb162acc6d0a0d88794ea2b64db5ab97ab8da640d02                                                                                            1.2s
 => [internal] load build context                                                                                                                                                                                                               0.3s
 => => transferring context: 65.67MB                                                                                                                                                                                                            0.3s
 => [linux/arm64 stage-1 1/4] FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2@sha256:38671d6b390b662ff06def57d163d8162403e80abddb51209bf8a0904bce068c                                                    1.2s
 => => resolve public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2@sha256:38671d6b390b662ff06def57d163d8162403e80abddb51209bf8a0904bce068c                                                                        1.2s
 => [linux/arm64 builder 1/4] FROM public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2@sha256:461dff837b3c329347af1eb162acc6d0a0d88794ea2b64db5ab97ab8da640d02                                                                        1.2s
 => => resolve public.ecr.aws/eks-distro-build-tooling/golang:1.22.5-gcc-al2@sha256:461dff837b3c329347af1eb162acc6d0a0d88794ea2b64db5ab97ab8da640d02                                                                                            1.2s
 => [linux/amd64 stage-1 1/4] FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2@sha256:38671d6b390b662ff06def57d163d8162403e80abddb51209bf8a0904bce068c                                                    1.2s
 => => resolve public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2@sha256:38671d6b390b662ff06def57d163d8162403e80abddb51209bf8a0904bce068c                                                                        1.2s
 => CACHED [linux/amd64 builder 2/4] WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s                                                                                                                                                          0.0s
 => [linux/amd64 builder 3/4] COPY . ./                                                                                                                                                                                                         0.2s
 => CACHED [linux/arm64 builder 2/4] WORKDIR /go/src/github.com/aws/amazon-vpc-cni-k8s                                                                                                                                                          0.0s
 => [linux/arm64 builder 3/4] COPY . ./                                                                                                                                                                                                         0.2s
 => [linux/arm64 builder 4/4] RUN make build-aws-vpc-cni && make build-linux                                                                                                                                                                  204.2s
 => [linux/amd64 builder 4/4] RUN make build-aws-vpc-cni && make build-linux                                                                                                                                                                  268.4s
 => CACHED [linux/arm64 stage-1 2/4] WORKDIR /app                                                                                                                                                                                               0.0s
 => [linux/arm64 stage-1 3/4] COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni     /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent     /go/src  0.1s
 => [linux/arm64 stage-1 4/4] RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]                                                                                                                                    0.0s
 => CACHED [linux/amd64 stage-1 2/4] WORKDIR /app                                                                                                                                                                                               0.0s
 => [linux/amd64 stage-1 3/4] COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni     /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent     /go/src  0.1s
 => [linux/amd64 stage-1 4/4] RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]                                                                                                                                    0.0s
 => exporting to image                                                                                                                                                                                                                          2.9s
 => => exporting layers                                                                                                                                                                                                                         2.6s
 => => exporting manifest sha256:587ec50d267aca516aac91b824d2522157f2b0f901e643136223d41b70e3c84c                                                                                                                                               0.0s
 => => exporting config sha256:9ecd0004cddb9e1d7b3dfb361d47198985e4703d9a9f2fce4e6447853ea488f2                                                                                                                                                 0.0s
 => => exporting attestation manifest sha256:061f2c0a33ef5552d33180f2c79b82a617864894962c90de7c4605a9f9a2f422                                                                                                                                   0.0s
 => => exporting manifest sha256:791abc6d5089eec95725eec8ff501e5767e5adb209612e5bd0248e34c679886c                                                                                                                                               0.0s
 => => exporting config sha256:ba11f35e444ed41f8f3dde34a09e9e5ad70bc1fe5e5b5bf96083d8c89c8fc80a                                                                                                                                                 0.0s
 => => exporting attestation manifest sha256:44ce6a0084f48bc896589435ffa1298ffe0634b6d7ca2f00825ed62a03ab46d0                                                                                                                                   0.0s
 => => exporting manifest list sha256:adaa5c1bfa768872d907b51a482dbb7adc742ba8aff02c32fd6be29a996b03b4                                                                                                                                          0.0s
 => => naming to moby-dangling@sha256:adaa5c1bfa768872d907b51a482dbb7adc742ba8aff02c32fd6be29a996b03b4                                                                                                                                          0.0s
 => => unpacking to moby-dangling@sha256:adaa5c1bfa768872d907b51a482dbb7adc742ba8aff02c32fd6be29a996b03b4                                                                                                                                       0.3s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/piuhbeo6zw6vd6lv9f1kgybv0

 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
 - InvalidDefaultArgInFrom: Default value for ARG $golang_image results in empty or invalid base image name (line 4)
 - InvalidDefaultArgInFrom: Default value for ARG $base_image results in empty or invalid base image name (line 15)

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
```