### PR TITLE
cni-metrics-helper metrics: do type assertion before type casting

### DIFF
--- a/cmd/cni-metrics-helper/metrics/cni_metrics_test.go
+++ b/cmd/cni-metrics-helper/metrics/cni_metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -16,6 +17,12 @@ import (
 	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/publisher/mock_publisher"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
+	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var logConfig = logger.Configuration{
@@ -49,11 +56,172 @@ func TestCNIMetricsNew(t *testing.T) {
 	m := setup(t)
 	ctx := context.Background()
 	_, _ = m.clientset.CoreV1().Pods("kube-system").Create(ctx, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "aws-node-1"}}, metav1.CreateOptions{})
-	//cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, m.discoverController, false, log)
+	// cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, m.discoverController, false, log)
 	cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, false, false, testLog, m.podWatcher)
 	assert.NotNil(t, cniMetric)
 	assert.NotNil(t, cniMetric.getCWMetricsPublisher())
 	assert.NotEmpty(t, cniMetric.getInterestingMetrics())
 	assert.Equal(t, testLog, cniMetric.getLogger())
 	assert.False(t, cniMetric.submitCloudWatch())
+}
+
+// Add these helper functions at the top of the test file
+func createTestMetricFamilies() map[string]*dto.MetricFamily {
+	return map[string]*dto.MetricFamily{
+		"awscni_eni_max": {
+			Name: aws.String("awscni_eni_max"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{{
+				Gauge: &dto.Gauge{Value: aws.Float64(10.0)},
+			}},
+		},
+		"awscni_ip_max": {
+			Name: aws.String("awscni_ip_max"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{{
+				Gauge: &dto.Gauge{Value: aws.Float64(20.0)},
+			}},
+		},
+		"awscni_eni_allocated": {
+			Name: aws.String("awscni_eni_allocated"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{{
+				Gauge: &dto.Gauge{Value: aws.Float64(3.0)},
+			}},
+		},
+		"awscni_total_ip_addresses": {
+			Name: aws.String("awscni_total_ip_addresses"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{{
+				Gauge: &dto.Gauge{Value: aws.Float64(30.0)},
+			}},
+		},
+		"awscni_assigned_ip_addresses": {
+			Name: aws.String("awscni_assigned_ip_addresses"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{{
+				Gauge: &dto.Gauge{Value: aws.Float64(15.0)},
+			}},
+		},
+	}
+}
+
+func createTestConvertDef(includeCloudWatch bool) map[string]metricsConvert {
+	testData := []struct {
+		metricName   string
+		value        float64
+		cwMetricName string
+	}{
+		{"awscni_eni_max", 10.0, "eni_max"},
+		{"awscni_ip_max", 20.0, "ip_max"},
+		{"awscni_eni_allocated", 3.0, "eni_allocated"},
+		{"awscni_total_ip_addresses", 30.0, "total_ip_addresses"},
+		{"awscni_assigned_ip_addresses", 15.0, "assigned_ip_addresses"},
+	}
+
+	result := make(map[string]metricsConvert)
+	for _, td := range testData {
+		action := metricsAction{
+			data: &dataPoints{curSingleDataPoint: td.value},
+		}
+		if includeCloudWatch {
+			action.cwMetricName = td.cwMetricName
+		}
+		result[td.metricName] = metricsConvert{
+			actions: []metricsAction{action},
+		}
+	}
+	return result
+}
+
+func createExpectedCloudWatchMetrics() []cloudwatchtypes.MetricDatum {
+	return []cloudwatchtypes.MetricDatum{
+		{
+			MetricName: aws.String("eni_max"),
+			Unit:       cloudwatchtypes.StandardUnitCount,
+			Value:      aws.Float64(10.0),
+		},
+		{
+			MetricName: aws.String("ip_max"),
+			Unit:       cloudwatchtypes.StandardUnitCount,
+			Value:      aws.Float64(20.0),
+		},
+		{
+			MetricName: aws.String("eni_allocated"),
+			Unit:       cloudwatchtypes.StandardUnitCount,
+			Value:      aws.Float64(3.0),
+		},
+		{
+			MetricName: aws.String("total_ip_addresses"),
+			Unit:       cloudwatchtypes.StandardUnitCount,
+			Value:      aws.Float64(30.0),
+		},
+		{
+			MetricName: aws.String("assigned_ip_addresses"),
+			Unit:       cloudwatchtypes.StandardUnitCount,
+			Value:      aws.Float64(15.0),
+		},
+	}
+}
+
+func TestProduceCloudWatchMetrics(t *testing.T) {
+	m := setup(t)
+	cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, true, false, testLog, m.podWatcher)
+
+	families := createTestMetricFamilies()
+	testConvertDef := createTestConvertDef(true)
+	expectedMetrics := createExpectedCloudWatchMetrics()
+
+	// Expect CloudWatch publish to be called for each metric
+	for _, expectedMetric := range expectedMetrics {
+		m.mockPublisher.EXPECT().Publish(expectedMetric).Times(1)
+	}
+
+	err := produceCloudWatchMetrics(cniMetric, families, testConvertDef, m.mockPublisher)
+	assert.NoError(t, err)
+}
+
+func TestProducePrometheusMetrics(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	m := setup(t)
+	cniMetric := CNIMetricsNew(m.clientset, m.mockPublisher, false, true, testLog, m.podWatcher)
+
+	families := createTestMetricFamilies()
+	testConvertDef := createTestConvertDef(false)
+
+	// Register and initialize Prometheus metrics
+	prometheusmetrics.PrometheusRegister()
+	metrics := prometheusmetrics.GetSupportedPrometheusCNIMetricsMapping()
+	for _, metric := range metrics {
+		if gauge, ok := metric.(prometheus.Gauge); ok {
+			gauge.Set(0)
+		}
+	}
+
+	err := producePrometheusMetrics(cniMetric, families, testConvertDef)
+	assert.NoError(t, err)
+
+	// Verify metrics
+	testCases := []struct {
+		metricName string
+		expected   float64
+	}{
+		{"awscni_eni_max", 10.0},
+		{"awscni_ip_max", 20.0},
+		{"awscni_eni_allocated", 3.0},
+		{"awscni_total_ip_addresses", 30.0},
+		{"awscni_assigned_ip_addresses", 15.0},
+	}
+
+	metrics = prometheusmetrics.GetSupportedPrometheusCNIMetricsMapping()
+	for _, tc := range testCases {
+		gauge, ok := metrics[tc.metricName].(prometheus.Gauge)
+		assert.True(t, ok, fmt.Sprintf("Metric %s should be registered as a Gauge", tc.metricName))
+
+		var metric dto.Metric
+		err = gauge.Write(&metric)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, *metric.Gauge.Value,
+			fmt.Sprintf("Metric %s value should be set to %f", tc.metricName, tc.expected))
+	}
 }

--- a/utils/prometheusmetrics/prometheusmetrics.go
+++ b/utils/prometheusmetrics/prometheusmetrics.go
@@ -225,24 +225,18 @@ func PrometheusRegister() {
 	prometheus.MustRegister(IpsPerCidr)
 	prometheus.MustRegister(NoAvailableIPAddrs)
 	prometheus.MustRegister(EniIPsInUse)
-
 }
 
 // This can be enhanced to get it programatically.
 // Initial CNI metrics helper enhancement includes only Gauge. Doesn't support GaugeVec, Counter, CounterVec and Summary
 func GetSupportedPrometheusCNIMetricsMapping() map[string]prometheus.Collector {
-	var prometheusCNIMetrics = map[string]prometheus.Collector{
-		"awscni_eni_max":                   EnisMax,
-		"awscni_ip_max":                    IpMax,
-		"awscni_add_ip_req_count":          AddIPCnt,
-		"awscni_del_ip_req_count":          DelIPCnt,
-		"awscni_eni_allocated":             Enis,
-		"awscni_total_ip_addresses":        TotalIPs,
-		"awscni_assigned_ip_addresses":     AssignedIPs,
-		"awscni_force_removed_enis":        ForceRemovedENIs,
-		"awscni_force_removed_ips":         ForceRemovedIPs,
-		"awscni_total_ipv4_prefixes":       TotalPrefixes,
-		"awscni_no_available_ip_addresses": NoAvailableIPAddrs,
+	prometheusCNIMetrics := map[string]prometheus.Collector{
+		"awscni_eni_max":               EnisMax,
+		"awscni_ip_max":                IpMax,
+		"awscni_eni_allocated":         Enis,
+		"awscni_total_ip_addresses":    TotalIPs,
+		"awscni_assigned_ip_addresses": AssignedIPs,
+		"awscni_total_ipv4_prefixes":   TotalPrefixes,
 	}
 	return prometheusCNIMetrics
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

Bug fix

<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->

#3144 



**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

Added unit tests for code path for publishing CloudWatch and Prometheus Metrics and also pasted debug logs to confirm that no panic happens. 

Built metrics helper image successfully using `make docker-metrics`.


### Unit tests passing

```

// Cloud watch unit test

$> go test -timeout 30s -run ^TestProduceCloudWatchMetrics$ github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics

ok  	github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics


// Prometheus Unit Test

$> go test -timeout 30s -run ^TestProducePrometheusMetrics$ github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics

ok  	github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics

```



### Debug logs before the change

```
// LIST MAINTAINED BY CNI METRICS HELPER

{"msg":"Printing out all the Prometheus Mappings"}
{"msg":"Metric Name: awscni_eni_max, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_del_ip_req_count, Metric Type: *prometheus.CounterVec"}
{"msg":"Metric Name: awscni_total_ip_addresses, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_assigned_ip_addresses, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_no_available_ip_addresses, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_total_ipv4_prefixes, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_ip_max, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_add_ip_req_count, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_eni_allocated, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_force_removed_enis, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_force_removed_ips, Metric Type: *prometheus.counter"}

// LIST RECIEVED FROM CNI

{"msg":"Printing out all the families recieved"}
{"msg":"Metric Name: awscni_ipamd_action_inprogress, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_reconcile_count, Metric Type: COUNTER"}
{"msg":"Metric Name: awscni_assigned_ip_per_cidr, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_ip_max, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_aws_api_latency_ms, Metric Type: SUMMARY"}
{"msg":"Metric Name: awscni_force_removed_enis, Metric Type: GAUGE"}
panic: interface conversion: *prometheus.counter is not prometheus.Gauge: missing method Dec

goroutine 1 [running]:
github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics.producePrometheusMetrics({0x35e8190, 0xc0004a6960}, 0xc0004a2150, 0xc0001aea50)
        /go/src/github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics/metrics.go:393 +0xce5
github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics.Handler({0x35e2690?, 0xc0001d7090?}, {0x35e8190, 0xc0004a6960})
        /go/src/github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/metrics/metrics.go:479 +0x16a
main.main()
        /go/src/github.com/aws/amazon-vpc-cni-k8s/cmd/cni-metrics-helper/main.go:176 +0xf7c

```


### Debug logs after the change

```
// LIST MAINTAINED BY CNI METRICS HELPER

{"msg":"Printing out all the Prometheus Mappings"}
{"msg":"Metric Name: awscni_eni_max, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_total_ip_addresses, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_force_removed_ips, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_total_ipv4_prefixes, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_ip_max, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_add_ip_req_count, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_del_ip_req_count, Metric Type: *prometheus.CounterVec"}
{"msg":"Metric Name: awscni_eni_allocated, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_assigned_ip_addresses, Metric Type: *prometheus.gauge"}
{"msg":"Metric Name: awscni_force_removed_enis, Metric Type: *prometheus.counter"}
{"msg":"Metric Name: awscni_no_available_ip_addresses, Metric Type: *prometheus.counter"}
{"msg":"\n\n"}

// LIST RECIEVED FROM CNI

{"msg":"Printing out all the families recieved"}
{"msg":"Metric Name: awscni_eni_max, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_assigned_ip_per_cidr, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_ipamd_action_inprogress, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_assigned_ip_addresses, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_reconcile_count, Metric Type: COUNTER"}
{"msg":"Metric Name: awscni_eni_allocated, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_del_ip_req_count, Metric Type: COUNTER"}
{"msg":"Metric Name: awscni_ec2api_req_count, Metric Type: COUNTER"}
{"msg":"Metric Name: awscni_ec2api_error_count, Metric Type: COUNTER"}

// TYPE ASSERTION CHECK
{"msg":"Metric Name: awscni_force_removed_ips, Metric Type: GAUGE"}
{"msg":"Metric awscni_force_removed_ips is not a Gauge type, skipping"}

// TYPE ASSERTION CHECK
{"msg":"Metric Name: awscni_force_removed_enis, Metric Type: GAUGE"}
{"msg":"Metric awscni_force_removed_enis is not a Gauge type, skipping"}

{"msg":"Metric Name: awscni_ip_max, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_aws_api_latency_ms, Metric Type: SUMMARY"}
{"msg":"Metric Name: awscni_aws_api_error_count, Metric Type: GAUGE"}

// TYPE ASSERTION CHECK
{"msg":"Metric Name: awscni_add_ip_req_count, Metric Type: GAUGE"}
{"msg":"Metric awscni_add_ip_req_count is not a Gauge type, skipping"}

{"msg":"Metric Name: awscni_total_ipv4_prefixes, Metric Type: GAUGE"}
{"msg":"Metric Name: awscni_total_ip_addresses, Metric Type: GAUGE"}


// NO PANIC HAPPENS

```








