### PR TITLE
build CNI plugin binaries from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ ALLPKGS = $(shell go list $(VENDOR_OVERRIDE_FLAG) ./... | grep -v cmd/packet-ver
 BINS = aws-k8s-agent aws-cni grpc-health-probe cni-metrics-helper aws-vpc-cni aws-vpc-cni-init egress-cni
 # CORE_PLUGIN_DIR is the directory containing upstream containernetworking plugins
 CORE_PLUGIN_DIR = $(MAKEFILE_PATH)/core-plugins/
+CORE_PLUGIN_TMP = $(MAKEFILE_PATH)/core-plugins-tmp
 
 # DOCKER_ARGS is extra arguments passed during container image build.
 DOCKER_ARGS ?=
@@ -289,8 +290,8 @@ docker-metrics-test:     ## Run metrics helper unit test suite in a container.
 		make metrics-unit-test
 
 # Fetch the CNI plugins
-plugins: FETCH_VERSION=1.5.1
-plugins: FETCH_URL=https://github.com/containernetworking/plugins/releases/download/v$(FETCH_VERSION)/cni-plugins-$(GOOS)-$(GOARCH)-v$(FETCH_VERSION).tgz
+plugins: FETCH_VERSION=1.7.1
+plugins: FETCH_URL=https://github.com/containernetworking/plugins/archive/refs/tags/v$(FETCH_VERSION).tar.gz
 plugins: VISIT_URL=https://github.com/containernetworking/plugins/tree/v$(FETCH_VERSION)/plugins/
 plugins:   ## Fetch the CNI plugins
 	@echo "Fetching Container networking plugins v$(FETCH_VERSION) from upstream release"
@@ -298,8 +299,12 @@ plugins:   ## Fetch the CNI plugins
 	@echo "Visit upstream project for plugin details:"
 	@echo "$(VISIT_URL)"
 	@echo
-	mkdir -p $(CORE_PLUGIN_DIR)
-	curl -s -L $(FETCH_URL) | tar xzvf - -C $(CORE_PLUGIN_DIR)
+	mkdir -p ${CORE_PLUGIN_DIR} ${CORE_PLUGIN_TMP}
+	curl -s -L $(FETCH_URL) | tar xzf - -C ${CORE_PLUGIN_TMP}
+	cd ${CORE_PLUGIN_TMP}/plugins-${FETCH_VERSION} && ./build_linux.sh
+	cp -a ${CORE_PLUGIN_TMP}/plugins-${FETCH_VERSION}/LICENSE ${CORE_PLUGIN_DIR}
+	cp -a ${CORE_PLUGIN_TMP}/plugins-${FETCH_VERSION}/bin/* ${CORE_PLUGIN_DIR}
+	rm -rf ${CORE_PLUGIN_TMP}
 
 ##@ Debug script
 


### PR DESCRIPTION

**What type of PR is this?** dependency update

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
