### PR TITLE
enabling pod egress traffic test for under mac address policy variation

### DIFF
--- a/test/integration/cni/pod_traffic_test.go
+++ b/test/integration/cni/pod_traffic_test.go
@@ -278,7 +278,9 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 	var originalPolicy string
 	var pod *coreV1.Pod
 	BeforeAll(func() {
-		Skip("Skipping pod egress traffic until addon release")
+		if primaryNode.Status.NodeInfo.OSImage == "Amazon Linux 2" {
+			Skip("Skipping pod egress traffic until addon release")
+		}
 		Expect(checkNodeShellPlugin()).To(BeNil())
 		originalPolicy, err = currentMacAddressPolicy(primaryNode.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -287,6 +289,9 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 		f.K8sResourceManagers.PodManager().DeleteAndWaitTillPodDeleted(pod)
 	})
 	AfterAll(func() {
+		if primaryNode.Status.NodeInfo.OSImage == "Amazon Linux 2" {
+			Skip("Skipping pod egress Mac address Policy test on Amazon linux 2 node")
+		}
 		err := setMACAddressPolicy(primaryNode.Name, originalPolicy)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -295,7 +300,6 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 		Context("When MAC address Policy is None", func() {
 			// check if current policy is none, if not make it none
 			It("can ping to 8.8.8.8", func() {
-				Skip("Skipping pod egress traffic until addon release")
 				Expect(setMACAddressPolicy(primaryNode.Name, None)).Error().ShouldNot(HaveOccurred())
 				// deploy pod on this node.
 				pod = manifest.NewDefaultPodBuilder().
@@ -305,7 +309,7 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 				pod, err = f.K8sResourceManagers.PodManager().CreateAndWaitTillRunning(pod)
 				Expect(err).ToNot(HaveOccurred())
 				command := []string{"ping", "-c", "1", "8.8.8.8"}
-				stdout, stderr, err := f.K8sResourceManagers.PodManager().PodExec("default", pod.Name, command)
+				stdout, stderr, err := f.K8sResourceManagers.PodManager().PodExec(utils.DefaultTestNamespace, pod.Name, command)
 				Expect(err).ToNot(HaveOccurred(), stderr, stdout)
 				Expect(stderr).To(BeEmpty(), stdout)
 				Expect(stdout).ToNot(BeEmpty())
@@ -314,7 +318,6 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 		Context("When MAC address policy is persistent", func() {
 			// check if current policy is none, if not make it none
 			It("can ping to 8.8.8.8", func() {
-				Skip("Skipping pod egress traffic until addon release")
 				Expect(setMACAddressPolicy(primaryNode.Name, Persistent)).Error().ShouldNot(HaveOccurred())
 				// deploy pod on this node.
 				pod := manifest.NewDefaultPodBuilder().
@@ -323,9 +326,8 @@ var _ = Describe("pod egress traffic test", Ordered, func() {
 					Build()
 				pod, err = f.K8sResourceManagers.PodManager().CreateAndWaitTillRunning(pod)
 				Expect(err).ToNot(HaveOccurred())
-
 				command := []string{"ping", "-c", "1", "8.8.8.8"}
-				stdout, stderr, err := f.K8sResourceManagers.PodManager().PodExec("default", pod.Name, command)
+				stdout, stderr, err := f.K8sResourceManagers.PodManager().PodExec(utils.DefaultTestNamespace, pod.Name, command)
 				Expect(err).ToNot(HaveOccurred(), stderr, stdout)
 				Expect(stderr).To(BeEmpty(), stdout)
 				Expect(stdout).ToNot(BeEmpty())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
improvement
**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
This PR enables Mac egress traffic test under mac address policy variation

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No
```release-note

```
### Note
This test skips under Amazon Linux 2 as it does not have systemd managing network interface.
This test requires node-shell plugin installed. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
