### PR TITLE
charts aws-vpc-cni: separate config values for windows & linux nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # amazon-vpc-cni-k8s
 
 Networking plugin for pod networking in [Kubernetes](https://kubernetes.io/) using [Elastic Network Interfaces](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html) on AWS.
@@ -301,6 +300,11 @@ Type: Integer
 Default: None
 
 Specifies the number of free IP addresses that the `ipamd` daemon should attempt to keep available for pod assignment on the node. Setting this to a non-positive value is the same as setting this to 0 or not setting the variable.
+
+For Windows nodes, use `--windows-warm-ip-target` flag or set the `WARM_WINDOWS_IP_TARGET` environment variable instead.
+The behavior is identical to `WARM_IP_TARGET` but applies specifically to Windows nodes. When using the Helm chart, these are
+configured via `warmIPTarget` and `warmWindowsIPTarget` values respectively.
+
 With `ENABLE_PREFIX_DELEGATION` set to `true` then `ipamd` daemon will check if the existing (/28) prefixes are enough to maintain the
 `WARM_IP_TARGET` if it is not sufficient then more prefixes will be attached.
 
@@ -332,6 +336,10 @@ Specifies the number of total IP addresses that the `ipamd` daemon should attemp
 `MINIMUM_IP_TARGET` behaves identically to `WARM_IP_TARGET` except that instead of setting a target number of free IP
 addresses to keep available at all times, it sets a target number for a floor on how many total IP addresses are allocated. Setting to a
 non-positive value is same as setting this to 0 or not setting the variable.
+
+For Windows nodes, use `--windows-minimum-ip-target` flag or set the `MINIMUM_WINDOWS_IP_TARGET` environment variable instead.
+The behavior is identical to `MINIMUM_IP_TARGET` but applies specifically to Windows nodes. When using the Helm chart, these are
+configured via `minimumIPTarget` and `minimumWindowsIPTarget` values respectively.
 
 `MINIMUM_IP_TARGET` is for pre-scaling, `WARM_IP_TARGET` is for dynamic scaling. For example, suppose a cluster has an
 expected pod density of approximately 30 pods per node. If `WARM_IP_TARGET` is set to 30 to ensure there are enough IPs
@@ -578,6 +586,11 @@ Type: Integer
 Default: None
 
 Specifies the number of free IPv4(/28) prefixes that the `ipamd` daemon should attempt to keep available for pod assignment on the node. Setting to a non-positive value is same as setting this to 0 or not setting the variable.
+
+For Windows nodes, use `--windows-warm-prefix-target` flag or set the `WARM_WINDOWS_PREFIX_TARGET` environment variable instead.
+The behavior is identical to `WARM_PREFIX_TARGET` but applies specifically to Windows nodes. When using the Helm chart, these are
+configured via `warmPrefixTarget` and `warmWindowsPrefixTarget` values respectively.
+
 This environment variable works when `ENABLE_PREFIX_DELEGATION` is set to `true` and is overridden when `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` are configured.
 
 #### `DISABLE_NETWORK_RESOURCE_PROVISIONING` (v1.9.1+)

--- a/charts/aws-vpc-cni/templates/configmap.yaml
+++ b/charts/aws-vpc-cni/templates/configmap.yaml
@@ -20,7 +20,15 @@ data:
   enable-windows-ipam: {{ .Values.enableWindowsIpam | quote }}
   enable-network-policy-controller: {{ .Values.enableNetworkPolicy | quote }}
   enable-windows-prefix-delegation: {{ .Values.enableWindowsPrefixDelegation | quote }}
-  warm-prefix-target: {{ .Values.warmWindowsPrefixTarget | quote }}
-  warm-ip-target: {{ .Values.warmWindowsIPTarget | quote }}
-  minimum-ip-target: {{ .Values.minimumWindowsIPTarget | quote }}
+
+  # Linux node IP management settings
+  warm-prefix-target: {{ .Values.warmPrefixTarget | quote }}
+  warm-ip-target: {{ .Values.warmIPTarget | quote }}
+  minimum-ip-target: {{ .Values.minimumIPTarget | quote }}
+
+  # Windows node IP management settings
+  windows-warm-prefix-target: {{ .Values.warmWindowsPrefixTarget | quote }}
+  windows-warm-ip-target: {{ .Values.warmWindowsIPTarget | quote }}
+  windows-minimum-ip-target: {{ .Values.minimumWindowsIPTarget | quote }}
+
   branch-eni-cooldown: {{ .Values.branchENICooldown | quote }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -114,14 +114,28 @@ originalMatchLabels: false
 # Settings for aws-vpc-cni ConfigMap
 # - Network Policy settings
 enableNetworkPolicy: "false"
-# - Windows settings
+
+# Linux node IP management settings
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#warm_ip_target
+warmIPTarget: 1
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#minimum_ip_target-v160
+minimumIPTarget: 3
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#warm_prefix_target-v190
+warmPrefixTarget: 1
+
+# Windows node settings
 enableWindowsIpam: "false"
-# - Windows Prefix Delegation settings
-enableWindowsPrefixDelegation: "false"
-warmWindowsPrefixTarget: 0
+
+# Windows node IP management settings
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#warm_ip_target
 warmWindowsIPTarget: 1
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#minimum_ip_target-v160
 minimumWindowsIPTarget: 3
-# - Security Groups for Pods settings
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master?tab=readme-ov-file#warm_prefix_target-v190
+warmWindowsPrefixTarget: 0
+enableWindowsPrefixDelegation: "false"
+
+# Security Groups for Pods settings
 branchENICooldown: 60
 
 cniConfig:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
