### PR TITLE
Migrate CNI/init/metrics base images to AL23 (latest-al23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ endif
 
 GOLANG_VERSION ?= $(shell cat .go-version)
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 # BASE_IMAGE_CNI is the base layer image for the primary AWS VPC CNI plugin container
-BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 # BASE_IMAGE_CNI_INIT is the base layer image for the AWS VPC CNI init container
-BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 # BASE_IMAGE_CNI_METRICS is the base layer image for the AWS VPC CNI metrics publisher sidecar container
-BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,7 +232,7 @@ The symptom for this issue is the presence of routing table 30200 or 30400.
 
 ## CNI Compatibility
 
-The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2 as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:
+The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2023 (AL23) as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:
 
 - **iptables**
   Prior to v1.12.1, the VPC CNI image only contained `iptables-legacy`. Newer distributions of RHEL (RHEL 8.x+), Ubuntu (Ubuntu 21.x+), etc. have moved to using `nftables`. This leads to issues such as [this](https://github.com/aws/amazon-vpc-cni-k8s/issues/1847) when running IPAMD.

--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
     -a -o snat-utils cmd/snat-utils/main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 
 WORKDIR /
 COPY --from=builder /workspace/ .

--- a/test/agent/Makefile
+++ b/test/agent/Makefile
@@ -18,7 +18,7 @@ PUBLIC_REPO_IMAGE=public.ecr.aws/$(REGISTRY_ID)/${IMAGE_NAME}:$(VERSION)
 PRIVATE_REPO_IMAGE=$(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME):$(VERSION)
 
 GOLANG_VERSION ?= $(shell cat ../../.go-version)
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
improvement

**Which issue does this PR fix?**:
Fixes #3657

**What does this PR do / Why do we need it?**:
- Switches the base images used to build the AWS VPC CNI images (CNI, init, metrics helper) to AL2023 (`latest-al23`).
- Switches the Go builder image to the AL23 variant (`gcc-al23`).
- Updates `test/agent` image build files to use AL23 as well, to keep CI/local test images aligned with the main image base OS.

This is needed to migrate off AL2 base images and align with AL23.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

I ran these commands listed below to verify the successful build as we are using AL23 for go lang image and base image.
- `make docker`
- `make docker-init`
- `make docker-metrics`

>Note:
>- Docker build may warn about missing default values for `ARG` used in `FROM` (args are provided via Makefile); builds succeed.

Unit tests:
- `make unit-test`



**Build command verification (dry-run)**

<details>
<summary><code>make -n docker</code> output</summary>

```text
if [ ""n"" = "y" ] ; then \
    ./scripts/ec2_model_override/setup.sh ; \
fi
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al23" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23" --network=host  \
        -f scripts/dockerfiles/Dockerfile.release \
        -t "amazon/amazon-k8s-cni:master-c5dc8821" \
        .
echo "Built Docker image \"amazon/amazon-k8s-cni:master-c5dc8821\""
```

</details>

<details>
<summary><code>make -n docker-init</code> output</summary>

```text
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al23" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23" --network=host  \
        -f scripts/dockerfiles/Dockerfile.init \
        -t "amazon/amazon-k8s-cni-init:master-c5dc8821" \
        .
echo "Built Docker image \"amazon/amazon-k8s-cni-init:master-c5dc8821\""
```

</details>

<details>
<summary><code>make -n docker-metrics</code> output</summary>

```text
docker build --build-arg golang_image="public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al23" --build-arg base_image="public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23" --network=host  \
        -f scripts/dockerfiles/Dockerfile.metrics \
        -t "amazon/cni-metrics-helper:master-c5dc8821" \
        .
echo "Built Docker image \"amazon/cni-metrics-helper:master-c5dc8821\""
```

</details>


Confirmed these pass AL23 build args (`golang_image=...gcc-al23`, `base_image=...latest-al23`).

Builder: `public.ecr.aws/eks-distro-build-tooling/golang:1.25-gcc-al23`
CNI base: `eks-distro-minimal-base-iptables:latest-al23`
Init base: `eks-distro-minimal-base-glibc:latest-al23`
Metrics base: `eks-distro-minimal-base-glibc:latest-al23`

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Not tested on a running cluster in this PR (local build + unit tests only).
No functional code changes; change is limited to container base images used during image builds.


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No. Image names/tags and manifest/helm configuration remain unchanged; only the image base layers change.


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No user-facing config changes. The container OS base for the published images changes to AL23.

```release-note
Improvement: Switch CNI, init, and metrics helper image base layers to Amazon Linux 2023 (AL2023/AL23).
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
