### PR TITLE
Add VPC sweeper for cleaning up orphaned test resources

### DIFF
--- a/.github/workflows/vpc-sweeper.yaml
+++ b/.github/workflows/vpc-sweeper.yaml
@@ -1,0 +1,48 @@
+name: VPC Sweeper
+
+on:
+  schedule:
+    - cron: "0 17 * * 0" # Weekly on Sunday at 9 AM PST (17:00 UTC)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode'
+        required: false
+        default: 'false'
+        type: boolean
+      max_age_hours:
+        description: 'Maximum age in hours for resources to be cleaned up'
+        required: false
+        default: '168'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  vpc-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # refs/tags/v5.0.0
+      
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
+        with:
+          role-to-assume: ${{ secrets.OSS_TEST_ROLE_ARN }}
+          role-duration-seconds: 3600
+          aws-region: us-west-2
+      
+      - name: Install eksctl
+        run: |
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin/
+      
+      - name: Run VPC sweeper
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '168' }}
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          ./scripts/vpc-sweeper.sh

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,12 @@ docker-unit-tests: build-docker-test     ## Run unit tests inside of the testing
 		$(TEST_IMAGE_NAME) \
 		make unit-test
 
+vpc-sweeper: ## Run VPC sweeper to clean up orphaned test resources (DRY_RUN=true by default)
+	./scripts/vpc-sweeper.sh
+
+vpc-sweeper-force: ## Run VPC sweeper with actual deletion (DRY_RUN=false)
+	DRY_RUN=false ./scripts/vpc-sweeper.sh
+
 ##@ Build the Test Binaries files in /test
 build-test-binaries:
 	mkdir -p ${MAKEFILE_PATH}test/build

--- a/scripts/vpc-sweeper.sh
+++ b/scripts/vpc-sweeper.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "$SCRIPT_DIR"/lib/common.sh
+
+: "${AWS_DEFAULT_REGION:=us-west-2}"
+: "${DRY_RUN:=true}"
+: "${MAX_AGE_HOURS:=168}"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+cleanup_test_vpcs() {
+    local cutoff_time=$(date -d "${MAX_AGE_HOURS} hours ago" -u +"%Y-%m-%dT%H:%M:%S")
+    
+    log "Looking for test VPCs older than ${MAX_AGE_HOURS} hours (before ${cutoff_time})"
+    
+    # Find VPCs with test cluster tags
+    local vpcs=$(aws ec2 describe-vpcs \
+        --region "$AWS_DEFAULT_REGION" \
+        --filters "Name=tag:kubernetes.io/cluster/cni-test-*,Values=owned" \
+        --query "Vpcs[?CreationTime<'${cutoff_time}'].{VpcId:VpcId,CreationTime:CreationTime,Tags:Tags}" \
+        --output json)
+    
+    if [[ $(echo "$vpcs" | jq length) -eq 0 ]]; then
+        log "No orphaned test VPCs found"
+        return
+    fi
+    
+    echo "$vpcs" | jq -r '.[] | "\(.VpcId) \(.CreationTime)"' | while read vpc_id creation_time; do
+        log "Found orphaned VPC: $vpc_id (created: $creation_time)"
+        
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log "DRY_RUN: Would delete VPC $vpc_id and associated resources"
+        else
+            delete_vpc_resources "$vpc_id"
+        fi
+    done
+}
+
+delete_vpc_resources() {
+    local vpc_id="$1"
+    log "Deleting resources for VPC: $vpc_id"
+    
+    # Delete EKS clusters in this VPC
+    local clusters=$(aws eks list-clusters --region "$AWS_DEFAULT_REGION" --query "clusters[?starts_with(@, 'cni-test-')]" --output text)
+    for cluster in $clusters; do
+        local cluster_vpc=$(aws eks describe-cluster --name "$cluster" --region "$AWS_DEFAULT_REGION" --query "cluster.resourcesVpcConfig.vpcId" --output text 2>/dev/null || echo "")
+        if [[ "$cluster_vpc" == "$vpc_id" ]]; then
+            log "Deleting EKS cluster: $cluster"
+            eksctl delete cluster "$cluster" --region "$AWS_DEFAULT_REGION" --wait || true
+        fi
+    done
+    
+    # Delete NAT Gateways
+    aws ec2 describe-nat-gateways --region "$AWS_DEFAULT_REGION" --filter "Name=vpc-id,Values=$vpc_id" --query "NatGateways[].NatGatewayId" --output text | xargs -r -n1 aws ec2 delete-nat-gateway --region "$AWS_DEFAULT_REGION" --nat-gateway-id || true
+    
+    # Delete Internet Gateways
+    aws ec2 describe-internet-gateways --region "$AWS_DEFAULT_REGION" --filters "Name=attachment.vpc-id,Values=$vpc_id" --query "InternetGateways[].InternetGatewayId" --output text | xargs -r -n1 -I {} sh -c 'aws ec2 detach-internet-gateway --region "$AWS_DEFAULT_REGION" --internet-gateway-id {} --vpc-id "$1" && aws ec2 delete-internet-gateway --region "$AWS_DEFAULT_REGION" --internet-gateway-id {}' -- "$vpc_id" || true
+    
+    # Delete subnets
+    aws ec2 describe-subnets --region "$AWS_DEFAULT_REGION" --filters "Name=vpc-id,Values=$vpc_id" --query "Subnets[].SubnetId" --output text | xargs -r -n1 aws ec2 delete-subnet --region "$AWS_DEFAULT_REGION" --subnet-id || true
+    
+    # Delete security groups (except default)
+    aws ec2 describe-security-groups --region "$AWS_DEFAULT_REGION" --filters "Name=vpc-id,Values=$vpc_id" --query "SecurityGroups[?GroupName!='default'].GroupId" --output text | xargs -r -n1 aws ec2 delete-security-group --region "$AWS_DEFAULT_REGION" --group-id || true
+    
+    # Delete VPC
+    aws ec2 delete-vpc --region "$AWS_DEFAULT_REGION" --vpc-id "$vpc_id" || true
+    log "Deleted VPC: $vpc_id"
+}
+
+main() {
+    log "Starting VPC sweeper (DRY_RUN=$DRY_RUN, MAX_AGE_HOURS=$MAX_AGE_HOURS)"
+    
+    check_is_installed aws
+    check_is_installed jq
+    check_is_installed eksctl
+    
+    cleanup_test_vpcs
+    
+    log "VPC sweeper completed"
+}
+
+main "$@"


### PR DESCRIPTION
- Add vpc-sweeper.sh script to clean up test VPCs older than 7 days
- Add GitHub workflow to run sweeper weekly on Sunday 9am PST
- Add Makefile targets for vpc-sweeper and vpc-sweeper-force
- Includes dry-run mode by default for safety

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
improvement
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Cron Jobs never run because VPC count is always exceeding quota. We need a sweeper that cleans up Stale VPCs and corresponding resources.


**What does this PR do / Why do we need it?**:
Cron Jobs never run because VPC count is always exceeding quota. We need a sweeper that cleans up Stale VPCs and corresponding resources.


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
