### PR TITLE
Remove deprecated preserveUnknownFields from CRDs

### DIFF
--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
-->
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
Fixes ArgoCD sync issues caused by deprecated `preserveUnknownFields: false` field in ENIConfig CRDs. This field was deprecated and removed in Kubernetes 1.22, causing resources to constantly fall out of sync in ArgoCD.


**What does this PR do / Why do we need it?**:
Removes the deprecated `preserveUnknownFields: false` field from all ENIConfig Custom Resource Definitions while preserving the modern `x-kubernetes-preserve-unknown-fields: true` annotation in schema sections. This fixes ArgoCD compatibility issues where resources would show as out-of-sync due to the deprecated field, while maintaining backward compatibility and all existing functionality.


**Testing done on this change**:
Unit tests: All tests passed
$ make test
PASS
coverage: 85.2% of statements

Metrics unit tests: All tests passed
$ make test-metrics
PASS
coverage: 78.9% of statements

Helm linting: All charts validated successfully
$ make lint-helm
Linting charts/aws-vpc-cni
==> Linting charts/aws-vpc-cni
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

CRD validation: All CRDs are valid Kubernetes v1 resources
$ kubectl apply --dry-run=client -f config/master/aws-k8s-cni.yaml
customresourcedefinition.apiextensions.k8s.io/eniconfigs.crd.k8s.amazonaws.com created (dry run)
customresourcedefinition.apiextensions.k8s.io/policyendpoints.networking.k8s.aws created (dry run)

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No breaking changes. This is a removal of deprecated fields only. The modern `x-kubernetes-preserve-unknown-fields: true` annotation remains intact, ensuring backward compatibility. Upgrades will work seamlessly as we're only removing deprecated syntax.

**Does this change require updates to the CNI daemonset config files to work?**:
No. This change only affects CRD definitions and does not require any daemonset configuration changes. A simple `kubectl patch` of the image tag will work.

**Does this PR introduce any user-facing change?**:
No user-facing changes. This is an internal fix for ArgoCD compatibility that maintains all existing functionality.

```release-note
Fix ArgoCD sync issues by removing deprecated preserveUnknownFields from CRDs
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
