### PR TITLE
Add env for node agent enabled

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -84,6 +84,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
 {{- end }}
+            - name: NODE_AGENT_ENABLED
+              value: {{ .Values.nodeAgent.enabled | quote }}
 {{- with .Values.extraEnv }}
       {{- toYaml .| nindent 12 }}
 {{- end }}

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -83,6 +83,7 @@ const (
 	defaultEnPrefixDelegation    = false
 	defaultIPCooldownPeriod      = 30
 	defaultDisablePodV6          = false
+	defaultNodeAgentEnabled      = "true"
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -106,6 +107,7 @@ const (
 	envRandomizeSNAT         = "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 	envDisablePodV6          = "DISABLE_POD_V6"
+	envNodeAgentEnabled      = "NODE_AGENT_ENABLED"
 )
 
 // NetConfList describes an ordered list of networks.
@@ -266,6 +268,8 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 	pluginLogFile := utils.GetEnv(envPluginLogFile, defaultPluginLogFile)
 	pluginLogLevel := utils.GetEnv(envPluginLogLevel, defaultPluginLogLevel)
 	randomizeSNAT := utils.GetEnv(envRandomizeSNAT, defaultRandomizeSNAT)
+	// check if np agent container is enabled
+	nodeAgentEnabled := utils.GetEnv(envNodeAgentEnabled, defaultNodeAgentEnabled)
 
 	netconf := string(byteValue)
 	netconf = strings.Replace(netconf, "__VETHPREFIX__", vethPrefix, -1)
@@ -280,6 +284,7 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 	netconf = strings.Replace(netconf, "__EGRESSPLUGINIPAMDATADIR__", egressIPAMDataDir, -1)
 	netconf = strings.Replace(netconf, "__RANDOMIZESNAT__", randomizeSNAT, -1)
 	netconf = strings.Replace(netconf, "__NODEIP__", nodeIP, -1)
+	netconf = strings.Replace(netconf, "__NODEAGENTENABLED__", nodeAgentEnabled, -1)
 
 	byteValue = []byte(netconf)
 

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -300,10 +300,10 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	defer cancel()
 	npConn, err := grpcClient.DialContext(ctx, npAgentAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	// No need to cleanup IP and network, kubelet will send delete.
-	if err != nil  {
+	if err != nil {
 		log.Errorf("Failed to connect to network policy agent: %v", err)
 		return errors.New("add cmd: failed to setup network policy")
-	} 
+	}
 	defer npConn.Close()
 
 	//Make a GRPC call for network policy agent
@@ -461,6 +461,16 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		}
 	} else {
 		log.Warnf("Container %s did not have a valid IP %s", args.ContainerID, r.IPv4Addr)
+	}
+
+	nodeAgentEnabled, err := strconv.ParseBool(conf.NodeAgentEnabled)
+	if err != nil {
+		log.Errorf("Failed to parse nodeAgentEnabled: %v", err)
+		return nil
+	}
+	if !nodeAgentEnabled {
+		log.Infof("NodeAgentEnabled set to false")
+		return nil
 	}
 
 	// Set up a connection to the network policy agent

--- a/misc/10-aws.conflist
+++ b/misc/10-aws.conflist
@@ -10,7 +10,8 @@
       "mtu": "__MTU__",
       "podSGEnforcingMode": "__PODSGENFORCINGMODE__",
       "pluginLogFile": "__PLUGINLOGFILE__",
-      "pluginLogLevel": "__PLUGINLOGLEVEL__"
+      "pluginLogLevel": "__PLUGINLOGLEVEL__",
+      "nodeAgentEnabled": "__NODEAGENTENABLED__"
     },
     {
       "name": "egress-cni",


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
We should fail on pod creation if we can't connect to np agent and fail to attach probes at pod start. 

**What does this PR do / Why do we need it?**:
Some of the cx might have deleted NP container if they are not using network policies, so adding env_var NODE_AGENT_ENABLED. If cx is deleting np container they have to set this to false. When this is set to false we don't try to connect to np container at all

**Testing done on this change**:
nodeAgentEnabled: true, removed np container and verified that pod creation is failing 
nodeAgentEnabled: true, np agent running - verified that pod creation is successful 
nodeAgentEnabled: false, np agent running - no calls being made to np agent 
nodeAgentEnabled: false, np agent not running - no calls being made to np agent

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
Adding a new env_var NODE_AGENT_ENABLED

**Does this PR introduce any user-facing change?**:
Yes. We are adding a new env_var. We need to add release notes and also update docs

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
