### PR TITLE
chore: remove deprecated preserveUnknownFields from CRDs

### DIFF
--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
**Which issue does this PR fix?**
Fixes #3358

**What does this PR do / Why do we need it?**
Removes the deprecated `spec.preserveUnknownFields` field from all CRD definitions. This field was deprecated in Kubernetes 1.22 and causes resources to constantly fall out of sync when deploying via ArgoCD 3.0+, which removed default ignoring of this field.

The modern replacement `x-kubernetes-preserve-unknown-fields: true` is already present in the schema sections and will continue to function correctly.

**Testing done on this change**
- Verified all occurrences of `preserveUnknownFields` have been removed (0 remaining)
- Confirmed `x-kubernetes-preserve-unknown-fields: true` is still present in all CRD schemas
- Reviewed YAML syntax and structure - all valid
- Changes affect 5 files: source CRD and 4 regional manifests

**Will this PR introduce any new dependencies?**
No

**Will this break upgrades or downgrades?**
No - this only removes a deprecated field that was removed from Kubernetes 1.22+. Given K8s versions before 1.22 have been EOL for several years, this should not impact any supported clusters. The functionality is preserved through `x-kubernetes-preserve-unknown-fields: true` in the schema.

**Does this change require updates to the CNI daemonset config files?**
No

**Does this PR introduce any user-facing change?**
```release-note
Removed deprecated spec.preserveUnknownFields field from CRDs (deprecated since Kubernetes 1.22). Resolves ArgoCD 3.0+ sync issues.
```