### PR TITLE
feat(helm): add liveness, readiness, and startup probes for aws-eks-nodeagent

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -90,6 +90,9 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
 | `nodeAgent.resources`   | Node Agent resources, will defualt to .Values.resources if not set | `{}`                     |
 | `nodeAgent.logLevel`    | Node Agent logging verbosity level.                     | `debug`                             |
+| `nodeAgent.livenessProbe`  | Liveness probe for the aws-eks-nodeagent container. `httpGet.port` defaults to `nodeAgent.healthProbeBindAddr`. Set to `null` to disable.  | `httpGet /healthz` (see `values.yaml`) |
+| `nodeAgent.readinessProbe` | Readiness probe for the aws-eks-nodeagent container. `httpGet.port` defaults to `nodeAgent.healthProbeBindAddr`. Set to `null` to disable. | `httpGet /readyz`  (see `values.yaml`) |
+| `nodeAgent.startupProbe`   | Startup probe for the aws-eks-nodeagent container. `httpGet.port` defaults to `nodeAgent.healthProbeBindAddr`. Set to `null` to disable.   | `httpGet /healthz` (see `values.yaml`) |
 | `extraVolumes`          | Array to add extra volumes                              | `[]`                                |
 | `extraVolumeMounts`     | Array to add extra mount                                | `[]`                                |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |

--- a/charts/aws-vpc-cni/templates/_helpers.tpl
+++ b/charts/aws-vpc-cni/templates/_helpers.tpl
@@ -108,3 +108,18 @@ The aws-network-policy-agent port to bind to for health probes
 {{- define "aws-vpc-cni.nodeAgentHealthProbeBindAddr" -}}
 {{- printf ":%s" .Values.nodeAgent.healthProbeBindAddr }}
 {{- end -}}
+
+{{/*
+Render an aws-eks-nodeagent probe spec, defaulting `httpGet.port` to
+`.Values.nodeAgent.healthProbeBindAddr` when the user has not set it explicitly.
+Expects a dict with keys:
+  probe: the probe value from .Values.nodeAgent.{liveness,readiness,startup}Probe
+  port:  the string port to default to (typically .Values.nodeAgent.healthProbeBindAddr)
+*/}}
+{{- define "aws-vpc-cni.nodeAgentProbe" -}}
+{{- $probe := deepCopy .probe -}}
+{{- if and (hasKey $probe "httpGet") (not (hasKey $probe.httpGet "port")) -}}
+{{- $_ := set $probe.httpGet "port" (int .port) -}}
+{{- end -}}
+{{- toYaml $probe -}}
+{{- end -}}

--- a/charts/aws-vpc-cni/templates/daemonset.yaml
+++ b/charts/aws-vpc-cni/templates/daemonset.yaml
@@ -157,6 +157,18 @@ spec:
             - --conntrack-cache-cleanup-period={{ .Values.nodeAgent.conntrackCacheCleanupPeriod }}
             - --conntrack-cache-table-size={{ .Values.nodeAgent.conntrackCacheTableSize }}
             - --log-level={{ .Values.nodeAgent.logLevel }}
+          {{- with .Values.nodeAgent.livenessProbe }}
+          livenessProbe:
+            {{- include "aws-vpc-cni.nodeAgentProbe" (dict "probe" . "port" $.Values.nodeAgent.healthProbeBindAddr) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeAgent.readinessProbe }}
+          readinessProbe:
+            {{- include "aws-vpc-cni.nodeAgentProbe" (dict "probe" . "port" $.Values.nodeAgent.healthProbeBindAddr) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeAgent.startupProbe }}
+          startupProbe:
+            {{- include "aws-vpc-cni.nodeAgentProbe" (dict "probe" . "port" $.Values.nodeAgent.healthProbeBindAddr) | nindent 12 }}
+          {{- end }}
           {{- with default .Values.resources .Values.nodeAgent.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -55,6 +55,33 @@ nodeAgent:
   conntrackCacheTableSize: 524288
   logLevel: "debug"
   resources: {}
+  # Probes for the aws-eks-nodeagent sidecar. Set any of these to `null` or `{}`
+  # to disable the corresponding probe. `httpGet.port` defaults to
+  # `nodeAgent.healthProbeBindAddr` above; set it here only if you need a port
+  # different from the one the agent actually binds to.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      scheme: HTTP
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      scheme: HTTP
+    initialDelaySeconds: 1
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  startupProbe:
+    httpGet:
+      path: /healthz
+      scheme: HTTP
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 60
 
 image:
   tag: v1.21.2

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -335,6 +335,32 @@ spec:
             - --conntrack-cache-cleanup-period=300
             - --conntrack-cache-table-size=524288
             - --log-level=debug
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -335,6 +335,32 @@ spec:
             - --conntrack-cache-cleanup-period=300
             - --conntrack-cache-table-size=524288
             - --log-level=debug
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -335,6 +335,32 @@ spec:
             - --conntrack-cache-cleanup-period=300
             - --conntrack-cache-table-size=524288
             - --log-level=debug
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 25m

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -335,6 +335,32 @@ spec:
             - --conntrack-cache-cleanup-period=300
             - --conntrack-cache-table-size=524288
             - --log-level=debug
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8163
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8163
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix?**:

N/A. The upstream `aws-eks-nodeagent` sidecar ships with no probes, so a crashed or wedged agent silently keeps running until the next pod replacement. Filing this directly against upstream rather than carrying it as a downstream patch.

**What does this PR do / Why do we need it?**:

Wires the `aws-eks-nodeagent` sidecar to its existing controller-runtime `/healthz` and `/readyz` endpoints on `--health-probe-bind-addr` (default `:8163`). These probes let the kubelet catch and restart a wedged agent.

Two commits:

1. **`feat(helm)`**: adds the three probes to `charts/aws-vpc-cni` as configurable values.

   - `charts/aws-vpc-cni/values.yaml`: adds `nodeAgent.livenessProbe`, `nodeAgent.readinessProbe`, and `nodeAgent.startupProbe` with sensible defaults. Each can be disabled by setting it to `null` or `{}`.
   - `charts/aws-vpc-cni/templates/daemonset.yaml`: renders the three probes on the `aws-eks-nodeagent` container through a shared helper.
   - `charts/aws-vpc-cni/templates/_helpers.tpl`: new `aws-vpc-cni.nodeAgentProbe` helper that deep-copies the user-supplied probe and injects `httpGet.port` from `nodeAgent.healthProbeBindAddr` when the user has not set one explicitly. This keeps the bind address authoritative and avoids duplicating the port literal in values defaults. Users may still override the per-probe port if needed.
   - `charts/aws-vpc-cni/README.md`: documents the three new values.

2. **`feat(manifests)`**: mirrors the same probes into the static `config/master/aws-k8s-cni*.yaml` manifests (commercial, cn, us-gov-east-1, us-gov-west-1) so consumers of the raw YAML get the same kubelet-driven restart behavior as Helm users.

Default probe shapes (Helm defaults and manifests are identical):

| Probe | path | initialDelaySeconds | periodSeconds | timeoutSeconds | failureThreshold |
|---|---|---|---|---|---|
| livenessProbe | /healthz | 5 | 15 | 3 | 5 |
| readinessProbe | /readyz | 1 | 15 | 3 | 3 |
| startupProbe | /healthz | (n/a) | 5 | 3 | 60 |

The startupProbe gives the agent 5 minutes (60 x 5s) to come up before liveness/readiness take over.

**Testing done on this change**:

Helm chart:

`helm lint` is clean. `helm template` renders correctly across the cases below.

1. Defaults: liveness/readiness/startup probes all rendered on the `aws-eks-nodeagent` container with `port: 8163` injected from `nodeAgent.healthProbeBindAddr`. The existing `aws-node` (main container) probes are unchanged.
2. `--set-string nodeAgent.healthProbeBindAddr=9999`: all three probe `httpGet.port` values automatically become `9999`. The `--health-probe-bind-addr=:9999` flag stays in sync.
3. `--set nodeAgent.livenessProbe.httpGet.port=7777`: only the liveness probe uses port 7777; the others still default to `healthProbeBindAddr`.
4. `--set nodeAgent.startupProbe=null`: the startupProbe block is omitted from the rendered manifest.
5. `--set nodeAgent.enabled=false`: no `aws-eks-nodeagent` container is rendered (no regression).

Static manifests:

All four files (`config/master/aws-k8s-cni{,-cn,-us-gov-east-1,-us-gov-west-1}.yaml`) parse cleanly under `yaml.safe_load_all`. Probe blocks verified equivalent across all four:

```
livenessProbe:  /healthz on :8163  failureThreshold=5
readinessProbe: /readyz  on :8163  failureThreshold=3
startupProbe:   /healthz on :8163  failureThreshold=60
```

**Will this PR introduce any new dependencies?**:

No. The `/healthz` and `/readyz` endpoints already exist in the running `aws-network-policy-agent` (controller-runtime serves them on `--health-probe-bind-addr`, which was already configured upstream).

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

Low risk. This adds three probes to a sidecar that previously had none. On upgrade, the kubelet starts probing endpoints that already exist; on downgrade, the probes are simply removed from the DaemonSet spec.

If a cluster's agent has a slower-than-expected first reconcile (for example, a large number of PolicyEndpoints), the startupProbe could trip and trigger a CrashLoopBackoff. Mitigated by the generous 5-minute startup budget (60 x 5s).

**Does this change require updates to the CNI daemonset config files to work?**:

The second commit updates the `config/master/*.yaml` daemonset config files. The Helm chart commit renders them automatically. No additional manual edits required.

**Does this PR introduce any user-facing change?**:

Yes. Three new Helm values: `nodeAgent.livenessProbe`, `nodeAgent.readinessProbe`, `nodeAgent.startupProbe`. Defaults are tuned for production use and do not require user action. Probes can be disabled per-probe by setting the corresponding value to `null`. Raw-manifest users see the probes appear on the `aws-eks-nodeagent` container with no opt-out short of editing the YAML.

```release-note
Add `nodeAgent.livenessProbe`, `nodeAgent.readinessProbe`, and `nodeAgent.startupProbe` to the `aws-vpc-cni` Helm chart and the corresponding `config/master/aws-k8s-cni*.yaml` manifests so the kubelet can detect and restart a wedged `aws-eks-nodeagent` sidecar. In the Helm chart, `httpGet.port` defaults to `nodeAgent.healthProbeBindAddr` so the bind address stays in sync.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.