### PR TITLE
Organize build outputs and fix IMDS resource leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vendor/
 # Unignore charts directory as its confilcts with `aws-vpc-cni` binary ignore rule
 !charts/**
 scripts/cni-test/
+build/

--- a/Makefile
+++ b/Makefile
@@ -141,20 +141,20 @@ dist: all
 BUILD_MODE ?= -buildmode=pie
 build-linux: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS)'
 build-linux:    ## Build the VPC CNI plugin agent using the host's Go toolchain.
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-k8s-agent     ./cmd/aws-k8s-agent
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-cni           ./cmd/routed-eni-cni-plugin
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o grpc-health-probe ./cmd/grpc-health-probe
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o egress-cni     ./cmd/egress-cni-plugin
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/aws-k8s-agent     ./cmd/aws-k8s-agent
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/aws-cni           ./cmd/routed-eni-cni-plugin
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/grpc-health-probe ./cmd/grpc-health-probe
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/egress-cni     ./cmd/egress-cni-plugin
 
 # Build VPC CNI init container entrypoint
 build-aws-vpc-cni-init: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS)'
 build-aws-vpc-cni-init:    ## Build the VPC CNI init container using the host's Go toolchain.
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-vpc-cni-init     ./cmd/aws-vpc-cni-init
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/aws-vpc-cni-init     ./cmd/aws-vpc-cni-init
 
 # Build VPC CNI container entrypoint
 build-aws-vpc-cni: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS)'
 build-aws-vpc-cni:    ## Build the VPC CNI container using the host's Go toolchain.
-	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-vpc-cni     ./cmd/aws-vpc-cni
+	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o build/aws-vpc-cni     ./cmd/aws-vpc-cni
 
 # Build VPC CNI plugin & agent container image.
 docker:	setup-ec2-sdk-override     ## Build VPC CNI plugin & agent container image.
@@ -261,7 +261,7 @@ build-test-binaries:
 # Build metrics helper agent.
 
 build-metrics:     ## Build metrics helper agent.
-	go build $(VENDOR_OVERRIDE_FLAG) -ldflags="-s -w" -o cni-metrics-helper ./cmd/cni-metrics-helper
+	go build $(VENDOR_OVERRIDE_FLAG) -ldflags="-s -w" -o build/cni-metrics-helper ./cmd/cni-metrics-helper
 
 # Build metrics helper agent Docker image.
 docker-metrics:    ## Build metrics helper agent Docker image.

--- a/scripts/dockerfiles/Dockerfile.init
+++ b/scripts/dockerfiles/Dockerfile.init
@@ -20,6 +20,6 @@ WORKDIR /init
 COPY --from=builder \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/core-plugins/* \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni-support.sh \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-vpc-cni-init /init/
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/build/aws-vpc-cni-init /init/
 
 CMD ["/init/aws-vpc-cni-init"]

--- a/scripts/dockerfiles/Dockerfile.metrics
+++ b/scripts/dockerfiles/Dockerfile.metrics
@@ -19,6 +19,6 @@ COPY ./misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/cni-metrics-helper /app
+COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/build/cni-metrics-helper /app
 
 ENTRYPOINT ["/app/cni-metrics-helper", "--cloudwatch=false"]

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -16,13 +16,13 @@ FROM $base_image
 
 WORKDIR /app
 
-COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-cni \
+COPY --from=builder /go/src/github.com/aws/amazon-vpc-cni-k8s/build/aws-cni \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/10-aws.conflist \
     /go/src/github.com/aws/amazon-vpc-cni-k8s/misc/eni-max-pods.txt \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-k8s-agent \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/grpc-health-probe \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/egress-cni \
-    /go/src/github.com/aws/amazon-vpc-cni-k8s/aws-vpc-cni /app/
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/build/aws-k8s-agent \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/build/grpc-health-probe \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/build/egress-cni \
+    /go/src/github.com/aws/amazon-vpc-cni-k8s/build/aws-vpc-cni /app/
 
 # Set iptables mode automatically based on kubelet hint
 RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]

--- a/utils/imds/imds.go
+++ b/utils/imds/imds.go
@@ -9,12 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 )
 
-// EC2Metadata wraps the methods from the amazon-sdk-go's ec2metadata package
-// type EC2Metadata interface {
-// 	GetMetadata(path string) (string, error)
-//	Region() (string, error)
-// }
-
 func GetMetaData(key string) (string, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRetryMaxAttempts(10))
 	if err != nil {
@@ -28,6 +22,7 @@ func GetMetaData(key string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get instance metadata: failed to retrieve %s - %s", key, err)
 	}
+	defer requestedData.Content.Close()
 	content, err := io.ReadAll(requestedData.Content)
 	if err != nil {
 		return "", fmt.Errorf("get instance metadata: failed to read %s - %s", key, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
improvement

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
Organize build outputs and fix IMDS resource leak

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**: no


**Does this change require updates to the CNI daemonset config files to work?**: no
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: no
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
