### PR TITLE
feat: add customizable health probe configuration for helm chart

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -104,6 +104,13 @@ The following table lists the configurable parameters for this chart and their d
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
 | `livenessProbe`         | Livenness probe settings for daemonset                  | (see `values.yaml`)                 |
 | `readinessProbe`        | Readiness probe settings for daemonset                  | (see `values.yaml`)                 |
+| `healthProbe.useCustomProbeConfig` | Enable customizable probe configuration (connect-timeout, rpc-timeout, initialDelaySeconds) | `false`                      |
+| `healthProbe.livenessProbe.connectTimeout` | Connect timeout for liveness probe grpc calls | `5s`                                |
+| `healthProbe.livenessProbe.rpcTimeout`     | RPC timeout for liveness probe grpc calls     | `5s`                                |
+| `healthProbe.livenessProbe.initialDelaySeconds` | Initial delay for liveness probe         | `60`                                |
+| `healthProbe.readinessProbe.connectTimeout` | Connect timeout for readiness probe grpc calls | `5s`                               |
+| `healthProbe.readinessProbe.rpcTimeout`     | RPC timeout for readiness probe grpc calls     | `5s`                               |
+| `healthProbe.readinessProbe.initialDelaySeconds` | Initial delay for readiness probe        | `1`                                 |
 | `tolerations`           | Optional deployment tolerations                         | `[{"operator": "Exists"}]`          |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
 

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -78,10 +78,30 @@ spec:
             - containerPort: 61678
               name: metrics
           livenessProbe:
+{{- if .Values.healthProbe.useCustomProbeConfig }}
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - '-addr=:50051'
+                - '-connect-timeout={{ .Values.healthProbe.livenessProbe.connectTimeout }}'
+                - '-rpc-timeout={{ .Values.healthProbe.livenessProbe.rpcTimeout }}'
+            initialDelaySeconds: {{ .Values.healthProbe.livenessProbe.initialDelaySeconds }}
+{{- else }}
 {{ toYaml .Values.livenessProbe | indent 12 }}
+{{- end }}
             timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }}
           readinessProbe:
+{{- if .Values.healthProbe.useCustomProbeConfig }}
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - '-addr=:50051'
+                - '-connect-timeout={{ .Values.healthProbe.readinessProbe.connectTimeout }}'
+                - '-rpc-timeout={{ .Values.healthProbe.readinessProbe.rpcTimeout }}'
+            initialDelaySeconds: {{ .Values.healthProbe.readinessProbe.initialDelaySeconds }}
+{{- else }}
 {{ toYaml .Values.readinessProbe | indent 12 }}
+{{- end }}
             timeoutSeconds: {{ .Values.readinessProbeTimeoutSeconds }}
           env:
 {{- range $key, $value := .Values.env }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -165,6 +165,19 @@ serviceAccount:
   annotations: {}
     # To set annotations - serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<AWS_ACCOUNT_ID>:<IAM_ROLE_NAME>
 
+# Health probe timeout settings
+healthProbe:
+  # Set "useCustomProbeConfig" to true to use customizable probe configuration
+  useCustomProbeConfig: false
+  livenessProbe:
+    connectTimeout: "5s"
+    rpcTimeout: "5s"
+    initialDelaySeconds: 60
+  readinessProbe:
+    connectTimeout: "5s"
+    rpcTimeout: "5s"
+    initialDelaySeconds: 1
+
 livenessProbe:
   exec:
     command:


### PR DESCRIPTION
**What type of PR is this?**

* feature
* improvement

**Which issue does this PR fix?**:

n/a

**What does this PR do / Why do we need it?**:

When it is about rolling version upgrade, a busy node or resource constraints node might required more time to complete health check, default `5s` might not enough.

By adding `healthProbe.useCustomProbeConfig` flag to enable custom `grpc-health-probe` timeouts and `initialDelaySeconds` for both `liveness` and `readiness` probes while maintaining backward compatibility.


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->


**Will this PR introduce any new dependencies?**:

n/a

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:

No

**Does this PR introduce any user-facing change?**:

```release-note
Allow user to custom `grpc-health-probe` setup.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
