### PR TITLE
adding eni owner tag if cluster name is present

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -64,6 +64,8 @@ const (
 	eniNodeTagKey           = "node.k8s.amazonaws.com/instance_id"
 	eniCreatedAtTagKey      = "node.k8s.amazonaws.com/createdAt"
 	eniClusterTagKey        = "cluster.k8s.amazonaws.com/name"
+	eniOwnerTagKey          = "eks:eni:owner"
+	eniOwnerTagValue        = "amazon-vpc-cni"
 	additionalEniTagsEnvVar = "ADDITIONAL_ENI_TAGS"
 	reservedTagKeyPrefix    = "k8s.amazonaws.com"
 	subnetDiscoveryTagKey   = "kubernetes.io/role/cni"
@@ -1060,6 +1062,7 @@ func (cache *EC2InstanceMetadataCache) buildENITags() map[string]string {
 	// tag the ENI with "cluster.k8s.amazonaws.com/name=<cluster_name>"
 	if cache.clusterName != "" {
 		tags[eniClusterTagKey] = cache.clusterName
+		tags[eniOwnerTagKey] = eniOwnerTagValue
 	}
 	for key, value := range cache.additionalENITags {
 		tags[key] = value

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -1304,7 +1304,7 @@ func TestEC2InstanceMetadataCache_buildENITags(t *testing.T) {
 				instanceID: "i-xxxxx",
 			},
 			want: map[string]string{
-				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
+				eniNodeTagKey: "i-xxxxx",
 			},
 		},
 		{
@@ -1314,9 +1314,9 @@ func TestEC2InstanceMetadataCache_buildENITags(t *testing.T) {
 				clusterName: "awesome-cluster",
 			},
 			want: map[string]string{
-				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
-				"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
-				"eks:eni:owner":                      "amazon-vpc-cni",
+				eniNodeTagKey:    "i-xxxxx",
+				eniClusterTagKey: "awesome-cluster",
+				eniOwnerTagKey:   eniOwnerTagValue,
 			},
 		},
 		{
@@ -1329,9 +1329,9 @@ func TestEC2InstanceMetadataCache_buildENITags(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
-				"tagKey-1":                           "tagVal-1",
-				"tagKey-2":                           "tagVal-2",
+				eniNodeTagKey: "i-xxxxx",
+				"tagKey-1":    "tagVal-1",
+				"tagKey-2":    "tagVal-2",
 			},
 		},
 	}

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -1376,7 +1376,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1409,7 +1409,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1431,11 +1431,11 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 											},
 										},
@@ -1453,11 +1453,11 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 					Status:             "available",
 					TagSet: []ec2types.Tag{
 						{
-							Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+							Key:   aws.String(eniNodeTagKey),
 							Value: aws.String("i-xxxxx"),
 						},
 						{
-							Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+							Key:   aws.String(eniCreatedAtTagKey),
 							Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 						},
 					},
@@ -1474,7 +1474,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1496,11 +1496,11 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 											},
 										},
@@ -1523,7 +1523,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1545,11 +1545,11 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(now.Format(time.RFC3339)),
 											},
 										},
@@ -1572,7 +1572,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1605,7 +1605,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1631,15 +1631,15 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 											},
 											{
-												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Key:   aws.String(eniClusterTagKey),
 												Value: aws.String("awesome-cluster"),
 											},
 										},
@@ -1657,15 +1657,15 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 					Status:             "available",
 					TagSet: []ec2types.Tag{
 						{
-							Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+							Key:   aws.String(eniNodeTagKey),
 							Value: aws.String("i-xxxxx"),
 						},
 						{
-							Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+							Key:   aws.String(eniCreatedAtTagKey),
 							Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 						},
 						{
-							Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+							Key:   aws.String(eniClusterTagKey),
 							Value: aws.String("awesome-cluster"),
 						},
 					},
@@ -1682,7 +1682,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1708,15 +1708,15 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(tenMinuteAgo.Format(time.RFC3339)),
 											},
 											{
-												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Key:   aws.String(eniClusterTagKey),
 												Value: aws.String("awesome-cluster"),
 											},
 										},
@@ -1739,7 +1739,7 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 							Filters: []ec2types.Filter{
 								{
 									Name:   aws.String("tag-key"),
-									Values: []string{"node.k8s.amazonaws.com/instance_id"},
+									Values: []string{eniNodeTagKey},
 								},
 								{
 									Name:   aws.String("status"),
@@ -1765,15 +1765,15 @@ func TestEC2InstanceMetadataCache_getLeakedENIs(t *testing.T) {
 										Status:             "available",
 										TagSet: []ec2types.Tag{
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+												Key:   aws.String(eniNodeTagKey),
 												Value: aws.String("i-xxxxx"),
 											},
 											{
-												Key:   aws.String("node.k8s.amazonaws.com/createdAt"),
+												Key:   aws.String(eniCreatedAtTagKey),
 												Value: aws.String(now.Format(time.RFC3339)),
 											},
 											{
-												Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+												Key:   aws.String(eniClusterTagKey),
 												Value: aws.String("awesome-cluster"),
 											},
 										},
@@ -1853,15 +1853,15 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 							Resources: []string{"eni-xxxx"},
 							Tags: []ec2types.Tag{
 								{
-									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Key:   aws.String(eniClusterTagKey),
 									Value: aws.String("awesome-cluster"),
 								},
 								{
-									Key:   aws.String("eks:eni:owner"),
-									Value: aws.String("amazon-vpc-cni"),
+									Key:   aws.String(eniOwnerTagKey),
+									Value: aws.String(eniOwnerTagValue),
 								},
 								{
-									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+									Key:   aws.String(eniNodeTagKey),
 									Value: aws.String("i-xxxx"),
 								},
 							},
@@ -1885,9 +1885,9 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 			args: args{
 				eniID: "eni-xxxx",
 				currentTags: map[string]string{
-					"node.k8s.amazonaws.com/instance_id": "i-xxxx",
-					"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
-					"eks:eni:owner":                      "amazon-vpc-cni",
+					eniNodeTagKey:    "i-xxxx",
+					eniClusterTagKey: "awesome-cluster",
+					eniOwnerTagKey:   eniOwnerTagValue,
 				},
 			},
 			wantErr: nil,
@@ -1903,12 +1903,12 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 							Resources: []string{"eni-xxxx"},
 							Tags: []ec2types.Tag{
 								{
-									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Key:   aws.String(eniClusterTagKey),
 									Value: aws.String("awesome-cluster"),
 								},
 								{
-									Key:   aws.String("eks:eni:owner"),
-									Value: aws.String("amazon-vpc-cni"),
+									Key:   aws.String(eniOwnerTagKey),
+									Value: aws.String(eniOwnerTagValue),
 								},
 							},
 						},
@@ -1918,8 +1918,8 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 			args: args{
 				eniID: "eni-xxxx",
 				currentTags: map[string]string{
-					"node.k8s.amazonaws.com/instance_id": "i-xxxx",
-					"anotherKey":                         "anotherDay",
+					eniNodeTagKey: "i-xxxx",
+					"anotherKey":  "anotherDay",
 				},
 			},
 			wantErr: nil,
@@ -1935,15 +1935,15 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 							Resources: []string{"eni-xxxx"},
 							Tags: []ec2types.Tag{
 								{
-									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
+									Key:   aws.String(eniClusterTagKey),
 									Value: aws.String("awesome-cluster"),
 								},
 								{
-									Key:   aws.String("eks:eni:owner"),
-									Value: aws.String("amazon-vpc-cni"),
+									Key:   aws.String(eniOwnerTagKey),
+									Value: aws.String(eniOwnerTagValue),
 								},
 								{
-									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
+									Key:   aws.String(eniNodeTagKey),
 									Value: aws.String("i-xxxx"),
 								},
 							},

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -1316,6 +1316,7 @@ func TestEC2InstanceMetadataCache_buildENITags(t *testing.T) {
 			want: map[string]string{
 				"node.k8s.amazonaws.com/instance_id": "i-xxxxx",
 				"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
+				"eks:eni:owner":                      "amazon-vpc-cni",
 			},
 		},
 		{
@@ -1856,6 +1857,10 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 									Value: aws.String("awesome-cluster"),
 								},
 								{
+									Key:   aws.String("eks:eni:owner"),
+									Value: aws.String("amazon-vpc-cni"),
+								},
+								{
 									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),
 									Value: aws.String("i-xxxx"),
 								},
@@ -1882,6 +1887,7 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 				currentTags: map[string]string{
 					"node.k8s.amazonaws.com/instance_id": "i-xxxx",
 					"cluster.k8s.amazonaws.com/name":     "awesome-cluster",
+					"eks:eni:owner":                      "amazon-vpc-cni",
 				},
 			},
 			wantErr: nil,
@@ -1899,6 +1905,10 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 								{
 									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
 									Value: aws.String("awesome-cluster"),
+								},
+								{
+									Key:   aws.String("eks:eni:owner"),
+									Value: aws.String("amazon-vpc-cni"),
 								},
 							},
 						},
@@ -1927,6 +1937,10 @@ func TestEC2InstanceMetadataCache_TagENI(t *testing.T) {
 								{
 									Key:   aws.String("cluster.k8s.amazonaws.com/name"),
 									Value: aws.String("awesome-cluster"),
+								},
+								{
+									Key:   aws.String("eks:eni:owner"),
+									Value: aws.String("amazon-vpc-cni"),
 								},
 								{
 									Key:   aws.String("node.k8s.amazonaws.com/instance_id"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
Feature. 
Now vpc-cni will add following tag when creating ENI which will help VPC-RC to help filter out ENI's created by vpc-cni and garbage clean them. Ref PR https://github.com/aws/amazon-vpc-resource-controller-k8s/pull/505
```
"eks:eni:owner":"amazon-vpc-cni"

```

Note:- With the current state of VPC-RC PR and VPC-CNI tag addition, there will be cleanup of eni's from both components. To resolve that customer has to disable cleanup of eni in VPC-CNI with env variable `DISABLE_LEAKED_ENI_CLEANUP`

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
