### PR TITLE
Remove deprecated preserveUnknownFields field from CRDs

### DIFF
--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
Fixes #3358. Removes deprecated preserveUnknownFields field from CRDs which was removed in Kubernetes 1.22. The x-kubernetes-preserve-unknown-fields is already present in CRDs.