### PR TITLE
Set godebug tlsmlkem=0 to avoid AWS Firewall issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/aws/amazon-vpc-cni-k8s
 
 go 1.24.4
 
+// At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
+// was having a good amount of issues linked to, affecting AWS Firewall.
+godebug tlsmlkem=0
+
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-vpc-cni-k8s/test/agent v0.0.0-20231212223725-21c4bd73015b


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix?**:

[3311](https://github.com/aws/amazon-vpc-cni-k8s/issues/3311)


**What does this PR do / Why do we need it?**:

Allows the vpc-cni addon to work in cases where AWS Firewall is allowing traffic based on TLS SNI rules

**Testing done on this change**:
N/A - tested via setting this as an environment variable to confirm the fix

**Will this PR introduce any new dependencies?**:

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:

No

**Does this PR introduce any user-facing change?**:

No

```release-note
Set godebug tlsmlkem=0 to avoid AWS Firewall issues
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
