### PR TITLE
fix a bug on returning primary subnet

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1331,6 +1331,7 @@ func isSubnetValidForENICreation(subnet ec2types.Subnet, isPrimarySubnet bool) b
 		if isPrimarySubnet {
 			// Primary subnets are included by default (backwards compatibility)
 			log.Debugf("Primary subnet %s has no %s tag, including it for ENI creation (backwards compatibility)", *subnet.SubnetId, subnetDiscoveryTagKey)
+			return true
 		} else {
 			// Secondary subnets require explicit opt-in via CNI tag
 			log.Debugf("Subnet %s has no %s tag, excluding it from ENI creation", *subnet.SubnetId, subnetDiscoveryTagKey)

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -2483,6 +2483,46 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 			want:            true,
 			description:     "Should be available when cluster tag key matches (value ignored)",
 		},
+		{
+			name: "primary subnet with no CNI tag and different cluster tag",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-other-cluster"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet without CNI tag should be included regardless of other cluster tags (backwards compatibility)",
+		},
+		{
+			name: "primary subnet with no CNI tag and matching cluster tag",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-our-cluster"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("kubernetes.io/cluster/" + testClusterName),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet without CNI tag should be included even with matching cluster tag",
+		},
+		{
+			name: "primary subnet with no tags at all",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-no-tags"),
+				Tags:     []ec2types.Tag{},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet with no tags should be included (backwards compatibility)",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug X
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Added return true in the isPrimarySubnet branch when there's no CNI tag. Previously, the code fell through to the cluster tag check (Rule 3), which would incorrectly exclude a primary subnet if it had cluster tags for a different cluster. This 
violated the backwards compatibility guarantee stated in both the function-level and inline comments.

**What does this PR do / Why do we need it?**:
New test cases in TestValidTagWithClusterSpecificTags:
1. primary subnet with no CNI tag and different cluster tag — the key regression test. Before the fix, this would have returned false because the cluster tag didn't match. Now correctly returns true.
2. primary subnet with no CNI tag and matching cluster tag — ensures primary subnets are included even with a matching cluster tag and no CNI tag.
3. primary subnet with no tags at all — edge case ensuring a completely untagged primary subnet is still included.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
