### PR TITLE
use extraEnv to redefine env variables

### DIFF
--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -1,3 +1,5 @@
+{{- $definedExtraEnvVars := list }}
+{{- range $env := .Values.extraEnv }}{{- $definedExtraEnvVars = append $definedExtraEnvVars $env.name}}{{- end}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -85,12 +87,20 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbeTimeoutSeconds }}
           env:
 {{- range $key, $value := .Values.env }}
-  {{- $skipKey := and (eq $key "NETWORK_POLICY_ENFORCING_MODE") (not $.Values.nodeAgent.enabled) }}
+  {{- $skipKey := false }}
+  {{- $skipReason := "" }}
+  {{- if and (eq $key "NETWORK_POLICY_ENFORCING_MODE") (not $.Values.nodeAgent.enabled)}}
+    {{- $skipKey = true }}
+    {{- $skipReason = "nodeAgent is disabled" }}
+  {{- else if (has $key $definedExtraEnvVars) }}
+    {{- $skipKey = true }}
+    {{- $skipReason = "environment variable redefined in extraEnv" }}
+  {{- end }}
   {{- if not $skipKey }}
             - name: {{ $key }}
               value: {{ $value | quote }}
   {{- else }}
-            # Skipping NETWORK_POLICY_ENFORCING_MODE because nodeAgent is disabled
+            # Skipping {{ $key }} because {{ $skipReason }}
   {{- end }}
 {{- end }}
 {{- with .Values.extraEnv }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
- bug: an invalid DaemonSet spec is rendered if a variable exists in both the `.Values.env` and `.Values.extraEnv` values.
- the fix for this bug enables a workaround for #3630 

**What does this PR do / Why do we need it?**:
This alters the DaemonSet template in the aws-vpc-cni helm chart to skip variables in `.Values.env` if there exists an entry in `.Values.extraEnv` with the same name. This allows default environment variables to be replaced without having to explicitly configure `.Values.env` to omit the variable you want to override, and prevents templating errors caused by defining the same environment variable multiple times.

In a real-world scenario: by combining this behavior with a mutating webhook controller like Kyverno, it is possible to add labels on the node that get forklifted by the webhook onto the aws-node pod, and then consumed via downward API by aws-vpc-cni.

**Testing done on this change**:
This is something I'm actually using on-the job and contributing upwards so others can benefit.


**Will this PR introduce any new dependencies?**:
No. This is a relatively simple logic change to the helm template.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
It would break downgrades of the helm chart, but not of aws-vpc-cni itself.

**Does this change require updates to the CNI daemonset config files to work?**:
Only in the sense that you inherently have to re-render the template to get any benefit. 

**Does this PR introduce any user-facing change?**:
yes (configuration behavior)

```release-note
The daemonset template in the helm chart has been updated so that environment variables in the
Values.extraEnv list will replace variables of the same name in Values.env. This allows redefining the
default environment variables to populate via a secret, configmap, or via downward API instead of
static values.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
