### PR TITLE
Init container changes for getting all the primary attached interfaces

### DIFF
--- a/pkg/awsutils/imds.go
+++ b/pkg/awsutils/imds.go
@@ -463,6 +463,30 @@ func (typedimds TypedIMDS) GetLocalIPv4s(ctx context.Context, mac string) ([]net
 		imdsErr := new(imdsRequestError)
 		oe := new(smithy.OperationError)
 		if errors.As(err, &imdsErr) || errors.As(err, &oe) {
+			if IsNotFound(err) {
+				// No IPv4 address on the interface, not an error
+				return nil, nil
+			}
+			log.Warnf("%v", err)
+			return nil, newIMDSRequestError(err.Error(), err)
+		}
+		return nil, err
+	}
+	return ips, err
+}
+
+// GetLocalIPv4s returns the private IPv6 addresses associated with the interface.  First returned address is the primary address.
+func (typedimds TypedIMDS) GetLocalIPv6s(ctx context.Context, mac string) ([]net.IP, error) {
+	key := fmt.Sprintf("network/interfaces/macs/%s/local-ipv6s", mac)
+	ips, err := typedimds.getIPs(ctx, key)
+	if err != nil {
+		imdsErr := new(imdsRequestError)
+		oe := new(smithy.OperationError)
+		if errors.As(err, &imdsErr) || errors.As(err, &oe) {
+			if IsNotFound(err) {
+				// No IPv6 address on the interface, not an error
+				return nil, nil
+			}
 			log.Warnf("%v", err)
 			return nil, newIMDSRequestError(err.Error(), err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature 
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
N/A
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
This adds changes to Init container for CNI. When Multiple NICs are initialized, the init container will identify these interfaces to set kernel parameters. 
We skip efa-only interfaces since these cannot be used for IP traffic

**Testing done on this change**:
Tested on single card instance and multi-card instance 

```
time="2025-02-28T07:26:45Z" level=info msg="Copying CNI plugin binaries ..."
time="2025-02-28T07:26:45Z" level=info msg="Copied all CNI plugin binaries to /host/opt/cni/bin"
time="2025-02-28T07:26:45Z" level=info msg="found primary interfaces for the host [eth0]"
time="2025-02-28T07:26:45Z" level=info msg="Found primaryIF [eth0]"
time="2025-02-28T07:26:45Z" level=info msg="Updated net/ipv4/conf/eth0/rp_filter to 2\n"
time="2025-02-28T07:26:45Z" level=info msg="Updated net/ipv4/tcp_early_demux to 1\n"
time="2025-02-28T07:26:45Z" level=info msg="CNI init container done"
```
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No new dependencies.. We already made IMDS calls. But we do have a bit more IMDS calls than previous
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No, should not break upgrade or downgrade.. 

**Does this change require updates to the CNI daemonset config files to work?**: 
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: 
Not with this change
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
