### PR TITLE
group the dependencies to reduce the number of individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,25 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      k8s-dependencies:
+        patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io/*"
+      aws-dependencies:
+        patterns:
+        - "github.com/aws*"
     schedule:
       interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/test/agent"
+    groups:
+      k8s-dependencies:
+        patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io/*"
+      aws-dependencies:
+        patterns:
+        - "github.com/aws*"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
**What type of PR is this?**
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:

This causes dependabot to combine some module updates which will reduce the number of PRs that need review (i.e. all K8s updates for a new patch release will be in a single PR instead of having one for each module).


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
