### PR TITLE
Bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-cni-k8s
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION
What type of PR is this?

Which issue does this PR fix?:

What does this PR do / Why do we need it?:

Testing done on this change:

Will this PR introduce any new dependencies?:

Will this break upgrades or downgrades? Has updating a running cluster been tested?:

Does this change require updates to the CNI daemonset config files to work?:

Does this PR introduce any user-facing change?:
```
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.