### PR TITLE
fixed integration test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/
 vendor/
 # Unignore charts directory as its confilcts with `aws-vpc-cni` binary ignore rule
 !charts/**
+scripts/cni-test/

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -9,9 +9,10 @@ ensure_ecr_repo() {
     echo "Ensuring that $2 exists for account $1"
     local __registry_account_id="$1"
     local __repo_name="$2"
-    if ! `aws ecr describe-repositories --registry-id "$__registry_account_id" --repository-names "$__repo_name" >/dev/null 2>&1`; then
+    local __region="$3"
+    if ! `aws ecr describe-repositories --registry-id "$__registry_account_id" --repository-names "$__repo_name" --region "$__region" >/dev/null 2>&1`; then
         echo "creating ECR repo with name $__repo_name in registry account $__registry_account_id"
-        aws ecr create-repository --repository-name "$__repo_name"
+        aws ecr create-repository --repository-name "$__repo_name" --region "$__region"
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
fixed integration test and setup scripts
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->

fixing failed integ tests - https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/14828353140/job/41624946104

**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
ran on personal setup

```
 ~/OSS/amazon-vpc-cni-k8s  master *1 !1 ?1  ./scripts/run-integration-tests.sh                                                                                         ✔  viveksbh@dev-dsk-viveksbh-1d-59b3746d  02:33:08 
EKS_CLUSTER_VERSION: 1.32
K8S_VERSION: 1.32.3


Running 9410 on cni-test-15559 in us-west-2
+ Cluster config dir: /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-15559
+ Result dir:         /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/20253306023311-9410
+ Tester:             /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/aws-k8s-tester/aws-k8s-tester
+ Kubeconfig:         /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-15559/kubeconfig
+ Cluster config:     /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-15559/cni-test-15559.yaml
+ AWS Account ID:     144465910773
+ CNI image to test:  144465910773.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:92feb0caaa16878964637176bc8aa8579b305488
+ CNI init container: 144465910773.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:92feb0caaa16878964637176bc8aa8579b305488
Copying test cluster config to /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-15559/cni-test-15559.yaml
Creating cluster cni-test-15559 (this may take ~20 mins. details: tail -f /home/viveksbh/OSS/amazon-vpc-cni-k8s/scripts/cni-test/cluster-cni-test-15559/cluster-manage.log)... ^[]11;rgb:1818/1818/1818^[\^[[31;176R2025-05-06 03:04:33 [ℹ]  eksctl version 0.207.0
2025-05-06 03:04:33 [ℹ]  using region us-west-2
2025-05-06 03:04:33 [ℹ]  subnets for us-west-2a - public:192.168.0.0/19 private:192.168.128.0/19
2025-05-06 03:04:33 [ℹ]  subnets for us-west-2b - public:192.168.32.0/19 private:192.168.160.0/19
2025-05-06 03:04:33 [ℹ]  subnets for us-west-2c - public:192.168.64.0/19 private:192.168.192.0/19
2025-05-06 03:04:33 [ℹ]  subnets for us-west-2d - public:192.168.96.0/19 private:192.168.224.0/19
2025-05-06 03:04:33 [ℹ]  nodegroup "cni-test-arm64-mng" will use "" [AmazonLinux2023/1.32]
2025-05-06 03:04:33 [ℹ]  nodegroup "cni-test-x86-mng" will use "" [AmazonLinux2023/1.32]
2025-05-06 03:04:33 [ℹ]  using Kubernetes version 1.32
2025-05-06 03:04:33 [ℹ]  creating EKS cluster "cni-test-15559" in "us-west-2" region with managed nodes
2025-05-06 03:04:33 [ℹ]  2 nodegroups (cni-test-arm64-mng, cni-test-x86-mng) were included (based on the include/exclude rules)
2025-05-06 03:04:33 [ℹ]  will create a CloudFormation stack for cluster itself and 2 managed nodegroup stack(s)



```

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
