### PR TITLE
fix: add timeout in DescribeNetworkInterface call

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1739,7 +1739,10 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 	for retryCount := 0; retryCount < maxENIEC2APIRetries && len(eniIDs) > 0; retryCount++ {
 		input := &ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: eniIDs}
 		start := time.Now()
-		ec2Response, err = cache.ec2SVC.DescribeNetworkInterfaces(ctx, input)
+
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ec2Response, err = cache.ec2SVC.DescribeNetworkInterfaces(reqCtx, input)
+		cancel()
 		prometheusmetrics.Ec2ApiReq.WithLabelValues("DescribeNetworkInterfaces").Inc()
 		prometheusmetrics.AwsAPILatency.WithLabelValues("DescribeNetworkInterfaces", fmt.Sprint(err != nil), awsReqStatus(err)).Observe(msSince(start))
 		if err == nil {

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1741,8 +1741,8 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		start := time.Now()
 
 		reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
 		ec2Response, err = cache.ec2SVC.DescribeNetworkInterfaces(reqCtx, input)
+		cancel()
 		prometheusmetrics.Ec2ApiReq.WithLabelValues("DescribeNetworkInterfaces").Inc()
 		prometheusmetrics.AwsAPILatency.WithLabelValues("DescribeNetworkInterfaces", fmt.Sprint(err != nil), awsReqStatus(err)).Observe(msSince(start))
 		if err == nil {

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1740,9 +1740,9 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		input := &ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: eniIDs}
 		start := time.Now()
 
-		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		ec2Response, err = cache.ec2SVC.DescribeNetworkInterfaces(reqCtx, input)
-		cancel()
 		prometheusmetrics.Ec2ApiReq.WithLabelValues("DescribeNetworkInterfaces").Inc()
 		prometheusmetrics.AwsAPILatency.WithLabelValues("DescribeNetworkInterfaces", fmt.Sprint(err != nil), awsReqStatus(err)).Observe(msSince(start))
 		if err == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: #3643 
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**: In the current state of the VPC CNI, when the Pod Identity Agent is not present in a cluster, but the VPC CNI is configured to use it, we end up in a stuck state without helpful error messages. The container continues to restart from liveness probe failures and there is no indication of the issue.

Adding this (5s) timeout to the `DescribeNetworkInterface` call allows for actual retries and for useful AWS SDK logs to show the true cause of the issue:
```
{"level":"debug","ts":"2026-04-01T22:01:25.395Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T22:01:25.395Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-0e4aad6f8000bb8e4]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
{"level":"debug","ts":"2026-04-01T22:01:30.396Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T22:01:30.396Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-0e4aad6f8000bb8e4]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
{"level":"debug","ts":"2026-04-01T22:01:35.407Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T22:01:35.408Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-0e4aad6f8000bb8e4]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
{"level":"debug","ts":"2026-04-01T22:01:40.432Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T22:01:40.432Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-0e4aad6f8000bb8e4]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"} 
```

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
### Before
```
{"level":"debug","ts":"2026-04-01T18:03:27.515Z","caller":"awsutils/awsutils.go:607","msg":"Found ENI MAC address: 0a:ff:f5:10:ec:b9"}
{"level":"debug","ts":"2026-04-01T18:03:27.519Z","caller":"awsutils/awsutils.go:607","msg":"Found ENI: eni-055cd09280c1f89cd, MAC 0a:ff:f5:10:ec:b9, device 0"}
{"level":"debug","ts":"2026-04-01T18:03:27.521Z","caller":"awsutils/awsutils.go:607","msg":"Found IPv4 addresses associated with interface. This is not efa-only interface"}

 ip-172-31-254-196  /host/var/log/aws-routed-eni 
```
### After
```
{"level":"debug","ts":"2026-04-01T21:02:27.046Z","caller":"awsutils/awsutils.go:1703","msg":"Total number of interfaces found: 1 "}
{"level":"debug","ts":"2026-04-01T21:02:27.046Z","caller":"awsutils/awsutils.go:800","msg":"Found ENI MAC address: 12:30:82:49:92:cb"}
{"level":"debug","ts":"2026-04-01T21:02:27.048Z","caller":"awsutils/awsutils.go:800","msg":"Found ENI: eni-06062e8004d46f6c7, MAC 12:30:82:49:92:cb, device 0"}
{"level":"debug","ts":"2026-04-01T21:02:27.050Z","caller":"awsutils/awsutils.go:800","msg":"Found IPv4 addresses associated with interface. This is not efa-only interface"}
{"level":"debug","ts":"2026-04-01T21:02:32.055Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T21:02:32.055Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-06062e8004d46f6c7]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
{"level":"debug","ts":"2026-04-01T21:02:37.056Z","caller":"awsutils/awsutils.go:1754","msg":"checkAPIErrorAndBroadcastEvent resulted in operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadlineexceeded"}
{"level":"error","ts":"2026-04-01T21:02:37.057Z","caller":"ipamd/ipamd.go:484","msg":"Failed to call ec2:DescribeNetworkInterfaces for [eni-06062e8004d46f6c7]: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
...
{"level":"error","ts":"2026-04-01T21:03:27.738Z","caller":"aws-k8s-agent/main.go:52","msg":"Initialization failure: ipamd init: failed to retrieve attached ENIs info: operation error EC2: DescribeNetworkInterfaces, get identity: get credentials: request canceled, context deadline exceeded"}
```

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
fix: add timeout in DescribeNetworkInterface call
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
