### PR TITLE
Move npagent server port to unix socket

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -105,7 +105,7 @@ func TestCmdAdd(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -150,7 +150,7 @@ func TestCmdAddWithNPenabled(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -195,7 +195,7 @@ func TestCmdAddWithNPenabledWithErr(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -352,7 +352,7 @@ func TestCmdAddForMultiNICAttachment(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -432,7 +432,7 @@ func TestCmdDel(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -720,7 +720,7 @@ func TestCmdAddForPodENINetwork(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)
@@ -765,7 +765,7 @@ func TestCmdDelForPodENINetwork(t *testing.T) {
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
 	mocksRPC.EXPECT().NewCNIBackendClient(conn).Return(mockC)
 
-	npConn, _ := grpc.Dial(npAgentAddress, grpc.WithInsecure())
+	npConn, _ := grpc.Dial("unix://"+npaSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(npConn, nil).Times(1)
 	mockNP := mock_rpc.NewMockNPBackendClient(ctrl)


### PR DESCRIPTION
**What type of PR is this?**
improvement

**Which issue does this PR fix?**:
NP agent not able to bind on ephemeral port 50052

**What does this PR do / Why do we need it?**:
In NPagent server change is being made to move from listening on port to unix sockets so we need to connect using the same unix port from cni https://github.com/aws/aws-network-policy-agent/pull/465 

**Testing done on this change**:
- CNI and NP agent coming up and able to connect on server using unix sockets 
- CNI comes up before NP agent 
- NP agent comes up before CNI

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Both CNI and NP images have to be in sync

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
