### PR TITLE
Include all plugins for Multus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,6 @@ docker-metrics-test:     ## Run metrics helper unit test suite in a container.
 plugins: FETCH_VERSION=1.7.1
 plugins: FETCH_URL=https://github.com/containernetworking/plugins/archive/refs/tags/v$(FETCH_VERSION).tar.gz
 plugins: VISIT_URL=https://github.com/containernetworking/plugins/tree/v$(FETCH_VERSION)/plugins/
-plugins: CORE_PLUGINS = bandwidth host-local loopback portmap sbr
 plugins:   ## Fetch the CNI plugins
 	@echo "Fetching Container networking plugins v$(FETCH_VERSION) from upstream release"
 	@echo
@@ -303,9 +302,7 @@ plugins:   ## Fetch the CNI plugins
 	curl -s -L $(FETCH_URL) | tar xzf - -C $(CORE_PLUGIN_TMP)
 	cd $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION) && ./build_linux.sh
 	cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/LICENSE $(CORE_PLUGIN_DIR)
-	for PLUGIN in $(CORE_PLUGINS); do \
-			cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/bin/$$PLUGIN $(CORE_PLUGIN_DIR); \
-	done
+	cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/bin/* $(CORE_PLUGIN_DIR)
 	rm -rf $(CORE_PLUGIN_TMP)
 
 ##@ Debug script


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
dependency
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: Multus operations fail if the plugins are missing
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
Multus does not install any plugins as a part of installation and expects these plugins to be present. AMI does not include these plugins today on AL23, so this cause Multus operations to fail starting v1.20.2 where we removed the unnecessary plugins.

**Testing done on this change**: N/A
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: Yes, it adds plugins which aren't directly used by VPC-CNI but by other meta plugins
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
