### PR TITLE
Fix print the error message in string instead of bytes.

### DIFF
--- a/test/agent/cmd/networking/main.go
+++ b/test/agent/cmd/networking/main.go
@@ -81,7 +81,7 @@ func main() {
 				}
 				fmt.Fprint(&errs, e.Error())
 			}
-			log.Fatalf("found 1 or more pod teardown validation failure: %v", errs)
+			log.Fatalf("found 1 or more pod teardown validation failure: %s", errs)
 		}
 	}
 }

--- a/test/agent/cmd/networking/main.go
+++ b/test/agent/cmd/networking/main.go
@@ -81,7 +81,7 @@ func main() {
 				}
 				fmt.Fprint(&errs, e.Error())
 			}
-			log.Fatalf("found 1 or more pod teardown validation failure: %s", errs)
+			log.Fatalf("found 1 or more pod teardown validation failure: %s", errs.String())
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug


**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->

When pod tear down was happening for regular pods in tests, the error message was printed in bytes.

```
{"level":"info","timestamp":"2025-02-20T20:00:32.071Z","caller":"tester/test.go:314","msg":"  2025/02/20 20:00:28 found 1 or more pod teardown validation failure: {[102 111 117 110 100 32 97 110 32 101 120 105 115 116 105 110 103 32 118 101 116 104 32 112 97 105 114 32 102 111 114 32 116 104 101 32 112 111 100 32 112 97 114 107 105 110 103 45 112 111 100 58 32 38 123 123 49 51 53 32 57 48 48 49 32 48 32 101 110 105 53 101 100 48 54 52 48 97 53 97 97 32 52 101 58 97 55 58 48 48 58 99 100 58 53 98 58 48 102 32 117 112 124 98 114 111 97 100 99 97 115 116 124 109 117 108 116 105 99 97 115 116 32 54 57 54 57 57 32 51 32 48 32 60 110 105 108 62 32 32 48 120 99 48 48 48 49 49 101 48 99 48 32 48 32 48 120 99 48 48 48 49 49 99 49 56 48 32 101 116 104 101 114 32 60 110 105 108 62 32 117 112 32 48 32 52 32 52 32 54 53 53 51 54 32 54 53 53 51 53 32 91 93 32 48 32 60 110 105 108 62 125 32 32 125] 0 0}"}
```

The error message that should be printed should be (converted).

```
found an existing veth pair for the pod parking-pod: &{{135 9001 0 eni5ed0640a5aa 4e:a7:00:cd:5b:0f up|broadcast|multicast 69699 3 0 <nil>  0xc00011e0c0 0 0xc00011c180 ether <nil> up 0 4 4 65536 65535 [] 0 <nil>}  }
```


This _mistake_ has been present since a long time, I am not sure why this is being observed now.

https://github.com/aws/amazon-vpc-cni-k8s/commit/876d8a6dce126870359ece58fe40158725eb8d88#diff-0df433f603135a259e0b9d482735233054dfcf6a216c3b2339e3883a4f19d3a4 



**Testing done**


```
package main

import (
	"fmt"
)

func main() {
	mystr := "{\"fake\":\"abc\"}"
	fmt.Printf("mystr:\t %v \n", []byte(mystr))
}

```

Will print `mystr:	 [123 34 102 97 107 101 34 58 34 97 98 99 34 125] `


With correct formatting

```
package main

import (
	"fmt"
)

func main() {
	mystr := "{\"fake\":\"abc\"}"
	fmt.Printf("mystr:\t %s \n", []byte(mystr))
}

```

will print `mystr:	 {"fake":"abc"} `

