### PR TITLE
Fix unmanaged eni

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2123,6 +2123,8 @@ func EnablePodIPAnnotation() bool {
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag
 func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutils.ENIMetadata {
 	numFiltered := 0
+	// Use a local slice to recount from scratch, avoiding accumulation across repeated calls.
+	unmanagedENI := make([]int, len(c.unmanagedENI))
 	ret := make([]awsutils.ENIMetadata, 0, len(enis))
 
 	for _, eni := range enis {
@@ -2140,7 +2142,7 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 					log.Debugf("Skipping ENI %s: IPv6 Mode is enabled and VPC CNI will only ENIs created by it in v6 PD mode",
 						eni.ENIID)
 					numFiltered++
-					c.unmanagedENI[eni.NetworkCard] += 1
+					unmanagedENI[eni.NetworkCard] += 1
 					continue
 				} else if isUnmanagedNIC {
 					log.Debugf("Skipping ENI %s: since it is on unmanaged network card index %d", eni.ENIID, eni.NetworkCard)
@@ -2148,14 +2150,14 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 				} else if isEfaOnlyENI {
 					log.Debugf("Skipping ENI %s: since it is EFA only ENI on network card index %d", eni.ENIID, eni.NetworkCard)
 					numFiltered++
-					c.unmanagedENI[eni.NetworkCard] += 1
+					unmanagedENI[eni.NetworkCard] += 1
 					continue
 				}
 			}
 		} else if isUnmanagedENI {
 			log.Debugf("Skipping ENI %s: since it is unmanaged", eni.ENIID)
 			numFiltered++
-			c.unmanagedENI[eni.NetworkCard] += 1
+			unmanagedENI[eni.NetworkCard] += 1
 			continue
 		} else if isUnmanagedNIC {
 			log.Debugf("Skipping ENI %s: since it is on unmanaged network card index %d", eni.ENIID, eni.NetworkCard)
@@ -2163,12 +2165,17 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 		} else if isEfaOnlyENI {
 			log.Debugf("Skipping ENI %s: since it is EFA only ENI on network card index %d", eni.ENIID, eni.NetworkCard)
 			numFiltered++
-			c.unmanagedENI[eni.NetworkCard] += 1
+			unmanagedENI[eni.NetworkCard] += 1
 			continue
 		}
 
 		ret = append(ret, eni)
 	}
+
+	for networkCard, unmanagedENIs := range unmanagedENI {
+		c.unmanagedENI[networkCard] = unmanagedENIs
+	}
+
 	c.updateIPStats(numFiltered)
 	return ret
 }

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -2114,6 +2114,8 @@ func EnablePodIPAnnotation() bool {
 // filterUnmanagedENIs filters out ENIs marked with the "node.k8s.amazonaws.com/no_manage" tag
 func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutils.ENIMetadata {
 	numFiltered := 0
+	// Use a local slice to recount from scratch, avoiding accumulation across repeated calls.
+	unmanagedENI := make([]int, len(c.unmanagedENI))
 	ret := make([]awsutils.ENIMetadata, 0, len(enis))
 
 	for _, eni := range enis {
@@ -2131,7 +2133,7 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 					log.Debugf("Skipping ENI %s: IPv6 Mode is enabled and VPC CNI will only ENIs created by it in v6 PD mode",
 						eni.ENIID)
 					numFiltered++
-					c.unmanagedENI[eni.NetworkCard] += 1
+					unmanagedENI[eni.NetworkCard] += 1
 					continue
 				} else if isUnmanagedNIC {
 					log.Debugf("Skipping ENI %s: since it is on unmanaged network card index %d", eni.ENIID, eni.NetworkCard)
@@ -2139,14 +2141,14 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 				} else if isEfaOnlyENI {
 					log.Debugf("Skipping ENI %s: since it is EFA only ENI on network card index %d", eni.ENIID, eni.NetworkCard)
 					numFiltered++
-					c.unmanagedENI[eni.NetworkCard] += 1
+					unmanagedENI[eni.NetworkCard] += 1
 					continue
 				}
 			}
 		} else if isUnmanagedENI {
 			log.Debugf("Skipping ENI %s: since it is unmanaged", eni.ENIID)
 			numFiltered++
-			c.unmanagedENI[eni.NetworkCard] += 1
+			unmanagedENI[eni.NetworkCard] += 1
 			continue
 		} else if isUnmanagedNIC {
 			log.Debugf("Skipping ENI %s: since it is on unmanaged network card index %d", eni.ENIID, eni.NetworkCard)
@@ -2154,12 +2156,17 @@ func (c *IPAMContext) filterUnmanagedENIs(enis []awsutils.ENIMetadata) []awsutil
 		} else if isEfaOnlyENI {
 			log.Debugf("Skipping ENI %s: since it is EFA only ENI on network card index %d", eni.ENIID, eni.NetworkCard)
 			numFiltered++
-			c.unmanagedENI[eni.NetworkCard] += 1
+			unmanagedENI[eni.NetworkCard] += 1
 			continue
 		}
 
 		ret = append(ret, eni)
 	}
+
+	for networkCard, unmanagedENIs := range unmanagedENI {
+		c.unmanagedENI[networkCard] = unmanagedENIs
+	}
+
 	c.updateIPStats(numFiltered)
 	return ret
 }

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -1799,6 +1799,58 @@ func TestIPAMContext_filterUnmanagedENIs_disableManageUntaggedMode(t *testing.T)
 	}
 }
 
+func TestFilterUnmanagedENIs_NoAccumulationAcrossCalls(t *testing.T) {
+	eni1, eni2, eni3 := getDummyENIMetadata()
+	allENIs := []awsutils.ENIMetadata{eni1, eni2, eni3}
+
+	// eni2 and eni3 are unmanaged
+	tagMap := map[string]awsutils.TagMap{
+		eni2.ENIID: {eniNoManageTagKey: "true"},
+		eni3.ENIID: {eniNoManageTagKey: "true"},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAWSUtils := mock_awsutils.NewMockAPIs(ctrl)
+
+	c := &IPAMContext{
+		awsClient:                mockAWSUtils,
+		enableManageUntaggedMode: true,
+		unmanagedENI:             make([]int, 1),
+		numNetworkCards:          1,
+	}
+
+	mockAWSUtils.EXPECT().SetUnmanagedENIs(gomock.Any()).AnyTimes()
+	mockAWSUtils.EXPECT().GetPrimaryENI().AnyTimes().Return(eni1.ENIID)
+	mockAWSUtils.EXPECT().GetInstanceID().AnyTimes().Return(instanceID)
+
+	c.setUnmanagedENIs(tagMap)
+
+	mockAWSUtils.EXPECT().IsUnmanagedENI(gomock.Any()).DoAndReturn(
+		func(eni string) bool {
+			tags := tagMap[eni]
+			return tags[eniNoManageTagKey] == "true"
+		}).AnyTimes()
+	mockAWSUtils.EXPECT().IsUnmanagedNIC(gomock.Any()).Return(false).AnyTimes()
+	mockAWSUtils.EXPECT().IsEfaOnlyENI(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+
+	// Call filterUnmanagedENIs twice with the same input
+	got1 := c.filterUnmanagedENIs(allENIs)
+	countAfterFirst := c.unmanagedENI[0]
+
+	got2 := c.filterUnmanagedENIs(allENIs)
+	countAfterSecond := c.unmanagedENI[0]
+
+	// Both calls should return only the primary ENI
+	assert.Equal(t, []awsutils.ENIMetadata{eni1}, got1)
+	assert.Equal(t, []awsutils.ENIMetadata{eni1}, got2)
+
+	// The unmanaged count must NOT accumulate — it should be the same after both calls
+	assert.Equal(t, 2, countAfterFirst, "expected 2 unmanaged ENIs after first call")
+	assert.Equal(t, countAfterFirst, countAfterSecond, "unmanagedENI count should not accumulate across calls")
+}
+
 func TestDisablingENIProvisioning(t *testing.T) {
 	m := setup(t)
 	defer m.ctrl.Finish()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: 
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
Fixes counter values when there's a unmanaged ENI


**What does this PR do / Why do we need it?**:
https://github.com/aws/amazon-vpc-cni-k8s/issues/3544

**Testing done on this change**: N/A
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
