### PR TITLE
assigning Mac addr to veth pair to bypass udev interference

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -14,6 +14,7 @@
 package driver
 
 import (
+	"fmt"
 	"net"
 	"syscall"
 	"testing"
@@ -39,6 +40,25 @@ var testLogCfg = logger.Configuration{
 }
 
 var testLogger = logger.New(&testLogCfg)
+
+type vethMatcher struct {
+	contVethName string
+	flags        net.Flags
+	mtu          int
+}
+
+func (m vethMatcher) Matches(x interface{}) bool {
+	veth, ok := x.(netlink.Link)
+	if !ok {
+		return false
+	}
+	attrs := veth.Attrs()
+	return attrs.Name == m.contVethName && attrs.Flags == m.flags && attrs.MTU == m.mtu
+}
+
+func (m vethMatcher) String() string {
+	return fmt.Sprintf("matches veth with contVethName=%s, flags=%s, mtu=%d", m.contVethName, m.flags, m.mtu)
+}
 
 func Test_linuxNetwork_SetupPodNetwork(t *testing.T) {
 	hostVethWithIndex9 := &netlink.Veth{
@@ -3124,7 +3144,7 @@ func Test_createVethPairContext_run(t *testing.T) {
 				netLink.EXPECT().LinkByName(call.linkName).Return(call.link, call.err)
 			}
 			for _, call := range tt.fields.linkAddCalls {
-				netLink.EXPECT().LinkAdd(call.link).Return(call.err)
+				netLink.EXPECT().LinkAdd(vethMatcher{contVethName: call.link.Attrs().Name, flags: call.link.Attrs().Flags, mtu: call.link.Attrs().MTU}).Return(call.err)
 			}
 			for _, call := range tt.fields.linkSetupCalls {
 				netLink.EXPECT().LinkSetUp(call.link).Return(call.err)
@@ -3166,10 +3186,11 @@ func Test_createVethPairContext_run(t *testing.T) {
 				mtu:          tt.args.mtu,
 				netLink:      netLink,
 				procSys:      procSys,
+				log:          testLogger,
 			}
 			err := createVethContext.run(hostNS)
 			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
+				assert.ErrorContains(t, err, tt.wantErr.Error())
 			} else {
 				assert.NoError(t, err)
 			}
@@ -5228,4 +5249,48 @@ func Test_buildVlanLink(t *testing.T) {
 			assert.Equal(t, tt.wantVlanLinkENIMac, got.Attrs().HardwareAddr)
 		})
 	}
+}
+
+func Test_generateUniqueRandomMAC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	existing, _ := net.ParseMAC("3a:af:0d:21:cd:fc")
+	hostLink := &netlink.Device{LinkAttrs: netlink.LinkAttrs{
+		Name: "eth0", HardwareAddr: existing}}
+	netLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+	netLink.EXPECT().LinkList().Return([]netlink.Link{hostLink}, nil).AnyTimes()
+
+	tests := []struct {
+		name     string
+		randFunc func() string
+		wantErr  bool
+	}{
+		{
+			name:     "generates unique MAC address",
+			randFunc: generateRandomMAC,
+			wantErr:  false,
+		},
+		{
+			name:     "collides with mac address on host",
+			randFunc: func() string { return "3a:af:0d:21:cd:fc" },
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		mgen := MACGenerator{netlink: netLink, randMACfn: tt.randFunc}
+		mac, err := mgen.generateUniqueRandomMAC()
+		if tt.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.True(t, isUnicastMAC(mac))
+		}
+	}
+}
+func isUnicastMAC(mac string) bool {
+	addr, err := net.ParseMAC(mac)
+	if err != nil || len(addr) != 6 {
+		return false
+	}
+	return addr[0]&0x1 == 0 && addr[0]&0x2 == 0x02
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
bug
**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
This will help resolve dependency on Mac address policy dependency for cni. It will not break pod networking. Ref code in udev where it will not assign Mac if user has provided mac address. https://github.com/systemd/systemd/blob/v257.7/src/udev/net/link-config.c#L609. 

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
