### PR TITLE
[WIP] feat(ipamd): move introspection API types to separate package

### DIFF
--- a/pkg/ipamd/api/v1/types.go
+++ b/pkg/ipamd/api/v1/types.go
@@ -1,0 +1,265 @@
+package v1
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+const (
+	// minENILifeTime is the shortest time before we consider deleting a newly created ENI
+	minENILifeTime = 1 * time.Minute
+)
+
+// IPAMKey is the IPAM primary key.  Quoting CNI spec:
+//
+//	Plugins that store state should do so using a primary key of
+//	(network name, CNI_CONTAINERID, CNI_IFNAME).
+type IPAMKey struct {
+	NetworkName string `json:"networkName"`
+	ContainerID string `json:"containerID"`
+	IfName      string `json:"ifName"`
+}
+
+// IsZero returns true if object is equal to the golang zero/null value.
+func (k IPAMKey) IsZero() bool {
+	return k == IPAMKey{}
+}
+
+// String() implements the fmt.Stringer interface.
+func (k IPAMKey) String() string {
+	return fmt.Sprintf("%s/%s/%s", k.NetworkName, k.ContainerID, k.IfName)
+}
+
+// IPAMMetadata is the metadata associated with IP allocations.
+type IPAMMetadata struct {
+	K8SPodNamespace string `json:"k8sPodNamespace,omitempty"`
+	K8SPodName      string `json:"k8sPodName,omitempty"`
+}
+
+// ENI represents a single ENI. Exported fields will be marshaled for introspection.
+type ENI struct {
+	// CreateTime is excluded from marshalled representation, used only by internal datastore
+	CreateTime time.Time `json:"-"`
+
+	// AWS ENI ID
+	ID string
+	// IsPrimary indicates whether ENI is a primary ENI
+	IsPrimary bool
+	// IsTrunk indicates whether this ENI is used to provide pods with dedicated ENIs
+	IsTrunk bool
+	// IsEFA indicates whether this ENI is tagged as an EFA
+	IsEFA bool
+	// DeviceNumber is the device number of ENI (0 means the primary ENI)
+	DeviceNumber int
+	// IPv4Addresses shows whether each address is assigned, the key is IP address, which must
+	// be in dot-decimal notation with no leading zeros and no whitespace(eg: "10.1.0.253")
+	// Key is the IP address - PD: "IP/28" and SIP: "IP/32"
+	AvailableIPv4Cidrs map[string]*CidrInfo
+	//IPv6CIDRs contains information tied to IPv6 Prefixes attached to the ENI
+	IPv6Cidrs map[string]*CidrInfo
+}
+
+// IsTooYoung returns true if the ENI hasn't been around long enough to be deleted.
+func (e *ENI) IsTooYoung() bool {
+	return time.Since(e.CreateTime) < minENILifeTime
+}
+
+// HasIPInCooling returns true if an IP address was unassigned recently.
+func (e *ENI) HasIPInCooling(ipCooldownPeriod time.Duration) bool {
+	for _, assignedaddr := range e.AvailableIPv4Cidrs {
+		for _, addr := range assignedaddr.IPAddresses {
+			if addr.InCoolingPeriod(ipCooldownPeriod) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasPods returns true if the ENI has pods assigned to it.
+func (e *ENI) HasPods() bool {
+	return e.AssignedIPv4Addresses() != 0
+}
+
+// AddressInfo contains information about an IP, Exported fields will be marshaled for introspection.
+type AddressInfo struct {
+	Address string
+
+	IPAMKey        IPAMKey
+	IPAMMetadata   IPAMMetadata
+	AssignedTime   time.Time
+	UnassignedTime time.Time
+}
+
+// CidrInfo
+type CidrInfo struct {
+	// Either v4/v6 Host or LPM Prefix
+	Cidr net.IPNet
+	// Key is individual IP addresses from the Prefix - /32 (v4) or /128 (v6)
+	IPAddresses map[string]*AddressInfo
+	// true if Cidr here is an LPM prefix
+	IsPrefix bool
+	// IP Address Family of the Cidr
+	AddressFamily string
+}
+
+func (cidr *CidrInfo) Size() int {
+	ones, bits := cidr.Cidr.Mask.Size()
+	return (1 << (bits - ones))
+}
+
+func (e *ENI) findAddressForSandbox(ipamKey IPAMKey) (*CidrInfo, *AddressInfo) {
+	// Either v4 or v6 for now.
+	// Check in V4 prefixes
+	for _, availableCidr := range e.AvailableIPv4Cidrs {
+		for _, addr := range availableCidr.IPAddresses {
+			if addr.IPAMKey == ipamKey {
+				return availableCidr, addr
+			}
+		}
+	}
+
+	// Check in V6 prefixes
+	for _, availableCidr := range e.IPv6Cidrs {
+		for _, addr := range availableCidr.IPAddresses {
+			if addr.IPAMKey == ipamKey {
+				return availableCidr, addr
+			}
+		}
+	}
+	return nil, nil
+}
+
+// AssignedIPv4Addresses is the number of IP addresses already assigned
+func (e *ENI) AssignedIPv4Addresses() int {
+	count := 0
+	for _, availableCidr := range e.AvailableIPv4Cidrs {
+		count += availableCidr.AssignedIPAddressesInCidr()
+	}
+	return count
+}
+
+// AssignedIPAddressesInCidr is the number of IP addresses already assigned in the IPv4 CIDR
+func (cidr *CidrInfo) AssignedIPAddressesInCidr() int {
+	count := 0
+	//SIP : This will run just once and count will be 0 if addr is not assigned or addr is not allocated yet(unused IP)
+	//PD : This will return count of number /32 assigned in /28 CIDR.
+	for _, addr := range cidr.IPAddresses {
+		if addr.Assigned() {
+			count++
+		}
+	}
+	return count
+}
+
+type CidrStats struct {
+	AssignedIPs int
+	CooldownIPs int
+}
+
+// Gets number of assigned IPs and the IPs in cooldown from a given CIDR
+func (cidr *CidrInfo) GetIPStatsFromCidr(ipCooldownPeriod time.Duration) CidrStats {
+	stats := CidrStats{}
+	for _, addr := range cidr.IPAddresses {
+		if addr.Assigned() {
+			stats.AssignedIPs++
+		} else if addr.InCoolingPeriod(ipCooldownPeriod) {
+			stats.CooldownIPs++
+		}
+	}
+	return stats
+}
+
+// Assigned returns true iff the address is allocated to a pod/sandbox.
+func (addr AddressInfo) Assigned() bool {
+	return !addr.IPAMKey.IsZero()
+}
+
+// InCoolingPeriod checks whether an addr is in ipCooldownPeriod
+func (addr AddressInfo) InCoolingPeriod(ipCooldownPeriod time.Duration) bool {
+	return time.Since(addr.UnassignedTime) <= ipCooldownPeriod
+}
+
+// ENIPool is a collection of ENI, keyed by ENI ID
+type ENIPool map[string]*ENI
+
+// AssignedIPv4Addresses is the number of IP addresses already assigned
+func (p *ENIPool) AssignedIPv4Addresses() int {
+	count := 0
+	for _, eni := range *p {
+		count += eni.AssignedIPv4Addresses()
+	}
+	return count
+}
+
+// FindAddressForSandbox returns ENI and AddressInfo or (nil, nil) if not found
+func (p *ENIPool) FindAddressForSandbox(ipamKey IPAMKey) (*ENI, *CidrInfo, *AddressInfo) {
+	for _, eni := range *p {
+		if availableCidr, addr := eni.findAddressForSandbox(ipamKey); addr != nil && availableCidr != nil {
+			return eni, availableCidr, addr
+		}
+	}
+	return nil, nil, nil
+}
+
+// PodIPInfo contains pod's IP and the device number of the ENI
+type PodIPInfo struct {
+	IPAMKey IPAMKey
+	// IP is the IPv4 address of pod
+	IP string
+	// DeviceNumber is the device number of the ENI
+	DeviceNumber int
+}
+
+// ENIInfos contains ENI IP information
+type ENIInfos struct {
+	// TotalIPs is the total number of IP addresses
+	TotalIPs int
+	// assigned is the number of IP addresses that has been assigned
+	AssignedIPs int
+	// ENIs contains ENI IP pool information
+	ENIs map[string]ENI
+}
+
+// CheckpointFormatVersion is the version stamp used on stored checkpoints.
+const CheckpointFormatVersion = "vpc-cni-ipam/1"
+
+// CheckpointData is the format of stored checkpoints. Note this is
+// deliberately a "dumb" format since efficiency is less important
+// than version stability here.
+type CheckpointData struct {
+	Version     string            `json:"version"`
+	Allocations []CheckpointEntry `json:"allocations"`
+}
+
+// CheckpointEntry is a "row" in the conceptual IPAM datastore, as stored
+// in checkpoints.
+type CheckpointEntry struct {
+	IPAMKey
+	IPv4                string       `json:"ipv4,omitempty"`
+	IPv6                string       `json:"ipv6,omitempty"`
+	AllocationTimestamp int64        `json:"allocationTimestamp"`
+	Metadata            IPAMMetadata `json:"metadata"`
+}
+
+type DataStoreStats struct {
+	// Total number of addresses allocated
+	TotalIPs int
+	// Total number of prefixes allocated
+	TotalPrefixes int
+
+	// Number of assigned addresses
+	AssignedIPs int
+	// Number of addresses in cooldown
+	CooldownIPs int
+}
+
+func (stats *DataStoreStats) String() string {
+	return fmt.Sprintf("Total IPs/Prefixes = %d/%d, AssignedIPs/CooldownIPs: %d/%d",
+		stats.TotalIPs, stats.TotalPrefixes, stats.AssignedIPs, stats.CooldownIPs)
+}
+
+func (stats *DataStoreStats) AvailableAddresses() int {
+	return stats.TotalIPs - stats.AssignedIPs
+}

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/api/v1"
 	mock_netlinkwrapper "github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
@@ -94,8 +95,8 @@ func TestDeleteENI(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, false)
 	assert.NoError(t, err)
 	ip, device, err := ds.AssignPodIPv4Address(
-		IPAMKey{"net1", "sandbox1", "eth0"},
-		IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod"})
+		v1.IPAMKey{NetworkName: "net1", ContainerID: "sandbox1", IfName: "eth0"},
+		v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod"})
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -144,8 +145,8 @@ func TestDeleteENIwithPDEnabled(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-4", ipv4Addr, true)
 	assert.NoError(t, err)
 	ip, device, err := ds.AssignPodIPv4Address(
-		IPAMKey{"net1", "sandbox1", "eth0"},
-		IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod"})
+		v1.IPAMKey{NetworkName: "net1", ContainerID: "sandbox1", IfName: "eth0"},
+		v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod"})
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.0", ip)
 	assert.Equal(t, 4, device)
@@ -329,8 +330,8 @@ func TestDelENIIPv4Address(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 
 	// Assign a pod.
-	key := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, device, err := ds.AssignPodIPv4Address(key, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, device, err := ds.AssignPodIPv4Address(key, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -387,8 +388,8 @@ func TestDelENIIPv4AddressWithPDEnabled(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 
 	// Assign a pod.
-	key := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, device, err := ds.AssignPodIPv4Address(key, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, device, err := ds.AssignPodIPv4Address(key, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.0", ip)
 	assert.Equal(t, 1, device)
@@ -447,8 +448,8 @@ func TestTogglePD(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 
 	// Assign a pod.
-	key := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, device, err := ds.AssignPodIPv4Address(key, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, device, err := ds.AssignPodIPv4Address(key, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -464,8 +465,8 @@ func TestTogglePD(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 2)
 
 	//Assign a pod
-	key = IPAMKey{"net0", "sandbox-2", "eth0"}
-	ip, device, err = ds.AssignPodIPv4Address(key, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key = v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	ip, device, err = ds.AssignPodIPv4Address(key, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.0", ip)
 	assert.Equal(t, 1, device)
@@ -517,8 +518,8 @@ func TestPodIPv4Address(t *testing.T) {
 	ds := NewDataStore(Testlog, checkpoint, false)
 
 	checkpointDataCmpOpts := cmp.Options{
-		cmpopts.IgnoreFields(CheckpointEntry{}, "AllocationTimestamp"),
-		cmpopts.SortSlices(func(lhs CheckpointEntry, rhs CheckpointEntry) bool {
+		cmpopts.IgnoreFields(v1.CheckpointEntry{}, "AllocationTimestamp"),
+		cmpopts.SortSlices(func(lhs v1.CheckpointEntry, rhs v1.CheckpointEntry) bool {
 			return lhs.ContainerID < rhs.ContainerID
 		}),
 	}
@@ -533,8 +534,8 @@ func TestPodIPv4Address(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-1", ipv4Addr1, false)
 	assert.NoError(t, err)
 
-	key1 := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, _, err := ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key1 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, _, err := ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
@@ -542,13 +543,13 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, 1, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs))
 	assert.Equal(t, 1, ds.eniPool["eni-1"].AssignedIPv4Addresses())
 
-	expectedCheckpointData := &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData := &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "1.1.1.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 		},
 	}
@@ -565,7 +566,7 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.NoError(t, err)
 
 	// duplicate add
-	ip, _, err = ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"}) // same id
+	ip, _, err = ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"}) // same id
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.1")
 	assert.Equal(t, ds.total, 2)
@@ -577,17 +578,17 @@ func TestPodIPv4Address(t *testing.T) {
 
 	// Checkpoint error
 	checkpoint.Error = errors.New("fake checkpoint error")
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.Error(t, err)
 
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "1.1.1.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 		},
 	}
@@ -597,7 +598,7 @@ func TestPodIPv4Address(t *testing.T) {
 	)
 	checkpoint.Error = nil
 
-	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.2.2")
 	assert.Equal(t, ds.total, 2)
@@ -605,18 +606,18 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-2"].AvailableIPv4Cidrs), 1)
 	assert.Equal(t, ds.eniPool["eni-2"].AssignedIPv4Addresses(), 1)
 
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "1.1.1.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
 				IPv4:     "1.1.2.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
 			},
 		},
 	}
@@ -632,31 +633,30 @@ func TestPodIPv4Address(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-1", ipv4Addr3, false)
 	assert.NoError(t, err)
 
-	key3 := IPAMKey{"net0", "sandbox-3", "eth0"}
-	ip, _, err = ds.AssignPodIPv4Address(key3, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
+	key3 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"}
+	ip, _, err = ds.AssignPodIPv4Address(key3, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "1.1.1.2")
 	assert.Equal(t, ds.total, 3)
 	assert.Equal(t, ds.assigned, 3)
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 2)
 	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 2)
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{{
+			IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+			IPv4:     "1.1.1.1",
+			Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+		},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
-				IPv4:     "1.1.1.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
-			},
-			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
 				IPv4:     "1.1.2.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
 				IPv4:     "1.1.1.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
 			},
 		},
 	}
@@ -666,8 +666,8 @@ func TestPodIPv4Address(t *testing.T) {
 	)
 
 	// no more IP addresses
-	key4 := IPAMKey{"net0", "sandbox-4", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key4, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-4"})
+	key4 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-4", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key4, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-4"})
 	assert.Error(t, err)
 	// Unassign unknown Pod
 	_, _, _, err = ds.UnassignPodIPAddress(key4)
@@ -680,18 +680,18 @@ func TestPodIPv4Address(t *testing.T) {
 	assert.Equal(t, deviceNum, pod1Ns2Device)
 	assert.Equal(t, len(ds.eniPool["eni-2"].AvailableIPv4Cidrs), 1)
 	assert.Equal(t, ds.eniPool["eni-2"].AssignedIPv4Addresses(), 0)
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "1.1.1.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
 				IPv4:     "1.1.1.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
 			},
 		},
 	}
@@ -708,7 +708,7 @@ func TestPodIPv4Address(t *testing.T) {
 	eni := ds.RemoveUnusedENIFromStore(noWarmIPTarget, noMinimumIPTarget, noWarmPrefixTarget)
 	assert.True(t, eni == "")
 
-	ds.eniPool["eni-2"].createTime = time.Time{}
+	ds.eniPool["eni-2"].CreateTime = time.Time{}
 	ds.eniPool["eni-2"].AvailableIPv4Cidrs[ipv4Addr2.String()].IPAddresses["1.1.2.2"].UnassignedTime = time.Time{}
 	eni = ds.RemoveUnusedENIFromStore(noWarmIPTarget, noMinimumIPTarget, noWarmPrefixTarget)
 	assert.Equal(t, eni, "eni-2")
@@ -722,8 +722,8 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	ds := NewDataStore(Testlog, checkpoint, true)
 
 	checkpointDataCmpOpts := cmp.Options{
-		cmpopts.IgnoreFields(CheckpointEntry{}, "AllocationTimestamp"),
-		cmpopts.SortSlices(func(lhs CheckpointEntry, rhs CheckpointEntry) bool {
+		cmpopts.IgnoreFields(v1.CheckpointEntry{}, "AllocationTimestamp"),
+		cmpopts.SortSlices(func(lhs v1.CheckpointEntry, rhs v1.CheckpointEntry) bool {
 			return lhs.ContainerID < rhs.ContainerID
 		}),
 	}
@@ -738,8 +738,8 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-1", ipv4Addr1, true)
 	assert.NoError(t, err)
 
-	key1 := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, _, err := ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key1 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, _, err := ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.0", ip)
@@ -747,13 +747,13 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	assert.Equal(t, 1, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs))
 	assert.Equal(t, 1, ds.eniPool["eni-1"].AssignedIPv4Addresses())
 
-	expectedCheckpointData := &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData := &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "10.0.0.0",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 		},
 	}
@@ -766,7 +766,7 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	assert.Equal(t, len(podsInfos), 1)
 
 	// duplicate add
-	ip, _, err = ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"}) // same id
+	ip, _, err = ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"}) // same id
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "10.0.0.0")
 	assert.Equal(t, ds.total, 16)
@@ -776,17 +776,17 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 
 	// Checkpoint error
 	checkpoint.Error = errors.New("fake checkpoint error")
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.Error(t, err)
 
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "10.0.0.0",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 		},
 	}
@@ -796,7 +796,7 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	)
 	checkpoint.Error = nil
 
-	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	ip, pod1Ns2Device, err := ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "10.0.0.1")
 	assert.Equal(t, ds.total, 16)
@@ -804,18 +804,18 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 2)
 
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "10.0.0.0",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
 				IPv4:     "10.0.0.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
 			},
 		},
 	}
@@ -827,31 +827,31 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	podsInfos = ds.AllocatedIPs()
 	assert.Equal(t, len(podsInfos), 2)
 
-	key3 := IPAMKey{"net0", "sandbox-3", "eth0"}
-	ip, _, err = ds.AssignPodIPv4Address(key3, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
+	key3 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"}
+	ip, _, err = ds.AssignPodIPv4Address(key3, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
 	assert.NoError(t, err)
 	assert.Equal(t, ip, "10.0.0.2")
 	assert.Equal(t, ds.total, 16)
 	assert.Equal(t, ds.assigned, 3)
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 3)
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "10.0.0.0",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"},
 				IPv4:     "10.0.0.1",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
 				IPv4:     "10.0.0.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
 			},
 		},
 	}
@@ -867,18 +867,18 @@ func TestPodIPv4AddressWithPDEnabled(t *testing.T) {
 	assert.Equal(t, deviceNum, pod1Ns2Device)
 	assert.Equal(t, len(ds.eniPool["eni-1"].AvailableIPv4Cidrs), 1)
 	assert.Equal(t, ds.eniPool["eni-1"].AssignedIPv4Addresses(), 2)
-	expectedCheckpointData = &CheckpointData{
-		Version: CheckpointFormatVersion,
-		Allocations: []CheckpointEntry{
+	expectedCheckpointData = &v1.CheckpointData{
+		Version: v1.CheckpointFormatVersion,
+		Allocations: []v1.CheckpointEntry{
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"},
 				IPv4:     "10.0.0.0",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"},
 			},
 			{
-				IPAMKey:  IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
+				IPAMKey:  v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-3", IfName: "eth0"},
 				IPv4:     "10.0.0.2",
-				Metadata: IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
+				Metadata: v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"},
 			},
 		},
 	}
@@ -900,18 +900,18 @@ func TestGetIPStatsV4(t *testing.T) {
 
 	ipv4Addr := net.IPNet{IP: net.ParseIP("1.1.1.1"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, false)
-	key1 := IPAMKey{"net0", "sandbox-1", "eth0"}
-	_, _, err := ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key1 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	_, _, err := ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 
 	ipv4Addr = net.IPNet{IP: net.ParseIP("1.1.1.2"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, false)
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:    2,
 			AssignedIPs: 2,
 			CooldownIPs: 0,
@@ -923,7 +923,7 @@ func TestGetIPStatsV4(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:    2,
 			AssignedIPs: 1,
 			CooldownIPs: 1,
@@ -936,7 +936,7 @@ func TestGetIPStatsV4(t *testing.T) {
 	time.Sleep(ds.ipCooldownPeriod)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:    2,
 			AssignedIPs: 1,
 			CooldownIPs: 0,
@@ -954,16 +954,16 @@ func TestGetIPStatsV4WithPD(t *testing.T) {
 
 	ipv4Addr := net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.IPv4Mask(255, 255, 255, 240)}
 	_ = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, true)
-	key1 := IPAMKey{"net0", "sandbox-1", "eth0"}
-	_, _, err := ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key1 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	_, _, err := ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:      16,
 			TotalPrefixes: 1,
 			AssignedIPs:   2,
@@ -976,7 +976,7 @@ func TestGetIPStatsV4WithPD(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:      16,
 			TotalPrefixes: 1,
 			AssignedIPs:   1,
@@ -990,7 +990,7 @@ func TestGetIPStatsV4WithPD(t *testing.T) {
 	time.Sleep(ds.ipCooldownPeriod)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:      16,
 			TotalPrefixes: 1,
 			AssignedIPs:   1,
@@ -1005,12 +1005,12 @@ func TestGetIPStatsV6(t *testing.T) {
 	_ = v6ds.AddENI("eni-1", 1, true, false, false)
 	ipv6Addr := net.IPNet{IP: net.IP{0x21, 0xdb, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: net.CIDRMask(80, 128)}
 	_ = v6ds.AddIPv6CidrToStore("eni-1", ipv6Addr, true)
-	key3 := IPAMKey{"netv6", "sandbox-3", "eth0"}
-	_, _, err := v6ds.AssignPodIPv6Address(key3, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
+	key3 := v1.IPAMKey{NetworkName: "netv6", ContainerID: "sandbox-3", IfName: "eth0"}
+	_, _, err := v6ds.AssignPodIPv6Address(key3, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-3"})
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		DataStoreStats{
+		v1.DataStoreStats{
 			TotalIPs:      281474976710656,
 			TotalPrefixes: 1,
 			AssignedIPs:   1,
@@ -1030,15 +1030,15 @@ func TestWarmENIInteractions(t *testing.T) {
 	// Add an IP address to ENI 1 and assign it to a pod
 	ipv4Addr := net.IPNet{IP: net.ParseIP("1.1.1.1"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, false)
-	key1 := IPAMKey{"net0", "sandbox-1", "eth0"}
-	_, _, err := ds.AssignPodIPv4Address(key1, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key1 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	_, _, err := ds.AssignPodIPv4Address(key1, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 
 	// Add another IP address to ENI 1 and assign a pod
 	ipv4Addr = net.IPNet{IP: net.ParseIP("1.1.1.2"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = ds.AddIPv4CidrToStore("eni-1", ipv4Addr, false)
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	_, _, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	_, _, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 
 	// Add two IP addresses to ENI 2 and one IP address to ENI 3
@@ -1049,8 +1049,8 @@ func TestWarmENIInteractions(t *testing.T) {
 	ipv4Addr = net.IPNet{IP: net.ParseIP("1.1.3.1"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	_ = ds.AddIPv4CidrToStore("eni-3", ipv4Addr, false)
 
-	ds.eniPool["eni-2"].createTime = time.Time{}
-	ds.eniPool["eni-3"].createTime = time.Time{}
+	ds.eniPool["eni-2"].CreateTime = time.Time{}
+	ds.eniPool["eni-3"].CreateTime = time.Time{}
 
 	// We have 3 ENIs, 5 IPs and 2 pods on ENI 1.
 	// ENI 1: 2 IPs allocated, 2 IPs in use
@@ -1091,8 +1091,8 @@ func TestWarmENIInteractions(t *testing.T) {
 	ds.AddIPv4CidrToStore("eni-4", ipv4Addr, false)
 	ipv4Addr = net.IPNet{IP: net.ParseIP("1.1.5.1"), Mask: net.IPv4Mask(255, 255, 255, 255)}
 	ds.AddIPv4CidrToStore("eni-5", ipv4Addr, false)
-	ds.eniPool["eni-4"].createTime = time.Time{}
-	ds.eniPool["eni-5"].createTime = time.Time{}
+	ds.eniPool["eni-4"].CreateTime = time.Time{}
+	ds.eniPool["eni-5"].CreateTime = time.Time{}
 
 	// We have 3 ENIs, 4 IPs and 2 pods on ENI 1.
 	// ENI 1: 2 IPs allocated, 2 IPs in use
@@ -1107,7 +1107,7 @@ func TestWarmENIInteractions(t *testing.T) {
 
 	// Add 1 more normal ENI to the datastore
 	ds.AddENI("eni-6", 6, false, false, false) // trunk ENI
-	ds.eniPool["eni-6"].createTime = time.Time{}
+	ds.eniPool["eni-6"].CreateTime = time.Time{}
 
 	// We have 4 ENIs, 4 IPs and 2 pods on ENI 1.
 	// ENI 1: 2 IPs allocated, 2 IPs in use
@@ -1147,13 +1147,13 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 		staleFromContainerRule *netlink.Rule
 	}
 	type args struct {
-		checkpoint CheckpointData
+		checkpoint v1.CheckpointData
 	}
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    CheckpointData
+		want    v1.CheckpointData
 		wantErr error
 	}{
 		{
@@ -1182,29 +1182,29 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 				},
 			},
 			args: args{
-				checkpoint: CheckpointData{
-					Version: CheckpointFormatVersion,
-					Allocations: []CheckpointEntry{
+				checkpoint: v1.CheckpointData{
+					Version: v1.CheckpointFormatVersion,
+					Allocations: []v1.CheckpointEntry{
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.9.106",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-qqbdh",
 							},
 						},
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "b4729ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e09553422",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.30.161",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-8ns9b",
 							},
@@ -1212,29 +1212,29 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 					},
 				},
 			},
-			want: CheckpointData{
-				Version: CheckpointFormatVersion,
-				Allocations: []CheckpointEntry{
+			want: v1.CheckpointData{
+				Version: v1.CheckpointFormatVersion,
+				Allocations: []v1.CheckpointEntry{
 					{
-						IPAMKey: IPAMKey{
+						IPAMKey: v1.IPAMKey{
 							ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 							NetworkName: "aws-cni",
 							IfName:      "eth0",
 						},
 						IPv4: "192.168.9.106",
-						Metadata: IPAMMetadata{
+						Metadata: v1.IPAMMetadata{
 							K8SPodNamespace: "kube-system",
 							K8SPodName:      "coredns-57ff979f67-qqbdh",
 						},
 					},
 					{
-						IPAMKey: IPAMKey{
+						IPAMKey: v1.IPAMKey{
 							ContainerID: "b4729ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e09553422",
 							NetworkName: "aws-cni",
 							IfName:      "eth0",
 						},
 						IPv4: "192.168.30.161",
-						Metadata: IPAMMetadata{
+						Metadata: v1.IPAMMetadata{
 							K8SPodNamespace: "kube-system",
 							K8SPodName:      "coredns-57ff979f67-8ns9b",
 						},
@@ -1270,35 +1270,35 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 				staleFromContainerRule: fromContainerRule,
 			},
 			args: args{
-				checkpoint: CheckpointData{
-					Version: CheckpointFormatVersion,
-					Allocations: []CheckpointEntry{
+				checkpoint: v1.CheckpointData{
+					Version: v1.CheckpointFormatVersion,
+					Allocations: []v1.CheckpointEntry{
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.9.106",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-qqbdh",
 							},
 						},
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "b4729ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e09553422",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.1.1",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-8ns9b",
 							},
 						},
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "d0437ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e0952341",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
@@ -1308,23 +1308,23 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 					},
 				},
 			},
-			want: CheckpointData{
-				Version: CheckpointFormatVersion,
-				Allocations: []CheckpointEntry{
+			want: v1.CheckpointData{
+				Version: v1.CheckpointFormatVersion,
+				Allocations: []v1.CheckpointEntry{
 					{
-						IPAMKey: IPAMKey{
+						IPAMKey: v1.IPAMKey{
 							ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 							NetworkName: "aws-cni",
 							IfName:      "eth0",
 						},
 						IPv4: "192.168.9.106",
-						Metadata: IPAMMetadata{
+						Metadata: v1.IPAMMetadata{
 							K8SPodNamespace: "kube-system",
 							K8SPodName:      "coredns-57ff979f67-qqbdh",
 						},
 					},
 					{
-						IPAMKey: IPAMKey{
+						IPAMKey: v1.IPAMKey{
 							ContainerID: "d0437ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e0952341",
 							NetworkName: "aws-cni",
 							IfName:      "eth0",
@@ -1344,29 +1344,29 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 				},
 			},
 			args: args{
-				checkpoint: CheckpointData{
-					Version: CheckpointFormatVersion,
-					Allocations: []CheckpointEntry{
+				checkpoint: v1.CheckpointData{
+					Version: v1.CheckpointFormatVersion,
+					Allocations: []v1.CheckpointEntry{
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.9.106",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-qqbdh",
 							},
 						},
 						{
-							IPAMKey: IPAMKey{
+							IPAMKey: v1.IPAMKey{
 								ContainerID: "b4729ce84caa9e585c2ba84fc9f9a058f4cf783292a84608f717035e09553422",
 								NetworkName: "aws-cni",
 								IfName:      "eth0",
 							},
 							IPv4: "192.168.30.161",
-							Metadata: IPAMMetadata{
+							Metadata: v1.IPAMMetadata{
 								K8SPodNamespace: "kube-system",
 								K8SPodName:      "coredns-57ff979f67-8ns9b",
 							},
@@ -1407,7 +1407,7 @@ func TestDataStore_normalizeCheckpointDataByPodVethExistence(t *testing.T) {
 
 func TestDataStore_validateAllocationByPodVethExistence(t *testing.T) {
 	type args struct {
-		allocation  CheckpointEntry
+		allocation  v1.CheckpointEntry
 		hostNSLinks []netlink.Link
 	}
 	tests := []struct {
@@ -1418,14 +1418,14 @@ func TestDataStore_validateAllocationByPodVethExistence(t *testing.T) {
 		{
 			name: "one veth pair found with matching suffix and eni prefix",
 			args: args{
-				allocation: CheckpointEntry{
-					IPAMKey: IPAMKey{
+				allocation: v1.CheckpointEntry{
+					IPAMKey: v1.IPAMKey{
 						ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 						NetworkName: "aws-cni",
 						IfName:      "eth0",
 					},
 					IPv4: "192.168.9.106",
-					Metadata: IPAMMetadata{
+					Metadata: v1.IPAMMetadata{
 						K8SPodNamespace: "kube-system",
 						K8SPodName:      "coredns-57ff979f67-qqbdh",
 					},
@@ -1448,14 +1448,14 @@ func TestDataStore_validateAllocationByPodVethExistence(t *testing.T) {
 		{
 			name: "one veth pair found with matching suffix and custom prefix",
 			args: args{
-				allocation: CheckpointEntry{
-					IPAMKey: IPAMKey{
+				allocation: v1.CheckpointEntry{
+					IPAMKey: v1.IPAMKey{
 						ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 						NetworkName: "aws-cni",
 						IfName:      "eth0",
 					},
 					IPv4: "192.168.9.106",
-					Metadata: IPAMMetadata{
+					Metadata: v1.IPAMMetadata{
 						K8SPodNamespace: "kube-system",
 						K8SPodName:      "coredns-57ff979f67-qqbdh",
 					},
@@ -1478,14 +1478,14 @@ func TestDataStore_validateAllocationByPodVethExistence(t *testing.T) {
 		{
 			name: "no veth pair found with matching suffix",
 			args: args{
-				allocation: CheckpointEntry{
-					IPAMKey: IPAMKey{
+				allocation: v1.CheckpointEntry{
+					IPAMKey: v1.IPAMKey{
 						ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 						NetworkName: "aws-cni",
 						IfName:      "eth0",
 					},
 					IPv4: "192.168.9.106",
-					Metadata: IPAMMetadata{
+					Metadata: v1.IPAMMetadata{
 						K8SPodNamespace: "kube-system",
 						K8SPodName:      "coredns-57ff979f67-qqbdh",
 					},
@@ -1508,14 +1508,14 @@ func TestDataStore_validateAllocationByPodVethExistence(t *testing.T) {
 		{
 			name: "allocation without metadata should pass validation",
 			args: args{
-				allocation: CheckpointEntry{
-					IPAMKey: IPAMKey{
+				allocation: v1.CheckpointEntry{
+					IPAMKey: v1.IPAMKey{
 						ContainerID: "5a1f9118a7125f87b4b0f2f601c0b55cfab8bcf28963bcf7c4ece3109a8b6b86",
 						NetworkName: "aws-cni",
 						IfName:      "eth0",
 					},
 					IPv4:     "192.168.9.106",
-					Metadata: IPAMMetadata{},
+					Metadata: v1.IPAMMetadata{},
 				},
 				hostNSLinks: []netlink.Link{
 					&netlink.Device{
@@ -1568,8 +1568,8 @@ func TestForceRemovalMetrics(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assign IP to a pod
-	key := IPAMKey{"net0", "sandbox-1", "eth0"}
-	ip, device, err := ds.AssignPodIPv4Address(key, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
+	key := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-1", IfName: "eth0"}
+	ip, device, err := ds.AssignPodIPv4Address(key, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-1"})
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", ip)
 	assert.Equal(t, 1, device)
@@ -1594,8 +1594,8 @@ func TestForceRemovalMetrics(t *testing.T) {
 	err = ds.AddIPv4CidrToStore("eni-1", ipv4Addr2, false)
 	assert.NoError(t, err)
 
-	key2 := IPAMKey{"net0", "sandbox-2", "eth0"}
-	ip, device, err = ds.AssignPodIPv4Address(key2, IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
+	key2 := v1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-2", IfName: "eth0"}
+	ip, device, err = ds.AssignPodIPv4Address(key2, v1.IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod-2"})
 	assert.NoError(t, err)
 	assert.Equal(t, "1.1.1.2", ip)
 	assert.Equal(t, 1, device)

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils"
 	mock_awsutils "github.com/aws/amazon-vpc-cni-k8s/pkg/awsutils/mocks"
 	mock_eniconfig "github.com/aws/amazon-vpc-cni-k8s/pkg/eniconfig/mocks"
+	ipamdv1 "github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/api/v1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	mock_networkutils "github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
@@ -116,10 +117,10 @@ func TestNodeInit(t *testing.T) {
 	defer m.ctrl.Finish()
 	ctx := context.Background()
 
-	fakeCheckpoint := datastore.CheckpointData{
-		Version: datastore.CheckpointFormatVersion,
-		Allocations: []datastore.CheckpointEntry{
-			{IPAMKey: datastore.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv4: ipaddr02},
+	fakeCheckpoint := ipamdv1.CheckpointData{
+		Version: ipamdv1.CheckpointFormatVersion,
+		Allocations: []ipamdv1.CheckpointEntry{
+			{IPAMKey: ipamdv1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv4: ipaddr02},
 		},
 	}
 
@@ -206,10 +207,10 @@ func TestNodeInitwithPDenabledIPv4Mode(t *testing.T) {
 	defer m.ctrl.Finish()
 	ctx := context.Background()
 
-	fakeCheckpoint := datastore.CheckpointData{
-		Version: datastore.CheckpointFormatVersion,
-		Allocations: []datastore.CheckpointEntry{
-			{IPAMKey: datastore.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv4: ipaddrPD01},
+	fakeCheckpoint := ipamdv1.CheckpointData{
+		Version: ipamdv1.CheckpointFormatVersion,
+		Allocations: []ipamdv1.CheckpointEntry{
+			{IPAMKey: ipamdv1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv4: ipaddrPD01},
 		},
 	}
 
@@ -294,10 +295,10 @@ func TestNodeInitwithPDenabledIPv6Mode(t *testing.T) {
 	defer m.ctrl.Finish()
 	ctx := context.Background()
 
-	fakeCheckpoint := datastore.CheckpointData{
-		Version: datastore.CheckpointFormatVersion,
-		Allocations: []datastore.CheckpointEntry{
-			{IPAMKey: datastore.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv6: ipaddrPD01},
+	fakeCheckpoint := ipamdv1.CheckpointData{
+		Version: ipamdv1.CheckpointFormatVersion,
+		Allocations: []ipamdv1.CheckpointEntry{
+			{IPAMKey: ipamdv1.IPAMKey{NetworkName: "net0", ContainerID: "sandbox-id", IfName: "eth0"}, IPv6: ipaddrPD01},
 		},
 	}
 
@@ -830,12 +831,12 @@ func TestDecreaseIPPool(t *testing.T) {
 	mockContext.dataStore.AddENI(primaryENIid, primaryDevice, true, false, false)
 	mockContext.dataStore.AddIPv4CidrToStore(primaryENIid, testAddr1, false)
 	mockContext.dataStore.AddIPv4CidrToStore(primaryENIid, testAddr2, false)
-	mockContext.dataStore.AssignPodIPv4Address(datastore.IPAMKey{ContainerID: "container1"}, datastore.IPAMMetadata{K8SPodName: "pod1"})
+	mockContext.dataStore.AssignPodIPv4Address(ipamdv1.IPAMKey{ContainerID: "container1"}, ipamdv1.IPAMMetadata{K8SPodName: "pod1"})
 
 	mockContext.dataStore.AddENI(secENIid, secDevice, true, false, false)
 	mockContext.dataStore.AddIPv4CidrToStore(secENIid, testAddr11, false)
 	mockContext.dataStore.AddIPv4CidrToStore(secENIid, testAddr12, false)
-	mockContext.dataStore.AssignPodIPv4Address(datastore.IPAMKey{ContainerID: "container2"}, datastore.IPAMMetadata{K8SPodName: "pod2"})
+	mockContext.dataStore.AssignPodIPv4Address(ipamdv1.IPAMKey{ContainerID: "container2"}, ipamdv1.IPAMMetadata{K8SPodName: "pod2"})
 
 	m.awsutils.EXPECT().DeallocPrefixAddresses(gomock.Any(), gomock.Any()).Times(1)
 	m.awsutils.EXPECT().DeallocIPAddresses(gomock.Any(), gomock.Any()).Times(1)
@@ -1361,11 +1362,11 @@ func TestIPAMContext_nodePrefixPoolTooLow(t *testing.T) {
 }
 
 func testDatastore() *datastore.DataStore {
-	return datastore.NewDataStore(log, datastore.NewTestCheckpoint(datastore.CheckpointData{Version: datastore.CheckpointFormatVersion}), false)
+	return datastore.NewDataStore(log, datastore.NewTestCheckpoint(ipamdv1.CheckpointData{Version: ipamdv1.CheckpointFormatVersion}), false)
 }
 
 func testDatastorewithPrefix() *datastore.DataStore {
-	return datastore.NewDataStore(log, datastore.NewTestCheckpoint(datastore.CheckpointData{Version: datastore.CheckpointFormatVersion}), true)
+	return datastore.NewDataStore(log, datastore.NewTestCheckpoint(ipamdv1.CheckpointData{Version: ipamdv1.CheckpointFormatVersion}), true)
 }
 
 func datastoreWith3FreeIPs() *datastore.DataStore {
@@ -1383,11 +1384,11 @@ func datastoreWith3FreeIPs() *datastore.DataStore {
 func datastoreWith1Pod1() *datastore.DataStore {
 	datastoreWith1Pod1 := datastoreWith3FreeIPs()
 
-	_, _, _ = datastoreWith1Pod1.AssignPodIPv4Address(datastore.IPAMKey{
+	_, _, _ = datastoreWith1Pod1.AssignPodIPv4Address(ipamdv1.IPAMKey{
 		NetworkName: "net0",
 		ContainerID: "sandbox-1",
 		IfName:      "eth0",
-	}, datastore.IPAMMetadata{
+	}, ipamdv1.IPAMMetadata{
 		K8SPodNamespace: "default",
 		K8SPodName:      "sample-pod",
 	})
@@ -1398,12 +1399,12 @@ func datastoreWith3Pods() *datastore.DataStore {
 	datastoreWith3Pods := datastoreWith3FreeIPs()
 
 	for i := 0; i < 3; i++ {
-		key := datastore.IPAMKey{
+		key := ipamdv1.IPAMKey{
 			NetworkName: "net0",
 			ContainerID: fmt.Sprintf("sandbox-%d", i),
 			IfName:      "eth0",
 		}
-		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key, datastore.IPAMMetadata{
+		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key, ipamdv1.IPAMMetadata{
 			K8SPodNamespace: "default",
 			K8SPodName:      fmt.Sprintf("sample-pod-%d", i),
 		})
@@ -1422,11 +1423,11 @@ func datastoreWithFreeIPsFromPrefix() *datastore.DataStore {
 func datastoreWith1Pod1FromPrefix() *datastore.DataStore {
 	datastoreWith1Pod1 := datastoreWithFreeIPsFromPrefix()
 
-	_, _, _ = datastoreWith1Pod1.AssignPodIPv4Address(datastore.IPAMKey{
+	_, _, _ = datastoreWith1Pod1.AssignPodIPv4Address(ipamdv1.IPAMKey{
 		NetworkName: "net0",
 		ContainerID: "sandbox-1",
 		IfName:      "eth0",
-	}, datastore.IPAMMetadata{
+	}, ipamdv1.IPAMMetadata{
 		K8SPodNamespace: "default",
 		K8SPodName:      "sample-pod",
 	})
@@ -1437,13 +1438,13 @@ func datastoreWith3PodsFromPrefix() *datastore.DataStore {
 	datastoreWith3Pods := datastoreWithFreeIPsFromPrefix()
 
 	for i := 0; i < 3; i++ {
-		key := datastore.IPAMKey{
+		key := ipamdv1.IPAMKey{
 			NetworkName: "net0",
 			ContainerID: fmt.Sprintf("sandbox-%d", i),
 			IfName:      "eth0",
 		}
 		_, _, _ = datastoreWith3Pods.AssignPodIPv4Address(key,
-			datastore.IPAMMetadata{
+			ipamdv1.IPAMMetadata{
 				K8SPodNamespace: "default",
 				K8SPodName:      fmt.Sprintf("sample-pod-%d", i),
 			})
@@ -2029,7 +2030,7 @@ func TestIPAMContext_enableSecurityGroupsForPods(t *testing.T) {
 		k8sClient:     m.k8sClient,
 		enableIPv4:    true,
 		enableIPv6:    false,
-		dataStore:     datastore.NewDataStore(log, datastore.NewTestCheckpoint(datastore.CheckpointData{Version: datastore.CheckpointFormatVersion}), false),
+		dataStore:     datastore.NewDataStore(log, datastore.NewTestCheckpoint(ipamdv1.CheckpointData{Version: ipamdv1.CheckpointFormatVersion}), false),
 		awsClient:     m.awsutils,
 		networkClient: m.network,
 		primaryIP:     make(map[string]string),

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	v1 "github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/api/v1"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
 	"github.com/aws/amazon-vpc-cni-k8s/rpc"
@@ -163,12 +164,12 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 			log.Errorf("Unable to generate IPAMKey from %+v", in)
 			return &failureResponse, nil
 		}
-		ipamKey := datastore.IPAMKey{
+		ipamKey := v1.IPAMKey{
 			ContainerID: in.ContainerID,
 			IfName:      in.IfName,
 			NetworkName: in.NetworkName,
 		}
-		ipamMetadata := datastore.IPAMMetadata{
+		ipamMetadata := v1.IPAMMetadata{
 			K8SPodNamespace: in.K8S_POD_NAMESPACE,
 			K8SPodName:      in.K8S_POD_NAME,
 		}
@@ -254,7 +255,7 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 		return nil, err
 	}
 
-	ipamKey := datastore.IPAMKey{
+	ipamKey := v1.IPAMKey{
 		ContainerID: in.ContainerID,
 		IfName:      in.IfName,
 		NetworkName: in.NetworkName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

feature

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:

Moves the types for `ipamd`'s "introspection" API to a separate package. This allows the types to be used without depending on (and compiling) broader portions of this project. For example, dependencies of the `datastore` layer like `netlink` are only buildable on `linux`.

Relocating theset ypes is technically a breaking change, though I don't see any existing public usage of the types: https://grep.app/search?q=github.com%2Faws%2Famazon-vpc-cni-k8s%2Fpkg%2Fipamd%2Fdatastore

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
The `ipamd` introspection API types have been moved to a dedicated package, `github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/api/v1`.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
