### PR TITLE
Migrate subnet cluster tag prefix and fix primary subnet exclusion logic

### DIFF
--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,6 +46,10 @@ func TestNew_SetsHTTPClientTimeout(t *testing.T) {
 	cfg, err := New(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg.HTTPClient)
+	// Verify the HTTP client is the buildable client type with timeout configured
+	httpClient, ok := cfg.HTTPClient.(*http.BuildableClient)
+	assert.True(t, ok, "HTTPClient should be BuildableClient")
+	assert.NotNil(t, httpClient)
 }
 
 func TestNewAWSSDKHTTPClient_SetsTimeout(t *testing.T) {

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1356,6 +1356,7 @@ func ValidSubnetTagsMatchingClusterName(subnet ec2types.Subnet) bool {
 	// Get cluster name for cluster-specific tag checks
 	localClusterName := os.Getenv(clusterNameEnvVar)
 	if localClusterName == "" {
+		log.Debugf("CLUSTER_NAME is not set, skipping cluster tag validation for subnet %s", *subnet.SubnetId)
 		return true
 	}
 	localClusterTagKey := clusterTagKeyPrefix + localClusterName
@@ -2640,26 +2641,20 @@ func (cache *EC2InstanceMetadataCache) IsSubnetExcluded(ctx context.Context, sub
 	// Find the specific subnet and check its tags
 	for _, subnet := range subnets {
 		if *subnet.SubnetId == subnetID {
-			// Check the cni role tag first
-			for _, tag := range subnet.Tags {
-				if *tag.Key == "kubernetes.io/role/cni" {
-					tagValue := *tag.Value
-					tagExcluded := tagValue == "0"
-					log.Debugf("IsSubnetExcluded: subnet %s has tag kubernetes.io/role/cni=%s, excluded=%t", subnetID, tagValue, tagExcluded)
-					if tagExcluded {
-						return true, nil
-					}
-					// cni=1, now check cluster tags
-					if !ValidSubnetTagsMatchingClusterName(subnet) {
-						log.Debugf("IsSubnetExcluded: subnet %s doesn't have valid cluster name tag", subnetID)
-						return true, nil
-					}
-					return false, nil
-				}
+			cniTagValue := getTagValue(subnet.Tags, subnetDiscoveryTagKey)
+			if cniTagValue == "" {
+				log.Debugf("IsSubnetExcluded: subnet %s has no %s tag, not excluded", subnetID, subnetDiscoveryTagKey)
+				return false, nil
 			}
-
-			// If no kubernetes.io/role/cni tag found, subnet is not explicitly excluded
-			log.Debugf("IsSubnetExcluded: subnet %s has no kubernetes.io/role/cni tag, not excluded", subnetID)
+			if cniTagValue == subnetDiscoveryTagValueExcluded {
+				log.Debugf("IsSubnetExcluded: subnet %s has %s=0, excluded", subnetID, subnetDiscoveryTagKey)
+				return true, nil
+			}
+			// cni=1, now check cluster tags
+			if !ValidSubnetTagsMatchingClusterName(subnet) {
+				log.Debugf("IsSubnetExcluded: subnet %s doesn't have valid cluster name tag", subnetID)
+				return true, nil
+			}
 			return false, nil
 		}
 	}

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -68,7 +68,7 @@ const (
 	clusterNameEnvVar = "CLUSTER_NAME"
 
 	// clusterTagKeyPrefix is the prefix for the cluster-specific subnet tags
-	clusterTagKeyPrefix = "kubernetes.io/cluster/"
+	clusterTagKeyPrefix = "cni.networking.k8s.aws/cluster/"
 
 	eniNodeTagKey                   = "node.k8s.amazonaws.com/instance_id"
 	eniCreatedAtTagKey              = "node.k8s.amazonaws.com/createdAt"
@@ -1332,6 +1332,7 @@ func isSubnetValidForENICreation(subnet ec2types.Subnet, isPrimarySubnet bool) b
 		if isPrimarySubnet {
 			// Primary subnets are included by default (backwards compatibility)
 			log.Debugf("Primary subnet %s has no %s tag, including it for ENI creation (backwards compatibility)", *subnet.SubnetId, subnetDiscoveryTagKey)
+			return true
 		} else {
 			// Secondary subnets require explicit opt-in via CNI tag
 			log.Debugf("Subnet %s has no %s tag, excluding it from ENI creation", *subnet.SubnetId, subnetDiscoveryTagKey)
@@ -1354,6 +1355,9 @@ func isSubnetValidForENICreation(subnet ec2types.Subnet, isPrimarySubnet bool) b
 func ValidSubnetTagsMatchingClusterName(subnet ec2types.Subnet) bool {
 	// Get cluster name for cluster-specific tag checks
 	localClusterName := os.Getenv(clusterNameEnvVar)
+	if localClusterName == "" {
+		return true
+	}
 	localClusterTagKey := clusterTagKeyPrefix + localClusterName
 	hasClusterTags, belongsToThisCluster := checkClusterTags(subnet.Tags, localClusterTagKey)
 	if !hasClusterTags || belongsToThisCluster {
@@ -2636,17 +2640,21 @@ func (cache *EC2InstanceMetadataCache) IsSubnetExcluded(ctx context.Context, sub
 	// Find the specific subnet and check its tags
 	for _, subnet := range subnets {
 		if *subnet.SubnetId == subnetID {
-			if !ValidSubnetTagsMatchingClusterName(subnet) {
-				log.Debugf("IsSubnetExcluded: subnet %s doesn't have valid cluster name tag", subnetID)
-				return true, nil
-			}
-			// Check if the subnet has the exclusion tag kubernetes.io/role/cni=0
+			// Check the cni role tag first
 			for _, tag := range subnet.Tags {
 				if *tag.Key == "kubernetes.io/role/cni" {
 					tagValue := *tag.Value
 					tagExcluded := tagValue == "0"
 					log.Debugf("IsSubnetExcluded: subnet %s has tag kubernetes.io/role/cni=%s, excluded=%t", subnetID, tagValue, tagExcluded)
-					return tagExcluded, nil
+					if tagExcluded {
+						return true, nil
+					}
+					// cni=1, now check cluster tags
+					if !ValidSubnetTagsMatchingClusterName(subnet) {
+						log.Debugf("IsSubnetExcluded: subnet %s doesn't have valid cluster name tag", subnetID)
+						return true, nil
+					}
+					return false, nil
 				}
 			}
 

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -2417,7 +2417,7 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 						Value: aws.String("1"),
 					},
 					{
-						Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
+						Key:   aws.String("cni.networking.k8s.aws/cluster/some-other-cluster"),
 						Value: aws.String("shared"),
 					},
 				},
@@ -2436,11 +2436,11 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 						Value: aws.String("1"),
 					},
 					{
-						Key:   aws.String("kubernetes.io/cluster/" + testClusterName),
+						Key:   aws.String("cni.networking.k8s.aws/cluster/" + testClusterName),
 						Value: aws.String("shared"),
 					},
 					{
-						Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
+						Key:   aws.String("cni.networking.k8s.aws/cluster/some-other-cluster"),
 						Value: aws.String("shared"),
 					},
 				},
@@ -2455,7 +2455,7 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 				SubnetId: aws.String("subnet-abc"),
 				Tags: []ec2types.Tag{
 					{
-						Key:   aws.String("kubernetes.io/cluster/" + testClusterName),
+						Key:   aws.String("cni.networking.k8s.aws/cluster/" + testClusterName),
 						Value: aws.String("shared"),
 					},
 				},
@@ -2474,7 +2474,7 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 						Value: aws.String("1"),
 					},
 					{
-						Key:   aws.String("kubernetes.io/cluster/" + testClusterName),
+						Key:   aws.String("cni.networking.k8s.aws/cluster/" + testClusterName),
 						Value: aws.String("not-shared"), // Value doesn't matter, only key
 					},
 				},
@@ -2482,6 +2482,46 @@ func TestValidTagWithClusterSpecificTags(t *testing.T) {
 			isPrimarySubnet: true,
 			want:            true,
 			description:     "Should be available when cluster tag key matches (value ignored)",
+		},
+		{
+			name: "primary subnet with no CNI tag and different cluster tag",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-other-cluster"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/some-other-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet without CNI tag should be included regardless of other cluster tags (backwards compatibility)",
+		},
+		{
+			name: "primary subnet with no CNI tag and matching cluster tag",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-our-cluster"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/" + testClusterName),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet without CNI tag should be included even with matching cluster tag",
+		},
+		{
+			name: "primary subnet with no tags at all",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-primary-no-tags"),
+				Tags:     []ec2types.Tag{},
+			},
+			isPrimarySubnet: true,
+			want:            true,
+			description:     "Primary subnet with no tags should be included (backwards compatibility)",
 		},
 	}
 
@@ -2635,6 +2675,102 @@ func TestValidTag(t *testing.T) {
 	}
 }
 
+func TestValidSubnetTagsMatchingClusterName(t *testing.T) {
+	// Save original environment and restore it after the test
+	originalClusterName := os.Getenv(clusterNameEnvVar)
+	defer os.Setenv(clusterNameEnvVar, originalClusterName)
+
+	tests := []struct {
+		name        string
+		clusterName string
+		subnet      ec2types.Subnet
+		want        bool
+	}{
+		{
+			name:        "empty CLUSTER_NAME returns true",
+			clusterName: "",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-1"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/some-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:        "no cluster tags returns true",
+			clusterName: "my-cluster",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-2"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("kubernetes.io/role/cni"),
+						Value: aws.String("1"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:        "matching cluster tag returns true",
+			clusterName: "my-cluster",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-3"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/my-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:        "different cluster tag returns false",
+			clusterName: "my-cluster",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-4"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/other-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "both matching and different cluster tags returns true",
+			clusterName: "my-cluster",
+			subnet: ec2types.Subnet{
+				SubnetId: aws.String("subnet-5"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/my-cluster"),
+						Value: aws.String("shared"),
+					},
+					{
+						Key:   aws.String("cni.networking.k8s.aws/cluster/other-cluster"),
+						Value: aws.String("shared"),
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(clusterNameEnvVar, tt.clusterName)
+			got := ValidSubnetTagsMatchingClusterName(tt.subnet)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestIsSubnetExcluded(t *testing.T) {
 	ctrl, mockEC2 := setup(t)
 	defer ctrl.Finish()
@@ -2692,7 +2828,7 @@ func TestIsSubnetExcluded(t *testing.T) {
 					Value: aws.String("1"),
 				},
 				{
-					Key:   aws.String("kubernetes.io/cluster/other-cluster"),
+					Key:   aws.String("cni.networking.k8s.aws/cluster/other-cluster"),
 					Value: aws.String("shared"),
 				},
 			},
@@ -2707,7 +2843,7 @@ func TestIsSubnetExcluded(t *testing.T) {
 					Value: aws.String("1"),
 				},
 				{
-					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+					Key:   aws.String("cni.networking.k8s.aws/cluster/test-cluster"),
 					Value: aws.String("shared"),
 				},
 			},
@@ -2719,6 +2855,32 @@ func TestIsSubnetExcluded(t *testing.T) {
 			describeError: errors.New("API error"),
 			want:          false,
 			wantErr:       true,
+		},
+		{
+			name: "subnet without cni tag but with different cluster tag - not excluded",
+			subnetTags: []ec2types.Tag{
+				{
+					Key:   aws.String("cni.networking.k8s.aws/cluster/other-cluster"),
+					Value: aws.String("shared"),
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "subnet with cni=0 and matching cluster tag - still excluded",
+			subnetTags: []ec2types.Tag{
+				{
+					Key:   aws.String("kubernetes.io/role/cni"),
+					Value: aws.String("0"),
+				},
+				{
+					Key:   aws.String("cni.networking.k8s.aws/cluster/test-cluster"),
+					Value: aws.String("shared"),
+				},
+			},
+			want:    true,
+			wantErr: false,
 		},
 		{
 			name:       "no subnets returned",

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -593,8 +593,10 @@ func (c *IPAMContext) nodeInit(ctx context.Context) error {
 		}
 
 		// Also refresh custom security groups for secondary subnets
-		// Custom security groups are only relevant when subnet discovery is enabled
-		if c.useSubnetDiscovery {
+		// Custom security groups are only relevant when subnet discovery is enabled and custom networking is disabled.
+		// When custom networking is enabled, ENIConfig defines the security groups for secondary ENIs,
+		// and auto-discovered SGs should not overwrite them.
+		if c.useSubnetDiscovery && !c.useCustomNetworking {
 			if err := c.awsClient.RefreshCustomSGIDs(ctx, c.dataStoreAccess); err != nil {
 				return err
 			}
@@ -605,7 +607,7 @@ func (c *IPAMContext) nodeInit(ctx context.Context) error {
 		go wait.Forever(func() {
 			c.awsClient.RefreshSGIDs(ctx, primaryENIMac, c.dataStoreAccess)
 			// Also refresh custom security groups for secondary subnets
-			if c.useSubnetDiscovery {
+			if c.useSubnetDiscovery && !c.useCustomNetworking {
 				c.awsClient.RefreshCustomSGIDs(ctx, c.dataStoreAccess)
 			}
 		}, 30*time.Second)

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
@@ -441,125 +441,19 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 			})
 
 			It("should not exclude primary subnet when it has old kubernetes.io/cluster/ tag for different cluster", func() {
-				By("Tagging primary subnet with old-style cluster tag for a different cluster (should be ignored)")
-				_, err = f.CloudServices.EC2().
-					CreateTags(
-						context.TODO(),
-						[]string{primarySubnetID},
-						[]ec2types.Tag{
-							{
-								Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
-								Value: aws.String("shared"),
-							},
-						},
-					)
-				Expect(err).ToNot(HaveOccurred())
-
-				defer func() {
-					By("Removing old-style cluster tag from primary subnet")
-					_, err = f.CloudServices.EC2().
-						DeleteTags(
-							context.TODO(),
-							[]string{primarySubnetID},
-							[]ec2types.Tag{
-								{
-									Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
-									Value: aws.String("shared"),
-								},
-							},
-						)
-					Expect(err).ToNot(HaveOccurred())
-				}()
-
-				By("creating deployment")
-				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
-					Command([]string{"sleep"}).
-					Args([]string{"3600"}).
-					Build()
-
-				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
-					Container(container).
-					Replicas(5).
-					PodLabel(enhancedPodLabelKey, "old-tag-compat").
-					NodeName(*primaryInstance.PrivateDnsName).
-					Build()
-
-				deployment, err = f.K8sResourceManagers.DeploymentManager().
-					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("verifying pods are running (primary subnet not excluded despite old cluster tag)")
-				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(enhancedPodLabelKey, "old-tag-compat")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(pods.Items)).To(BeNumerically(">", 0), "Pods should be running, primary subnet should not be excluded by old-style cluster tags")
-
-				By("deleting deployment")
-				err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("sleeping to allow CNI Plugin to delete unused ENIs")
-				time.Sleep(time.Second * 90)
+				verifyPrimarySubnetNotExcludedWithTag(
+					"kubernetes.io/cluster/some-other-cluster", "shared",
+					"old-tag-compat",
+					"primary subnet should not be excluded by old-style cluster tags",
+				)
 			})
 
 			It("should not exclude primary subnet when it has no cni tag but has new cluster tag for different cluster", func() {
-				By("Tagging primary subnet with new-style cluster tag for a different cluster but no cni tag")
-				_, err = f.CloudServices.EC2().
-					CreateTags(
-						context.TODO(),
-						[]string{primarySubnetID},
-						[]ec2types.Tag{
-							{
-								Key:   aws.String("cni.networking.k8s.aws/cluster/different-cluster"),
-								Value: aws.String("shared"),
-							},
-						},
-					)
-				Expect(err).ToNot(HaveOccurred())
-
-				defer func() {
-					By("Removing new-style cluster tag from primary subnet")
-					_, err = f.CloudServices.EC2().
-						DeleteTags(
-							context.TODO(),
-							[]string{primarySubnetID},
-							[]ec2types.Tag{
-								{
-									Key:   aws.String("cni.networking.k8s.aws/cluster/different-cluster"),
-									Value: aws.String("shared"),
-								},
-							},
-						)
-					Expect(err).ToNot(HaveOccurred())
-				}()
-
-				By("creating deployment")
-				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
-					Command([]string{"sleep"}).
-					Args([]string{"3600"}).
-					Build()
-
-				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
-					Container(container).
-					Replicas(5).
-					PodLabel(enhancedPodLabelKey, "no-cni-tag-compat").
-					NodeName(*primaryInstance.PrivateDnsName).
-					Build()
-
-				deployment, err = f.K8sResourceManagers.DeploymentManager().
-					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("verifying pods are running (primary subnet not excluded - cluster check only applies when cni=1)")
-				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(enhancedPodLabelKey, "no-cni-tag-compat")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(pods.Items)).To(BeNumerically(">", 0), "Pods should be running, primary subnet should not be excluded when no cni tag present")
-
-				By("deleting deployment")
-				err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("sleeping to allow CNI Plugin to delete unused ENIs")
-				time.Sleep(time.Second * 90)
+				verifyPrimarySubnetNotExcludedWithTag(
+					"cni.networking.k8s.aws/cluster/different-cluster", "shared",
+					"no-cni-tag-compat",
+					"primary subnet should not be excluded when no cni tag present",
+				)
 			})
 		})
 
@@ -984,7 +878,10 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 	})
 })
 
-// verifyAPIServerConnectivity checks that pods can reach the Kubernetes API server
+// verifyAPIServerConnectivity checks that pods can reach the Kubernetes API server.
+// Uses wget --server-response (not -q) so the HTTP status is always printed,
+// and parses the echoed exit code to distinguish connectivity failures from
+// expected auth errors (401/403).
 func verifyAPIServerConnectivity(labelKey, labelVal string) {
 	pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(labelKey, labelVal)
 	Expect(err).ToNot(HaveOccurred())
@@ -995,19 +892,70 @@ func verifyAPIServerConnectivity(labelKey, labelVal string) {
 			continue
 		}
 		By(fmt.Sprintf("Testing API server connectivity from pod %s", pod.Name))
-		// Use the KUBERNETES_SERVICE_HOST env var inside the pod (always set by kubelet)
-		// to avoid DNS dependency. A 401 response confirms network connectivity.
+		// Use --server-response so wget always prints the HTTP status line.
+		// The API server returns 401/403 for unauthenticated requests, which
+		// still proves network connectivity. wget returns non-zero for HTTP
+		// errors, so we echo the exit code and only fail on network-level errors.
 		stdout, stderr, _ := f.K8sResourceManagers.PodManager().PodExec(
 			pod.Namespace, pod.Name,
-			[]string{"sh", "-c", "wget --spider --timeout=5 -q https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api --no-check-certificate 2>&1; echo EXIT:$?"},
+			[]string{"sh", "-c",
+				"wget --server-response --timeout=5 -O /dev/null " +
+					"https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api " +
+					"--no-check-certificate 2>&1; echo EXIT:$?"},
 		)
 		combined := stdout + stderr
-		if strings.Contains(combined, "401") || strings.Contains(combined, "EXIT:0") {
-			GinkgoWriter.Printf("Pod %s reached API server\n", pod.Name)
-		} else {
-			Fail(fmt.Sprintf("Pod %s failed to reach API server. output: %s", pod.Name, combined))
+		// wget exit code 4 = network failure (timeout/connection refused).
+		// Any other exit code (0, 6, 8) means the server was reached.
+		if strings.Contains(combined, "EXIT:4") {
+			Fail(fmt.Sprintf("Pod %s failed to reach API server (network failure). output: %s", pod.Name, combined))
 		}
+		GinkgoWriter.Printf("Pod %s reached API server\n", pod.Name)
 		testedCount++
 	}
 	Expect(testedCount).To(BeNumerically(">", 0), "Should have tested at least one pod for connectivity")
+}
+
+// verifyPrimarySubnetNotExcludedWithTag is a shared helper for tests that verify
+// the primary subnet is not excluded when tagged with various cluster tag prefixes.
+func verifyPrimarySubnetNotExcludedWithTag(tagKey, tagValue, labelVal, assertMsg string) {
+	By(fmt.Sprintf("Tagging primary subnet with %s=%s", tagKey, tagValue))
+	_, err := f.CloudServices.EC2().
+		CreateTags(context.TODO(), []string{primarySubnetID}, []ec2types.Tag{
+			{Key: aws.String(tagKey), Value: aws.String(tagValue)},
+		})
+	Expect(err).ToNot(HaveOccurred())
+
+	defer func() {
+		By(fmt.Sprintf("Removing tag %s from primary subnet", tagKey))
+		_, err = f.CloudServices.EC2().
+			DeleteTags(context.TODO(), []string{primarySubnetID}, []ec2types.Tag{
+				{Key: aws.String(tagKey), Value: aws.String(tagValue)},
+			})
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	By("creating deployment")
+	container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+		Command([]string{"sleep"}).Args([]string{"3600"}).Build()
+
+	deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+		Container(container).Replicas(5).
+		PodLabel(enhancedPodLabelKey, labelVal).
+		NodeName(*primaryInstance.PrivateDnsName).Build()
+
+	dep, err := f.K8sResourceManagers.DeploymentManager().
+		CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("verifying pods are running")
+	pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(enhancedPodLabelKey, labelVal)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(pods.Items)).To(BeNumerically(">", 0), "Pods should be running, "+assertMsg)
+
+	By("deleting deployment")
+	err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(dep)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("sleeping to allow CNI Plugin to delete unused ENIs")
+	time.Sleep(time.Second * 90)
 }

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
@@ -294,6 +294,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 
 		Context("when using cluster-specific subnet tags", func() {
 			var clusterName string
+			var otherClusterSubnetID string
 
 			BeforeEach(func() {
 				// Get the cluster name from environment or use a default
@@ -309,7 +310,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 						[]string{createdSubnet},
 						[]ec2types.Tag{
 							{
-								Key:   aws.String("kubernetes.io/cluster/" + clusterName),
+								Key:   aws.String("cni.networking.k8s.aws/cluster/" + clusterName),
 								Value: aws.String("shared"),
 							},
 							{
@@ -342,16 +343,16 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 					CreateSubnet(context.TODO(), subnetCidr.String(), f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
 				Expect(err).ToNot(HaveOccurred())
 
-				otherSubnetID := *otherSubnetOutput.Subnet.SubnetId
+				otherClusterSubnetID = *otherSubnetOutput.Subnet.SubnetId
 
 				By("Tagging other subnet with different cluster tag")
 				_, err = f.CloudServices.EC2().
 					CreateTags(
 						context.TODO(),
-						[]string{otherSubnetID},
+						[]string{otherClusterSubnetID},
 						[]ec2types.Tag{
 							{
-								Key:   aws.String("kubernetes.io/cluster/different-cluster"),
+								Key:   aws.String("cni.networking.k8s.aws/cluster/different-cluster"),
 								Value: aws.String("shared"),
 							},
 							{
@@ -371,7 +372,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 						[]string{createdSubnet},
 						[]ec2types.Tag{
 							{
-								Key:   aws.String("kubernetes.io/cluster/" + clusterName),
+								Key:   aws.String("cni.networking.k8s.aws/cluster/" + clusterName),
 								Value: aws.String("shared"),
 							},
 							{
@@ -381,6 +382,14 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 						},
 					)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting other cluster subnet")
+				if otherClusterSubnetID != "" {
+					err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), otherClusterSubnetID)
+					if err != nil {
+						GinkgoWriter.Printf("Warning: Failed to delete other cluster subnet %s: %v\n", otherClusterSubnetID, err)
+					}
+				}
 			})
 
 			It("should only use subnets tagged for this cluster", func() {
@@ -412,13 +421,136 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 				for _, nwInterface := range instance.NetworkInterfaces {
 					if !common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress) {
 						secondaryENICount++
-						// All secondary ENIs should be in the cluster-tagged subnet
+						// All secondary ENIs should be in the cluster-tagged subnet, not the other cluster's subnet
 						Expect(*nwInterface.SubnetId).To(Equal(createdSubnet))
+						Expect(*nwInterface.SubnetId).ToNot(Equal(otherClusterSubnetID))
 					}
 				}
 
 				By("verifying at least one secondary ENI was created")
 				Expect(secondaryENICount).To(BeNumerically(">", 0))
+
+				By("deleting deployment")
+				err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("sleeping to allow CNI Plugin to delete unused ENIs")
+				time.Sleep(time.Second * 90)
+			})
+
+			It("should not exclude primary subnet when it has old kubernetes.io/cluster/ tag for different cluster", func() {
+				By("Tagging primary subnet with old-style cluster tag for a different cluster (should be ignored)")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{primarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
+								Value: aws.String("shared"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					By("Removing old-style cluster tag from primary subnet")
+					_, err = f.CloudServices.EC2().
+						DeleteTags(
+							context.TODO(),
+							[]string{primarySubnetID},
+							[]ec2types.Tag{
+								{
+									Key:   aws.String("kubernetes.io/cluster/some-other-cluster"),
+									Value: aws.String("shared"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				By("creating deployment")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).
+					Args([]string{"3600"}).
+					Build()
+
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).
+					Replicas(5).
+					PodLabel(enhancedPodLabelKey, "old-tag-compat").
+					NodeName(*primaryInstance.PrivateDnsName).
+					Build()
+
+				deployment, err = f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("verifying pods are running (primary subnet not excluded despite old cluster tag)")
+				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(enhancedPodLabelKey, "old-tag-compat")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pods.Items)).To(BeNumerically(">", 0), "Pods should be running, primary subnet should not be excluded by old-style cluster tags")
+
+				By("deleting deployment")
+				err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("sleeping to allow CNI Plugin to delete unused ENIs")
+				time.Sleep(time.Second * 90)
+			})
+
+			It("should not exclude primary subnet when it has no cni tag but has new cluster tag for different cluster", func() {
+				By("Tagging primary subnet with new-style cluster tag for a different cluster but no cni tag")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{primarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("cni.networking.k8s.aws/cluster/different-cluster"),
+								Value: aws.String("shared"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					By("Removing new-style cluster tag from primary subnet")
+					_, err = f.CloudServices.EC2().
+						DeleteTags(
+							context.TODO(),
+							[]string{primarySubnetID},
+							[]ec2types.Tag{
+								{
+									Key:   aws.String("cni.networking.k8s.aws/cluster/different-cluster"),
+									Value: aws.String("shared"),
+								},
+							},
+						)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				By("creating deployment")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).
+					Args([]string{"3600"}).
+					Build()
+
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).
+					Replicas(5).
+					PodLabel(enhancedPodLabelKey, "no-cni-tag-compat").
+					NodeName(*primaryInstance.PrivateDnsName).
+					Build()
+
+				deployment, err = f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("verifying pods are running (primary subnet not excluded - cluster check only applies when cni=1)")
+				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(enhancedPodLabelKey, "no-cni-tag-compat")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pods.Items)).To(BeNumerically(">", 0), "Pods should be running, primary subnet should not be excluded when no cni tag present")
 
 				By("deleting deployment")
 				err = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/apparentlymart/go-cidr/cidr"
@@ -30,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -738,5 +740,274 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 				Expect(finalSGIDs).ToNot(ContainElements(primarySGs), "Primary SGs should remain replaced")
 			})
 		})
+
+		Context("when security group without cni tag should be excluded", func() {
+			var untaggedSGID string
+
+			BeforeEach(func() {
+				By("Creating a security group WITHOUT cni=1 tag")
+				createSGOutput, err := f.CloudServices.EC2().
+					CreateSecurityGroup(context.TODO(), fmt.Sprintf("cni-exclusion-test-sg-%d", time.Now().Unix()), "SG without cni tag for exclusion test", f.Options.AWSVPCID)
+				Expect(err).ToNot(HaveOccurred())
+				untaggedSGID = *createSGOutput.GroupId
+
+				By("Tagging secondary subnet with cni=1")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{createdSubnet},
+						[]ec2types.Tag{
+							{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Excluding primary subnet to force ENI creation in secondary subnet")
+				_, err = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{primarySubnetID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("0")}})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Setting WARM_ENI_TARGET=2 to force ENI creation")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{
+						"WARM_ENI_TARGET":         "2",
+						"ENABLE_SUBNET_DISCOVERY": "true",
+					})
+				time.Sleep(60 * time.Second)
+			})
+
+			AfterEach(func() {
+				By("Restoring primary subnet tag")
+				_, _ = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{primarySubnetID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+
+				By("Resetting WARM_ENI_TARGET to 0")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
+				time.Sleep(60 * time.Second)
+
+				By("Cleaning up untagged security group")
+				if untaggedSGID != "" {
+					_ = f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), untaggedSGID)
+				}
+				_, _ = f.CloudServices.EC2().
+					DeleteTags(context.TODO(), []string{createdSubnet},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+			})
+
+			It("should not apply untagged security group to secondary ENIs and pods should have API server connectivity", func() {
+				By("Checking secondary ENI exists in tagged subnet")
+				var testENIID string
+				instance, err := f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, nwInterface := range instance.NetworkInterfaces {
+					if !common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress) && *nwInterface.SubnetId == createdSubnet {
+						testENIID = *nwInterface.NetworkInterfaceId
+						break
+					}
+				}
+				Expect(testENIID).ToNot(BeEmpty(), "Should have a secondary ENI in tagged subnet")
+
+				By("Verifying untagged SG is NOT applied to secondary ENI")
+				eni, err := f.CloudServices.EC2().DescribeNetworkInterface(context.TODO(), []string{testENIID})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(eni.NetworkInterfaces)).To(BeNumerically(">", 0))
+
+				var sgIDs []string
+				for _, sg := range eni.NetworkInterfaces[0].Groups {
+					sgIDs = append(sgIDs, *sg.GroupId)
+				}
+				GinkgoWriter.Printf("ENI %s security groups: %v (untagged SG: %s)\n", testENIID, sgIDs, untaggedSGID)
+				Expect(sgIDs).ToNot(ContainElement(untaggedSGID),
+					"Security group without cni=1 tag should NOT be applied to secondary ENIs")
+
+				By("Deploying pods and verifying API server connectivity")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).Args([]string{"3600"}).Build()
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).Replicas(3).
+					PodLabel(enhancedPodLabelKey, "sg-exclusion").
+					NodeName(*primaryInstance.PrivateDnsName).Build()
+				dep, err := f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					_ = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(dep)
+				}()
+
+				time.Sleep(10 * time.Second) // Allow DNS to be ready
+				verifyAPIServerConnectivity(enhancedPodLabelKey, "sg-exclusion")
+			})
+		})
+
+		Context("when tagged security group is removed (cni=1 tag deleted)", func() {
+			var removableSGID string
+
+			BeforeEach(func() {
+				By("Creating a security group with cni=1 tag")
+				createSGOutput, err := f.CloudServices.EC2().
+					CreateSecurityGroup(context.TODO(), fmt.Sprintf("cni-removal-test-sg-%d", time.Now().Unix()), "SG for removal test", f.Options.AWSVPCID)
+				Expect(err).ToNot(HaveOccurred())
+				removableSGID = *createSGOutput.GroupId
+
+				_, err = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{removableSGID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Tagging secondary subnet with cni=1")
+				_, err = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{createdSubnet},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Excluding primary subnet to force ENI creation in secondary subnet")
+				_, err = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{primarySubnetID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("0")}})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Setting WARM_ENI_TARGET=2 to force ENI creation")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{
+						"WARM_ENI_TARGET":         "2",
+						"ENABLE_SUBNET_DISCOVERY": "true",
+					})
+				time.Sleep(60 * time.Second)
+			})
+
+			AfterEach(func() {
+				By("Restoring primary subnet tag")
+				_, _ = f.CloudServices.EC2().
+					CreateTags(context.TODO(), []string{primarySubnetID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+
+				By("Resetting WARM_ENI_TARGET to 0")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
+				time.Sleep(60 * time.Second)
+
+				By("Cleaning up removable security group")
+				if removableSGID != "" {
+					_, _ = f.CloudServices.EC2().
+						DeleteTags(context.TODO(), []string{removableSGID},
+							[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+					_ = f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), removableSGID)
+				}
+				_, _ = f.CloudServices.EC2().
+					DeleteTags(context.TODO(), []string{createdSubnet},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+			})
+
+			It("should revert to primary SGs after custom SG tag is removed and maintain API server connectivity", func() {
+				By("Finding secondary ENI in tagged subnet")
+				var testENIID string
+				instance, err := f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, nwInterface := range instance.NetworkInterfaces {
+					if !common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress) && *nwInterface.SubnetId == createdSubnet {
+						testENIID = *nwInterface.NetworkInterfaceId
+						break
+					}
+				}
+				Expect(testENIID).ToNot(BeEmpty(), "Should have a secondary ENI in tagged subnet")
+
+				By("Verifying custom SG is applied to secondary ENI")
+				Eventually(func() []string {
+					eni, err := f.CloudServices.EC2().DescribeNetworkInterface(context.TODO(), []string{testENIID})
+					if err != nil || len(eni.NetworkInterfaces) == 0 {
+						return nil
+					}
+					var ids []string
+					for _, sg := range eni.NetworkInterfaces[0].Groups {
+						ids = append(ids, *sg.GroupId)
+					}
+					return ids
+				}, 50*time.Second, 5*time.Second).Should(ContainElement(removableSGID),
+					"Custom SG should be applied to secondary ENI")
+
+				By("Deploying pods to verify they can run with the custom SG")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).Args([]string{"3600"}).Build()
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).Replicas(3).
+					PodLabel(enhancedPodLabelKey, "sg-removal").
+					NodeName(*primaryInstance.PrivateDnsName).Build()
+				dep, err := f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					_ = f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(dep)
+				}()
+
+				By("Removing cni=1 tag from custom security group")
+				_, err = f.CloudServices.EC2().
+					DeleteTags(context.TODO(), []string{removableSGID},
+						[]ec2types.Tag{{Key: aws.String("kubernetes.io/role/cni"), Value: aws.String("1")}})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Getting primary ENI security groups for comparison")
+				instance, err = f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)
+				Expect(err).ToNot(HaveOccurred())
+				var primarySGs []string
+				for _, nwInterface := range instance.NetworkInterfaces {
+					if common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress) {
+						for _, sg := range nwInterface.Groups {
+							primarySGs = append(primarySGs, *sg.GroupId)
+						}
+						break
+					}
+				}
+
+				By("Waiting for refresh to revert ENI to primary security groups")
+				Eventually(func() []string {
+					eni, err := f.CloudServices.EC2().DescribeNetworkInterface(context.TODO(), []string{testENIID})
+					if err != nil || len(eni.NetworkInterfaces) == 0 {
+						return nil
+					}
+					var ids []string
+					for _, sg := range eni.NetworkInterfaces[0].Groups {
+						ids = append(ids, *sg.GroupId)
+					}
+					GinkgoWriter.Printf("ENI %s SGs after tag removal: %v\n", testENIID, ids)
+					return ids
+				}, 50*time.Second, 5*time.Second).Should(And(
+					ContainElements(primarySGs),
+					Not(ContainElement(removableSGID)),
+				), "ENI should revert to primary SGs after custom SG tag is removed")
+			})
+		})
 	})
 })
+
+// verifyAPIServerConnectivity checks that pods can reach the Kubernetes API server
+func verifyAPIServerConnectivity(labelKey, labelVal string) {
+	pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(labelKey, labelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+	testedCount := 0
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning || testedCount >= 3 {
+			continue
+		}
+		By(fmt.Sprintf("Testing API server connectivity from pod %s", pod.Name))
+		// Use the KUBERNETES_SERVICE_HOST env var inside the pod (always set by kubelet)
+		// to avoid DNS dependency. A 401 response confirms network connectivity.
+		stdout, stderr, _ := f.K8sResourceManagers.PodManager().PodExec(
+			pod.Namespace, pod.Name,
+			[]string{"sh", "-c", "wget --spider --timeout=5 -q https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api --no-check-certificate 2>&1; echo EXIT:$?"},
+		)
+		combined := stdout + stderr
+		if strings.Contains(combined, "401") || strings.Contains(combined, "EXIT:0") {
+			GinkgoWriter.Printf("Pod %s reached API server\n", pod.Name)
+		} else {
+			Fail(fmt.Sprintf("Pod %s failed to reach API server. output: %s", pod.Name, combined))
+		}
+		testedCount++
+	}
+	Expect(testedCount).To(BeNumerically(">", 0), "Should have tested at least one pod for connectivity")
+}

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
@@ -233,6 +233,343 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 				})
 			})
 		})
+
+		Context("when secondary subnet has no cni tag (discovery gating)", func() {
+			var untaggedSubnetID string
+			var untaggedSubnetCIDR *net.IPNet
+
+			BeforeEach(func() {
+				By("Creating an untagged secondary subnet")
+				untaggedSubnetOutput, err := f.CloudServices.EC2().
+					CreateSubnet(context.TODO(), "100.64.64.0/24", f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
+				Expect(err).ToNot(HaveOccurred())
+
+				untaggedSubnetID = *untaggedSubnetOutput.Subnet.SubnetId
+				untaggedSubnetCIDR = getSubnetCIDR(untaggedSubnetID)
+
+				By("Creating another subnet with cni=1 for comparison")
+				taggedSubnetOutput, err := f.CloudServices.EC2().
+					CreateSubnet(context.TODO(), "100.64.65.0/24", f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
+				Expect(err).ToNot(HaveOccurred())
+
+				taggedSubnetID := *taggedSubnetOutput.Subnet.SubnetId
+
+				By("Tagging comparison subnet with cni=1")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{taggedSubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("1"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Restarting aws-node pods to apply subnet discovery")
+				restartAwsNodePods()
+
+				By("Waiting for configuration to take effect")
+				time.Sleep(30 * time.Second)
+			})
+
+			AfterEach(func() {
+				By("Deleting untagged subnet")
+				err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), untaggedSubnetID)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to delete untagged subnet %s: %v\n", untaggedSubnetID, err)
+				}
+			})
+
+			It("should not discover secondary subnet without cni tag", func() {
+				By("Creating deployment that requires secondary ENIs")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).
+					Args([]string{"3600"}).
+					Build()
+
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).
+					Replicas(15). // Enough to force secondary ENI creation
+					PodLabel(secondaryExclusionPodLabelKey, "no-cni-tag-gating").
+					NodeName(*primaryInstance.PrivateDnsName).
+					Build()
+
+				var err error
+				deployment, err := f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					By("Cleaning up deployment")
+					err := f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+					Expect(err).ToNot(HaveOccurred())
+					time.Sleep(60 * time.Second)
+				}()
+
+				By("Verifying no pods are placed in the untagged subnet (gating mechanism works)")
+				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(secondaryExclusionPodLabelKey, "no-cni-tag-gating")
+				Expect(err).ToNot(HaveOccurred())
+
+				podsInUntaggedSubnet := 0
+				for _, pod := range pods.Items {
+					if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+						podIP := net.ParseIP(pod.Status.PodIP)
+						if untaggedSubnetCIDR.Contains(podIP) {
+							podsInUntaggedSubnet++
+							GinkgoWriter.Printf("ERROR: Pod %s found in untagged subnet %s\n", pod.Name, pod.Status.PodIP)
+						}
+					}
+				}
+
+				Expect(podsInUntaggedSubnet).To(Equal(0),
+					"Secondary subnet without cni tag should be excluded - no pods should be placed there (gating mechanism)")
+			})
+		})
+
+		Context("when secondary subnet has cni=1 with old cluster tag prefix", func() {
+			var secondarySubnetWithOldTagID string
+
+			BeforeEach(func() {
+				By("Creating secondary subnet with cni=1 and old cluster tag prefix")
+				subnetOutput, err := f.CloudServices.EC2().
+					CreateSubnet(context.TODO(), "100.64.66.0/24", f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
+				Expect(err).ToNot(HaveOccurred())
+
+				secondarySubnetWithOldTagID = *subnetOutput.Subnet.SubnetId
+
+				By("Tagging test subnet with cni=1 (opt-in) and old-style cluster tag")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{secondarySubnetWithOldTagID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("1"),
+							},
+							{
+								Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+								Value: aws.String("shared"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Excluding primary subnet with cni=0 to force CNI to use secondary subnets")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{primarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("0"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Also excluding the BeforeSuite secondary subnet so only our test subnet is available")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{secondarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("0"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Setting WARM_ENI_TARGET=2 to force secondary ENI creation")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{
+						"WARM_ENI_TARGET":         "2",
+						"ENABLE_SUBNET_DISCOVERY": "true",
+					})
+
+				By("Waiting for ENI allocation to take effect")
+				time.Sleep(60 * time.Second)
+			})
+
+			AfterEach(func() {
+				By("Restoring primary subnet tag to cni=1 before releasing ENIs")
+				_, err := f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{primarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("1"),
+							},
+						},
+					)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to restore primary subnet tag: %v\n", err)
+				}
+
+				By("Restoring BeforeSuite secondary subnet tag to cni=1")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{secondarySubnetID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("1"),
+							},
+						},
+					)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to restore secondary subnet tag: %v\n", err)
+				}
+
+				By("Excluding test subnet with cni=0 so CNI stops using it")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{secondarySubnetWithOldTagID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("0"),
+							},
+						},
+					)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to exclude test subnet: %v\n", err)
+				}
+
+				By("Resetting WARM_ENI_TARGET to 0 to release ENIs")
+				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
+				time.Sleep(90 * time.Second)
+
+				By("Deleting test subnet")
+				err = f.CloudServices.EC2().DeleteSubnet(context.TODO(), secondarySubnetWithOldTagID)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to delete subnet %s: %v\n", secondarySubnetWithOldTagID, err)
+				}
+			})
+
+			It("should include subnet with cni=1 even if old cluster tag is present (old prefix is ignored)", func() {
+				By("Checking if any ENI was created in the old-tag subnet")
+				instance, err := f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				enisInOldTagSubnet := 0
+				for _, eni := range instance.NetworkInterfaces {
+					if eni.SubnetId != nil && *eni.SubnetId == secondarySubnetWithOldTagID {
+						enisInOldTagSubnet++
+						GinkgoWriter.Printf("  Found ENI %s in old-tag subnet\n", *eni.NetworkInterfaceId)
+					}
+				}
+
+				GinkgoWriter.Printf("Found %d of %d ENIs in subnet %s (old-prefix cluster tag)\n",
+					enisInOldTagSubnet, len(instance.NetworkInterfaces), secondarySubnetWithOldTagID)
+
+				Expect(enisInOldTagSubnet).To(BeNumerically(">", 0),
+					"Subnet with cni=1 and old-style cluster tag should be discoverable (old prefix is invisible to new logic) — expected ENI creation in this subnet")
+			})
+		})
+
+		Context("when secondary subnet has cni=1 with different new cluster tag", func() {
+			var secondarySubnetWithDifferentClusterID string
+
+			BeforeEach(func() {
+				By("Creating secondary subnet for different cluster")
+				subnetOutput, err := f.CloudServices.EC2().
+					CreateSubnet(context.TODO(), "100.64.67.0/24", f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
+				Expect(err).ToNot(HaveOccurred())
+
+				secondarySubnetWithDifferentClusterID = *subnetOutput.Subnet.SubnetId
+
+				By("Tagging with cni=1 and new-style cluster tag for different cluster")
+				_, err = f.CloudServices.EC2().
+					CreateTags(
+						context.TODO(),
+						[]string{secondarySubnetWithDifferentClusterID},
+						[]ec2types.Tag{
+							{
+								Key:   aws.String("kubernetes.io/role/cni"),
+								Value: aws.String("1"),
+							},
+							{
+								Key:   aws.String("cni.networking.k8s.aws/cluster/other-cluster"),
+								Value: aws.String("shared"),
+							},
+						},
+					)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Restarting aws-node pods to apply subnet discovery")
+				restartAwsNodePods()
+
+				By("Waiting for configuration to take effect")
+				time.Sleep(30 * time.Second)
+			})
+
+			AfterEach(func() {
+				By("Deleting secondary subnet")
+				err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), secondarySubnetWithDifferentClusterID)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to delete subnet %s: %v\n", secondarySubnetWithDifferentClusterID, err)
+				}
+			})
+
+			It("should exclude subnet with cni=1 if cluster tag belongs to different cluster", func() {
+				By("Creating deployment that requires secondary ENIs")
+				container := manifest.NewNetCatAlpineContainer(f.Options.TestImageRegistry).
+					Command([]string{"sleep"}).
+					Args([]string{"3600"}).
+					Build()
+
+				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
+					Container(container).
+					Replicas(15).
+					PodLabel(secondaryExclusionPodLabelKey, "different-cluster-isolation").
+					NodeName(*primaryInstance.PrivateDnsName).
+					Build()
+
+				var err error
+				deployment, err := f.K8sResourceManagers.DeploymentManager().
+					CreateAndWaitTillDeploymentIsReady(deploymentBuilder, utils.DefaultDeploymentReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					By("Cleaning up deployment")
+					err := f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
+					Expect(err).ToNot(HaveOccurred())
+					time.Sleep(60 * time.Second)
+				}()
+
+				subnetCIDR := getSubnetCIDR(secondarySubnetWithDifferentClusterID)
+
+				By("Verifying pods avoid the subnet tagged for different cluster")
+				pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(secondaryExclusionPodLabelKey, "different-cluster-isolation")
+				Expect(err).ToNot(HaveOccurred())
+
+				podsInDifferentClusterSubnet := 0
+				for _, pod := range pods.Items {
+					if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+						podIP := net.ParseIP(pod.Status.PodIP)
+						if subnetCIDR.Contains(podIP) {
+							podsInDifferentClusterSubnet++
+							GinkgoWriter.Printf("WARNING: Pod %s found in different-cluster subnet %s\n", pod.Name, pod.Status.PodIP)
+						}
+					}
+				}
+
+				Expect(podsInDifferentClusterSubnet).To(Equal(0),
+					"Subnet with cni=1 but belonging to different cluster should be excluded (cluster isolation)")
+			})
+		})
 	})
 })
 

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
@@ -237,6 +237,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 		Context("when secondary subnet has no cni tag (discovery gating)", func() {
 			var untaggedSubnetID string
 			var untaggedSubnetCIDR *net.IPNet
+			var taggedSubnetID string
 
 			BeforeEach(func() {
 				By("Creating an untagged secondary subnet")
@@ -252,7 +253,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 					CreateSubnet(context.TODO(), "100.64.65.0/24", f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
 				Expect(err).ToNot(HaveOccurred())
 
-				taggedSubnetID := *taggedSubnetOutput.Subnet.SubnetId
+				taggedSubnetID = *taggedSubnetOutput.Subnet.SubnetId
 
 				By("Tagging comparison subnet with cni=1")
 				_, err = f.CloudServices.EC2().
@@ -280,6 +281,12 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 				err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), untaggedSubnetID)
 				if err != nil {
 					GinkgoWriter.Printf("Warning: Failed to delete untagged subnet %s: %v\n", untaggedSubnetID, err)
+				}
+
+				By("Deleting tagged comparison subnet")
+				err = f.CloudServices.EC2().DeleteSubnet(context.TODO(), taggedSubnetID)
+				if err != nil {
+					GinkgoWriter.Printf("Warning: Failed to delete tagged subnet %s: %v\n", taggedSubnetID, err)
 				}
 			})
 

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -145,8 +145,19 @@ var _ = BeforeSuite(func() {
 					alreadyAssociated = true
 					break
 				} else if state == "disassociating" {
-					By(fmt.Sprintf("CIDR %s is disassociating, waiting for it to complete", cidrRange.String()))
-					time.Sleep(30 * time.Second)
+					By(fmt.Sprintf("CIDR %s is disassociating, polling until complete", cidrRange.String()))
+					Eventually(func() bool {
+						info, err := f.CloudServices.EC2().DescribeVPC(context.TODO(), f.Options.AWSVPCID)
+						if err != nil {
+							return false
+						}
+						for _, a := range info.Vpcs[0].CidrBlockAssociationSet {
+							if a.CidrBlock != nil && *a.CidrBlock == cidrRange.String() {
+								return a.CidrBlockState.State != "disassociating"
+							}
+						}
+						return true // CIDR no longer listed, disassociation complete
+					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "CIDR disassociation should complete")
 				}
 			}
 		}
@@ -186,6 +197,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	subnetID := *createSubnetOutput.Subnet.SubnetId
+
+	By("tagging the subnet for test ownership")
+	_, err = f.CloudServices.EC2().CreateTags(context.TODO(), []string{subnetID}, []ec2types.Tag{
+		{Key: aws.String(staleSubnetTag), Value: aws.String("true")},
+	})
+	Expect(err).ToNot(HaveOccurred())
 
 	By("associating the route table with the newly created subnet")
 	err = f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
@@ -252,9 +269,13 @@ var _ = AfterSuite(func() {
 	}
 })
 
-// cleanupStaleSubnetsInCIDR removes any subnets in the secondary CIDR range that were
-// leaked from previous failed test runs. This makes BeforeSuite idempotent so repeated
-// runs on the same cluster don't fail with subnet conflicts.
+// staleSubnetTag is applied to all subnets created by this test suite so that
+// cleanupStaleSubnetsInCIDR only removes resources it owns.
+const staleSubnetTag = "eni-subnet-discovery-test"
+
+// cleanupStaleSubnetsInCIDR removes subnets in the secondary CIDR range that were
+// leaked from previous failed test runs. Only subnets tagged by this suite are removed,
+// preventing accidental deletion of unrelated infrastructure in the VPC.
 func cleanupStaleSubnetsInCIDR() {
 	ctx := context.TODO()
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(f.Options.AWSRegion))
@@ -264,11 +285,11 @@ func cleanupStaleSubnetsInCIDR() {
 	}
 	ec2Client := ec2.NewFromConfig(cfg)
 
-	// Find all subnets in the VPC within the secondary CIDR range
+	// Only find subnets tagged by this test suite
 	result, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []ec2types.Filter{
 			{Name: aws.String("vpc-id"), Values: []string{f.Options.AWSVPCID}},
-			{Name: aws.String("cidr-block"), Values: []string{cidrRange.String()}},
+			{Name: aws.String("tag-key"), Values: []string{staleSubnetTag}},
 		},
 	})
 	if err != nil {
@@ -276,31 +297,17 @@ func cleanupStaleSubnetsInCIDR() {
 		return
 	}
 
-	// Also find subnets in smaller CIDRs within the range (e.g. /24 subnets from individual tests)
-	smallerResult, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
-		Filters: []ec2types.Filter{
-			{Name: aws.String("vpc-id"), Values: []string{f.Options.AWSVPCID}},
-		},
-	})
-	if err != nil {
-		GinkgoWriter.Printf("Warning: failed to describe all subnets for cleanup: %v\n", err)
-		return
-	}
-
-	for _, subnet := range append(result.Subnets, smallerResult.Subnets...) {
+	for _, subnet := range result.Subnets {
 		if subnet.CidrBlock == nil || subnet.SubnetId == nil {
 			continue
 		}
-		// Check if this subnet falls within our secondary CIDR range
+		// Double-check the subnet falls within our secondary CIDR range
 		_, subnetNet, err := net.ParseCIDR(*subnet.CidrBlock)
-		if err != nil {
-			continue
-		}
-		if !cidrRange.Contains(subnetNet.IP) {
+		if err != nil || !cidrRange.Contains(subnetNet.IP) {
 			continue
 		}
 
-		GinkgoWriter.Printf("Found stale subnet %s (%s), cleaning up\n", *subnet.SubnetId, *subnet.CidrBlock)
+		GinkgoWriter.Printf("Found stale test subnet %s (%s), cleaning up\n", *subnet.SubnetId, *subnet.CidrBlock)
 
 		// Detach and delete any ENIs in this subnet
 		eniResult, err := ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
@@ -328,7 +335,6 @@ func cleanupStaleSubnetsInCIDR() {
 			}
 		}
 
-		// Delete the subnet
 		if err := f.CloudServices.EC2().DeleteSubnet(ctx, *subnet.SubnetId); err != nil {
 			GinkgoWriter.Printf("  Warning: failed to delete stale subnet %s: %v\n", *subnet.SubnetId, err)
 		} else {

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/apparentlymart/go-cidr/cidr"
@@ -128,10 +131,31 @@ var _ = BeforeSuite(func() {
 			Skip("IPv6 tests require a VPC with IPv6 already enabled")
 		}
 	} else {
-		// IPv4 association works with current framework
-		association, err := f.CloudServices.EC2().AssociateVPCCIDRBlock(context.TODO(), f.Options.AWSVPCID, cidrRange.String())
+		// IPv4: check if the CIDR is already associated (from a previous leaked run)
+		vpcInfo, err := f.CloudServices.EC2().DescribeVPC(context.TODO(), f.Options.AWSVPCID)
 		Expect(err).ToNot(HaveOccurred())
-		cidrBlockAssociationID = *association.CidrBlockAssociation.AssociationId
+
+		alreadyAssociated := false
+		for _, assoc := range vpcInfo.Vpcs[0].CidrBlockAssociationSet {
+			if assoc.CidrBlock != nil && *assoc.CidrBlock == cidrRange.String() {
+				state := assoc.CidrBlockState.State
+				if state == "associated" {
+					By(fmt.Sprintf("CIDR %s already associated (id: %s), reusing", cidrRange.String(), *assoc.AssociationId))
+					cidrBlockAssociationID = *assoc.AssociationId
+					alreadyAssociated = true
+					break
+				} else if state == "disassociating" {
+					By(fmt.Sprintf("CIDR %s is disassociating, waiting for it to complete", cidrRange.String()))
+					time.Sleep(30 * time.Second)
+				}
+			}
+		}
+
+		if !alreadyAssociated {
+			association, err := f.CloudServices.EC2().AssociateVPCCIDRBlock(context.TODO(), f.Options.AWSVPCID, cidrRange.String())
+			Expect(err).ToNot(HaveOccurred())
+			cidrBlockAssociationID = *association.CidrBlockAssociation.AssociationId
+		}
 	}
 
 	By(fmt.Sprintf("creating the subnet in %s", *primaryInstance.Placement.AvailabilityZone))
@@ -152,6 +176,10 @@ var _ = BeforeSuite(func() {
 		subnetCidr, err = cidr.Subnet(cidrRange, 2, 0)
 		Expect(err).ToNot(HaveOccurred())
 	}
+
+	// Clean up stale subnets from previous failed runs in the secondary CIDR range
+	By("cleaning up any stale subnets from previous runs")
+	cleanupStaleSubnetsInCIDR()
 
 	createSubnetOutput, err := f.CloudServices.EC2().
 		CreateSubnet(context.TODO(), subnetCidr.String(), f.Options.AWSVPCID, *primaryInstance.Placement.AvailabilityZone)
@@ -223,3 +251,88 @@ var _ = AfterSuite(func() {
 		// Don't fail the test suite for cleanup issues, just log them
 	}
 })
+
+// cleanupStaleSubnetsInCIDR removes any subnets in the secondary CIDR range that were
+// leaked from previous failed test runs. This makes BeforeSuite idempotent so repeated
+// runs on the same cluster don't fail with subnet conflicts.
+func cleanupStaleSubnetsInCIDR() {
+	ctx := context.TODO()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(f.Options.AWSRegion))
+	if err != nil {
+		GinkgoWriter.Printf("Warning: failed to create EC2 client for cleanup: %v\n", err)
+		return
+	}
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	// Find all subnets in the VPC within the secondary CIDR range
+	result, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{f.Options.AWSVPCID}},
+			{Name: aws.String("cidr-block"), Values: []string{cidrRange.String()}},
+		},
+	})
+	if err != nil {
+		GinkgoWriter.Printf("Warning: failed to describe subnets for cleanup: %v\n", err)
+		return
+	}
+
+	// Also find subnets in smaller CIDRs within the range (e.g. /24 subnets from individual tests)
+	smallerResult, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{f.Options.AWSVPCID}},
+		},
+	})
+	if err != nil {
+		GinkgoWriter.Printf("Warning: failed to describe all subnets for cleanup: %v\n", err)
+		return
+	}
+
+	for _, subnet := range append(result.Subnets, smallerResult.Subnets...) {
+		if subnet.CidrBlock == nil || subnet.SubnetId == nil {
+			continue
+		}
+		// Check if this subnet falls within our secondary CIDR range
+		_, subnetNet, err := net.ParseCIDR(*subnet.CidrBlock)
+		if err != nil {
+			continue
+		}
+		if !cidrRange.Contains(subnetNet.IP) {
+			continue
+		}
+
+		GinkgoWriter.Printf("Found stale subnet %s (%s), cleaning up\n", *subnet.SubnetId, *subnet.CidrBlock)
+
+		// Detach and delete any ENIs in this subnet
+		eniResult, err := ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+			Filters: []ec2types.Filter{
+				{Name: aws.String("subnet-id"), Values: []string{*subnet.SubnetId}},
+			},
+		})
+		if err == nil {
+			for _, eni := range eniResult.NetworkInterfaces {
+				if eni.Attachment != nil && eni.Attachment.AttachmentId != nil {
+					GinkgoWriter.Printf("  Detaching ENI %s\n", *eni.NetworkInterfaceId)
+					_, _ = ec2Client.DetachNetworkInterface(ctx, &ec2.DetachNetworkInterfaceInput{
+						AttachmentId: eni.Attachment.AttachmentId,
+						Force:        aws.Bool(true),
+					})
+					time.Sleep(5 * time.Second)
+				}
+				GinkgoWriter.Printf("  Deleting ENI %s\n", *eni.NetworkInterfaceId)
+				_, _ = ec2Client.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+					NetworkInterfaceId: eni.NetworkInterfaceId,
+				})
+			}
+			if len(eniResult.NetworkInterfaces) > 0 {
+				time.Sleep(10 * time.Second)
+			}
+		}
+
+		// Delete the subnet
+		if err := f.CloudServices.EC2().DeleteSubnet(ctx, *subnet.SubnetId); err != nil {
+			GinkgoWriter.Printf("  Warning: failed to delete stale subnet %s: %v\n", *subnet.SubnetId, err)
+		} else {
+			GinkgoWriter.Printf("  Deleted stale subnet %s\n", *subnet.SubnetId)
+		}
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
X improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
New cluster tag prefix
Decision was made referring to https://github.com/aws/amazon-vpc-cni-k8s/issues/2904#issuecomment-4185382047
- Migrates the cluster-specific subnet tag from kubernetes.io/cluster/<cluster-name> to cni.networking.k8s.aws/cluster/<cluster-name>. This avoids conflicts with the widely-used kubernetes.io/cluster/ tag which is
set by many tools (EKS, kOps, Cluster API, etc.) for general cluster ownership, and gives VPC CNI its own dedicated namespace for subnet selection.

Primary subnet backwards compatibility fix
- Fixes a bug in isSubnetValidForENICreation where primary subnets without the kubernetes.io/role/cni tag were falling through instead of returning true. The log message indicated inclusion for backwards
compatibility, but the missing return true meant execution continued to the secondary subnet exclusion path.

Empty CLUSTER_NAME handling
- ValidSubnetTagsMatchingClusterName now returns true early when CLUSTER_NAME is empty, skipping cluster tag validation entirely. Previously, an empty cluster name could produce an empty tag key prefix and match
unintended tags.

IsSubnetExcluded evaluation order
- Reorders the checks in IsSubnetExcluded so that kubernetes.io/role/cni is evaluated first. A subnet with cni=0 is now excluded immediately regardless of cluster tags. Cluster tag validation only applies when
cni=1, which is the correct semantic: opt-in to CNI use first, then filter by cluster ownership.

Implemented behaviors:

| Resource | `kubernetes.io/role/cni` | `cni.networking.k8s.aws/cluster/` | Final Decision |
|----------|--------------------------|-----------------------------------|----------------|
| Primary Subnet | None | N/A | ✅ Allow |
| Primary Subnet | None | home cluster | ✅ Allow |
| Primary Subnet | None | another cluster | ✅ Allow |
| Primary Subnet | `0` | Any | ❌ Deny |
| Primary Subnet | `1` | home cluster | ✅ Allow |
| Primary Subnet | `1` | another cluster | ❌ Deny |
| Secondary Subnet | None | Any | ❌ Deny |
| Secondary Subnet | `0` | Any | ❌ Deny |
| Secondary Subnet | `1` | home cluster | ✅ Allow |
| Secondary Subnet | `1` | another cluster | ❌ Deny |

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

Testing:
- Unit tests: 32 subtests across 4 test suites (10 new test cases)
- Manual cluster validation: 4 functional tests on EKS (us-west-2)
- Integration tests: 2 new Ginkgo tests validating primary subnet is not excluded with old-style or new-style cluster tags for different clusters

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
