### PR TITLE
To pick up EKS CVE patched container plugin binaries for internal builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,12 +302,13 @@ plugins:   ## Fetch the CNI plugins
 		echo "Visit upstream project for plugin details:"; \
 		echo "$(VISIT_URL)"; \
 		echo; \
-		mkdir -p $(CORE_PLUGIN_DIR) $(CORE_PLUGIN_TMP); \
-		curl -s -L $(FETCH_URL) | tar xzf - -C $(CORE_PLUGIN_TMP); \
-		cd $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION) && ./build_linux.sh; \
-		cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/LICENSE $(CORE_PLUGIN_DIR); \
-		cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/bin/* $(CORE_PLUGIN_DIR); \
-		rm -rf $(CORE_PLUGIN_TMP); \
+		mkdir -p $(CORE_PLUGIN_DIR) $(CORE_PLUGIN_TMP) || exit 1; \
+		curl -fsSL $(FETCH_URL) | tar xzf - -C $(CORE_PLUGIN_TMP) || { echo "Error: Failed to download plugins"; rm -rf $(CORE_PLUGIN_TMP); exit 1; }; \
+		cd $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION) && ./build_linux.sh || { echo "Error: Failed to build plugins"; rm -rf $(CORE_PLUGIN_TMP); exit 1; }; \
+		cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/LICENSE $(CORE_PLUGIN_DIR) && \
+		cp -a $(CORE_PLUGIN_TMP)/plugins-$(FETCH_VERSION)/bin/* $(CORE_PLUGIN_DIR) && \
+		rm -rf $(CORE_PLUGIN_TMP) && \
+		echo "Successfully built and installed CNI plugins"; \
 	fi
 
 ##@ Debug script


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
improvement
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
To help CVE patching via internal pipelines

**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
1. if case test: built image with a case where binaries are available from other internal source 

Successfully built the image
```
make docker-init
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al2" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2" --network=host  \
        -f scripts/dockerfiles/Dockerfile.init \
        -t "amazon/amazon-k8s-cni-init:master-7be853de" \
        .

...

 => => exporting manifest list sha256:c1299c803eae9b9bf3bb0407c1fc95a12b94bfc1b71a5686117820a1b8212acb                          0.0s
 => => naming to docker.io/amazon/amazon-k8s-cni-init:master-7be853de                                                           0.0s
 => => unpacking to docker.io/amazon/amazon-k8s-cni-init:master-7be853de                                                        0.4s
Built Docker image "amazon/amazon-k8s-cni-init:master-7be853de"
```
Verified the image has internal binaries i.e. `portmap_meeta` 

```
## Binaries in amazon/amazon-k8s-cni-init:master-7be853de

The container contains 2 executable binaries and 20 CNI plugin binaries:

### Main Executables:
- **aws-vpc-cni-init** - The main initialization binary (9MB, dynamically linked Go binary)
- **aws-cni-support.sh** - Support script for debugging and troubleshooting (36KB shell script)

### CNI Plugin Binaries (statically linked, ~4-14MB each):
- bandwidth - Traffic shaping plugin
- bridge - Bridge networking plugin  
- dhcp - DHCP IP allocation plugin
- portmap_meeta - Port mapping plugin (custom variant)
...

```

ran unit tests successfully 

```
PASS
coverage: 94.3% of statements
ok      github.com/aws/amazon-vpc-cni-k8s/cmd/routed-eni-cni-plugin/driver      0.078s  coverage: 94.3% of statements
make: *** [unit-test] Error 1
```

2. else case test: built image from source without any internal dependencies 

built image successfully

```
dev-dsk-kaposmee-2c-6ef44606 % make docker-init
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al2" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2" --network=host  \
        -f scripts/dockerfiles/Dockerfile.init \
        -t "amazon/amazon-k8s-cni-init:master-7be853de" \
        .

 => => exporting manifest list sha256:39db7812c2cfead88392971f74f454201de6aca58fd146886  0.0s
 => => naming to docker.io/amazon/amazon-k8s-cni-init:master-7be853de                    0.0s
 => => unpacking to docker.io/amazon/amazon-k8s-cni-init:master-7be853de                 0.4s
Built Docker image "amazon/amazon-k8s-cni-init:master-7be853de"

```
Verified the image has binaries from containers plugins upstream 

```
CNI Plugin binaries:
- bandwidth - Bandwidth limiting plugin (5.0MB)
- bridge - Bridge networking plugin (5.7MB) 
- dhcp - DHCP plugin (13.7MB)
- portmap - Port mapping plugin (5.1MB)
- ptp - Point-to-point plugin (5.5MB)
 ...
```

ran unit tests successfully 

```
--- PASS: TestSetInstance (0.00s)
PASS
coverage: 94.9% of statements
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/vpc       (cached)        coverage: 94.9% of statements

```

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
No

<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
