### PR TITLE
fix: use awshttp.BuildableClient to prevent panic in air-gapped regions

### DIFF
--- a/pkg/awsutils/awssession/session.go
+++ b/pkg/awsutils/awssession/session.go
@@ -16,7 +16,6 @@ package awssession
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -39,8 +38,10 @@ const (
 )
 
 // NewAWSSDKHTTPClient returns a new HTTP client with the configured AWS SDK timeout.
-func NewAWSSDKHTTPClient() *http.Client {
-	return &http.Client{Timeout: getHTTPTimeout()}
+// It returns *awshttp.BuildableClient (instead of *http.Client) so the SDK can
+// inject custom CA bundles via WithTransportOptions in air-gapped regions.
+func NewAWSSDKHTTPClient() *awshttp.BuildableClient {
+	return awshttp.NewBuildableClient().WithTimeout(getHTTPTimeout())
 }
 
 var (
@@ -62,7 +63,7 @@ func getHTTPTimeout() time.Duration {
 
 // New will return aws.Config to be used by Service Clients.
 func New(ctx context.Context) (aws.Config, error) {
-	httpClient := awshttp.NewBuildableClient().WithTimeout(getHTTPTimeout())
+	httpClient := NewAWSSDKHTTPClient()
 	optFns := []func(*config.LoadOptions) error{
 		config.WithHTTPClient(httpClient),
 		config.WithRetryMaxAttempts(maxRetries),

--- a/pkg/awsutils/awssession/session_test.go
+++ b/pkg/awsutils/awssession/session_test.go
@@ -50,11 +50,11 @@ func TestNew_SetsHTTPClientTimeout(t *testing.T) {
 func TestNewAWSSDKHTTPClient_SetsTimeout(t *testing.T) {
 	client := NewAWSSDKHTTPClient()
 	assert.NotNil(t, client)
-	assert.Equal(t, DefaultAWSSDKClientTimeout, client.Timeout)
+	assert.Equal(t, DefaultAWSSDKClientTimeout, client.GetTimeout())
 }
 
 func TestNewAWSSDKHTTPClient_RespectsEnv(t *testing.T) {
 	t.Setenv(httpTimeoutEnv, "20")
 	client := NewAWSSDKHTTPClient()
-	assert.Equal(t, 20*time.Second, client.Timeout)
+	assert.Equal(t, 20*time.Second, client.GetTimeout())
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**Which issue does this PR fix?**:
Fixes panic in air-gapped regions introduced by #3649

**What does this PR do / Why do we need it?**:
In air-gapped regions, the AWS SDK's `resolveCustomCABundle()` needs to inject custom CA certificates into the HTTP client's TLS transport via `WithTransportOptions()`. PR #3649 introduced `NewAWSSDKHTTPClient()` which returns a plain `*http.Client`, but the SDK expects `*awshttp.BuildableClient` for CA bundle injection. This causes a panic:

```
panic: unable to add custom RootCAs HTTPClient, has no WithTransportOptions, *http.Client
```

Note: The `New()` function in session.go already correctly uses `awshttp.NewBuildableClient()`, but `NewAWSSDKHTTPClient()` (used by `awsutils.go`, `ec2metadatawrapper.go`, `ec2wrapper.go`, and `imds.go`) still returned `*http.Client`.

This PR changes `NewAWSSDKHTTPClient()` to return `*awshttp.BuildableClient` via `awshttp.NewBuildableClient().WithTimeout(...)`, preserving the type the SDK requires while still setting the timeout.

**Testing done on this change**:
- All session tests pass (`go test ./pkg/awsutils/awssession/... -v`)
- All affected packages compile (`go build ./pkg/awsutils/... ./pkg/ec2metadatawrapper/... ./pkg/ec2wrapper/... ./utils/imds/...`)

**Will this PR introduce any new dependencies?**: No
**Will this break upgrades or downgrades?**: No
**Does this change require updates to the CNI daemonset config files to work?**: No
**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.