### PR TITLE
fixed cluster_created to cleanup resources during failure

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -104,6 +104,8 @@ function up-kops-cluster {
     --image ${HOST_IMAGE_SSM_PARAMETER} \
     ${CLUSTER_NAME}
 
+    __cluster_created=1
+
     $KOPS_BIN update cluster --name ${CLUSTER_NAME} --yes
     sleep 100
     $KOPS_BIN export kubeconfig --admin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
This fixes the cleanup of resources which are created as part of kops test.

**What does this PR do / Why do we need it?**:
PR fixes the condition which are checked because of failure in `on_error()` 
https://github.com/aws/amazon-vpc-cni-k8s/blob/6c63260e6ad7c604f75fdf9d1962af985b0ad119/scripts/run-integration-tests.sh#L46

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
kops test failures shows that `on_error` is called but cleanup doesn't happen 

https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/15751833540/job/44398407535

https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/15760914383/job/44427171471#step:8:1093

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
