### PR TITLE
Soak cluster ip probe

### DIFF
--- a/.github/workflows/soak-tests.yml
+++ b/.github/workflows/soak-tests.yml
@@ -36,6 +36,5 @@ jobs:
           RUN_CNI_INTEGRATION_TESTS=false RUN_SOAK_TEST=true RUN_UBUNTU_TEST=true ./scripts/run-integration-tests.sh
         env:
           AWS_DEFAULT_REGION: us-west-2
-          # us-west-2 has public-internet egress; safe to enable. Skip in
-          # isolated regions by leaving this unset or setting to "false".
+          # Enabled here because this runner has outbound internet access.
           RUN_EXTERNAL_PROBE: "true"

--- a/.github/workflows/soak-tests.yml
+++ b/.github/workflows/soak-tests.yml
@@ -36,3 +36,6 @@ jobs:
           RUN_CNI_INTEGRATION_TESTS=false RUN_SOAK_TEST=true RUN_UBUNTU_TEST=true ./scripts/run-integration-tests.sh
         env:
           AWS_DEFAULT_REGION: us-west-2
+          # us-west-2 has public-internet egress; safe to enable. Skip in
+          # isolated regions by leaving this unset or setting to "false".
+          RUN_EXTERNAL_PROBE: "true"

--- a/test/integration/cni/soak_test.go
+++ b/test/integration/cni/soak_test.go
@@ -16,6 +16,7 @@ package cni
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -49,11 +50,21 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 		protocol                          string
 		primaryNodeDeployment             *v1.Deployment
 		secondaryNodeDeployment           *v1.Deployment
+		primaryNodeService                *coreV1.Service
+		secondaryNodeService              *coreV1.Service
 		interfaceToPodListOnPrimaryNode   common.InterfaceTypeToPodList
 		interfaceToPodListOnSecondaryNode common.InterfaceTypeToPodList
 		timesToRunTheTest                 = 12
 		waitDuringInMinutes               = time.Duration(5) * time.Minute
 	)
+
+	// External probe is opt-in so this suite stays runnable in isolated regions
+	// (ADC, MDW, etc.) where checkip.amazonaws.com is unreachable.
+	externalProbeEnabled := os.Getenv("RUN_EXTERNAL_PROBE") == "true"
+	externalProbeHost := os.Getenv("EXTERNAL_PROBE_HOST")
+	if externalProbeHost == "" {
+		externalProbeHost = "checkip.amazonaws.com"
+	}
 
 	BeforeAll(func() {
 		fmt.Println("Starting SOAK test")
@@ -161,9 +172,42 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 
 			Expect(len(interfaceToPodListOnSecondaryNode.PodsOnSecondaryENI)).
 				Should(BeNumerically(">", 1))
+
+			By("Creating ClusterIP services in front of each deployment")
+			primaryNodeService, err = f.K8sResourceManagers.ServiceManager().
+				CreateService(context.TODO(), manifest.NewHTTPService().
+					ServiceType(coreV1.ServiceTypeClusterIP).
+					Name("primary-node-svc").
+					Port(int32(serverPort)).
+					Protocol(coreV1.ProtocolTCP).
+					Selector("node", "primary").
+					Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			secondaryNodeService, err = f.K8sResourceManagers.ServiceManager().
+				CreateService(context.TODO(), manifest.NewHTTPService().
+					ServiceType(coreV1.ServiceTypeClusterIP).
+					Name("secondary-node-svc").
+					Port(int32(serverPort)).
+					Protocol(coreV1.ProtocolTCP).
+					Selector("node", "secondary").
+					Build())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
+			By("TearDown services")
+			if primaryNodeService != nil {
+				err = f.K8sResourceManagers.ServiceManager().
+					DeleteAndWaitTillServiceDeleted(context.TODO(), primaryNodeService)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			if secondaryNodeService != nil {
+				err = f.K8sResourceManagers.ServiceManager().
+					DeleteAndWaitTillServiceDeleted(context.TODO(), secondaryNodeService)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			By("TearDown Pods")
 			err = f.K8sResourceManagers.DeploymentManager().
 				DeleteAndWaitTillDeploymentIsDeleted(primaryNodeDeployment)
@@ -191,8 +235,51 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 					interfaceToPodListOnPrimaryNode.PodsOnPrimaryENI[1], serverPort,
 					testFailedConnectionCommandFunc)
 
+				By("verifying ClusterIP service connectivity from secondary-ENI pods")
+				verifyClusterIPConnectivity(
+					interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[0],
+					secondaryNodeService.Spec.ClusterIP, serverPort)
+				verifyClusterIPConnectivity(
+					interfaceToPodListOnSecondaryNode.PodsOnSecondaryENI[0],
+					primaryNodeService.Spec.ClusterIP, serverPort)
+
+				if externalProbeEnabled {
+					By(fmt.Sprintf("verifying external connectivity to %s from secondary-ENI pod", externalProbeHost))
+					verifySoakExternalConnectivity(
+						interfaceToPodListOnPrimaryNode.PodsOnSecondaryENI[0],
+						externalProbeHost)
+				}
+
 				time.Sleep(waitDuringInMinutes)
 			})
 		}
 	})
 })
+
+// verifyClusterIPConnectivity exercises the kube-proxy dstnat → aws-cni
+// nat-prerouting chain ordering. ClusterIP traffic stays within the VPC CIDR
+// so it returns early in the snat-mark chain — this validates chain priority,
+// not the mark-set side.
+func verifyClusterIPConnectivity(senderPod coreV1.Pod, clusterIP string, port int) {
+	cmd := []string{"nc", "-v", "-w5", clusterIP, strconv.Itoa(port)}
+	stdout, stderr, err := f.K8sResourceManagers.PodManager().
+		PodExec(senderPod.Namespace, senderPod.Name, cmd)
+	fmt.Fprintf(GinkgoWriter, "clusterIP probe [%s → %s:%d]: stdout=%s stderr=%s\n",
+		senderPod.Name, clusterIP, port, stdout, stderr)
+	Expect(err).ToNot(HaveOccurred(), "ClusterIP probe failed from pod %s to %s", senderPod.Name, clusterIP)
+	Expect(stderr).To(ContainSubstring("succeeded!"))
+}
+
+// verifySoakExternalConnectivity exercises the mark-set side of the snat-mark
+// chain by opening a TCP connection to a non-VPC destination. Opt-in via
+// RUN_EXTERNAL_PROBE=true; not safe to run in isolated regions where the
+// default host (checkip.amazonaws.com:80) is unreachable.
+func verifySoakExternalConnectivity(senderPod coreV1.Pod, host string) {
+	cmd := []string{"nc", "-v", "-w5", host, "80"}
+	stdout, stderr, err := f.K8sResourceManagers.PodManager().
+		PodExec(senderPod.Namespace, senderPod.Name, cmd)
+	fmt.Fprintf(GinkgoWriter, "external probe [%s → %s:80]: stdout=%s stderr=%s\n",
+		senderPod.Name, host, stdout, stderr)
+	Expect(err).ToNot(HaveOccurred(), "external probe failed from pod %s to %s", senderPod.Name, host)
+	Expect(stderr).To(ContainSubstring("succeeded!"))
+}

--- a/test/integration/cni/soak_test.go
+++ b/test/integration/cni/soak_test.go
@@ -58,8 +58,8 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 		waitDuringInMinutes               = time.Duration(5) * time.Minute
 	)
 
-	// External probe is opt-in so this suite stays runnable in isolated regions
-	// (ADC, MDW, etc.) where checkip.amazonaws.com is unreachable.
+	// External probe is opt-in so it only runs where we have outbound
+	// internet access.
 	externalProbeEnabled := os.Getenv("RUN_EXTERNAL_PROBE") == "true"
 	externalProbeHost := os.Getenv("EXTERNAL_PROBE_HOST")
 	if externalProbeHost == "" {
@@ -272,8 +272,8 @@ func verifyClusterIPConnectivity(senderPod coreV1.Pod, clusterIP string, port in
 
 // verifySoakExternalConnectivity exercises the mark-set side of the snat-mark
 // chain by opening a TCP connection to a non-VPC destination. Opt-in via
-// RUN_EXTERNAL_PROBE=true; not safe to run in isolated regions where the
-// default host (checkip.amazonaws.com:80) is unreachable.
+// RUN_EXTERNAL_PROBE=true; only enable where outbound internet access is
+// available.
 func verifySoakExternalConnectivity(senderPod coreV1.Pod, host string) {
 	cmd := []string{"nc", "-v", "-w5", host, "80"}
 	stdout, stderr, err := f.K8sResourceManagers.PodManager().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
