### PR TITLE
feat: add ENABLE_ENA_EXPRESS flag for network interface attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,18 @@ Any of the WARM targets do not impact the scale of the branch ENI pods so you wi
 
 **NOTE!** Toggling `ENABLE_POD_ENI` from `true` to `false` will not detach the Trunk ENI from an instance. To delete/detach the Trunk ENI from an instance, you need to recycle the instance.
 
+#### `ENABLE_ENA_EXPRESS` (v1.20.0+)
+
+Type: Boolean as a String
+
+Default: `false`
+
+Setting `ENABLE_ENA_EXPRESS` to `true` will enable ENA Express when attaching a new Network Interface, as long as the instance type supports it.
+
+**NOTE!** Toggling `ENABLE_POD_ENI` from `true` to `false` will not change ENA Express value. To disable/enable existing ENIs, you need to recycle the instance.
+
+See [AWS Docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-express.html#ena-express-how-it-works)
+
 #### `POD_SECURITY_GROUP_ENFORCING_MODE` (v1.11.0+)
 
 Type: String

--- a/pkg/awsutils/mocks/awsutils_mocks.go
+++ b/pkg/awsutils/mocks/awsutils_mocks.go
@@ -54,7 +54,7 @@ func (m *MockAPIs) EXPECT() *MockAPIsMockRecorder {
 }
 
 // AllocENI mocks base method.
-func (m *MockAPIs) AllocENI(arg0 bool, arg1 []*string, arg2 string, arg3 int) (string, error) {
+func (m *MockAPIs) AllocENI(useCustomCfg bool, sg []*string, eniCfgSubnet string, numIPs int, express bool) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocENI", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -2499,7 +2499,7 @@ func TestPodENIErrInc(t *testing.T) {
 
 func (c *IPAMContext) tryAssignPodENI(ctx context.Context, pod *corev1.Pod, fnName string) error {
 	// Mock implementation for the test
-	_, err := c.awsClient.AllocENI(false, nil, "", 0)
+	_, err := c.awsClient.AllocENI(false, nil, "", 0, false)
 	if err != nil {
 		prometheusmetrics.PodENIErr.With(prometheus.Labels{"fn": fnName}).Inc()
 		return err


### PR DESCRIPTION
Adds a new flag to optionally enable ENA Express when attaching a network interface, only for supported instances

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
https://github.com/aws/amazon-vpc-cni-k8s/issues/3340

**What does this PR do / Why do we need it?**:
Adds flag for enabling ENA Express when attaching a Network Interface

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
![image](https://github.com/user-attachments/assets/9b73136c-0d46-4434-9fe6-e87d1f541ef4)

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

Yes, it introduces a new flag to enable this feature

```release-note
Enable ENA Express when attaching a network interface for supported instances
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
