### PR TITLE
Make the ipv4 check optional to initialize the IPAM controller.

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -484,9 +484,9 @@ func (cache *EC2InstanceMetadataCache) initWithEC2Metadata(ctx context.Context) 
 	cache.localIPv4, err = cache.imds.GetLocalIPv4(ctx)
 	if err != nil {
 		awsAPIErrInc("GetLocalIPv4", err)
-		return err
+	} else {
+		log.Debugf("Discovered the instance primary IPv4 address: %s", cache.localIPv4)
 	}
-	log.Debugf("Discovered the instance primary IPv4 address: %s", cache.localIPv4)
 
 	// retrieve instance-id
 	cache.instanceID, err = cache.imds.GetInstanceID(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

At this stage, the PR is more a proposal to discuss.

**Which issue does this PR fix?**:
fix https://github.com/aws/amazon-vpc-cni-k8s/issues/3654

**What does this PR do / Why do we need it?**:


**Testing done on this change**:
Not yet, no local dev env

**Will this PR introduce any new dependencies?**:
NO

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
?

**Does this change require updates to the CNI daemonset config files to work?**:
NO

**Does this PR introduce any user-facing change?**:
NO

```release-note
TODO
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
