### PR TITLE
Handle route addition with retry with egress-cni plugin

### DIFF
--- a/cmd/egress-cni-plugin/egressContext.go
+++ b/cmd/egress-cni-plugin/egressContext.go
@@ -203,19 +203,19 @@ func (ec *egressContext) setupContainerVethV4() (*current.Interface, *current.In
 func (ec *egressContext) addRouteWithRetry(route *netlink.Route) error {
 	const maxAttempts = 5
 	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		lastErr = ec.Link.RouteAdd(route)
 		if lastErr == nil {
-			if attempt > 0 {
-				ec.Log.Infof("addRouteWithRetry: route %v added successfully on attempt %d", route, attempt+1)
+			if attempt > 1 {
+				ec.Log.Infof("addRouteWithRetry: route %v added successfully on attempt %d", route, attempt)
 			}
 			return nil
 		}
 		if !os.IsExist(lastErr) {
 			return lastErr
 		}
-		ec.Log.Warnf("addRouteWithRetry: route %v already exists (attempt %d/%d), retrying in %v", route, attempt+1, maxAttempts, routeRetryInterval)
-		if attempt < maxAttempts-1 {
+		ec.Log.Warnf("addRouteWithRetry: route %v already exists (attempt %d/%d), retrying in %v", route, attempt, maxAttempts, routeRetryInterval)
+		if attempt < maxAttempts {
 			time.Sleep(routeRetryInterval)
 		}
 	}

--- a/cmd/egress-cni-plugin/egressContext.go
+++ b/cmd/egress-cni-plugin/egressContext.go
@@ -45,6 +45,8 @@ const (
 	// DadTimeout Time duration CNI waits for an IPv6 address assigned to an interface
 	// to move to stable state before error'ing out.
 	DadTimeout = 10 * time.Second
+	// routeRetryInterval is the delay between retries when RouteAdd fails with EEXIST
+	routeRetryInterval = 100 * time.Millisecond
 )
 
 // egressContext includes all info to run container ADD or DEL action
@@ -195,6 +197,27 @@ func (ec *egressContext) setupContainerVethV4() (*current.Interface, *current.In
 	}
 	return hostInterface, containerInterface, nil
 }
+
+// addRouteWithRetry attempts RouteAdd and retries on EEXIST, which can occur when a
+// stale route from a dying pod's veth has not yet been cleaned up by the container runtime.
+func (ec *egressContext) addRouteWithRetry(route *netlink.Route) error {
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		lastErr = ec.Link.RouteAdd(route)
+		if lastErr == nil {
+			return nil
+		}
+		if !os.IsExist(lastErr) {
+			return lastErr
+		}
+		if attempt < maxAttempts-1 {
+			time.Sleep(routeRetryInterval)
+		}
+	}
+	return fmt.Errorf("stale route still exists after %d attempts: %w", maxAttempts, lastErr)
+}
+
 func (ec *egressContext) setupHostVethV4(vethName string) error {
 	// hostVeth moved namespaces and may have a new ifindex
 	veth, err := ec.Link.LinkByName(vethName)
@@ -226,12 +249,12 @@ func (ec *egressContext) setupHostVethV4(vethName string) error {
 			IP:   ipc.Address.IP,
 			Mask: net.CIDRMask(maskLen, maskLen),
 		}
-		err := ec.Link.RouteAdd(&netlink.Route{
+		route := &netlink.Route{
 			LinkIndex: veth.Attrs().Index,
 			Scope:     netlink.SCOPE_LINK, // <- ptp uses SCOPE_HOST here
 			Dst:       ipn,
-		})
-		if err != nil && !os.IsExist(err) {
+		}
+		if err := ec.addRouteWithRetry(route); err != nil {
 			return fmt.Errorf("failed to add route on host: %v", err)
 		}
 	}
@@ -467,14 +490,15 @@ func (ec *egressContext) setupHostIPv6Route(hostInterface *current.Interface, co
 		return err
 	}
 	// set up to container return traffic route in host
-	return link.RouteAdd(&netlink.Route{
+	route := &netlink.Route{
 		LinkIndex: hostIf.Attrs().Index,
 		Scope:     netlink.SCOPE_HOST,
 		Dst: &net.IPNet{
 			IP:   containerIPv6,
 			Mask: net.CIDRMask(128, 128),
 		},
-	})
+	}
+	return ec.addRouteWithRetry(route)
 }
 
 func (ec *egressContext) setupContainerVethV6() (hostInterface, containerInterface *current.Interface, err error) {

--- a/cmd/egress-cni-plugin/egressContext.go
+++ b/cmd/egress-cni-plugin/egressContext.go
@@ -206,11 +206,15 @@ func (ec *egressContext) addRouteWithRetry(route *netlink.Route) error {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		lastErr = ec.Link.RouteAdd(route)
 		if lastErr == nil {
+			if attempt > 0 {
+				ec.Log.Infof("addRouteWithRetry: route %v added successfully on attempt %d", route, attempt+1)
+			}
 			return nil
 		}
 		if !os.IsExist(lastErr) {
 			return lastErr
 		}
+		ec.Log.Warnf("addRouteWithRetry: route %v already exists (attempt %d/%d), retrying in %v", route, attempt+1, maxAttempts, routeRetryInterval)
 		if attempt < maxAttempts-1 {
 			time.Sleep(routeRetryInterval)
 		}

--- a/cmd/egress-cni-plugin/egressContext_test.go
+++ b/cmd/egress-cni-plugin/egressContext_test.go
@@ -1,0 +1,88 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+
+	mock_netlink "github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
+)
+
+func testRoute() *netlink.Route {
+	return &netlink.Route{
+		LinkIndex: 100,
+		Scope:     netlink.SCOPE_LINK,
+		Dst: &net.IPNet{
+			IP:   net.ParseIP("169.254.172.10"),
+			Mask: net.CIDRMask(32, 32),
+		},
+	}
+}
+
+func TestAddRouteWithRetry_SuccessFirstAttempt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLink := mock_netlink.NewMockNetLink(ctrl)
+	ec := egressContext{Link: mockLink}
+
+	mockLink.EXPECT().RouteAdd(gomock.Any()).Return(nil)
+
+	err := ec.addRouteWithRetry(testRoute())
+	assert.NoError(t, err)
+}
+
+func TestAddRouteWithRetry_SuccessAfterEEXIST(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLink := mock_netlink.NewMockNetLink(ctrl)
+	ec := egressContext{Link: mockLink}
+
+	gomock.InOrder(
+		mockLink.EXPECT().RouteAdd(gomock.Any()).Return(syscall.EEXIST),
+		mockLink.EXPECT().RouteAdd(gomock.Any()).Return(syscall.EEXIST),
+		mockLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+	)
+
+	err := ec.addRouteWithRetry(testRoute())
+	assert.NoError(t, err)
+}
+
+func TestAddRouteWithRetry_NonEEXISTError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLink := mock_netlink.NewMockNetLink(ctrl)
+	ec := egressContext{Link: mockLink}
+
+	mockLink.EXPECT().RouteAdd(gomock.Any()).Return(fmt.Errorf("permission denied"))
+
+	err := ec.addRouteWithRetry(testRoute())
+	assert.EqualError(t, err, "permission denied")
+}
+
+func TestAddRouteWithRetry_ExhaustedRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockLink := mock_netlink.NewMockNetLink(ctrl)
+	ec := egressContext{Link: mockLink}
+
+	mockLink.EXPECT().RouteAdd(gomock.Any()).Return(syscall.EEXIST).Times(5)
+
+	err := ec.addRouteWithRetry(testRoute())
+	assert.ErrorContains(t, err, "stale route still exists after 5 attempts")
+	assert.True(t, errors.Is(err, syscall.EEXIST))
+}

--- a/cmd/egress-cni-plugin/egressContext_test.go
+++ b/cmd/egress-cni-plugin/egressContext_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	mock_netlink "github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper/mocks"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 )
 
 func testRoute() *netlink.Route {
@@ -52,7 +53,8 @@ func TestAddRouteWithRetry_SuccessFirstAttempt(t *testing.T) {
 func TestAddRouteWithRetry_SuccessAfterEEXIST(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLink := mock_netlink.NewMockNetLink(ctrl)
-	ec := egressContext{Link: mockLink}
+	log := logger.New(&logger.Configuration{LogLevel: "DEBUG"})
+	ec := egressContext{Link: mockLink, Log: log}
 
 	gomock.InOrder(
 		mockLink.EXPECT().RouteAdd(gomock.Any()).Return(syscall.EEXIST),
@@ -78,7 +80,8 @@ func TestAddRouteWithRetry_NonEEXISTError(t *testing.T) {
 func TestAddRouteWithRetry_ExhaustedRetries(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLink := mock_netlink.NewMockNetLink(ctrl)
-	ec := egressContext{Link: mockLink}
+	log := logger.New(&logger.Configuration{LogLevel: "DEBUG"})
+	ec := egressContext{Link: mockLink, Log: log}
 
 	mockLink.EXPECT().RouteAdd(gomock.Any()).Return(syscall.EEXIST).Times(5)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
  Fixes a race condition where pods permanently lose IPv4 egress connectivity on IPv6 clusters with egress-cni enabled during burst pod creation. When CNI DEL releases an IP back to host-local IPAM but the old pod's network namespace (veth + host route) hasn't been destroyed yet, a new pod assigned the same IP hits EEXIST on RouteAdd. The old code swallowed this error, leaving the route pointing to the stale veth. When the runtime eventually destroys the old netns, the route is deleted — leaving the new pod with no host route.

  Before the fix- there was no log to say why the route was missing as it was being ignored.
 
 ```
Pod v4if0 interface: inet 169.254.175.30/22
Host route for 169.254.175.30: <EMPTY - NO ROUTE>
 ```
  
  
  

**What does this PR do / Why do we need it?**:
Adds a simple retry (5 attempts, 100ms interval) around RouteAdd in setupHostVethV4 and setupHostIPv6Route. If RouteAdd fails with EEXIST, we retry after a short delay to allow the container runtime to finish cleaning up the old pod's netns and stale route. If retries are exhausted, the error is propagated (rather than swallowed), allowing kubelet to retry CNI ADD.


**Testing done on this change**:
  - Unit tests added for addRouteWithRetry covering: success on first attempt, success after transient EEXIST, non-EEXIST errors returned immediately, and exhausted retries returning error.
  - Verified build passes with GOOS=linux go vet ./cmd/egress-cni-plugin/
 
**Workload**: 300 replicas pinned to ONE node, maxSurge=200, NO topologySpreadConstraints
**Trigger**: 15 overlapping rollout restarts spaced 10s apart

```
{"level":"warn","ts":"2026-06-18T06:02:45.259Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.15/32} already exists (attempt 1/5), retrying in 100ms"}
{"level":"warn","ts":"2026-06-18T06:02:45.359Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.15/32} already exists (attempt 2/5), retrying in 100ms"}
{"level":"warn","ts":"2026-06-18T06:02:45.459Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.15/32} already exists (attempt 3/5), retrying in 100ms"}
{"level":"warn","ts":"2026-06-18T06:02:45.560Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.15/32} already exists (attempt 4/5), retrying in 100ms"}
{"level":"info","ts":"2026-06-18T06:02:45.660Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.15/32} added successfully on attempt 5"}

{"level":"warn","ts":"2026-06-18T06:03:20.310Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.41/32} already exists (attempt 1/5), retrying in 100ms"}
{"level":"info","ts":"2026-06-18T06:03:23.782Z","msg":"addRouteWithRetry: route {Dst: 169.254.175.41/32} added successfully on attempt 2"}

```
  
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
  No. Works with a standard image tag update via kubectl patch.
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**: 
No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: 
No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
