### PR TITLE
fix: prevent nil pointer panic in PodLogs when Stream fails

### DIFF
--- a/test/framework/resources/k8s/resources/pod.go
+++ b/test/framework/resources/k8s/resources/pod.go
@@ -169,6 +169,9 @@ func (d *defaultPodManager) PodLogs(namespace string, name string) (string, erro
 	req := d.k8sClientset.CoreV1().Pods(namespace).GetLogs(name, &podLogOpts)
 
 	podLogs, err := req.Stream(context.Background())
+	if err != nil {
+		return "", err
+	}
 	defer podLogs.Close()
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**Which issue does this PR fix?**:
Fixes a nil pointer panic in the test framework's `PodLogs` function.

**What does this PR do / Why do we need it?**:
`PodLogs` called `defer podLogs.Close()` before checking if `Stream()` returned an error. When the pod is completed or deleted, `Stream()` returns nil and the deferred `Close()` panics with a nil pointer dereference. This was observed in custom networking integration tests (PR #3668) when `logJobPodDiag` called `PodLogs` on completed Job pods.

The fix moves `defer podLogs.Close()` after the error check so it only runs when the stream is non-nil.

**Testing done on this change**:
Ran full custom networking integration test suite — all 6 tests pass (previously the API ClusterIP test panicked).

**Will this PR introduce any new dependencies?**: No
**Will this break upgrades or downgrades?**: No
**Does this change require updates to the CNI daemonset config files to work?**: No
**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.