### PR TITLE
feat: add configurable tag key for subnet discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,8 +552,16 @@ Type: Boolean as a String
 
 Default: `true`
 
-Subnet discovery is enabled by default. VPC-CNI will pick the subnet with the most number of free IPs from the nodes' VPC/AZ to create the secondary ENIs. The subnets considered are the subnet the node is created in and subnets tagged with `kubernetes.io/role/cni`.
+Subnet discovery is enabled by default. VPC-CNI will pick the subnet with the most number of free IPs from the nodes' VPC/AZ to create the secondary ENIs. The subnets considered are the subnet the node is created in and subnets tagged with the value specified in `SUBNET_DISCOVERY_TAG_KEY` (defaults to `kubernetes.io/role/cni`).
 If `ENABLE_SUBNET_DISCOVERY` is set to `false` or if DescribeSubnets fails due to IAM permissions, all secondary ENIs will be created in the subnet the node is created in.
+
+#### `SUBNET_DISCOVERY_TAG_KEY` (v1.19.5+)
+
+Type: String
+
+Default: `kubernetes.io/role/cni`
+
+Specifies the tag key to use for subnet discovery. This allows sharing a VPC across multiple EKS clusters, each with their own set of subnets. For example, setting this to `kubernetes.io/cluster/cluster-name` would limit subnet discovery to only subnets tagged specifically for that cluster.
 
 #### `ENABLE_PREFIX_DELEGATION` (v1.9.0+)
 

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -85,6 +85,7 @@ env:
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
   ENABLE_SUBNET_DISCOVERY: "true"
+  SUBNET_DISCOVERY_TAG_KEY: "kubernetes.io/role/cni"
   VPC_CNI_VERSION: "v1.19.5"
   NETWORK_POLICY_ENFORCING_MODE: "standard"
 

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -501,6 +501,8 @@ spec:
               value: "false"
             - name: ENABLE_SUBNET_DISCOVERY
               value: "true"
+            - name: SUBNET_DISCOVERY_TAG_KEY
+              value: "kubernetes.io/role/cni"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -501,6 +501,8 @@ spec:
               value: "false"
             - name: ENABLE_SUBNET_DISCOVERY
               value: "true"
+            - name: SUBNET_DISCOVERY_TAG_KEY
+              value: "kubernetes.io/role/cni"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -501,6 +501,8 @@ spec:
               value: "false"
             - name: ENABLE_SUBNET_DISCOVERY
               value: "true"
+            - name: SUBNET_DISCOVERY_TAG_KEY
+              value: "kubernetes.io/role/cni"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -501,6 +501,8 @@ spec:
               value: "false"
             - name: ENABLE_SUBNET_DISCOVERY
               value: "true"
+            - name: SUBNET_DISCOVERY_TAG_KEY
+              value: "kubernetes.io/role/cni"
             - name: NETWORK_POLICY_ENFORCING_MODE
               value: "standard"
             - name: VPC_CNI_VERSION


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** improvement
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: #2904 
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**: Enhances subnet discovery so that multiple eks clusters can exist in the same VPC without sharing subnets


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**: The default value of the new config is the same as the hard-coded value. If someone customizes and then downgrades, it would go back to the hard-coded value.


**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
* The enhanced subnet discovery can now be configured to use a custom tag key using the `SUBNET_DISCOVERY_TAG_KEY` environment variable.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
