### PR TITLE
fix: Skip SetupENINetwork for trunk ENIs in IPv6 mode

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1276,8 +1276,8 @@ func (c *IPAMContext) setupENI(eni string, eniMetadata awsutils.ENIMetadata, isT
 		}
 	}
 
-	// For other ENIs, set up the network
-	if eni != primaryENI {
+	// Set up network for non-primary, non-trunk ENIs
+	if eni != primaryENI && !isTrunkENI {
 		subnetCidr := eniMetadata.SubnetIPv4CIDR
 		if c.enableIPv6 {
 			subnetCidr = eniMetadata.SubnetIPv6CIDR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
Closes: https://github.com/aws/amazon-vpc-cni-k8s/issues/3572

**What does this PR do / Why do we need it?**:
Trunk ENIs in IPv6 prefix delegation mode have no IP addresses and only serve as attachment points for branch ENIs. Attempting to call SetupENINetwork with an empty primaryIP causes "numerical result out of range" errors when net.ParseIP("") returns nil.

Add !isTrunkENI check before SetupENINetwork call to skip network setup for trunk ENIs, consistent with existing checks that skip IP allocation and IP rules for trunk ENIs.

**Testing done on this change**:
Tested on the same environment I reported in the issue, and the error went away.

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
