### PR TITLE
Allow create extra object(s) and use envFrom referencing configmap(s) / secret(s) in helm chart

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -97,6 +97,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          {{- if .Values.envFrom }}
+          envFrom:
+          {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-vpc-cni/templates/extra-manifests.yaml
+++ b/charts/aws-vpc-cni/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -106,6 +106,22 @@ env:
 #       key: SECRET_VAR1
 extraEnv: []
 
+# Use envFrom to reference ConfigMaps and Secrets
+envFrom: []
+# - secretRef:
+#      name: proxy-settings
+
+# extraObjects -- Extra K8s manifests to deploy
+extraObjects: []
+#  - apiVersion: v1
+#    kind: Secret
+#    metadata:
+#      name: proxy-settings
+#    data:
+#      http_proxy: "base64 encoded string with proxy uri, credentials, port, ..."
+#      https_proxy: "base64 encoded string with proxy uri, credentials, port, ..."
+#      no_proxy: "base64 encoded string with no_proxy settings"
+
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
https://github.com/aws/amazon-vpc-cni-k8s/issues/3179

**What does this PR do / Why do we need it?**:
It adds ability ty create extra object like secret or configmap and use envFrom referencing configmap(s) / secret(s) in helm chart


**Testing done on this change**:
deployed on our EKS using changed helm chart, both added fields used.
<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

no, tested

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->



```self documented in values.yaml of helm chart

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
