### PR TITLE
Optionally setting up Route table

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -626,7 +626,7 @@ func teardownPodNetworkWithPrevResult(driverClient driver.NetworkAPIs, conf *Net
 	// We have a path for migration where the dummy interface can be completely removed for regular network pods when we move completely to v1.20+
 	// This is currently done to support downgrade to v1.19 and below
 
-	routeTableId := networkutils.CalculateRouteTableId(deviceNumber, 0, 0)
+	routeTableId := networkutils.CalculateRouteTableId(deviceNumber, 0)
 	// The number of interfaces attached to the pod is taken as the length of the interfaces array - 1 (for dummy interface) divided by 2 (for host and container interface)
 	var interfacesAttached = (len(prevResult.Interfaces) - 1) / 2
 	var vethMetadata []driver.VirtualInterfaceMetadata

--- a/pkg/networkutils/helper.go
+++ b/pkg/networkutils/helper.go
@@ -2,11 +2,18 @@ package networkutils
 
 import "net"
 
-func CalculateRouteTableId(deviceNumber int, networkCardIndex int, maxENIsPerNetworkCard int) int {
+const BaseNumber = 10000
+
+// func CalculateOldRouteTableId(deviceNumber int, networkCardIndex int, maxENIsPerNetworkCard int) int {
+// 	return deviceNumber + 1 + (networkCardIndex * maxENIsPerNetworkCard)
+// }
+
+func CalculateRouteTableId(deviceNumber int, networkCardIndex int) int {
 	if networkCardIndex == 0 {
 		return deviceNumber + 1
 	} else {
-		return deviceNumber + 1 + (networkCardIndex * maxENIsPerNetworkCard)
+		// https://github.com/amazonlinux/amazon-ec2-net-utils/blob/main/lib/lib.sh#L285
+		return BaseNumber + deviceNumber + (100 * networkCardIndex)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** 
improvement
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
CNI SetupENINetwork changes to let `ec2-net-utils` handle ENI setup on the host where multiple cards are in use
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
This allows ec2-net-utils to setup all the ENIs on NC > 0 instead of depending on enabling multi NIC feature of CNI. 
CNI will verify if the ENI is already setup on the host and reuse the route tables configured by EC2

**Testing done on this change**: In Progress
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: No, but it might have some issues when AMI is updated but CNI is not.

<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Downgrades

**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
