### PR TITLE
Update multus-daemonset-thick.yml

### DIFF
--- a/config/multus/v4.1.4-eksbuild.3/multus-daemonset-thick.yml
+++ b/config/multus/v4.1.4-eksbuild.3/multus-daemonset-thick.yml
@@ -167,10 +167,10 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "50Mi"
+              memory: "200Mi"
             limits:
               cpu: "100m"
-              memory: "50Mi"
+              memory: "200Mi"
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError
@@ -213,6 +213,7 @@ spec:
           image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/multus-cni:v4.1.4-eksbuild.3_thick
           command:
             - "cp"
+            - "-f"
             - "/usr/src/multus-cni/bin/multus-shim"
             - "/host/opt/cni/bin/multus-shim"
           resources:


### PR DESCRIPTION
There is a race condition when the Multus daemonset comes up after a node reboot, which makes the initContainer hang up because of line number 215. It was supposed to be “cp -f,” but the original upstream used “cp” only, which makes it hang if the shim directory already exists. In customer sites, we made a workaround fix to update this using kubectl patch, but it would be better to fix it in the manifest file (since this is not touching the upstream code itself). The Multus daemonset gets killed by OOM occasionally. We think it would be better to increase the memory limits to 200Mi from the current 50Mi (line 171).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
