### PR TITLE
run make generate-limits

### DIFF
--- a/misc/eni-max-pods.txt
+++ b/misc/eni-max-pods.txt
@@ -208,6 +208,8 @@ c7gn.large 29
 c7gn.medium 8
 c7gn.metal 737
 c7gn.xlarge 58
+c7i-flex.12xlarge 234
+c7i-flex.16xlarge 737
 c7i-flex.2xlarge 58
 c7i-flex.4xlarge 234
 c7i-flex.8xlarge 234
@@ -256,6 +258,9 @@ dl2q.24xlarge 737
 f1.16xlarge 394
 f1.2xlarge 58
 f1.4xlarge 234
+f2.12xlarge 234
+f2.48xlarge 737
+f2.6xlarge 234
 g4ad.16xlarge 234
 g4ad.2xlarge 8
 g4ad.4xlarge 29
@@ -357,11 +362,14 @@ i7ie.3xlarge 58
 i7ie.48xlarge 737
 i7ie.6xlarge 234
 i7ie.large 29
+i7ie.metal-24xl 737
+i7ie.metal-48xl 737
 i7ie.xlarge 58
 i8g.12xlarge 234
 i8g.16xlarge 737
 i8g.24xlarge 737
 i8g.2xlarge 58
+i8g.48xlarge 737
 i8g.4xlarge 234
 i8g.8xlarge 234
 i8g.large 29
@@ -562,6 +570,8 @@ m7gd.large 29
 m7gd.medium 8
 m7gd.metal 737
 m7gd.xlarge 58
+m7i-flex.12xlarge 234
+m7i-flex.16xlarge 737
 m7i-flex.2xlarge 58
 m7i-flex.4xlarge 234
 m7i-flex.8xlarge 234
@@ -857,6 +867,8 @@ u-6tb1.metal 147
 u-9tb1.112xlarge 737
 u-9tb1.metal 147
 u7i-12tb.224xlarge 737
+u7i-6tb.112xlarge 737
+u7i-8tb.112xlarge 737
 u7in-16tb.224xlarge 394
 u7in-24tb.224xlarge 394
 u7in-32tb.224xlarge 394

--- a/pkg/vpc/vpc_ip_resource_limit.go
+++ b/pkg/vpc/vpc_ip_resource_limit.go
@@ -2378,6 +2378,34 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 		HypervisorType: "nitro",
 		IsBareMetal: false,
 	},
+	"c7i-flex.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"c7i-flex.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
 	"c7i-flex.2xlarge":	   {
 		ENILimit: 4, 
 		IPv4Limit: 15, 
@@ -3058,6 +3086,48 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 			
 		},
 		HypervisorType: "xen",
+		IsBareMetal: false,
+	},
+	"f2.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"f2.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"f2.6xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
 		IsBareMetal: false,
 	},
 	"g4ad.16xlarge":	   {
@@ -4514,6 +4584,34 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 		HypervisorType: "nitro",
 		IsBareMetal: false,
 	},
+	"i7ie.metal-24xl":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
+	"i7ie.metal-48xl":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "unknown",
+		IsBareMetal: true,
+	},
 	"i7ie.xlarge":	   {
 		ENILimit: 4, 
 		IPv4Limit: 15, 
@@ -4577,6 +4675,20 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 		NetworkCards: []NetworkCard{
 				{
 					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"i8g.48xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
 					NetworkCardIndex: 0,
 				},
 			
@@ -7397,6 +7509,34 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 		NetworkCards: []NetworkCard{
 				{
 					MaximumNetworkInterfaces: 4,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.12xlarge":	   {
+		ENILimit: 8, 
+		IPv4Limit: 30, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 8,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"m7i-flex.16xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
 					NetworkCardIndex: 0,
 				},
 			
@@ -12096,6 +12236,34 @@ var instanceNetworkingLimits = map[string]InstanceTypeLimits{
 		IsBareMetal: true,
 	},
 	"u7i-12tb.224xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u7i-6tb.112xlarge":	   {
+		ENILimit: 15, 
+		IPv4Limit: 50, 
+		DefaultNetworkCardIndex: 0,
+		NetworkCards: []NetworkCard{
+				{
+					MaximumNetworkInterfaces: 15,
+					NetworkCardIndex: 0,
+				},
+			
+		},
+		HypervisorType: "nitro",
+		IsBareMetal: false,
+	},
+	"u7i-8tb.112xlarge":	   {
 		ENILimit: 15, 
 		IPv4Limit: 50, 
 		DefaultNetworkCardIndex: 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
Update instance type and max pods in static file.
```
dev-dsk-sonyingy-2c-61cf589a % make generate-limits
go run  scripts/gen_vpc_ip_limits.go
2025-04-15 20:38:56.663841217 +0000 UTC m=+0.000423270 write error: can't make directories for new logfile: mkdir /host: permission denied
2025-04-15 20:38:56.664012731 +0000 UTC m=+0.000594778 write error: can't make directories for new logfile: mkdir /host: permission denied
{"level":"info","ts":"2025-04-15T20:38:57.464Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-northeast-1"}
{"level":"info","ts":"2025-04-15T20:38:59.296Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-northeast-2"}
{"level":"info","ts":"2025-04-15T20:39:00.896Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-northeast-3"}
{"level":"info","ts":"2025-04-15T20:39:02.027Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-south-1"}
{"level":"info","ts":"2025-04-15T20:39:05.835Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-southeast-1"}
{"level":"info","ts":"2025-04-15T20:39:09.167Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ap-southeast-2"}
{"level":"info","ts":"2025-04-15T20:39:12.407Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=ca-central-1"}
{"level":"info","ts":"2025-04-15T20:39:13.675Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=eu-central-1"}
{"level":"info","ts":"2025-04-15T20:39:17.025Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=eu-north-1"}
{"level":"info","ts":"2025-04-15T20:39:19.724Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=eu-west-1"}
{"level":"info","ts":"2025-04-15T20:39:22.706Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=eu-west-2"}
{"level":"info","ts":"2025-04-15T20:39:25.032Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=eu-west-3"}
{"level":"info","ts":"2025-04-15T20:39:27.054Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=sa-east-1"}
{"level":"info","ts":"2025-04-15T20:39:30.066Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=us-east-1"}
{"level":"info","ts":"2025-04-15T20:39:32.049Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=us-east-2"}
{"level":"info","ts":"2025-04-15T20:39:33.602Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=us-west-1"}
{"level":"info","ts":"2025-04-15T20:39:34.281Z","caller":"/home/sonyingy/go/src/github.com/aws/amazon-vpc-cni-k8s/scripts/gen_vpc_ip_limits.go:62","msg":"Describing instance types in region=us-west-2"}
Adding "u-18tb1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "u-6tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
Adding "c5a.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "p4de.24xlarge": {15 50 0 [] "nitro" false} since it is missing from the API
Adding "cr1.8xlarge": {8 30 0 [] "unknown" false} since it is missing from the API
Adding "hs1.8xlarge": {8 30 0 [] "unknown" false} since it is missing from the API
Adding "u-24tb1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "u-9tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
Adding "c5ad.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Replacing API value {15 50 0 [{15 0 }] "unknown" true} with override {15 50 0 [] "nitro" true} for "c7g.metal"
Adding "bmn-sf1.metal": {15 50 0 [] "unknown" true} since it is missing from the API
Adding "u-12tb1.metal": {5 30 0 [] "unknown" true} since it is missing from the API
{"level":"info","ts":"2025-04-15T20:39:35.119Z","caller":"/home/sonyingy/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/proc.go:283","msg":"Generated pkg/vpc/vpc_ip_resource_limit.go"}
{"level":"info","ts":"2025-04-15T20:39:35.126Z","caller":"/home/sonyingy/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/proc.go:283","msg":"Generated misc/eni-max-pods.txt"}

```
**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
