### PR TITLE
feat: add secondary IPv6 support for pod ENI feature

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -141,6 +141,10 @@ const (
 	// envEnablePodENI is used to attach a Trunk ENI to every node. Required in order to give Branch ENIs to pods.
 	envEnablePodENI = "ENABLE_POD_ENI"
 
+	// Enable dual-stack (IPv4+IPv6) support for pod ENIs (security groups per pod)
+	// When enabled in IPv4 clusters, pod ENI pods can have both IPv4 and IPv6 addresses
+	envEnablePodENIDualStack = "ENABLE_POD_ENI_DUAL_STACK"
+
 	// envNodeName will be used to store Node name
 	envNodeName = "MY_NODE_NAME"
 
@@ -251,6 +255,7 @@ type IPAMContext struct {
 	maxPods                   int // maximum number of pods that can be scheduled on the node
 	networkPolicyMode         string
 	enableMultiNICSupport     bool
+	enablePodENIDualStack     bool
 	withApiServer             bool
 }
 
@@ -408,6 +413,7 @@ func New(k8sClient client.Client, withApiServer bool) (*IPAMContext, error) {
 	c.enablePrefixDelegation = usePrefixDelegation()
 	c.enableIPv4 = isIPv4Enabled()
 	c.enableIPv6 = isIPv6Enabled()
+	c.enablePodENIDualStack = isPodENIDualStackEnabled()
 	c.disableENIProvisioning = disableENIProvisioning()
 	client, err := awsutils.New(c.useSubnetDiscovery, c.useCustomNetworking, disableLeakedENICleanup(), c.enableIPv4, c.enableIPv6)
 	if err != nil {
@@ -426,6 +432,9 @@ func New(k8sClient client.Client, withApiServer bool) (*IPAMContext, error) {
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
 	c.enablePodIPAnnotation = EnablePodIPAnnotation()
 	c.enableMultiNICSupport = enableMultiNICSupport()
+	if c.enablePodENI && c.enablePodENIDualStack && c.enableIPv6 {
+		return nil, fmt.Errorf("ipamd: ENABLE_POD_ENI_DUAL_STACK is only supported for IPv4 clusters (ENABLE_IPv6=false)")
+	}
 	c.networkPolicyMode, err = getNetworkPolicyMode()
 	if err != nil {
 		return nil, err
@@ -2071,6 +2080,10 @@ func isIPv4Enabled() bool {
 
 func isIPv6Enabled() bool {
 	return utils.GetBoolAsStringEnvVar(envEnableIPv6, false)
+}
+
+func isPodENIDualStackEnabled() bool {
+	return utils.GetBoolAsStringEnvVar(envEnablePodENIDualStack, false)
 }
 
 func enableManageUntaggedMode() bool {


### PR DESCRIPTION




**What type of PR is this?**
feature

**Which issue does this PR fix?**:
Addresses Phase 1 for: https://github.com/aws/amazon-vpc-cni-k8s/issues/3582

**What does this PR do / Why do we need it?**:
The pod ENI feature (security groups for pods) only supported single IP family configurations. Pods in IPv4 clusters received only an IPv4 address, preventing them from communicating over IPv6 even when the underlying infrastructure supported dual-stack networking.

Add support for assigning a secondary IPv6 address to pods using pod ENIs in IPv4 clusters. The IPv6Address field in VirtualInterfaceMetadata carries the secondary address, while IPAddress continues to hold the primary IPv4 address. When both are present, the CNI plugin configures the pod's network namespace with both addresses, enables IPv6 forwarding on the host veth interface, and sets up routing for both IP families through the VLAN interface to the pod ENI.

This implementation is limited to IPv4 clusters with secondary IPv6. Support for IPv6 clusters with secondary IPv4 is explicitly blocked in this change to reduce scope, though the ENABLE_POD_ENI_DUAL_STACK feature flag is named generically to allow for that support in the future. The ipamd validates the cluster IP family at startup and fails to start if dual-stack is enabled on an IPv6 cluster.

**Testing done on this change**:
Tested and verified on a 1.33 IPv4 EKS cluster.

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No update break. Tested on a running cluster.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes. Requires `ENABLE_POD_ENI_DUAL_STACK` to be set on the CNI daemonset. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
