### PR TITLE
Release-1.19.1 - Revert #3122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Feature: run make generate-limits to update the max pods file by @tzneal in https://github.com/aws/amazon-vpc-cni-k8s/pull/3141
 * Tests: Fix KOps Integration Test by @dshehbaj in https://github.com/aws/amazon-vpc-cni-k8s/pull/3140
-* Bug-fix:  Fix issues with handling unmanaged ENIs with IPv6 only by @gavinbunney in https://github.com/aws/amazon-vpc-cni-k8s/pull/3122
 * Bug-Fix:  Revert "utils prometheusmetrics: convert gauges to counters (#3093)" by @orsenthil in https://github.com/aws/amazon-vpc-cni-k8s/pull/3147
 * Docs: Update NP strict mode doc by @Pavani-Panakanti in https://github.com/aws/amazon-vpc-cni-k8s/pull/3125
 * Docs: adding email to share node bundle by @yash97 in https://github.com/aws/amazon-vpc-cni-k8s/pull/3134

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -53,7 +53,6 @@ const (
 	metadataSubnetCIDR   = "/subnet-ipv4-cidr-block"
 	metadataIPv4s        = "/local-ipv4s"
 	metadataIPv4Prefixes = "/ipv4-prefix"
-	metadataIPv6s        = "/ipv6s"
 	metadataIPv6Prefixes = "/ipv6-prefix"
 
 	az                   = "us-east-1a"
@@ -77,14 +76,12 @@ const (
 	eni2Device           = "1"
 	eni2PrivateIP        = "10.0.0.2"
 	eni2Prefix           = "10.0.2.0/28"
-	eni2v6IP             = "2001:db8:8:4::2"
 	eni2v6Prefix         = "2001:db8::/64"
 	eni2ID               = "eni-12341234"
 	metadataVPCIPv4CIDRs = "192.168.0.0/16	100.66.0.0/1"
 	myNodeName           = "testNodeName"
 	imdsMACFields        = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv4-cidr-block local-ipv4s ipv4-prefix ipv6-prefix"
 	imdsMACFieldsEfaOnly = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv4-cidr-block ipv4-prefix ipv6-prefix"
-	imdsMACFieldsV6Only  = "security-group-ids subnet-id vpc-id vpc-ipv4-cidr-blocks device-number interface-id subnet-ipv6-cidr-blocks ipv6s ipv6-prefix"
 )
 
 func testMetadata(overrides map[string]interface{}) FakeIMDS {
@@ -232,23 +229,6 @@ func TestGetAttachedENIsWithEfaOnly(t *testing.T) {
 		metadataMACPath + eni2MAC + metadataDeviceNum:  eni2Device,
 		metadataMACPath + eni2MAC + metadataInterface:  eni2ID,
 		metadataMACPath + eni2MAC + metadataSubnetCIDR: subnetCIDR,
-	})
-
-	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}}
-	ens, err := cache.GetAttachedENIs()
-	if assert.NoError(t, err) {
-		assert.Equal(t, len(ens), 2)
-	}
-}
-
-func TestGetAttachedENIsWithIPv6Only(t *testing.T) {
-	mockMetadata := testMetadata(map[string]interface{}{
-		metadataMACPath:                                  primaryMAC + " " + eni2MAC,
-		metadataMACPath + eni2MAC:                        imdsMACFieldsV6Only,
-		metadataMACPath + eni2MAC + metadataDeviceNum:    eni2Device,
-		metadataMACPath + eni2MAC + metadataInterface:    eni2ID,
-		metadataMACPath + eni2MAC + metadataIPv6s:        eni2v6IP,
-		metadataMACPath + eni2MAC + metadataIPv6Prefixes: eni2v6Prefix,
 	})
 
 	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}}


### PR DESCRIPTION
This PR reverts #3122 for release of 1.19.1 which is in progress.

```
 1175  git revert 7b46f6bff35f006bb4a4384138ca19d09be4e2a3
 1176  # update CHANGELOG.md
 1180  git commit -m "Update Changelog to reflect on revert of #3122"
```

--- 

An issue with VPC CNI 1.19.1 was caught in internal CI.

Cluster was created with IPV6 Address always assigned -  https://github.com/aws/aws-k8s-tester/blob/c6bee21d2bbc2756f4a91bb5bc68495d2533b323/kubetest2/internal/deployers/eksapi/templates/infra.yaml#L289

IPAMD Initialization failed with this log message.

```
{"level":"debug","ts":"2024-12-17T15:40:40.867Z","caller":"awsutils/awsutils.go:1325","msg":"Total number of interfaces found: 1 "}
{"level":"debug","ts":"2024-12-17T15:40:40.867Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI MAC address: 02:72:68:d4:0c:a7"}
{"level":"debug","ts":"2024-12-17T15:40:40.869Z","caller":"awsutils/awsutils.go:567","msg":"Found ENI: eni-0b1edf4cf07ae1f95, MAC 02:72:68:d4:0c:a7, device 0"}
{"level":"debug","ts":"2024-12-17T15:40:40.870Z","caller":"awsutils/awsutils.go:567","msg":"Found IPv6 addresses associated with interface. This is not efa-only interface"}
{"level":"info","ts":"2024-12-17T15:40:41.010Z","caller":"ipamd/ipamd.go:424","msg":"Got network card index 0 for ENI eni-0b1edf4cf07ae1f95"}
{"level":"info","ts":"2024-12-17T15:40:41.010Z","caller":"ipamd/ipamd.go:424","msg":"eni-0b1edf4cf07ae1f95 is of type: interface"}
{"level":"error","ts":"2024-12-17T15:40:41.010Z","caller":"ipamd/ipamd.go:424","msg":"Missing IP addresses from IMDS. Non efa-only interface should have IP address associated with it eni-0b1edf4cf07ae1f95"}
{"level":"error","ts":"2024-12-17T15:40:41.010Z","caller":"aws-k8s-agent/main.go:42","msg":"Initialization failure: ipamd init: failed to retrieve attached ENIs info: DescribeAllENIs: No IPv4 and IPv6 addresses found"}

```

This is due to change we brought in 
[Fix issues with handling unmanaged ENIs with IPv6 only](https://github.com/aws/amazon-vpc-cni-k8s/pull/3122/files) - #3122

Previously we assumed the ENI (primary ENI) always will have an IPV4 and went with getting the IPv4 address. Primary ENI will always have an IPV4 address. However, when https://github.com/aws/amazon-vpc-cni-k8s/pull/3122 was introduced, we are checking ipv4Available explicitly. The way in which the ipv4 or ipv6 is checked in based on the value of IMDS metadata on MAC, dependent on the order in which IMDS returned the value due to using a break condition introduced here - https://github.com/aws/amazon-vpc-cni-k8s/pull/3047/files . So, when both `IPv6` and `IPv4` were assigned on interface, it tried to pick up `IPv6` address even when the cluster was not IPV6.

Fix in the master is in review here - https://github.com/aws/amazon-vpc-cni-k8s/pull/3156 