### PR TITLE
Remove dependency on apiserver for IPAMD startup

### DIFF
--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
@@ -24,6 +25,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/version"
 	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	metrics "github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -36,10 +38,53 @@ const (
 
 	// Environment variable to disable the IPAMD introspection endpoint on 61679
 	envDisableIntrospection = "DISABLE_INTROSPECTION"
+
+	restCfgTimeout = 5 * time.Second
+	pollInterval   = 5 * time.Second
+	pollTimeout    = 30 * time.Second
 )
 
 func main() {
 	os.Exit(_main())
+}
+
+// startBackgroundAPIServerCheck checks API connectivity in the background
+func startBackgroundAPIServerCheck(ipamContext *ipamd.IPAMContext) {
+	go func() {
+		log := logger.Get()
+		log.Info("Starting background API server connectivity check...")
+
+		// Create a new client for API server check
+		restCfg, err := k8sapi.GetRestConfig()
+		if err != nil {
+			log.Errorf("Failed to get REST config for background API check: %v", err)
+			return
+		}
+		restCfg.Timeout = restCfgTimeout
+		clientSet, err := kubernetes.NewForConfig(restCfg)
+		if err != nil {
+			log.Errorf("Failed to create k8s client for background API check: %v", err)
+			return
+		}
+
+		// Keep checking until connection is established
+		for {
+			version, err := clientSet.Discovery().ServerVersion()
+			if err == nil {
+				log.Infof("API server connectivity established in background! Cluster Version is: %s", version.GitVersion)
+
+				// Update IPAM context with new API server connectivity
+				ipamContext.SetAPIServerConnectivity(true)
+
+				// Exit the goroutine after successful connection
+				log.Info("Background API server check completed successfully")
+				return
+			}
+
+			log.Debugf("Still waiting for API server connectivity in background: %v", err)
+			time.Sleep(pollInterval)
+		}
+	}()
 }
 
 func _main() int {
@@ -49,29 +94,49 @@ func _main() int {
 	log.Infof("Starting L-IPAMD %s  ...", version.Version)
 	version.RegisterMetric()
 
+	enabledPodEni := ipamd.EnablePodENI()
+	enabledCustomNetwork := ipamd.UseCustomNetworkCfg()
+	withApiServer := false
 	// Check API Server Connectivity
-	if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
-		log.Errorf("Failed to check API server connectivity: %s", err)
-		return 1
+	if enabledPodEni || enabledCustomNetwork {
+		log.Info("SGP or custom networking feature in use, waiting for API server connectivity to start IPAMD")
+		if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
+			log.Errorf("Failed to check API server connectivity: %s", err)
+			return 1
+		} else {
+			log.Info("API server connectivity established.")
+			withApiServer = true
+		}
+	} else {
+		log.Infof("Waiting to connect API server for upto %s...", pollTimeout)
+		// Try a quick check first
+		if err := k8sapi.CheckAPIServerConnectivityWithTimeout(pollInterval, pollTimeout); err != nil {
+			log.Warn("Proceeding without API server connectivity, will run background API server connectivity check")
+			withApiServer = false
+		} else {
+			log.Info("API server connectivity established.")
+			withApiServer = true
+		}
 	}
-
 	// Create Kubernetes client for API server requests
 	k8sClient, err := k8sapi.CreateKubeClient(appName)
 	if err != nil {
 		log.Errorf("Failed to create kube client: %s", err)
-		return 1
 	}
-
 	// Create EventRecorder for use by IPAMD
-	if err := eventrecorder.Init(k8sClient); err != nil {
+	if err := eventrecorder.Init(k8sClient, withApiServer); err != nil {
 		log.Errorf("Failed to create event recorder: %s", err)
-		return 1
+		log.Warn("Skipping event recorder initialization")
 	}
-
-	ipamContext, err := ipamd.New(k8sClient)
+	ipamContext, err := ipamd.New(k8sClient, withApiServer)
 	if err != nil {
 		log.Errorf("Initialization failure: %v", err)
 		return 1
+	}
+
+	// If not connected to API server yet, start background checks
+	if !withApiServer {
+		startBackgroundAPIServerCheck(ipamContext)
 	}
 
 	// Pool manager

--- a/cmd/aws-k8s-agent/main.go
+++ b/cmd/aws-k8s-agent/main.go
@@ -96,10 +96,11 @@ func _main() int {
 
 	enabledPodEni := ipamd.EnablePodENI()
 	enabledCustomNetwork := ipamd.UseCustomNetworkCfg()
+	enabledPodAnnotation := ipamd.EnablePodIPAnnotation()
 	withApiServer := false
 	// Check API Server Connectivity
-	if enabledPodEni || enabledCustomNetwork {
-		log.Info("SGP or custom networking feature in use, waiting for API server connectivity to start IPAMD")
+	if enabledPodEni || enabledCustomNetwork || enabledPodAnnotation {
+		log.Info("SGP, custom networking or pod annotation feature is in use, waiting for API server connectivity to start IPAMD")
 		if err := k8sapi.CheckAPIServerConnectivity(); err != nil {
 			log.Errorf("Failed to check API server connectivity: %s", err)
 			return 1

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -16,7 +16,6 @@ package ipamd
 import (
 	"context"
 	"fmt"
-	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 	"net"
 	"os"
 	"strconv"
@@ -24,6 +23,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/k8sapi"
 
 	"github.com/aws/smithy-go"
 
@@ -1770,24 +1771,6 @@ func parseMaxPodsFile(content string) instanceTypeMaxPodsMapping {
 
 	return mapping
 }
-
-//func getMaxPodsFromKubelet() (int64, error) {
-//	data, err := os.ReadFile(kubeletConfigPath)
-//	if err != nil {
-//		return defaultMaxPodsFromKubelet, fmt.Errorf("failed to read kubelet config: %w", err)
-//	}
-//
-//	var config kubeletConfig
-//	if err := json.Unmarshal(data, &config); err != nil {
-//		return defaultMaxPodsFromKubelet, fmt.Errorf("failed to parse kubelet config JSON: %w", err)
-//	}
-//
-//	if config.MaxPods != nil {
-//		return *config.MaxPods, nil
-//	}
-//
-//	return defaultMaxPodsFromKubelet, nil
-//}
 
 // UseCustomNetworkCfg returns whether Pods needs to use pod specific configuration or not.
 func UseCustomNetworkCfg() bool {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -375,7 +375,7 @@ func New(k8sClient client.Client, withApiServer bool) (*IPAMContext, error) {
 	c.warmPrefixTarget = getWarmPrefixTarget()
 	c.enablePodENI = EnablePodENI()
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
-	c.enablePodIPAnnotation = enablePodIPAnnotation()
+	c.enablePodIPAnnotation = EnablePodIPAnnotation()
 	c.numNetworkCards = len(c.awsClient.GetNetworkCards())
 
 	c.networkPolicyMode, err = getNetworkPolicyMode()
@@ -1877,7 +1877,7 @@ func enableManageUntaggedMode() bool {
 	return utils.GetBoolAsStringEnvVar(envManageUntaggedENI, true)
 }
 
-func enablePodIPAnnotation() bool {
+func EnablePodIPAnnotation() bool {
 	return utils.GetBoolAsStringEnvVar(envAnnotatePodIP, false)
 }
 

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1649,11 +1649,11 @@ func TestPodENIConfigFlag(t *testing.T) {
 	defer m.ctrl.Finish()
 
 	_ = os.Setenv(envEnablePodENI, "true")
-	disabled := enablePodENI()
+	disabled := EnablePodENI()
 	assert.True(t, disabled)
 
 	_ = os.Unsetenv(envEnablePodENI)
-	disabled = enablePodENI()
+	disabled = EnablePodENI()
 	assert.False(t, disabled)
 }
 

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -137,6 +137,7 @@ func TestNodeInit(t *testing.T) {
 		myNodeName:    myNodeName,
 		enableIPv4:    true,
 		enableIPv6:    false,
+		withApiServer: true,
 	}
 
 	eni1, eni2, _ := getDummyENIMetadata()
@@ -228,6 +229,7 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 		enablePrefixDelegation: true,
 		enableIPv4:             true,
 		enableIPv6:             false,
+		withApiServer:          true,
 	}
 
 	eni1, eni2 := getDummyENIMetadataWithPrefix()
@@ -315,6 +317,7 @@ func TestNodeInitwithPDenabledIPv6Mode(t *testing.T) {
 		enablePrefixDelegation: true,
 		enableIPv4:             false,
 		enableIPv6:             true,
+		withApiServer:          true,
 	}
 
 	eni1 := getDummyENIMetadataWithV6Prefix()

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -3,18 +3,19 @@ package k8sapi
 import (
 	"context"
 	"fmt"
+	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"os"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-
-	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	rcscheme "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -28,6 +29,7 @@ import (
 const (
 	awsNode         = "aws-node"
 	envEnablePodENI = "ENABLE_POD_ENI"
+	restCfgTimeout  = 5 * time.Second
 )
 
 var log = logger.Get()
@@ -101,7 +103,7 @@ func StartKubeClientCache(cache cache.Cache) {
 
 // CreateKubeClient creates a k8s client
 func CreateKubeClient(appName string) (client.Client, error) {
-	restCfg, err := getRestConfig()
+	restCfg, err := GetRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -120,27 +122,30 @@ func CreateKubeClient(appName string) (client.Client, error) {
 	}
 	cacheReader, err := CreateKubeClientCache(restCfg, vpcCniScheme, filterMap)
 	if err != nil {
-		return nil, err
+		log.Warnf("Skipping cache-based Kubernetes client: %s", err)
+		cacheReader = nil
 	}
-	// Start cache and wait for initial sync
-	StartKubeClientCache(cacheReader)
 
-	// The cache will start a WATCH for all GVKs in the scheme.
-	k8sClient, err := client.New(restCfg, client.Options{
-		Cache: &client.CacheOptions{
-			Reader: cacheReader,
-		},
-		Scheme: vpcCniScheme,
-	})
+	clientOpts := client.Options{Scheme: vpcCniScheme}
+	if cacheReader != nil {
+		log.Info("Cache-based Kubernetes client successfully created.")
+		StartKubeClientCache(cacheReader)
+		clientOpts.Cache = &client.CacheOptions{Reader: cacheReader}
+	} else {
+		log.Warn("Running Kubernetes client in direct mode (no cache)")
+	}
+
+	k8sClient, err := client.New(restCfg, clientOpts)
 	if err != nil {
 		return nil, err
 	}
+	log.Info("k8sClient created successfully")
 	return k8sClient, nil
 }
 
 func GetKubeClientSet() (kubernetes.Interface, error) {
 	// creates the in-cluster config
-	config, err := getRestConfig()
+	config, err := GetRestConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -154,11 +159,11 @@ func GetKubeClientSet() (kubernetes.Interface, error) {
 }
 
 func CheckAPIServerConnectivity() error {
-	restCfg, err := getRestConfig()
+	restCfg, err := GetRestConfig()
 	if err != nil {
 		return err
 	}
-	restCfg.Timeout = 5 * time.Second
+	restCfg.Timeout = restCfgTimeout
 	clientSet, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
 		return fmt.Errorf("creating kube config, %w", err)
@@ -182,7 +187,34 @@ func CheckAPIServerConnectivity() error {
 	})
 }
 
-func getRestConfig() (*rest.Config, error) {
+func CheckAPIServerConnectivityWithTimeout(pollInterval time.Duration, pollTimeout time.Duration) error {
+	restCfg, err := GetRestConfig()
+	if err != nil {
+		return err
+	}
+	// timeout for each connect try
+	restCfg.Timeout = restCfgTimeout
+	clientSet, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("creating kube config, %w", err)
+	}
+
+	log.Info("Testing communication with server ...")
+
+	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		version, err := clientSet.Discovery().ServerVersion()
+		if err != nil {
+			log.Errorf("Unable to reach API Server: %v", err)
+			return false, nil // Retry
+		}
+
+		log.Infof("Successful communication with the Cluster! Cluster Version is: %s", version.GitVersion)
+		return true, nil
+	})
+}
+
+// GetRestConfig returns a Kubernetes REST config for API interactions
+func GetRestConfig() (*rest.Config, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
@@ -195,12 +227,28 @@ func getRestConfig() (*rest.Config, error) {
 }
 
 func GetNode(ctx context.Context, k8sClient client.Client) (corev1.Node, error) {
-	log.Infof("Get Node Info for: %s", os.Getenv("MY_NODE_NAME"))
-	var node corev1.Node
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: os.Getenv("MY_NODE_NAME")}, &node)
+	nodeName := os.Getenv("MY_NODE_NAME")
+	log.Infof("Get Node Info for: %s", nodeName)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	}
+
+	// If API server is unavailable, return immediately
+	if k8sClient == nil {
+		log.Warnf("Skipping GetNode() as Kubernetes API client is unavailable.")
+		return node, fmt.Errorf("Kubernetes API client is not available")
+	}
+
+	// Create a context with timeout to avoid hanging indefinitely
+	apiCtx, cancel := context.WithTimeout(ctx, 3*time.Second) // Set 3-second timeout
+	defer cancel()
+
+	err := k8sClient.Get(apiCtx, types.NamespacedName{Name: nodeName}, &node)
 	if err != nil {
-		log.Errorf("error retrieving node: %s", err)
+		klog.Errorf("Failed to get node %s: %v", nodeName, err)
 		return node, err
 	}
+
 	return node, nil
 }

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -3,12 +3,13 @@ package k8sapi
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	eniconfigscheme "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"os"
-	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/utils"

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -18,6 +18,7 @@ WORKDIR /app
 
 COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/eni-max-pods.txt \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/grpc-health-probe \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/egress-cni \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
Improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Currently, IPAMD blocks startup until it can connect to the K8s API server. This is unnecessary when features like SGP or custom networking or pod annotation are not enabled. In regular cases without these features, the only API dependency is retrieving maxPods from the node object — a value that can be derived from the instance type using a local file (`eni-max-pods.txt`).

This hard dependency causes major issues in large-scale clusters:
- ipamd relies on kube-proxy to program proxy rules before it can reach the API server.
- If the node and DaemonSet scale are large, kube-proxy startup can be delayed significantly due to rate limits in the DaemonSet controller.
- We've observed real cases where ipamd waits over 1hr for API server access. During that wait, no pods can start, as they are blocked on IP allocation from ipamd.

**What does this PR do / Why do we need it?**:
This PR removes the hard dependency from apiserver in IPAMD startup, to allow this system-critical component to start asap, and thus unblock the pods launch. 
- For normal use case, IPAMD only waits for 30s to connect with API server, if not, it will proceed without apiserver, (the k8sClient cache cannot start in this case), and fallback to retrieve `maxPods` from the local file. Once the connectivity to API server established in background, it will recreate the k8sClient with cache and re-retrieve the `maxPods` from node status.
- For SGP or custom networking or pod annotate use case, IPAMD still waits for API server connectivity as-is.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
1. Start IPAMD with APIserver connectivity blocked. Verified it will start, and fallback to read the `maxPods` from local file, and run background check for APIserver connectivity
```
{"level":"info","ts":"2025-03-24T06:01:36.088Z","caller":"aws-k8s-agent/main.go:48","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2025-03-24T06:01:36.088Z","caller":"aws-k8s-agent/main.go:48","msg":"Waiting to connect API server for upto 30s…”}
{"level":"info","ts":"2025-03-24T06:01:36.089Z","caller":"aws-k8s-agent/main.go:113","msg":"Testing communication with server ..."}
{"level":"error","ts":"2025-03-24T06:01:41.092Z","caller":"wait/wait.go:109","msg":"Unable to reach API Server: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"error","ts":"2025-03-24T06:01:51.096Z","caller":"wait/wait.go:109","msg":"Unable to reach API Server: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"error","ts":"2025-03-24T06:02:01.096Z","caller":"wait/wait.go:109","msg":"Unable to reach API Server: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"error","ts":"2025-03-24T06:02:11.094Z","caller":"wait/wait.go:109","msg":"Unable to reach API Server: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"error","ts":"2025-03-24T06:02:16.098Z","caller":"wait/wait.go:109","msg":"Unable to reach API Server: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"warn","ts":"2025-03-24T06:02:16.098Z","caller":"aws-k8s-agent/main.go:48","msg":"Proceeding without API server connectivity, will run background API server connectivity check""}
{"level":"warn","ts":"2025-03-24T06:02:46.125Z","caller":"aws-k8s-agent/main.go:123","msg":"Skipping cache-based Kubernetes client due to API connectivity issues: failed to determine if *v1.Pod is namespaced: failed to get restmapping: failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Get \"https://10.100.0.1:443/api/v1\": dial tcp 10.100.0.1:443: i/o timeout"}
{"level":"warn","ts":"2025-03-24T06:02:46.125Z","caller":"aws-k8s-agent/main.go:123","msg":"Running Kubernetes client in direct mode (no cache)"}
{"level":"info","ts":"2025-03-24T06:02:46.126Z","caller":"aws-k8s-agent/main.go:123","msg":"k8sClient created successfully"}
...
"level":"info","ts":"2025-03-24T06:02:47.691Z","caller":"ipamd/ipamd.go:557","msg":"Read maxPods as 29, for instanceType m5.large"}
{"level":"debug","ts":"2025-03-24T06:02:47.691Z","caller":"ipamd/ipamd.go:402","msg":"node init completed successfully"}
{"level":"info","ts":"2025-03-24T06:02:47.691Z","caller":"runtime/asm_amd64.s:1695","msg":"IP pool manager - max pods: 29, warm IP target: 0, warm prefix target: 1, warm ENI target: 1, minimum IP target: 0"}
{"level":"info","ts":"2025-03-24T06:02:47.691Z","caller":"runtime/asm_amd64.s:1695","msg":"Starting background API server connectivity check..."}
{"level":"info","ts":"2025-03-24T06:02:47.692Z","caller":"runtime/asm_amd64.s:1695","msg":"Serving metrics on port 61678"}
{"level":"info","ts":"2025-03-24T06:02:47.691Z","caller":"aws-k8s-agent/main.go:159","msg":"Serving RPC Handler version  on 127.0.0.1:50051"}
{"level":"info","ts":"2025-03-24T06:02:47.692Z","caller":"runtime/asm_amd64.s:1695","msg":"Setting up shutdown hook."}
{"level":"info","ts":"2025-03-24T06:02:47.692Z","caller":"ipamd/introspect.go:54","msg":"Serving introspection endpoints on 127.0.0.1:61679"}
```
2. Re-establish the connectivity with APIserver, verified the background check detects it and recreated the k8sClient, and update `maxPods` retrieved from node directly
```
{"level":"debug","ts":"2025-03-24T06:00:16.530Z","caller":"runtime/asm_amd64.s:1695","msg":"Still waiting for API server connectivity in background: Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
{"level":"debug","ts":"2025-03-24T06:00:19.282Z","caller":"ipamd/ipamd.go:690","msg":"IP stats - total IPs: 18, assigned IPs: 8, cooldown IPs: 0"}
{"level":"info","ts":"2025-03-24T06:00:21.539Z","caller":"runtime/asm_amd64.s:1695","msg":"API server connectivity established in background! Cluster Version is: v1.31.6-eks-bc803b4"}
{"level":"info","ts":"2025-03-24T06:00:21.539Z","caller":"aws-k8s-agent/main.go:77","msg":"Updating API server connectivity status from false to true"}
{"level":"info","ts":"2025-03-24T06:00:21.545Z","caller":"ipamd/ipamd.go:2472","msg":"Cache-based Kubernetes client successfully created."}
{"level":"info","ts":"2025-03-24T06:00:21.546Z","caller":"ipamd/ipamd.go:2472","msg":"k8sClient created successfully"}
{"level":"info","ts":"2025-03-24T06:00:21.546Z","caller":"aws-k8s-agent/main.go:77","msg":"Successfully recreated k8s client with cache after API server became available"}
{"level":"info","ts":"2025-03-24T06:00:21.546Z","caller":"ipamd/ipamd.go:2482","msg":"Get Node Info for: ip-192-168-85-156.us-west-2.compute.internal"}
{"level":"info","ts":"2025-03-24T06:00:21.647Z","caller":"aws-k8s-agent/main.go:77","msg":"Updated maxPods from 29 to 29 based on node capacity"}
{"level":"info","ts":"2025-03-24T06:00:21.647Z","caller":"runtime/asm_amd64.s:1695","msg":"Background API server check completed successfully"}
{"level":"debug","ts":"2025-03-24T06:00:24.284Z","caller":"ipamd/ipamd.go:690","msg":"IP stats - total IPs: 18, assigned IPs: 8, cooldown IPs: 0"}
{"level":"debug","ts":"2025-03-24T06:00:29.286Z","caller":"ipamd/ipamd.go:690","msg":"IP stats - total IPs: 18, assigned IPs: 8, cooldown IPs: 0"}
{"level":"debug","ts":"2025-03-24T06:00:34.288Z","caller":"ipamd/ipamd.go:690","msg":"IP stats - total IPs: 18, assigned IPs: 8, cooldown IPs: 0"}
```
3. Start IPAMD with SGP and custom networking enabled, verified it waits for APIserver connectivty as-is
```
{"level":"info","ts":"2025-03-24T06:38:38.931Z","caller":"aws-k8s-agent/main.go:48","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2025-03-24T06:38:38.931Z","caller":"aws-k8s-agent/main.go:48","msg":"Waiting to connect API server for upto 30s..."}
{"level":"info","ts":"2025-03-24T06:38:38.932Z","caller":"aws-k8s-agent/main.go:113","msg":"Testing communication with server ..."}
{"level":"info","ts":"2025-03-24T06:38:52.984Z","caller":"logger/logger.go:52","msg":"Constructed new logger instance"}
{"level":"info","ts":"2025-03-24T06:38:52.984Z","caller":"networkutils/network.go:143","msg":"Initialized new logger as an existing instance was not found"}
{"level":"info","ts":"2025-03-24T06:38:52.995Z","caller":"aws-k8s-agent/main.go:48","msg":"Starting L-IPAMD   ..."}
{"level":"info","ts":"2025-03-24T06:38:52.995Z","caller":"aws-k8s-agent/main.go:48","msg":"SGP or custom networking feature in use, waiting for API server connectivityto start IPAMD"}
{"level":"info","ts":"2025-03-24T06:38:52.996Z","caller":"aws-k8s-agent/main.go:103","msg":"Testing communication with server"}
{"level":"error","ts":"2025-03-24T06:38:57.996Z","caller":"wait/loop.go:53","msg":"Unable to reach API Server, Get \"https://10.100.0.1:443/version?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
```
4. Start IPAMD with SGP or custom networking, verified when API server is connected, the IPAMD starts as expected.
5. Manually ran integration tests passed:
```
[AfterSuite]
/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/ipamd/ipamd_suite_test.go:115
  STEP: restoring coredns deployment @ 03/27/25 21:49:35.722
  STEP: deleting test namespace @ 03/27/25 21:49:35.731
[AfterSuite] PASSED [8.119 seconds]
------------------------------

Ran 1 of 26 Specs in 94.001 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 25 Skipped
PASS 

/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/test/integration/cni/pod_networking_suite_test.go:112
  STEP: deleting test namespace @ 03/27/25 22:05:13.761
  STEP: update environment variables map[AWS_VPC_ENI_MTU:9001 AWS_VPC_K8S_CNI_VETHPREFIX:eni], remove map[IP_COOLDOWN_PERIOD:{} WARM_ENI_TARGET:{} WARM_IP_TARGET:{}] @ 03/27/25 22:05:35.874
  STEP: getting the aws-node daemon set in namespace kube-system @ 03/27/25 22:05:35.874
  STEP: updating the daemon set with new environment variable @ 03/27/25 22:05:35.875
[AfterSuite] PASSED [32.135 seconds]
------------------------------

Ran 6 of 28 Specs in 699.195 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS
 ```

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
