### PR TITLE
feat: add support for extra volume mounts in aws-vpc-cni-init container

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -56,6 +56,9 @@ spec:
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix?**:

This addresses a gap when running the VPC CNI on non-EKS Kubernetes distributions (e.g. OpenShift/ROSA with CRI-O) where CNI binaries and config reside in different host paths (`/var/lib/cni/bin` and `/etc/kubernetes/cni/net.d` instead of `/opt/cni/bin` and `/etc/cni/net.d`).

**What does this PR do / Why do we need it?**:

The Helm chart already supports `extraVolumeMounts` and `extraVolumes` for the main `aws-node` container, but the `aws-vpc-cni-init` init container does not render `extraVolumeMounts`. This means users cannot mount additional host paths into the init container via values alone.

On non-EKS distributions like OpenShift (ROSA HCP) with CRI-O, the CNI binary and config directories differ from the EKS defaults. The init container supports `HOST_CNI_BIN_PATH` and `HOST_CNI_CONFDIR_PATH` env vars to control where it installs files, but without the corresponding volume mounts, these env vars are ineffective - the target paths are not accessible inside the container.

This PR adds the existing `.Values.extraVolumeMounts` to the init container's `volumeMounts`, matching the pattern already used in the main container. Combined with `extraVolumes`, users can now mount custom host paths into both containers.

The change is 3 lines in `templates/daemonset.yaml`:
```yaml
{{- with .Values.extraVolumeMounts }}
{{- toYaml . | nindent 10 }}
{{- end }}
```

**Testing done on this change**:

Tested on a ROSA HCP 4.18.35 cluster created with `--no-cni`:
- Set `HOST_CNI_BIN_PATH=/host/var/lib/cni/bin` and `HOST_CNI_CONFDIR_PATH=/host/etc/kubernetes/cni/net.d` in `init.env` and `env`
- Added `extraVolumeMounts` for `/host/var/lib/cni/bin` and `/host/etc/kubernetes/cni/net.d`
- Added corresponding `extraVolumes` with hostPath entries
- Init container successfully installed CNI binaries to `/var/lib/cni/bin` and config to `/etc/kubernetes/cni/net.d`
- All aws-node pods running, nodes transitioned to Ready
- Pod-to-pod connectivity verified (ping + curl)
- EC2-to-pod connectivity verified from a test instance in the same VPC
- Verified no change in behavior when `extraVolumeMounts` is not set (empty list / unset produces identical template output)

A full end-to-end guide for installing and testing the VPC CNI on ROSA HCP is available at: https://github.com/phbergsmann/rosa-vpc-cni/

**Will this PR introduce any new dependencies?**:

No. No new APIs, binaries, or dependencies. Reuses the existing `extraVolumeMounts` value.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No breaking changes. When `extraVolumeMounts` is not set (the default), the template renders identically to the current chart. Existing deployments are unaffected.

**Possible side effect**: If `extraVolumeMounts` was already configured prior to this change, upgrading the chart will now also mount those volumes into the `aws-vpc-cni-init` init container (previously they were only mounted in the main `aws-node` container). This should be harmless in practice - the init container runs briefly to copy CNI binaries and exits - but users with custom extra mounts should be aware of the expanded scope.

**Does this change require updates to the CNI daemonset config files to work?**:

No. This works with a standard `helm upgrade` using updated values. No manual patching required.

**Does this PR introduce any user-facing change?**:

The `extraVolumeMounts` value is now also rendered in the `aws-vpc-cni-init` init container, allowing users to mount additional host paths (e.g. for non-EKS CNI binary/config directories).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.