### PR TITLE
Getting ENI settings from primary ENI and reusing it for secondary ENIs

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -266,6 +266,7 @@ type EC2InstanceMetadataCache struct {
 	additionalENITags        map[string]string
 	imds                     TypedIMDS
 	ec2SVC                   ec2wrapper.EC2
+	connectionTrackingSpec   *ec2types.ConnectionTrackingSpecificationRequest
 }
 
 // ENIMetadata contains information about an ENI
@@ -1152,6 +1153,11 @@ func (cache *EC2InstanceMetadataCache) createENIInput(eniDescription string, tag
 		SubnetId:          aws.String(cache.subnetID),
 		TagSpecifications: tags,
 	}
+
+	if cache.connectionTrackingSpec != nil {
+		input.ConnectionTrackingSpecification = cache.connectionTrackingSpec
+	}
+
 	// Even though IPv6 PD is enabled, we require a Primary IP for the ENI.
 	// This always creates an ENI which has 1 Primary IPv6 address
 	// We use assignIPv6Prefix to assign a prefix during setupENI
@@ -1167,6 +1173,32 @@ func (cache *EC2InstanceMetadataCache) createENIInput(eniDescription string, tag
 	}
 
 	return input
+}
+
+// setConnectionTrackingSettings applies connection tracking settings only if the primary ENI has it configured.
+// Only non-nil values from the primary ENI configuration are stored.
+func (cache *EC2InstanceMetadataCache) setConnectionTrackingSettings(config *ec2types.ConnectionTrackingConfiguration) {
+	if config == nil || (config.TcpEstablishedTimeout == nil && config.UdpStreamTimeout == nil && config.UdpTimeout == nil) {
+		cache.connectionTrackingSpec = nil
+		return
+	}
+
+	settings := &ec2types.ConnectionTrackingSpecificationRequest{}
+	msg := "Connection tracking settings from primary ENI"
+	if config.TcpEstablishedTimeout != nil {
+		settings.TcpEstablishedTimeout = config.TcpEstablishedTimeout
+		msg += fmt.Sprintf(" tcpEstablishedTimeout=%d", *config.TcpEstablishedTimeout)
+	}
+	if config.UdpStreamTimeout != nil {
+		settings.UdpStreamTimeout = config.UdpStreamTimeout
+		msg += fmt.Sprintf(" udpStreamTimeout=%d", *config.UdpStreamTimeout)
+	}
+	if config.UdpTimeout != nil {
+		settings.UdpTimeout = config.UdpTimeout
+		msg += fmt.Sprintf(" udpTimeout=%d", *config.UdpTimeout)
+	}
+	cache.connectionTrackingSpec = settings
+	log.Debug(msg)
 }
 
 // return ENI id, error
@@ -1803,8 +1835,13 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		// Validate that Attachment is populated by EC2 response before logging
 		if attachment != nil {
 			log.Infof("Got network card index %v for ENI %v", aws.ToInt32(attachment.NetworkCardIndex), eniID)
-			if aws.ToInt32(attachment.DeviceIndex) == 0 && aws.ToInt32(attachment.NetworkCardIndex) == 0 && !aws.ToBool(attachment.DeleteOnTermination) {
-				log.Warn("Primary ENI will not get deleted when node terminates because 'delete_on_termination' is set to false")
+			if aws.ToInt32(attachment.DeviceIndex) == 0 && aws.ToInt32(attachment.NetworkCardIndex) == 0 {
+				// Check if DeleteOnTermination is set for Primary ENI
+				if !aws.ToBool(attachment.DeleteOnTermination) {
+					log.Warn("Primary ENI will not get deleted when node terminates because 'delete_on_termination' is set to false")
+				}
+				// Set Connection Tracking settings from Primary ENI
+				cache.setConnectionTrackingSettings(ec2res.ConnectionTrackingConfiguration)
 			}
 			enisByNetworkCard[int(aws.ToInt32(attachment.NetworkCardIndex))] = append(enisByNetworkCard[int(aws.ToInt32(attachment.NetworkCardIndex))], eniID)
 			// Network Card where EFA-only ENI is attached

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -4038,3 +4038,211 @@ func TestIsUnmanagedENI(t *testing.T) {
 	assert.False(t, cache.IsUnmanagedENI("eni-managed"))
 	assert.False(t, cache.IsUnmanagedENI(""))
 }
+
+func TestSetConnectionTrackingSettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *ec2types.ConnectionTrackingConfiguration
+		expectSettings bool
+		expectedTCP    int32
+		expectedUDPS   int32
+		expectedUDP    int32
+	}{
+		{
+			name:           "nil config leaves settings nil",
+			config:         nil,
+			expectSettings: false,
+		},
+		{
+			name:           "all fields nil in config leaves settings nil",
+			config:         &ec2types.ConnectionTrackingConfiguration{},
+			expectSettings: false,
+		},
+		{
+			name: "all fields set uses actual values",
+			config: &ec2types.ConnectionTrackingConfiguration{
+				TcpEstablishedTimeout: aws.Int32(350),
+				UdpStreamTimeout:      aws.Int32(120),
+				UdpTimeout:            aws.Int32(45),
+			},
+			expectSettings: true,
+			expectedTCP:    350,
+			expectedUDPS:   120,
+			expectedUDP:    45,
+		},
+		{
+			name: "partial config leaves missing fields nil",
+			config: &ec2types.ConnectionTrackingConfiguration{
+				TcpEstablishedTimeout: aws.Int32(350),
+			},
+			expectSettings: true,
+			expectedTCP:    350,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &EC2InstanceMetadataCache{}
+			cache.setConnectionTrackingSettings(tt.config)
+			if !tt.expectSettings {
+				assert.Nil(t, cache.connectionTrackingSpec)
+				return
+			}
+			assert.NotNil(t, cache.connectionTrackingSpec)
+			if tt.config.TcpEstablishedTimeout != nil {
+				assert.Equal(t, tt.expectedTCP, *cache.connectionTrackingSpec.TcpEstablishedTimeout)
+			} else {
+				assert.Nil(t, cache.connectionTrackingSpec.TcpEstablishedTimeout)
+			}
+			if tt.config.UdpStreamTimeout != nil {
+				assert.Equal(t, tt.expectedUDPS, *cache.connectionTrackingSpec.UdpStreamTimeout)
+			} else {
+				assert.Nil(t, cache.connectionTrackingSpec.UdpStreamTimeout)
+			}
+			if tt.config.UdpTimeout != nil {
+				assert.Equal(t, tt.expectedUDP, *cache.connectionTrackingSpec.UdpTimeout)
+			} else {
+				assert.Nil(t, cache.connectionTrackingSpec.UdpTimeout)
+			}
+		})
+	}
+}
+
+func TestCreateENIInputConnectionTrackingSpecification(t *testing.T) {
+	tests := []struct {
+		name      string
+		settings  *ec2types.ConnectionTrackingSpecificationRequest
+		expectNil bool
+	}{
+		{
+			name:      "nil settings omits connection tracking from ENI input",
+			settings:  nil,
+			expectNil: true,
+		},
+		{
+			name: "non-nil settings includes connection tracking in ENI input",
+			settings: &ec2types.ConnectionTrackingSpecificationRequest{
+				TcpEstablishedTimeout: aws.Int32(350),
+				UdpStreamTimeout:      aws.Int32(120),
+				UdpTimeout:            aws.Int32(45),
+			},
+			expectNil: false,
+		},
+		{
+			name: "partial settings only includes non-nil fields in ENI input",
+			settings: &ec2types.ConnectionTrackingSpecificationRequest{
+				TcpEstablishedTimeout: aws.Int32(350),
+			},
+			expectNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &EC2InstanceMetadataCache{
+				securityGroups:         StringSet{},
+				subnetID:               subnetID,
+				connectionTrackingSpec: tt.settings,
+			}
+			input := cache.createENIInput("test", nil, 1)
+			if tt.expectNil {
+				assert.Nil(t, input.ConnectionTrackingSpecification)
+			} else {
+				assert.NotNil(t, input.ConnectionTrackingSpecification)
+				assert.Equal(t, tt.settings.TcpEstablishedTimeout, input.ConnectionTrackingSpecification.TcpEstablishedTimeout)
+				assert.Equal(t, tt.settings.UdpStreamTimeout, input.ConnectionTrackingSpecification.UdpStreamTimeout)
+				assert.Equal(t, tt.settings.UdpTimeout, input.ConnectionTrackingSpecification.UdpTimeout)
+			}
+		})
+	}
+
+	// IPv6 mode also applies connection tracking settings
+	t.Run("IPv6 mode applies connection tracking settings", func(t *testing.T) {
+		settings := &ec2types.ConnectionTrackingSpecificationRequest{
+			TcpEstablishedTimeout: aws.Int32(350),
+			UdpStreamTimeout:      aws.Int32(120),
+			UdpTimeout:            aws.Int32(45),
+		}
+		cache := &EC2InstanceMetadataCache{
+			securityGroups:         StringSet{},
+			subnetID:               subnetID,
+			v6Enabled:              true,
+			connectionTrackingSpec: settings,
+		}
+		input := cache.createENIInput("test", nil, 1)
+		assert.NotNil(t, input.Ipv6AddressCount)
+		assert.NotNil(t, input.ConnectionTrackingSpecification)
+		assert.Equal(t, settings.TcpEstablishedTimeout, input.ConnectionTrackingSpecification.TcpEstablishedTimeout)
+		assert.Equal(t, settings.UdpStreamTimeout, input.ConnectionTrackingSpecification.UdpStreamTimeout)
+		assert.Equal(t, settings.UdpTimeout, input.ConnectionTrackingSpecification.UdpTimeout)
+	})
+
+	t.Run("IPv6 mode without connection tracking settings", func(t *testing.T) {
+		cache := &EC2InstanceMetadataCache{
+			securityGroups: StringSet{},
+			subnetID:       subnetID,
+			v6Enabled:      true,
+		}
+		input := cache.createENIInput("test", nil, 1)
+		assert.NotNil(t, input.Ipv6AddressCount)
+		assert.Nil(t, input.ConnectionTrackingSpecification)
+	})
+}
+
+func TestDescribeAllENIsConnectionTracking(t *testing.T) {
+	ctrl, mockEC2 := setup(t)
+	defer ctrl.Finish()
+
+	mockMetadata := testMetadata(nil)
+
+	result := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []ec2types.NetworkInterface{{
+			NetworkInterfaceId: aws.String(primaryeniID),
+			Attachment: &ec2types.NetworkInterfaceAttachment{
+				DeviceIndex:      aws.Int32(0),
+				NetworkCardIndex: aws.Int32(0),
+			},
+			ConnectionTrackingConfiguration: &ec2types.ConnectionTrackingConfiguration{
+				TcpEstablishedTimeout: aws.Int32(350),
+				UdpStreamTimeout:      aws.Int32(120),
+				UdpTimeout:            aws.Int32(45),
+			},
+		}},
+	}
+
+	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
+	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2, instanceType: "test"}
+	vpc.SetInstance("test", 4, 10, 0, []vpc.NetworkCard{{MaximumNetworkInterfaces: 4, NetworkCardIndex: 0}}, "nitro", false)
+
+	_, err := cache.DescribeAllENIs(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, cache.connectionTrackingSpec)
+	assert.Equal(t, int32(350), *cache.connectionTrackingSpec.TcpEstablishedTimeout)
+	assert.Equal(t, int32(120), *cache.connectionTrackingSpec.UdpStreamTimeout)
+	assert.Equal(t, int32(45), *cache.connectionTrackingSpec.UdpTimeout)
+}
+
+func TestDescribeAllENIsNoConnectionTracking(t *testing.T) {
+	ctrl, mockEC2 := setup(t)
+	defer ctrl.Finish()
+
+	mockMetadata := testMetadata(nil)
+
+	result := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []ec2types.NetworkInterface{{
+			NetworkInterfaceId: aws.String(primaryeniID),
+			Attachment: &ec2types.NetworkInterfaceAttachment{
+				DeviceIndex:      aws.Int32(0),
+				NetworkCardIndex: aws.Int32(0),
+			},
+		}},
+	}
+
+	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(result, nil)
+	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2, instanceType: "test"}
+	vpc.SetInstance("test", 4, 10, 0, []vpc.NetworkCard{{MaximumNetworkInterfaces: 4, NetworkCardIndex: 0}}, "nitro", false)
+
+	_, err := cache.DescribeAllENIs(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, cache.connectionTrackingSpec)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: 
https://github.com/aws/amazon-vpc-cni-k8s/issues/2677
CNI discovery primary ENI settings during startup and uses these same settings during secondary ENI creation. This helps replicate the eni settings across the node. eg: connection timeout settings on ENI 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html

<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
Replicate the EC2 ENI settings across secondary ENIs

**Testing done on this change**: Yes, tested with multiple cases. 
1. Primary ENI is created without any settings - Secondary ENI creation also doesn't pass any of the values
2. Primary ENI is created with atleast one setting - Secondary ENI creation passes these values during ENI creation. 
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: No. Existing calls only no new API calls
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**: No 
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
CNI now discovers ENI settings from primary ENI and uses it while creating secondary ENIs
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
