### PR TITLE
pkg/networkutils: fix dropped error

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -1203,6 +1203,10 @@ func getRouteTableNumberForENI(networkCard int, eniIP string, mask int, deviceNu
 			IP:   net.ParseIP(eniIP),
 			Mask: net.CIDRMask(mask, mask),
 		})
+		if err != nil {
+			log.Errorf("checkENIHasExistingRules: failed to get rule list by source %v", err)
+			return 0, false, err
+		}
 
 		if len(srcRuleList) == 1 {
 			// Reuse the rules present on the node. This happens


### PR DESCRIPTION
This fixes a dropped `err` variaable in `pkg/networkutils`. Unit tests pass both before and after the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
