### PR TITLE
fix: format string bug in GetPodMTU error logging

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -1388,7 +1388,7 @@ func GetEthernetMTU() int {
 func GetPodMTU(podMTU string) int {
 	mtu, err := strconv.Atoi(podMTU)
 	if err != nil {
-		log.Errorf("Failed to parse pod MTU %s: %v", mtu, err)
+		log.Errorf("Failed to parse pod MTU %s: %v", podMTU, err)
 		return defaultMTU
 	}
 


### PR DESCRIPTION
Changed error log in GetPodMTU to use podMTU (string input) instead of mtu (int result) when logging parse failures.

**What type of PR is this?**

bug

**Which issue does this PR fix?**:

This fixes the format string mismatch that causes:

`{"level":"error","ts":"2025-10-02T23:03:58.442+0200","caller":"routed-eni-cni-plugin/cni.go:163","msg":"Failed to parse pod MTU %!s(int=0): strconv.Atoi: parsing \"\": invalid syntax"}`

`{"level":"error","ts":"2025-10-02T23:04:00.652+0200","caller":"networkutils/network_test.go:448","msg":"Failed to parse pod MTU %!s(int=0): strconv.Atoi: parsing \"abc\": invalid syntax"}`

in the output of "make unit-test".

**What does this PR do / Why do we need it?**:

Bugfix

**Testing done on this change**:

Unit tests passed, the errors above are no longer displayed.

**Will this PR introduce any new dependencies?**:

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No / Yes

**Does this change require updates to the CNI daemonset config files to work?**:

No

**Does this PR introduce any user-facing change?**:

No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
