### PR TITLE
Add chaining tuning plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,29 @@ Setting `ENABLE_BANDWIDTH_PLUGIN` to `true` will update `10-aws.conflist` to inc
 
 NOTE: Kubernetes Network Policy is supported in Amazon VPC CNI starting with version v1.14.0. Note that bandwidth plugin is not compatible with Amazon VPC CNI based Network policy. Network Policy agent uses TC (traffic classifier) system to enforce configured network policies for the pods. The policy enforcement will fail if bandwidth plugin is enabled due to conflict between TC configuration of bandwidth plugin and Network policy agent. We're exploring options to support bandwidth plugin along with Network policy feature and the issue is tracked [here](https://github.com/aws/aws-network-policy-agent/issues/68)
 
+#### `ENABLE_TUNING_PLUGIN`
+
+Type: Boolean as a String
+
+Default: `false`
+
+Setting `ENABLE_TUNING_PLUGIN` to `true` will update `10-aws.conflist` to include the upstream [tuning plugin](https://www.cni.dev/plugins/current/meta/tuning/) as a chained plugin. The tuning plugin allows you to configure sysctl settings in the pod network namespace. Use this in combination with `TUNING_SYSCTLS` to specify which sysctls to set.
+
+#### `TUNING_SYSCTLS`
+
+Type: JSON-encoded string
+
+Default: `""`
+
+A JSON-encoded map of sysctl settings to apply in the pod network namespace. When this variable is set (non-empty), the tuning plugin will be automatically chained regardless of the `ENABLE_TUNING_PLUGIN` setting.
+
+Example:
+```
+TUNING_SYSCTLS='{"net.core.somaxconn":"1024","net.ipv4.tcp_max_syn_backlog":"2048"}'
+```
+
+Note: The `DISABLE_POD_V6` environment variable also enables the tuning plugin with IPv6 disable sysctls. If both `DISABLE_POD_V6` and `TUNING_SYSCTLS` are set, the sysctls will be merged, with `TUNING_SYSCTLS` values taking precedence for any overlapping keys.
+
 #### `ANNOTATE_POD_IP` (v1.9.3+)
 
 Type: Boolean as a String

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -96,6 +96,8 @@ env:
   NETWORK_POLICY_ENFORCING_MODE: "standard"
   ENABLE_IMDS_ONLY_MODE: "false"
   ENABLE_MULTI_NIC: "false"
+  # ENABLE_TUNING_PLUGIN: "false"
+  # TUNING_SYSCTLS: '{"net.core.somaxconn":"1024"}'
 
 # Add env from configMap or from secrets
 # - name: ENV_VAR1

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -84,7 +84,7 @@ const (
 	defaultIPCooldownPeriod      = 30
 	defaultDisablePodV6          = false
 	defaultEnableMultiNICSupport = false
-	defaultEnTuningPlugin        = false
+	defaultEnableTuningPlugin    = false
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -109,7 +109,7 @@ const (
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 	envDisablePodV6          = "DISABLE_POD_V6"
 	envEnableMultiNICSupport = "ENABLE_MULTI_NIC"
-	envEnTuningPlugin        = "ENABLE_TUNING_PLUGIN"
+	envEnableTuningPlugin    = "ENABLE_TUNING_PLUGIN"
 	envTuningSysctls         = "TUNING_SYSCTLS"
 )
 
@@ -291,11 +291,11 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 	// Chain any requested CNI plugins
 	enBandwidthPlugin := utils.GetBoolAsStringEnvVar(envEnBandwidthPlugin, defaultEnBandwidthPlugin)
 	disablePodV6 := utils.GetBoolAsStringEnvVar(envDisablePodV6, defaultDisablePodV6)
-	enTuningPlugin := utils.GetBoolAsStringEnvVar(envEnTuningPlugin, defaultEnTuningPlugin)
+	enableTuningPlugin := utils.GetBoolAsStringEnvVar(envEnableTuningPlugin, defaultEnableTuningPlugin)
 	tuningSysctls := utils.GetEnv(envTuningSysctls, "")
 
 	// Determine if we need to chain the tuning plugin
-	chainTuningPlugin := disablePodV6 || enTuningPlugin || tuningSysctls != ""
+	chainTuningPlugin := disablePodV6 || enableTuningPlugin || tuningSysctls != ""
 
 	if enBandwidthPlugin || chainTuningPlugin {
 		// Unmarshall current conflist into data

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -84,6 +84,7 @@ const (
 	defaultIPCooldownPeriod      = 30
 	defaultDisablePodV6          = false
 	defaultEnableMultiNICSupport = false
+	defaultEnTuningPlugin        = false
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -108,6 +109,8 @@ const (
 	envIPCooldownPeriod      = "IP_COOLDOWN_PERIOD"
 	envDisablePodV6          = "DISABLE_POD_V6"
 	envEnableMultiNICSupport = "ENABLE_MULTI_NIC"
+	envEnTuningPlugin        = "ENABLE_TUNING_PLUGIN"
+	envTuningSysctls         = "TUNING_SYSCTLS"
 )
 
 // NetConfList describes an ordered list of networks.
@@ -288,7 +291,13 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 	// Chain any requested CNI plugins
 	enBandwidthPlugin := utils.GetBoolAsStringEnvVar(envEnBandwidthPlugin, defaultEnBandwidthPlugin)
 	disablePodV6 := utils.GetBoolAsStringEnvVar(envDisablePodV6, defaultDisablePodV6)
-	if enBandwidthPlugin || disablePodV6 {
+	enTuningPlugin := utils.GetBoolAsStringEnvVar(envEnTuningPlugin, defaultEnTuningPlugin)
+	tuningSysctls := utils.GetEnv(envTuningSysctls, "")
+
+	// Determine if we need to chain the tuning plugin
+	chainTuningPlugin := disablePodV6 || enTuningPlugin || tuningSysctls != ""
+
+	if enBandwidthPlugin || chainTuningPlugin {
 		// Unmarshall current conflist into data
 		data := NetConfList{}
 		err = json.Unmarshal(byteValue, &data)
@@ -305,15 +314,33 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 			data.Plugins = append(data.Plugins, &bwPlugin)
 		}
 
-		// Chain the tuning plugin (configured to disable IPv6 in pod network namespace) when requested
-		if disablePodV6 {
+		// Chain the tuning plugin when enabled via DISABLE_POD_V6, ENABLE_TUNING_PLUGIN, or TUNING_SYSCTLS
+		if chainTuningPlugin {
+			sysctls := make(map[string]string)
+
+			// Add IPv6 disable sysctls when DISABLE_POD_V6 is enabled
+			if disablePodV6 {
+				sysctls["net.ipv6.conf.all.disable_ipv6"] = "1"
+				sysctls["net.ipv6.conf.default.disable_ipv6"] = "1"
+				sysctls["net.ipv6.conf.lo.disable_ipv6"] = "1"
+			}
+
+			// Parse and merge custom sysctls from TUNING_SYSCTLS environment variable
+			if tuningSysctls != "" {
+				customSysctls := make(map[string]string)
+				err = json.Unmarshal([]byte(tuningSysctls), &customSysctls)
+				if err != nil {
+					log.Errorf("Failed to parse TUNING_SYSCTLS: %v", err)
+					return err
+				}
+				for k, v := range customSysctls {
+					sysctls[k] = v
+				}
+			}
+
 			tuningPlugin := NetConf{
-				Type: "tuning",
-				Sysctl: map[string]string{
-					"net.ipv6.conf.all.disable_ipv6":     "1",
-					"net.ipv6.conf.default.disable_ipv6": "1",
-					"net.ipv6.conf.lo.disable_ipv6":      "1",
-				},
+				Type:   "tuning",
+				Sysctl: sysctls,
 			}
 			data.Plugins = append(data.Plugins, &tuningPlugin)
 		}

--- a/cmd/aws-vpc-cni/main_test.go
+++ b/cmd/aws-vpc-cni/main_test.go
@@ -51,8 +51,8 @@ func TestGenerateJSONPlusBandwidthAndTuning(t *testing.T) {
 
 // Validate that generateJSON runs without error when ENABLE_TUNING_PLUGIN is set
 func TestGenerateJSONWithEnableTuningPlugin(t *testing.T) {
-	_ = os.Setenv(envEnTuningPlugin, "true")
-	defer os.Unsetenv(envEnTuningPlugin)
+	_ = os.Setenv(envEnableTuningPlugin, "true")
+	defer os.Unsetenv(envEnableTuningPlugin)
 	err := generateJSON(awsConflist, devNull, getPrimaryIPMock)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
https://github.com/aws/amazon-vpc-cni-k8s/issues/3586

**What does this PR do / Why do we need it?**:
- Add tuning plugin to CNI plugin chain.
- Support tuning config

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
- Unit test. 
- Integration test TBD

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
- No, tuning plugin is already used minimally in VPC CNI

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
- No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
- No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes. 
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
