### PR TITLE
cherry-pick:  fix node init failure, add sgpp test in script (#3277) 

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -538,7 +538,7 @@ func (c *IPAMContext) nodeInit() error {
 	// if apiserver is connected, get the maxPods from node
 	var node corev1.Node
 	if c.withApiServer {
-		node, err := k8sapi.GetNode(ctx, c.k8sClient)
+		node, err = k8sapi.GetNode(ctx, c.k8sClient)
 		if err != nil {
 			log.Errorf("Failed to get node, %s", err)
 			podENIErrInc("nodeInit")

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -45,9 +45,6 @@ func getIPAMDCacheFilters() map[client.Object]cache.ByObject {
 			&corev1.Node{}: {
 				Field: fields.Set{"metadata.name": nodeName}.AsSelector(),
 			},
-			&rcscheme.CNINode{}: {
-				Field: fields.Set{"metadata.name": nodeName}.AsSelector(),
-			},
 		}
 		// only cache CNINode when SGP is in use
 		enabledPodENI := utils.GetBoolAsStringEnvVar(envEnablePodENI, false)

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -235,6 +235,7 @@ if [[ $RUN_CNI_INTEGRATION_TESTS == true ]]; then
     echo "Running ginkgo tests with focus: $focus"
     (cd "$INTEGRATION_TEST_DIR/cni" && CGO_ENABLED=0 ginkgo --focus="$focus" --skip="$skip" -v --timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBECONFIG" --cluster-name="$CLUSTER_NAME" --aws-region="$AWS_DEFAULT_REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux")
     (cd "$INTEGRATION_TEST_DIR/ipamd" && CGO_ENABLED=0 ginkgo --focus="$focus" -v --timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBECONFIG" --cluster-name="$CLUSTER_NAME" --aws-region="$AWS_DEFAULT_REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux")
+    (cd "$INTEGRATION_TEST_DIR/custom-networking-sgpp" && CGO_ENABLED=0 ginkgo -v --timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBECONFIG" --cluster-name="$CLUSTER_NAME" --aws-region="$AWS_DEFAULT_REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="kubernetes.io/os" --ng-name-label-val="linux")
     TEST_PASS=$?
     CURRENT_IMAGE_INTEGRATION_DURATION=$((SECONDS - START))
     echo "TIMELINE: Current image integration tests took $CURRENT_IMAGE_INTEGRATION_DURATION seconds."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
1. Cherry pick [fix node init failure, add sgpp test in script (](https://github.com/aws/amazon-vpc-cni-k8s/commit/f4b72ec15a06fcd0e66ba31f3e28e3a7c2c3f274)https://github.com/aws/amazon-vpc-cni-k8s/pull/3277[)](https://github.com/aws/amazon-vpc-cni-k8s/commit/f4b72ec15a06fcd0e66ba31f3e28e3a7c2c3f274)
2. remove redundant cnicache filter due to previous merge commit in the release branch

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
