### PR TITLE
Created GetIptablesMode to log legacy or nftables backend

### DIFF
--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -115,10 +115,13 @@ func (i ipTables) HasRandomFully() bool {
 	return i.ipt.HasRandomFully()
 }
 
+
+var iptablesModeExecCommand = exec.Command
+
 // Runs "iptables --version" to get the mode  (nf_tables or legacy)
 func GetIptablesMode() (string, error) {
 	path := "iptables"
-	cmd := exec.Command(path, "--version")
+	cmd := iptablesModeExecCommand(path, "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -17,9 +17,10 @@ package iptableswrapper
 import (
 	"bytes"
 	"fmt"
-	"github.com/coreos/go-iptables/iptables"
 	"os/exec"
 	"regexp"
+
+	"github.com/coreos/go-iptables/iptables"
 )
 
 // IPTablesIface is an interface created to make code unit testable.

--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -115,7 +115,6 @@ func (i ipTables) HasRandomFully() bool {
 	return i.ipt.HasRandomFully()
 }
 
-
 var iptablesModeExecCommand = exec.Command
 
 // Runs "iptables --version" to get the mode  (nf_tables or legacy)

--- a/pkg/iptableswrapper/iptables_test.go
+++ b/pkg/iptableswrapper/iptables_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package iptableswrapper
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+func TestGetIptablesMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		cmdErr      error
+		wantMode    string
+		wantErr     bool
+	}{
+		{
+			name:     "iptables-nft",
+			output:   "iptables v1.8.8 (nf_tables)",
+			wantMode: "nf_tables",
+			wantErr:  false,
+		},
+		{
+			name:     "iptables-legacy",
+			output:   "iptables v1.8.8 (legacy)",
+			wantMode: "legacy",
+			wantErr:  false,
+		},
+		{
+			name:     "iptables-legacy implicitly",
+			output:   "iptables v1.6.1",
+			wantMode: "legacy",
+			wantErr:  false,
+		},
+		{
+			name:     "iptables-nft different version",
+			output:   "iptables v1.8.4 (nf_tables)",
+			wantMode: "nf_tables",
+			wantErr:  false,
+		},
+		{
+			name:    "command execution error",
+			cmdErr:  fmt.Errorf("command not found"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mocked exec.Command
+			oldExecCommand := iptablesModeExecCommand
+			defer func() { iptablesModeExecCommand = oldExecCommand }()
+			
+			iptablesModeExecCommand = func(name string, args ...string) *exec.Cmd {
+				return mockCommand(tt.output, tt.cmdErr)
+			}
+
+			mode, err := GetIptablesMode()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetIptablesMode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && mode != tt.wantMode {
+				t.Errorf("GetIptablesMode() = %v, want %v", mode, tt.wantMode)
+			}
+		})
+	}
+}
+
+func mockCommand(output string, err error) *exec.Cmd {
+	cmd := exec.Command("echo", output)
+	if err != nil {
+		cmd = exec.Command("false")
+	}
+	return cmd
+}

--- a/pkg/iptableswrapper/iptables_test.go
+++ b/pkg/iptableswrapper/iptables_test.go
@@ -21,11 +21,11 @@ import (
 
 func TestGetIptablesMode(t *testing.T) {
 	tests := []struct {
-		name        string
-		output      string
-		cmdErr      error
-		wantMode    string
-		wantErr     bool
+		name     string
+		output   string
+		cmdErr   error
+		wantMode string
+		wantErr  bool
 	}{
 		{
 			name:     "iptables-nft",
@@ -63,7 +63,7 @@ func TestGetIptablesMode(t *testing.T) {
 			// Mocked exec.Command
 			oldExecCommand := iptablesModeExecCommand
 			defer func() { iptablesModeExecCommand = oldExecCommand }()
-			
+
 			iptablesModeExecCommand = func(name string, args ...string) *exec.Cmd {
 				return mockCommand(tt.output, tt.cmdErr)
 			}

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -446,6 +446,11 @@ func (n *linuxNetwork) updateHostIptablesRules(vpcCIDRs []string, primaryMAC str
 		if err != nil {
 			return errors.Wrap(err, "host network setup: failed to create iptables")
 		}
+		mode, err := iptableswrapper.GetIptablesMode()
+		if err != nil {
+			log.Error("Failed to get iptables mode")
+		}
+		log.Info(fmt.Sprintf("Using iptables mode (%s)", mode))
 
 		iptablesSNATRules, err := n.buildIptablesSNATRules(vpcCIDRs, primaryAddr, primaryIntf, ipt)
 		if err != nil {


### PR DESCRIPTION

**What type of PR is this?** improvement

**Which issue does this PR fix?**: 

**What does this PR do / Why do we need it?**: `/usr/sbin/iptables-wrapper` picks the iptables backend used based on a few conditions. With this change, a method is introduced to get the iptables mode (either nf_tables or legacy) in-use.

The package `go-iptables` that the vpc cni uses to interact with iptables is no longer being maintained, so this is the current solution. Following this change, we get the following log line during startup, prior to creation and insertion of iptables rules.

```
{"level":"info","ts":"2026-01-08T00:37:15.024Z","caller":"networkutils/network.go:377","msg":"Using iptables mode (nf_tables)"}
```

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Add GetIptablesMode() function to log iptables backend in-use
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
