### PR TITLE
Add ConfigMap-driven dynamic SNAT exclusion CIDRs

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -250,6 +250,7 @@ type IPAMContext struct {
 	networkPolicyMode         string
 	enableMultiNICSupport     bool
 	withApiServer             bool
+	enableDynamicSNATCfg      bool
 }
 
 type kubeletConfig struct {
@@ -444,6 +445,7 @@ func New(ctx context.Context, k8sClient client.Client, withApiServer bool) (*IPA
 	c.awsClient.InitCachedPrefixDelegation(c.enablePrefixDelegation)
 	c.myNodeName = os.Getenv(envNodeName)
 	c.withApiServer = withApiServer
+	c.enableDynamicSNATCfg = utils.GetBoolAsStringEnvVar(envEnableDynamicSNATCfg, false)
 
 	if err := c.nodeInit(ctx); err != nil {
 		return nil, err
@@ -757,6 +759,23 @@ func (c *IPAMContext) updateCIDRsRulesOnChange(oldVPCCIDRs []string) []string {
 	if err != nil {
 		log.Warnf("skipping periodic update to VPC CIDRs due to error: %v", err)
 		return oldVPCCIDRs
+	}
+
+	// If dynamic SNAT config is enabled, merge ConfigMap CIDRs into the exclusion set
+	if c.enableDynamicSNATCfg && c.k8sClient != nil {
+		ctx := context.Background()
+		configMapCIDRs, cmErr := GetExcludeSNATCIDRsFromConfigMap(ctx, c.k8sClient)
+		if cmErr != nil {
+			log.Warnf("failed to read SNAT exclusion ConfigMap (keeping previous set): %v", cmErr)
+		} else if len(configMapCIDRs) > 0 {
+			// Merge ConfigMap CIDRs with the env-var CIDRs and update networkClient
+			envCIDRs := c.networkClient.GetExcludeSNATCIDRs()
+			merged := sets.NewString(envCIDRs...)
+			merged.Insert(configMapCIDRs...)
+			c.networkClient.SetExcludeSNATCIDRs(merged.List())
+			log.Debugf("Dynamic SNAT exclusion: merged %d env + %d ConfigMap CIDRs = %d total",
+				len(envCIDRs), len(configMapCIDRs), merged.Len())
+		}
 	}
 
 	old := sets.NewString(oldVPCCIDRs...)

--- a/pkg/ipamd/snat_configmap.go
+++ b/pkg/ipamd/snat_configmap.go
@@ -1,0 +1,86 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	snatConfigMapName      = "aws-node-vpc-cidrs"
+	snatConfigMapNamespace = "kube-system"
+	snatConfigMapKey       = "exclude-snat-cidrs"
+
+	envEnableDynamicSNATCfg = "AWS_VPC_K8S_CNI_ENABLE_DYNAMIC_SNAT_CFG"
+)
+
+// GetExcludeSNATCIDRsFromConfigMap reads the aws-node-vpc-cidrs ConfigMap and returns
+// the parsed list of CIDRs from the exclude-snat-cidrs key. Returns nil (not error) if
+// the ConfigMap doesn't exist or the key is empty.
+func GetExcludeSNATCIDRsFromConfigMap(ctx context.Context, k8sClient client.Client) ([]string, error) {
+	if k8sClient == nil {
+		return nil, nil
+	}
+
+	var cm corev1.ConfigMap
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      snatConfigMapName,
+		Namespace: snatConfigMapNamespace,
+	}, &cm)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	raw := cm.Data[snatConfigMapKey]
+	if raw == "" {
+		return nil, nil
+	}
+
+	return parseSNATCIDRs(raw), nil
+}
+
+// parseSNATCIDRs parses a newline or comma separated list of CIDRs.
+// Invalid entries are logged and skipped.
+func parseSNATCIDRs(raw string) []string {
+	var cidrs []string
+
+	// Support both newline and comma separation
+	raw = strings.ReplaceAll(raw, ",", "\n")
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		_, parsed, err := net.ParseCIDR(line)
+		if err != nil {
+			log.Warnf("invalid CIDR %q in ConfigMap %s/%s: %v (skipping)", line, snatConfigMapNamespace, snatConfigMapName, err)
+			continue
+		}
+		if parsed.IP.To4() == nil {
+			log.Warnf("IPv6 CIDR %q in ConfigMap %s/%s not supported (skipping)", line, snatConfigMapNamespace, snatConfigMapName)
+			continue
+		}
+		cidrs = append(cidrs, parsed.String())
+	}
+	return cidrs
+}

--- a/pkg/ipamd/snat_configmap_test.go
+++ b/pkg/ipamd/snat_configmap_test.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSNATCIDRs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "newline separated",
+			input:    "10.0.0.0/16\n10.1.0.0/16\n10.2.0.0/16",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16"},
+		},
+		{
+			name:     "comma separated",
+			input:    "10.0.0.0/16,10.1.0.0/16,10.2.0.0/16",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16"},
+		},
+		{
+			name:     "mixed separators",
+			input:    "10.0.0.0/16\n10.1.0.0/16,10.2.0.0/16",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16"},
+		},
+		{
+			name:     "with whitespace and empty lines",
+			input:    "  10.0.0.0/16  \n\n  10.1.0.0/16\n",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "only whitespace",
+			input:    "  \n  \n  ",
+			expected: nil,
+		},
+		{
+			name:     "invalid CIDR skipped",
+			input:    "10.0.0.0/16\nnot-a-cidr\n10.1.0.0/16",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16"},
+		},
+		{
+			name:     "IPv6 CIDR skipped",
+			input:    "10.0.0.0/16\nfd00::/64\n10.1.0.0/16",
+			expected: []string{"10.0.0.0/16", "10.1.0.0/16"},
+		},
+		{
+			name:     "normalizes CIDR notation",
+			input:    "10.0.1.5/16",
+			expected: []string{"10.0.0.0/16"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSNATCIDRs(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/k8sapi/k8sutils.go
+++ b/pkg/k8sapi/k8sutils.go
@@ -45,6 +45,11 @@ func getIPAMDCacheFilters() map[client.Object]cache.ByObject {
 			&corev1.Node{}: {
 				Field: fields.Set{"metadata.name": nodeName}.AsSelector(),
 			},
+			// Cache the SNAT exclusion ConfigMap for dynamic SNAT config (Phase 2).
+			// The cached client will serve reads locally after initial sync.
+			&corev1.ConfigMap{}: {
+				Field: fields.Set{"metadata.name": "aws-node-vpc-cidrs", "metadata.namespace": "kube-system"}.AsSelector(),
+			},
 		}
 		// only cache CNINode when SGP is in use
 		enabledPodENI := utils.GetBoolAsStringEnvVar(envEnablePodENI, false)

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -161,6 +162,7 @@ type NetworkAPIs interface {
 	CleanUpStaleAWSChains(v4Enabled, v6Enabled bool) error
 	UseExternalSNAT() bool
 	GetExcludeSNATCIDRs() []string
+	SetExcludeSNATCIDRs(cidrs []string)
 	GetExternalServiceCIDRs() []string
 	GetRuleList(v6enabled bool) ([]netlink.Rule, error)
 	GetRuleListBySrc(ruleList []netlink.Rule, src net.IPNet) ([]netlink.Rule, error)
@@ -175,6 +177,7 @@ type linuxNetwork struct {
 	useExternalSNAT        bool
 	ipv6EgressEnabled      bool
 	excludeSNATCIDRs       []string
+	excludeSNATCIDRsMu     sync.RWMutex
 	externalServiceCIDRs   []string
 	typeOfSNAT             snatType
 	nodePortSupportEnabled bool
@@ -477,7 +480,11 @@ func (n *linuxNetwork) buildIptablesSNATRules(vpcCIDRs []string, primaryAddr *ne
 		log.Debugf("Adding %s CIDR to NAT chain", cidr)
 		allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: false})
 	}
-	for _, cidr := range n.excludeSNATCIDRs {
+	n.excludeSNATCIDRsMu.RLock()
+	excludeCIDRs := make([]string, len(n.excludeSNATCIDRs))
+	copy(excludeCIDRs, n.excludeSNATCIDRs)
+	n.excludeSNATCIDRsMu.RUnlock()
+	for _, cidr := range excludeCIDRs {
 		log.Debugf("Adding %s Excluded CIDR to NAT chain", cidr)
 		allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: true})
 	}
@@ -887,7 +894,19 @@ func (n *linuxNetwork) GetExcludeSNATCIDRs() []string {
 	if useExternalSNAT() {
 		return nil
 	}
-	return parseCIDRString(envExcludeSNATCIDRs)
+	n.excludeSNATCIDRsMu.RLock()
+	defer n.excludeSNATCIDRsMu.RUnlock()
+	result := make([]string, len(n.excludeSNATCIDRs))
+	copy(result, n.excludeSNATCIDRs)
+	return result
+}
+
+// SetExcludeSNATCIDRs replaces the SNAT exclusion CIDR list. Called by IPAMD after merging
+// env var + ConfigMap sources. Thread-safe.
+func (n *linuxNetwork) SetExcludeSNATCIDRs(cidrs []string) {
+	n.excludeSNATCIDRsMu.Lock()
+	defer n.excludeSNATCIDRsMu.Unlock()
+	n.excludeSNATCIDRs = cidrs
 }
 
 // GetExternalServiceCIDRs return a list of CIDRs that should always be routed to via main routing table.


### PR DESCRIPTION
Add support for reading SNAT exclusion CIDRs from a ConfigMap (kube-system/aws-node-vpc-cidrs) in addition to the existing AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS environment variable. This enables operators to update SNAT exclusions cluster-wide without triggering a DaemonSet restart.

Gated behind AWS_VPC_K8S_CNI_ENABLE_DYNAMIC_SNAT_CFG=true (default off). When enabled, the periodic reconcile loop reads the ConfigMap, merges its CIDRs with the env-var set, and updates iptables rules. ConfigMap absent or unreadable = no-op (existing behavior preserved).

Motivating use case: cross-region EKS worker nodes that need SNAT exclusions for multiple VPC CIDRs, managed dynamically as satellite regions are added/removed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
It used to automatically update the AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS environment variable across all the nodes in the cluster. This is useful when you deploy EKS worker nodes that are running in other AWS regions/VPCs. If this change is not accepted, you will need to update AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS manually. This will trigger a rolling restart of all aws-node pods cluster-wide.

**Testing done on this change**:
1. Unit tests for CIDR parsing (pkg/ipamd/snat_configmap_test.go)
9 test cases covering newline/comma/mixed separators, whitespace handling, empty input, invalid CIDRs, IPv6 rejection, and CIDR normalization.

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No. 

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Have not tried updating a cluster yet. 

**Does this change require updates to the CNI daemonset config files to work?**:
No. 
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
The feature is gated behind AWS_VPC_K8S_CNI_ENABLE_DYNAMIC_SNAT_CFG=true, which defaults to false. With the default:

  - The ConfigMap is never read.
  - SetExcludeSNATCIDRs is never called.
  - The mutex adds negligible overhead (one RLock/RUnlock per iptables rebuild, same codepath that was already executing).
  - iptables rules are byte-identical to before.

No user action required on upgrade. An existing cluster upgrading to a VPC CNI version with this change will see zero behavioral difference. No new env vars are set by default, no ConfigMap is created, no RBAC changes are needed until the feature is opted into.

When a user does opt in, they must:
1. Set AWS_VPC_K8S_CNI_ENABLE_DYNAMIC_SNAT_CFG=true on the aws-node DaemonSet.
2. Create the kube-system/aws-node-vpc-cidrs ConfigMap with an exclude-snat-cidrs key.

Without both, nothing happens.
```release-note
You can now manage SNAT exclusion CIDRs through a ConfigMap (`kube-system/aws-node-vpc-cidrs`) instead of only through the `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` environment variable. This allows updating SNAT exclusions cluster-wide without triggering a DaemonSet restart.

create the ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-node-vpc-cidrs
  namespace: kube-system
data:
  exclude-snat-cidrs: |
    10.0.0.0/16
    10.1.0.0/16
    10.2.0.0/16
```

CIDRs from the ConfigMap are merged with any CIDRs already set via `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS`. The env var continues to work as before.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
