### PR TITLE
Add log line for VPC CNI version in aws-vpc-cni entrypoint

### DIFF
--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -108,6 +108,7 @@ const (
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 	envDisablePodV6          = "DISABLE_POD_V6"
 	envEnableMultiNICSupport = "ENABLE_MULTI_NIC"
+	envVpcCniVersion         = "VPC_CNI_VERSION"
 )
 
 // NetConfList describes an ordered list of networks.
@@ -427,6 +428,10 @@ func _main() int {
 	if err != nil {
 		log.WithError(err).Error("Failed to install CNI binaries")
 		return 1
+	}
+
+	if vpcCniVersion := utils.GetEnv(envVpcCniVersion, ""); vpcCniVersion != "" {
+		log.Infof("VPC CNI Version: %s", vpcCniVersion)
 	}
 
 	log.Infof("Starting IPAM daemon... ")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: When [log bundles](https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/linux/README.md) are reviewed for nodes in EKS, we often see 1 or a few files showing the logs from the entrypoint script of the CNI:
```
# aws-node-xxxxx_kube-system_aws-vpc-cni-<container-id>.log
..
2025-12-19T05:14:39.429734839Z stderr F time="2025-12-19T05:14:39Z" level=info msg="Starting IPAM daemon... "
2025-12-19T05:14:39.429987407Z stderr F time="2025-12-19T05:14:39Z" level=info msg="Checking for IPAM connectivity... "
2025-12-19T05:14:41.43968166Z stderr F time="2025-12-19T05:14:41Z" level=info msg="Copying config file... "
2025-12-19T05:14:41.440028409Z stderr F time="2025-12-19T05:14:41Z" level=info msg="Successfully copied CNI plugin binary and config file."
```

My change adds a log line for the VPC CNI version if that environment variable is set. With this log, we can tell what versions a node was on prior to its current state. Following my change if the version environment variable is set (like with managed addon) , we have:
```
# aws-node-xxxxx_kube-system_aws-vpc-cni-<container-id>.log
..
time="2025-12-19T12:24:49Z" level=info msg="VPC CNI Version: v1.20.5"
time="2025-12-19T12:24:49Z" level=info msg="Starting IPAM daemon... "
time="2025-12-19T12:24:49Z" level=info msg="Checking for IPAM connectivity... "
time="2025-12-19T12:24:51Z" level=info msg="Copying config file... "
time="2025-12-19T12:24:51Z" level=info msg="Successfully copied CNI plugin binary and config file."
```


<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Add log line for CNI version in aws-vpc-cni entrypoint
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
