### PR TITLE
Update helm chart to ensure that created eniconfig name is always a string

### DIFF
--- a/charts/aws-vpc-cni/templates/eniconfig.yaml
+++ b/charts/aws-vpc-cni/templates/eniconfig.yaml
@@ -3,7 +3,7 @@
 apiVersion: crd.k8s.amazonaws.com/v1alpha1
 kind: ENIConfig
 metadata:
-  name: {{ $key }}
+  name: "{{ $key }}"
 spec:
   {{- if $value.securityGroups }}
   securityGroups:


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
no issue # created for this

**What does this PR do / Why do we need it?**:
There's a bug that's possible with the current helm chart, where if `.Values.eniConfig.subnets` is specified, and the keys for this `subnets` objects contains any strings that are numbers, or other strings like "true", "false", "null", etc, then when the helm chart tries to apply these ENIConfigs, the `metadata.name` field is not properly quoted, and the name value ends up being the wrong data type.

This PR updates to simply wrap this key in quotes, so even if these sorts of keys are used, they are properly treated as strings.

**Testing done on this change**:
tried templating/installing the helm chart and confirmed the output. For example:

In values, set `eniconfig` as:

```yaml
eniConfig:
  # Specifies whether ENIConfigs should be created
  create: true
  region: us-west-2
  subnets:
    2:
      id: subnet-123
      securityGroups:
      - sg-123
```

Output from `helm template charts/aws-vpc-cni`

```yaml
...
---
# Source: aws-vpc-cni/templates/eniconfig.yaml
apiVersion: crd.k8s.amazonaws.com/v1alpha1
kind: ENIConfig
metadata:
  name: "2"
spec:
  securityGroups:
    - sg-123
  subnet: subnet-123
```

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
no

**Does this PR introduce any user-facing change?**:
no

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
