### PR TITLE
feat: dual-stack same-ENI for IPAMD pods (IPv6 + IPv4)

### DIFF
--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -84,6 +84,7 @@ const (
 	defaultIPCooldownPeriod      = 30
 	defaultDisablePodV6          = false
 	defaultEnableMultiNICSupport = false
+	defaultEnableIPv4           = true
 
 	envHostCniBinPath        = "HOST_CNI_BIN_PATH"
 	envHostCniConfDirPath    = "HOST_CNI_CONFDIR_PATH"
@@ -101,6 +102,7 @@ const (
 	envMinIPTarget           = "MINIMUM_IP_TARGET"
 	envWarmPrefixTarget      = "WARM_PREFIX_TARGET"
 	envEnBandwidthPlugin     = "ENABLE_BANDWIDTH_PLUGIN"
+	envEnIPv4                = "ENABLE_IPv4"
 	envEnIPv6                = "ENABLE_IPv6"
 	envEnIPv6Egress          = "ENABLE_V6_EGRESS"
 	envEnIPv4Egress          = "ENABLE_V4_EGRESS"
@@ -218,9 +220,7 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		return err
 	}
 
-	// enabledIPv6 is to determine if EKS cluster is IPv4 or IPv6 cluster
-	// if this EKS cluster is IPv6 cluster, egress-cni-plugin will enable IPv4 egress by default
-	// if this EKS cluster is IPv4 cluster, egress-cni-plugin will only enable IPv6 egress if env var "ENABLE_V6_EGRESS" is "true"
+	enabledIPv4 := utils.GetBoolAsStringEnvVar(envEnIPv4, defaultEnableIPv4)
 	enabledIPv6 := utils.GetBoolAsStringEnvVar(envEnIPv6, defaultEnableIPv6)
 	var egressIPAMSubnet string
 	var egressIPAMDst string
@@ -228,22 +228,28 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 	var egressEnabled bool
 	var egressPluginLogFile string
 	var nodeIP = ""
-	if enabledIPv6 {
-		// EKS IPv6 cluster
+	if enabledIPv4 && enabledIPv6 {
+		// Dual-stack: egress plugin not needed, both families on eth0
+		egressEnabled = false
 		egressIPAMSubnet = egressPluginIpamSubnetV4
 		egressIPAMDst = egressPluginIpamDstV4
 		egressIPAMDataDir = egressPluginIpamDataDirV4
-		// Enable IPv4 egress when "ENABLE_V4_EGRESS" is "true" (default)
+		egressPluginLogFile = utils.GetEnv(envEgressV4PluginLogFile, defaultEgressV4PluginLogFile)
+		log.Infof("Dual-stack mode: egress plugin disabled (both IPv4 and IPv6 on eth0)")
+	} else if enabledIPv6 {
+		// IPv6-only cluster: IPv4 egress via v4if0
+		egressIPAMSubnet = egressPluginIpamSubnetV4
+		egressIPAMDst = egressPluginIpamDstV4
+		egressIPAMDataDir = egressPluginIpamDataDirV4
 		egressEnabled = utils.GetBoolAsStringEnvVar(envEnIPv4Egress, defaultEnableIPv4Egress)
 		egressPluginLogFile = utils.GetEnv(envEgressV4PluginLogFile, defaultEgressV4PluginLogFile)
 		nodeIP, err = getPrimaryIP(true)
-		// Node should have a IPv4 address even in IPv6 cluster
 		if err != nil {
 			log.Errorf("Failed to get Node IP, error: %v", err)
 			return err
 		}
 	} else {
-		// EKS IPv4 cluster
+		// IPv4-only cluster: IPv6 egress via v6if0 (only if ENABLE_V6_EGRESS=true)
 		egressIPAMSubnet = egressPluginIpamSubnetV6
 		egressIPAMDst = egressPluginIpamDstV6
 		egressIPAMDataDir = egressPluginIpamDataDirV6
@@ -252,8 +258,6 @@ func generateJSON(jsonFile string, outFile string, getPrimaryIP func(ipv4 bool) 
 		if egressEnabled {
 			nodeIP, err = getPrimaryIP(false)
 			if err != nil {
-				// When ENABLE_V6_EGRESS is set, but the node is lacking an IPv6 address, log a warning and disable the egress-v6-cni plugin.
-				// This allows IPv4-only nodes to function while still alerting the customer to the possibility of a misconfiguration.
 				log.Warnf("To support IPv6 egress, node primary ENI must have a global IPv6 address, error: %v", err)
 				egressEnabled = false
 			}

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -239,8 +239,12 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 		containerVethName := networkutils.GenerateContainerVethName(args.IfName, containerVethNamePrefix, index)
 
+		// For dual-stack IPAMD pods, extract secondary IPv6 address
+		secondaryIPv6 := getSecondaryIPv6AddressFromIpAllocationMetadata(ipAllocMetadata)
+
 		vethMetadata = append(vethMetadata, driver.VirtualInterfaceMetadata{
 			IPAddress:         ipAddr,
+			IPv6Address:       secondaryIPv6, // nil for single-stack, populated for dual-stack
 			DeviceNumber:      getDeviceNumberFromIpAllocationMetadata(ipAllocMetadata),
 			RouteTable:        getRouteTableIdFromIpAllocationMetadata(ipAllocMetadata),
 			HostVethName:      hostVethName,
@@ -261,6 +265,15 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 			Address:   *ipAddr,
 			Gateway:   gw,
 		})
+
+		// Add secondary IPv6 to CNI result for dual-stack IPAMD pods
+		if secondaryIPv6 != nil {
+			podIPs = append(podIPs, &current.IPConfig{
+				Interface: &containerInterfaceIndex,
+				Address:   *secondaryIPv6,
+				Gateway:   networkutils.CalculatePodIPv6GatewayIP(0), // fe80::1 (IPAMD convention)
+			})
+		}
 	}
 
 	// The dummy interface is purely virtual and is stored in the prevResult struct to assist in cleanup during the DEL command.
@@ -466,8 +479,10 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 		addr := getIPAddressFromIpAllocationMetadata(ipAllocationMetadata)
 
 		if addr != nil {
+			secondaryIPv6 := getSecondaryIPv6AddressFromIpAllocationMetadata(ipAllocationMetadata)
 			vethMetadata = append(vethMetadata, driver.VirtualInterfaceMetadata{
 				IPAddress:    addr,
+				IPv6Address:  secondaryIPv6,
 				DeviceNumber: getDeviceNumberFromIpAllocationMetadata(ipAllocationMetadata),
 				RouteTable:   getRouteTableIdFromIpAllocationMetadata(ipAllocationMetadata),
 			})
@@ -695,6 +710,19 @@ func getIPAddressFromIpAllocationMetadata(v *pb.IPAllocationMetadata) *net.IPNet
 		}
 	}
 
+	return nil
+}
+
+// getSecondaryIPv6AddressFromIpAllocationMetadata returns the IPv6 address as a secondary address
+// when both IPv4 and IPv6 are present in the allocation metadata (dual-stack IPAMD case)
+func getSecondaryIPv6AddressFromIpAllocationMetadata(v *pb.IPAllocationMetadata) *net.IPNet {
+	// Only return IPv6 as secondary if BOTH IPv4 and IPv6 are present
+	if v != nil && v.IPv4Addr != "" && v.IPv6Addr != "" {
+		return &net.IPNet{
+			IP:   net.ParseIP(v.IPv6Addr),
+			Mask: net.CIDRMask(128, 128),
+		}
+	}
 	return nil
 }
 

--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -49,6 +49,7 @@ const (
 
 type VirtualInterfaceMetadata struct {
 	IPAddress         *net.IPNet
+	IPv6Address       *net.IPNet // IPv6 address for dual-stack configurations (nil when single-stack)
 	DeviceNumber      int
 	RouteTable        int
 	HostVethName      string
@@ -270,8 +271,8 @@ func (createVethContext *createVethPairContext) run(hostNS ns.NetNS) error {
 func (n *linuxNetwork) SetupPodNetwork(vethMetadata []VirtualInterfaceMetadata, netnsPath string, mtu int, log logger.Logger) error {
 	for index, vethData := range vethMetadata {
 
-		log.Debugf("SetupPodNetwork: hostVethName=%s, contVethName=%s, netnsPath=%s, ipAddr=%v, routeTableNumber=%d, mtu=%d",
-			vethData.HostVethName, vethData.ContainerVethName, netnsPath, vethData.IPAddress, vethData.RouteTable, mtu)
+		log.Debugf("SetupPodNetwork: hostVethName=%s, contVethName=%s, netnsPath=%s, ipAddr=%v, ipv6Addr=%v, routeTableNumber=%d, mtu=%d",
+			vethData.HostVethName, vethData.ContainerVethName, netnsPath, vethData.IPAddress, vethData.IPv6Address, vethData.RouteTable, mtu)
 
 		hostVeth, err := n.setupVeth(vethData.HostVethName, vethData.ContainerVethName, netnsPath, vethData.IPAddress, mtu, log, index)
 		if err != nil {
@@ -286,6 +287,27 @@ func (n *linuxNetwork) SetupPodNetwork(vethMetadata []VirtualInterfaceMetadata, 
 		if err := n.setupIPBasedContainerRouteRules(hostVeth, vethData.IPAddress, rtTable, log); err != nil {
 			return errors.Wrapf(err, "SetupPodNetwork: unable to setup IP based container routes and rules")
 		}
+
+		// Dual-stack: add secondary IPv6 address to container and set up host-side routes/rules
+		if vethData.IPv6Address != nil {
+			// Enable IPv6 forwarding on host veth
+			if err := n.procSys.Set(fmt.Sprintf("net/ipv6/conf/%s/forwarding", vethData.HostVethName), "1"); err != nil {
+				if !os.IsNotExist(err) {
+					return errors.Wrapf(err, "SetupPodNetwork: failed to enable IPv6 forwarding on hostVeth %s", vethData.HostVethName)
+				}
+			}
+
+			// Add IPv6 address + gateway + default route inside container
+			if err := n.addSecondaryIPToContainer(netnsPath, vethData.ContainerVethName,
+				vethData.IPv6Address, hostVeth.Attrs().HardwareAddr, log); err != nil {
+				return errors.Wrapf(err, "SetupPodNetwork: failed to add secondary IPv6 address")
+			}
+
+			// Host-side IPv6 route/rule — same route table as IPv4
+			if err := n.setupIPBasedContainerRouteRules(hostVeth, vethData.IPv6Address, rtTable, log); err != nil {
+				return errors.Wrapf(err, "SetupPodNetwork: unable to setup IP based container routes and rules for IPv6")
+			}
+		}
 	}
 	return nil
 }
@@ -295,7 +317,7 @@ func (n *linuxNetwork) TeardownPodNetwork(vethMetadata []VirtualInterfaceMetadat
 
 	for _, vethData := range vethMetadata {
 
-		log.Debugf("TeardownPodNetwork: containerAddr=%s, routeTable=%d", vethData.IPAddress.String(), vethData.RouteTable)
+		log.Debugf("TeardownPodNetwork: containerAddr=%s, containerIPv6Addr=%v, routeTable=%d", vethData.IPAddress.String(), vethData.IPv6Address, vethData.RouteTable)
 
 		// Route table ID for primary ENI was previously calculated as (Network 0, Device 0) => (0* MaxENI + 0 + 1)
 		// which is why we only take action if the route table is not 1
@@ -306,6 +328,13 @@ func (n *linuxNetwork) TeardownPodNetwork(vethMetadata []VirtualInterfaceMetadat
 
 		if err := n.teardownIPBasedContainerRouteRules(vethData.IPAddress, rtTable, log); err != nil {
 			return errors.Wrapf(err, "TeardownPodNetwork: unable to teardown IP based container routes and rules")
+		}
+
+		// Dual-stack: also clean up IPv6 rules
+		if vethData.IPv6Address != nil {
+			if err := n.teardownIPBasedContainerRouteRules(vethData.IPv6Address, rtTable, log); err != nil {
+				return errors.Wrapf(err, "TeardownPodNetwork: unable to teardown IP based container routes and rules for IPv6")
+			}
 		}
 	}
 
@@ -650,6 +679,87 @@ func (n *linuxNetwork) teardownIIFBasedContainerRouteRules(rtTable int, family i
 	log.Debugf("Successfully deleted IIF based rules, rtTable=%v", rtTable)
 
 	return nil
+}
+
+// addSecondaryIPToContainer adds a secondary IP address to an existing container veth interface.
+// Used for dual-stack IPAMD pods to add IPv6 after the primary IPv4 veth is set up by setupVeth.
+// Invariant: in dual-stack, setupVeth always creates the veth with IPv4 as primary, so when this
+// function is called with an IPv6 addr, the veth already has IPv4 + its gateway/neighbor entries.
+func (n *linuxNetwork) addSecondaryIPToContainer(netnsPath, containerIfName string,
+	addr *net.IPNet, hostMAC net.HardwareAddr, log logger.Logger) error {
+
+	return n.ns.WithNetNSPath(netnsPath, func(_ ns.NetNS) error {
+		contVeth, err := n.netLink.LinkByName(containerIfName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to find container veth %s", containerIfName)
+		}
+
+		// For IPv6: disable DAD (static assignment in isolated netns, no conflict possible)
+		if addr.IP.To4() == nil {
+			if err := n.procSys.Set(fmt.Sprintf("net/ipv6/conf/%s/accept_dad", containerIfName), "0"); err != nil {
+				if !os.IsNotExist(err) {
+					return errors.Wrapf(err, "failed to disable DAD on container veth %s", containerIfName)
+				}
+			}
+		}
+
+		// Add address to container veth
+		if err := n.netLink.AddrAdd(contVeth, &netlink.Addr{IPNet: addr}); err != nil {
+			return errors.Wrapf(err, "failed to add secondary IP %s to container veth %s", addr.String(), containerIfName)
+		}
+		log.Debugf("Added secondary IP %s to container veth %s", addr.String(), containerIfName)
+
+		if addr.IP.To4() != nil {
+			// IPv4 secondary: gateway 169.254.1.1 onlink
+			gw := net.ParseIP("169.254.1.1")
+
+			// Static ARP entry for gateway -> host veth MAC
+			if err := n.netLink.NeighAdd(&netlink.Neigh{
+				LinkIndex:    contVeth.Attrs().Index,
+				State:        netlink.NUD_PERMANENT,
+				IP:           gw,
+				HardwareAddr: hostMAC,
+			}); err != nil {
+				return errors.Wrapf(err, "failed to add ARP entry for gateway %s", gw.String())
+			}
+
+			// Default IPv4 route via gateway, onlink
+			if err := n.netLink.RouteAdd(&netlink.Route{
+				LinkIndex: contVeth.Attrs().Index,
+				Dst:       &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+				Gw:        gw,
+				Flags:     int(netlink.FLAG_ONLINK),
+			}); err != nil {
+				return errors.Wrapf(err, "failed to add default IPv4 route via %s", gw.String())
+			}
+		} else {
+			// IPv6 secondary: gateway fe80::1 (IPAMD pod convention from setupVeth)
+			gw := networkutils.CalculatePodIPv6GatewayIP(0) // fe80::1
+
+			// Static NDP entry for gateway -> host veth MAC
+			if err := n.netLink.NeighAdd(&netlink.Neigh{
+				LinkIndex:    contVeth.Attrs().Index,
+				Family:       unix.AF_INET6,
+				State:        netlink.NUD_PERMANENT,
+				IP:           gw,
+				HardwareAddr: hostMAC,
+			}); err != nil {
+				return errors.Wrapf(err, "failed to add NDP entry for gateway %s", gw.String())
+			}
+
+			// Default IPv6 route via gateway
+			if err := n.netLink.RouteAdd(&netlink.Route{
+				LinkIndex: contVeth.Attrs().Index,
+				Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+				Gw:        gw,
+			}); err != nil {
+				return errors.Wrapf(err, "failed to add default IPv6 route via %s", gw.String())
+			}
+		}
+
+		log.Debugf("Successfully configured secondary IP %s with routes in container", addr.String())
+		return nil
+	})
 }
 
 // buildRoutesForVlan builds routes required for the vlan link.

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -777,6 +777,71 @@ func (ds *DataStore) AssignPodIPv6Address(ipamKey IPAMKey, ipamMetadata IPAMMeta
 	return "", -1, 0, ErrNoAvailableIPInDataStore
 }
 
+// AssignPodIPv6AddressFromENI allocates an IPv6 address from a specific ENI (identified by device number).
+// Used in dual-stack mode to ensure IPv6 is allocated from the same ENI as IPv4.
+func (ds *DataStore) AssignPodIPv6AddressFromENI(ipamKey IPAMKey, ipamMetadata IPAMMetadata, targetDeviceNumber int) (ipv6Address string, deviceNumber int, routeTableId int, err error) {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+
+	// Dedup check
+	if eni, _, addr := ds.eniPool.FindAddressForSandbox(ipamKey); addr != nil {
+		return addr.Address, eni.DeviceNumber, eni.RouteTableID, nil
+	}
+
+	// Find the target ENI and allocate from its IPv6 pool
+	for _, eni := range ds.eniPool {
+		if eni.DeviceNumber != targetDeviceNumber {
+			continue
+		}
+		for _, v6Cidr := range eni.IPv6Cidrs {
+			if !v6Cidr.IsPrefix {
+				continue
+			}
+			ipv6Addr, err := ds.getFreeIPv6AddrFromCidr(v6Cidr)
+			if err != nil {
+				ds.log.Debugf("Unable to get IPv6 address from prefix on ENI device %d: %v", targetDeviceNumber, err)
+				continue
+			}
+			addr := &AddressInfo{Address: ipv6Addr}
+			v6Cidr.IPAddresses[ipv6Addr] = addr
+
+			ds.assignPodIPAddressUnsafe(addr, ipamKey, ipamMetadata, time.Now())
+			if err := ds.writeBackingStoreUnsafe(); err != nil {
+				ds.log.Warnf("Failed to update backing store: %v", err)
+				ds.unassignPodIPAddressUnsafe(addr)
+				delete(v6Cidr.IPAddresses, addr.Address)
+				return "", 0, 0, err
+			}
+			prometheusmetrics.EniIPsInUse.WithLabelValues(eni.ID).Inc()
+			return addr.Address, eni.DeviceNumber, eni.RouteTableID, nil
+		}
+		return "", 0, 0, fmt.Errorf("no available IPv6 address on ENI device %d", targetDeviceNumber)
+	}
+	return "", 0, 0, fmt.Errorf("ENI device %d not found in datastore", targetDeviceNumber)
+}
+
+// AllocatedIPv6s returns a snapshot of all assigned IPv6 addresses (for restart reconciliation in dual-stack).
+func (ds *DataStore) AllocatedIPv6s() []PodIPInfo {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+
+	var ret []PodIPInfo
+	for _, eni := range ds.eniPool {
+		for _, v6Cidr := range eni.IPv6Cidrs {
+			for _, addr := range v6Cidr.IPAddresses {
+				if addr.Assigned() {
+					ret = append(ret, PodIPInfo{
+						IPAMKey:      addr.IPAMKey,
+						IP:           addr.Address,
+						DeviceNumber: eni.DeviceNumber,
+					})
+				}
+			}
+		}
+	}
+	return ret
+}
+
 // AssignPodIPv4Address assigns an IPv4 address to pod
 // It returns the assigned IPv4 address, device number, route table ID, and error
 func (ds *DataStore) AssignPodIPv4Address(ipamKey IPAMKey, ipamMetadata IPAMMetadata) (ipv4address string, deviceNumber int, routeTableId int, err error) {

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -249,6 +249,7 @@ type IPAMContext struct {
 	maxPods                   int // maximum number of pods that can be scheduled on the node
 	networkPolicyMode         string
 	enableMultiNICSupport     bool
+	enableDualStack           bool // derived: enableIPv4 && enableIPv6 && enablePrefixDelegation
 	withApiServer             bool
 }
 
@@ -423,6 +424,10 @@ func New(ctx context.Context, k8sClient client.Client, withApiServer bool) (*IPA
 	c.enableManageUntaggedMode = enableManageUntaggedMode()
 	c.enablePodIPAnnotation = EnablePodIPAnnotation()
 	c.enableMultiNICSupport = enableMultiNICSupport()
+	c.enableDualStack = c.enableIPv4 && c.enableIPv6 && c.enablePrefixDelegation
+	if c.enableDualStack {
+		log.Infof("Dual-stack mode: IPv6 + IPv4 prefixes on same ENI (primary first)")
+	}
 	c.networkPolicyMode, err = getNetworkPolicyMode()
 	if err != nil {
 		return nil, err
@@ -667,11 +672,13 @@ func (c *IPAMContext) nodeInit(ctx context.Context) error {
 	}
 
 	if !c.disableENIProvisioning {
-		if c.enableIPv6 {
+		if c.enableIPv6 && !c.enableDualStack {
+			// Pure IPv6-only: create secondary ENIs for multi-NIC support
 			// We do not return an error here as create ENI failure shouldn not cause the node to go in not ready state.
 			// However that does restrict multi-nic pods to get failed
 			c.createSecondaryIPv6ENIs(ctx)
 		} else {
+			// IPv4 or dual-stack: run warm pool pre-scaling for IPv4 prefixes
 			if err = c.handlePreScaling(ctx); err != nil {
 				return err
 			}
@@ -715,7 +722,8 @@ func (c *IPAMContext) configureIPRulesForPods() error {
 			// TODO(gus): This should really be done via CNI CHECK calls, rather than in ipam (requires upstream k8s changes).
 			var mask int
 			// Update ip rules in case there is a change in VPC CIDRs, AWS_VPC_K8S_CNI_EXTERNALSNAT setting
-			if c.enableIPv6 {
+			// Only use /128 mask for pure IPv6-only mode; dual-stack IPv4 loop always uses /32
+			if c.enableIPv6 && !c.enableIPv4 {
 				mask = 128
 			} else {
 				mask = 32
@@ -725,6 +733,17 @@ func (c *IPAMContext) configureIPRulesForPods() error {
 			err = c.networkClient.UpdateRuleListBySrc(rules, srcIPNet)
 			if err != nil {
 				log.Warnf("UpdateRuleListBySrc in nodeInit() failed for IP %s: %v", info.IP, err)
+			}
+		}
+
+		// Restore IPv6 host-side rules (dual-stack only)
+		if c.enableDualStack {
+			for _, ipv6Info := range ds.AllocatedIPv6s() {
+				srcIPNet := net.IPNet{IP: net.ParseIP(ipv6Info.IP), Mask: net.CIDRMask(128, 128)}
+				err = c.networkClient.UpdateRuleListBySrc(rules, srcIPNet)
+				if err != nil {
+					log.Warnf("UpdateRuleListBySrc in nodeInit() failed for IPv6 %s: %v", ipv6Info.IP, err)
+				}
 			}
 		}
 	}
@@ -746,7 +765,7 @@ func (c *IPAMContext) updateCIDRsRulesOnChange(oldVPCCIDRs []string) []string {
 	var err error
 	var primaryIP net.IP
 
-	if c.enableIPv6 {
+	if c.enableIPv6 && !c.enableIPv4 {
 		newVPCCIDRs, err = c.awsClient.GetVPCIPv6CIDRs()
 		primaryIP = c.awsClient.GetLocalIPv6()
 	} else {
@@ -778,8 +797,9 @@ func (c *IPAMContext) updateIPStats(unmanaged int) {
 
 // StartNodeIPPoolManager monitors the IP pool, add or del them when it is required.
 func (c *IPAMContext) StartNodeIPPoolManager(ctx context.Context) {
-	// For IPv6, if Security Groups for Pods is enabled, wait until trunk ENI is attached and add it to the datastore.
-	if c.enableIPv6 {
+	// For pure IPv6-only (no dual-stack), no warm pool needed (one /80 = 2^48 addresses).
+	// If Security Groups for Pods is enabled, wait until trunk ENI is attached and add it to the datastore.
+	if c.enableIPv6 && !c.enableDualStack {
 		if c.enablePodENI && c.dataStoreAccess.GetDataStore(DefaultNetworkCardIndex).GetTrunkENI() == "" {
 			for !c.checkForTrunkENI(ctx) {
 				time.Sleep(ipPoolMonitorInterval)
@@ -789,6 +809,7 @@ func (c *IPAMContext) StartNodeIPPoolManager(ctx context.Context) {
 		// The prefix used for the primary ENI is more than enough for all pods.
 		return
 	}
+	// IPv4 or dual-stack: run warm pool for IPv4 prefixes (primary ENI first, then secondary)
 
 	log.Infof("IP pool manager - max pods: %d, warm IP target: %d, warm prefix target: %d, warm ENI target: %d, minimum IP target: %d",
 		c.maxPods, c.warmIPTarget, c.warmPrefixTarget, c.warmENITarget, c.minimumIPTarget)
@@ -951,14 +972,15 @@ func (c *IPAMContext) tryUnassignCidrsFromAll(ctx context.Context, networkCard i
 }
 
 func (c *IPAMContext) initNetworkConfig() ([]string, net.IP, error) {
-	if c.enableIPv4 {
-		primaryIP := c.awsClient.GetLocalIPv4()
-		vpcCIDRs, err := c.awsClient.GetVPCIPv4CIDRs()
+	if c.enableIPv6 && !c.enableIPv4 {
+		// IPv6-only
+		primaryIP := c.awsClient.GetLocalIPv6()
+		vpcCIDRs, err := c.awsClient.GetVPCIPv6CIDRs()
 		return vpcCIDRs, primaryIP, err
 	}
-
-	primaryIP := c.awsClient.GetLocalIPv6()
-	vpcCIDRs, err := c.awsClient.GetVPCIPv6CIDRs()
+	// IPv4 or dual-stack: use IPv4 CIDRs
+	primaryIP := c.awsClient.GetLocalIPv4()
+	vpcCIDRs, err := c.awsClient.GetVPCIPv4CIDRs()
 	return vpcCIDRs, primaryIP, err
 }
 
@@ -1277,7 +1299,8 @@ func (c *IPAMContext) tryAssignPrefixes(ctx context.Context, networkCard int) (i
 func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsutils.ENIMetadata, isTrunkENI, isEFAENI bool) error {
 	primaryENI := c.awsClient.GetPrimaryENI()
 	var primaryIP string
-	if c.enableIPv6 {
+	// In dual-stack, use IPv4 ENI primary (IPv6 has no per-ENI primary)
+	if c.enableIPv6 && !c.enableIPv4 {
 		primaryIP = eniMetadata.PrimaryIPv6Address()
 	} else {
 		primaryIP = eniMetadata.PrimaryIPv4Address()
@@ -1311,8 +1334,10 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 
 	if c.enableIPv6 {
 		if !isTrunkENI {
-			// In v6 PD mode, VPC CNI will manage the primary ENI, ENIs on NC > 0 and trunk ENI. Once we start supporting secondary
-			// IP and custom networking modes for IPv6, this restriction can be relaxed.
+			// In v6 PD mode, VPC CNI will manage the primary ENI, ENIs on NC > 0 and trunk ENI.
+			// Once we start supporting secondary IP and custom networking modes for IPv6,
+			// this restriction can be relaxed.
+			// In dual-stack, both primary and secondary ENIs get IPv6 prefixes (same-ENI invariant).
 			err := c.assignIPv6Prefix(ctx, eni, eniMetadata.NetworkCard)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to allocate IPv6 Prefixes to ENI")
@@ -1320,10 +1345,13 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 		}
 	}
 
-	// For other ENIs, set up the network
-	if eni != primaryENI {
+	// Set up network for non-primary, non-trunk ENIs.
+	// Trunk ENIs are excluded because they carry traffic via branch ENI sub-interfaces,
+	// not directly — they have no usable primary IP for route table setup, and calling
+	// SetupENINetwork with an empty primary IP causes a nil-pointer panic in net.ParseIP.
+	if eni != primaryENI && !isTrunkENI {
 		subnetCidr := eniMetadata.SubnetIPv4CIDR
-		if c.enableIPv6 {
+		if c.enableIPv6 && !c.enableIPv4 {
 			subnetCidr = eniMetadata.SubnetIPv6CIDR
 		}
 		err := c.networkClient.SetupENINetwork(c.primaryIP[eni], eniMetadata.MAC, eniMetadata.NetworkCard, subnetCidr, c.maxENI, isTrunkENI, routeTableID, isRuleConfigured)
@@ -1336,9 +1364,17 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 			delete(c.primaryIP, eni)
 			return errors.Wrapf(err, "failed to set up ENI %s network", eni)
 		}
+
+		// Add IPv6 default route to the per-ENI route table for dual-stack secondary ENIs
+		if c.enableDualStack {
+			if err := c.networkClient.AddIPv6DefaultRouteToENITable(eniMetadata.MAC, routeTableID); err != nil {
+				log.Warnf("Failed to add IPv6 default route to ENI %s table %d: %v", eni, routeTableID, err)
+			}
+		}
 	}
 
-	if !c.enableIPv6 {
+	// Add IPv4 IPs/prefixes to datastore when IPv4 is enabled (including dual-stack)
+	if c.enableIPv4 {
 		log.Infof("Found ENIs having %d secondary IPs and %d Prefixes", len(eniMetadata.IPv4Addresses), len(eniMetadata.IPv4Prefixes))
 		// Either case add the IPs and prefixes to datastore.
 		c.addENIsecondaryIPsToDataStore(eniMetadata.IPv4Addresses, eni, eniMetadata.NetworkCard)
@@ -2756,17 +2792,23 @@ func (c *IPAMContext) initENIAndIPLimits() (err error) {
 }
 
 func (c *IPAMContext) isConfigValid() bool {
-	// Validate that only one among v4 and v6 is enabled.
 	if c.enableIPv4 && c.enableIPv6 {
-		log.Errorf("IPv4 and IPv6 are both enabled. VPC CNI currently does not support dual stack mode")
-		return false
+		if !c.enablePrefixDelegation {
+			log.Errorf("Dual-stack requires ENABLE_PREFIX_DELEGATION=true")
+			return false
+		}
+		if c.useCustomNetworking {
+			log.Errorf("Custom networking not supported in dual-stack mode")
+			return false
+		}
+		log.Infof("Dual-stack mode: IPv6 + IPv4 prefixes on same ENI")
 	} else if !c.enableIPv4 && !c.enableIPv6 {
-		log.Errorf("IPv4 and IPv6 are both disabled. One of them have to be enabled")
+		log.Errorf("At least one of ENABLE_IPv4 or ENABLE_IPv6 must be true")
 		return false
 	}
 
 	// Validate PD mode is enabled if VPC CNI is operating in IPv6 mode. Custom networking is not supported in IPv6 mode.
-	if c.enableIPv6 && (c.useCustomNetworking || !c.enablePrefixDelegation) {
+	if c.enableIPv6 && !c.enableIPv4 && (c.useCustomNetworking || !c.enablePrefixDelegation) {
 		log.Errorf("IPv6 is supported only in Prefix Delegation mode. Custom Networking is not supported in IPv6 mode. Please set the env variables accordingly.")
 		return false
 	}

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -214,33 +214,68 @@ func (s *server) AddNetwork(ctx context.Context, in *rpc.AddNetworkRequest) (*rp
 				break
 			}
 
-			ipamKey = datastore.IPAMKey{
-				ContainerID: in.ContainerID,
-				IfName:      in.IfName,
-				NetworkName: in.NetworkName,
-			}
-
 			ipamMetadata = datastore.IPAMMetadata{
 				K8SPodNamespace: in.K8S_POD_NAMESPACE,
 				K8SPodName:      in.K8S_POD_NAME,
 				InterfacesCount: ipsRequired,
 			}
 
-			ipv4Addr, ipv6Addr, deviceNumber, routeTableId, err = ds.AssignPodIPAddress(ipamKey, ipamMetadata, s.ipamContext.enableIPv4, s.ipamContext.enableIPv6)
-
-			if err != nil {
-				log.Warnf("Failed to assign IPs from network card %d: %v", networkCard, err)
-				// continue to look through other datastores till you are unable to find an IP address when ONLY 1 ip is required
-				// if the last datastore also return ErrNoAvailableIPInDataStore, return an error
-				if err == datastore.ErrNoAvailableIPInDataStore && ipsRequired == defaultIpPerPodRequired && networkCard != len(s.ipamContext.dataStoreAccess.DataStores)-1 {
-					continue
+			if s.ipamContext.enableDualStack {
+				// Dual-stack: allocate IPv4 first (scarce), then IPv6 from same ENI
+				v4Key := datastore.IPAMKey{
+					ContainerID: in.ContainerID,
+					IfName:      in.IfName,
+					NetworkName: in.NetworkName + "/v4",
+				}
+				v6Key := datastore.IPAMKey{
+					ContainerID: in.ContainerID,
+					IfName:      in.IfName,
+					NetworkName: in.NetworkName + "/v6",
 				}
 
-				errors = multiErr.Append(errors, err)
-				break
+				ipv4Addr, _, deviceNumber, routeTableId, err = ds.AssignPodIPAddress(v4Key, ipamMetadata, true, false)
+				if err != nil {
+					log.Warnf("Dual-stack: failed to assign IPv4 from network card %d: %v", networkCard, err)
+					if err == datastore.ErrNoAvailableIPInDataStore && ipsRequired == defaultIpPerPodRequired && networkCard != len(s.ipamContext.dataStoreAccess.DataStores)-1 {
+						continue
+					}
+					errors = multiErr.Append(errors, err)
+					break
+				}
+
+				// Allocate IPv6 from the SAME ENI
+				ipv6Addr, _, _, err = ds.AssignPodIPv6AddressFromENI(v6Key, ipamMetadata, deviceNumber)
+				if err != nil {
+					// Rollback: release IPv4 before returning error
+					ds.UnassignPodIPAddress(v4Key)
+					log.Errorf("Dual-stack: IPv4 allocated but IPv6 failed on ENI device %d: %v", deviceNumber, err)
+					errors = multiErr.Append(errors, fmt.Errorf("dual-stack: IPv4 allocated but IPv6 failed on ENI device %d: %w", deviceNumber, err))
+					break
+				}
+
+				log.Infof("Dual-stack assigned from network card %d -> IPv4: %s, IPv6: %s, device: %d", networkCard, ipv4Addr, ipv6Addr, deviceNumber)
+			} else {
+				// Single-family path (unchanged)
+				ipamKey = datastore.IPAMKey{
+					ContainerID: in.ContainerID,
+					IfName:      in.IfName,
+					NetworkName: in.NetworkName,
+				}
+
+				ipv4Addr, ipv6Addr, deviceNumber, routeTableId, err = ds.AssignPodIPAddress(ipamKey, ipamMetadata, s.ipamContext.enableIPv4, s.ipamContext.enableIPv6)
+
+				if err != nil {
+					log.Warnf("Failed to assign IPs from network card %d: %v", networkCard, err)
+					if err == datastore.ErrNoAvailableIPInDataStore && ipsRequired == defaultIpPerPodRequired && networkCard != len(s.ipamContext.dataStoreAccess.DataStores)-1 {
+						continue
+					}
+					errors = multiErr.Append(errors, err)
+					break
+				}
+
+				log.Infof("Assigned IP from network card: %d -> IPv4: %s, IPv6: %s, device number: %d, ", networkCard, ipv4Addr, ipv6Addr, deviceNumber)
 			}
 
-			log.Infof("Assigned IP from network card: %d -> IPv4: %s, IPv6: %s, device number: %d, ", networkCard, ipv4Addr, ipv6Addr, deviceNumber)
 			ipAddrs = append(ipAddrs, &rpc.IPAllocationMetadata{
 				IPv4Addr:     ipv4Addr,
 				IPv6Addr:     ipv6Addr,
@@ -350,20 +385,59 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 			break
 		}
 
-		eni, ip, deviceNumber, ipsAllocated, routeTableId, err := ds.UnassignPodIPAddress(ipamKey)
+		var eni *datastore.ENI
+		var ip string
+		var deviceNumber, ipsAllocated, routeTableId int
+		var err error
+
+		if s.ipamContext.enableDualStack {
+			// Dual-stack: release both IPv4 and IPv6 with family-qualified keys
+			v4Key := datastore.IPAMKey{
+				ContainerID: in.ContainerID,
+				IfName:      in.IfName,
+				NetworkName: in.NetworkName + "/v4",
+			}
+			v6Key := datastore.IPAMKey{
+				ContainerID: in.ContainerID,
+				IfName:      in.IfName,
+				NetworkName: in.NetworkName + "/v6",
+			}
+
+			// Best-effort cleanup: release both regardless of individual errors
+			eni, ip, deviceNumber, ipsAllocated, routeTableId, err = ds.UnassignPodIPAddress(v4Key)
+			_, v6IP, _, _, _, v6Err := ds.UnassignPodIPAddress(v6Key)
+
+			if err == nil {
+				ipv4Addr = ip
+				cidr := net.IPNet{IP: net.ParseIP(ip), Mask: net.IPv4Mask(255, 255, 255, 255)}
+				cidrStr = cidr.String()
+			}
+			if v6Err == nil {
+				ipv6Addr = v6IP
+			}
+
+			if err != nil && v6Err != nil {
+				// Both failed — treat as unknown pod
+				err = fmt.Errorf("dual-stack cleanup failed: v4=%v, v6=%v", err, v6Err)
+			} else if v6Err != nil {
+				log.Warnf("Failed to unassign IPv6 address: %v", v6Err)
+			}
+		} else {
+			eni, ip, deviceNumber, ipsAllocated, routeTableId, err = ds.UnassignPodIPAddress(ipamKey)
+
+			if s.ipamContext.enableIPv4 {
+				ipv4Addr = ip
+				cidr := net.IPNet{IP: net.ParseIP(ip), Mask: net.IPv4Mask(255, 255, 255, 255)}
+				cidrStr = cidr.String()
+			} else if s.ipamContext.enableIPv6 {
+				ipv6Addr = ip
+			}
+		}
 
 		// ipsAllocated will always be same in all datastores for a Pod, so this will not change ever between datastores
 		if ipsAllocated > 0 {
 			log.Debugf("IPs allocated for the pod: %d", ipsAllocated)
 			ipsToMatch = ipsAllocated
-		}
-
-		if s.ipamContext.enableIPv4 {
-			ipv4Addr = ip
-			cidr := net.IPNet{IP: net.ParseIP(ip), Mask: net.IPv4Mask(255, 255, 255, 255)}
-			cidrStr = cidr.String()
-		} else if s.ipamContext.enableIPv6 {
-			ipv6Addr = ip
 		}
 
 		if s.ipamContext.enableIPv4 && eni != nil {

--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -121,6 +121,20 @@ func (mr *MockNetworkAPIsMockRecorder) GetLinkByMac(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkByMac", reflect.TypeOf((*MockNetworkAPIs)(nil).GetLinkByMac), arg0, arg1)
 }
 
+// AddIPv6DefaultRouteToENITable mocks base method.
+func (m *MockNetworkAPIs) AddIPv6DefaultRouteToENITable(eniMAC string, routeTableID int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddIPv6DefaultRouteToENITable", eniMAC, routeTableID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddIPv6DefaultRouteToENITable indicates an expected call of AddIPv6DefaultRouteToENITable.
+func (mr *MockNetworkAPIsMockRecorder) AddIPv6DefaultRouteToENITable(eniMAC, routeTableID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIPv6DefaultRouteToENITable", reflect.TypeOf((*MockNetworkAPIs)(nil).AddIPv6DefaultRouteToENITable), eniMAC, routeTableID)
+}
+
 // GetRuleList mocks base method.
 func (m *MockNetworkAPIs) GetRuleList(arg0 bool) ([]netlink.Rule, error) {
 	m.ctrl.T.Helper()

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -169,6 +169,8 @@ type NetworkAPIs interface {
 	GetLinkByMac(mac string, retryInterval time.Duration) (netlink.Link, error)
 	DeleteRulesBySrc(eniIP string, v6enabled bool) error
 	GetRouteTableNumberForENI(networkCard int, eniIP string, deviceNumber int, maxENIsPerNetworkCard int, isV6 bool) (int, bool, error)
+	// AddIPv6DefaultRouteToENITable adds an IPv6 default route to a per-ENI route table (for dual-stack secondary ENIs)
+	AddIPv6DefaultRouteToENITable(eniMAC string, routeTableID int) error
 }
 
 type linuxNetwork struct {
@@ -1028,6 +1030,25 @@ func (n *linuxNetwork) GetRouteTableNumberForENI(networkCard int, eniIP string, 
 // SetupENINetwork adds default route to route table (eni-<eni_table>), so it does not need to be called on the primary ENI
 func (n *linuxNetwork) SetupENINetwork(eniIP string, eniMAC string, networkCard int, eniSubnetCIDR string, maxENIPerNIC int, isTrunkENI bool, routeTableID int, isRuleConfigured bool) error {
 	return setupENINetwork(eniIP, eniMAC, networkCard, eniSubnetCIDR, n.netLink, retryLinkByMacInterval, retryRouteAddInterval, n.mtu, maxENIPerNIC, isTrunkENI, routeTableID, isRuleConfigured)
+}
+
+// AddIPv6DefaultRouteToENITable adds an IPv6 default route to a per-ENI route table.
+// Used in dual-stack mode for secondary ENIs so that IPv6 traffic from pods on those ENIs
+// egresses through the correct ENI via source-based routing.
+func (n *linuxNetwork) AddIPv6DefaultRouteToENITable(eniMAC string, routeTableID int) error {
+	eniLink, err := n.GetLinkByMac(eniMAC, retryLinkByMacInterval)
+	if err != nil {
+		return errors.Wrapf(err, "AddIPv6DefaultRouteToENITable: failed to find ENI by MAC %s", eniMAC)
+	}
+
+	// ip -6 route add default via fe80:ec2::1 dev <eni> table <eni-table>
+	// Uses the VPC subnet gateway (same as setupENINetwork for IPv6)
+	return n.netLink.RouteAdd(&netlink.Route{
+		LinkIndex: eniLink.Attrs().Index,
+		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+		Gw:        GetIPv6Gateway(), // fe80:ec2::1
+		Table:     routeTableID,
+	})
 }
 
 func setupENINetwork(eniIP string, eniMac string, networkCard int, eniSubnetCIDR string, netLink netlinkwrapper.NetLink,


### PR DESCRIPTION
> **Note**: Refresh of #3616 (auto-closed by stale-bot on 2026-05-16 — no human review). No content changes vs. the closed PR; mechanically replayed on current master with no conflicts. Patch continues to ship in our internal fork against upstream v1.22.0 and runs in production.

**What type of PR is this?**
feature

**Which issue does this PR fix?**:
#3615

**What does this PR do / Why do we need it?**:

Enables dual-stack pod networking by allowing `ENABLE_IPv4=true` and `ENABLE_IPv6=true` simultaneously. Both address families are assigned to pod `eth0` from prefix-delegated addresses on the same ENI. No NAT/SNAT, no egress interfaces.

Currently the CNI rejects this combination in `isConfigValid()`. Pods must choose IPv4-only or IPv6-only, relying on NAT egress (`v4if0`/`v6if0`) for the other family. This change removes that restriction when `ENABLE_PREFIX_DELEGATION=true`.

Key behaviors:
- IPv6 `/80` and IPv4 `/28` prefixes are allocated on the same ENI (primary first, secondary for overflow)
- Both addresses assigned directly to pod `eth0` — no egress interfaces created
- No SNAT/CONNMARK iptables rules (upstream `updateHostIptablesRules()` returns nil when `enableIPv6=true`)
- IPv4 warm pool manages prefix capacity; IPv6 is abundant (2^48 addresses per /80)
- Secondary ENIs get source-based routing for both families via per-ENI route tables
- Egress plugin is automatically disabled in dual-stack mode regardless of `ENABLE_V4_EGRESS`/`ENABLE_V6_EGRESS` values
- Single-stack behavior is completely unchanged

**Testing done on this change**:
Deployed to a dev EKS cluster (5 nodes, v1.21.0 base).

Sample pod verification:
$ ip addr show eth0
    inet 100.89.89.128/32 scope global eth0
    inet6 2a03:5640:f13c:1:7a::4/128 scope global

$ ip link show v4if0
Device "v4if0" does not exist.

$ ip link show v6if0
Device "v6if0" does not exist.

IPAMD logs confirm: `"Dual-stack mode: IPv6 + IPv4 prefixes on same ENI (primary first)"`
Entrypoint logs confirm: `"Dual-stack mode: egress plugin disabled (both IPv4 and IPv6 on eth0)"`

Patch has been running in production on Netflix's internal fork against upstream v1.22.0 since the original PR was opened.

**Will this PR introduce any new dependencies?**:
No. No new APIs, IMDS calls, kernel modules, or binary dependencies. Uses existing EC2 prefix delegation APIs already called in single-stack modes.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No. Dual-stack only activates when all three flags are explicitly true (`ENABLE_IPv4`, `ENABLE_IPv6`, `ENABLE_PREFIX_DELEGATION`). Existing single-stack configurations are unchanged. Tested upgrade from single-stack to dual-stack via `kubectl set env` on a running cluster — pods created after the rollout get dual-stack, existing pods continue working until recycled.

**Does this change require updates to the CNI daemonset config files to work?**:
Yes — set `ENABLE_IPv6=true` on a cluster already running with `ENABLE_IPv4=true` and `ENABLE_PREFIX_DELEGATION=true`. Works with `kubectl set env daemonset/aws-node -n kube-system ENABLE_IPv6=true`. No other config changes required.

**Does this PR introduce any user-facing change?**:
Yes. Setting `ENABLE_IPv4=true` together with `ENABLE_IPv6=true` (with `ENABLE_PREFIX_DELEGATION=true`) is now a valid configuration that enables same-ENI dual-stack pod networking. Previously this combination was rejected at startup by `isConfigValid()`. No action required for users who don't opt into dual-stack; single-stack behavior is unchanged.

```release-note
Add dual-stack support for IPAMD pods. Setting ENABLE_IPv4=true, ENABLE_IPv6=true, and ENABLE_PREFIX_DELEGATION=true simultaneously now assigns both IPv4 and IPv6 addresses to pod eth0 from prefix-delegated addresses on the same ENI. No NAT/SNAT is applied. The egress plugin (v4if0/v6if0) is automatically disabled in dual-stack mode. Single-stack behavior is unchanged.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.