### PR TITLE
Clean up primaryIP map entry when ENI is freed in tryFreeENI

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -882,9 +882,10 @@ func (c *IPAMContext) tryFreeENI(ctx context.Context, networkCard int) {
 
 	err = c.networkClient.DeleteRulesBySrc(c.primaryIP[eni], c.enableIPv6)
 	if err != nil {
-		log.Errorf("Failed to delete rules for Primary IP of ENI err: %v", err)
-		return
+		ipamdErrInc("freeENIDeleteRulesFailed")
+		log.Errorf("Failed to delete rules for Primary IP of ENI %s, err: %v", eni, err)
 	}
+	delete(c.primaryIP, eni)
 }
 
 // When warm IP/prefix targets are defined, free extra IPs

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -978,6 +978,92 @@ func TestDecreaseIPPool(t *testing.T) {
 	assert.Equal(t, true, enabled) // there is warm ip target enabled with the value of 1
 }
 
+func TestTryFreeENI_DeletesPrimaryIPEntry(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:     m.awsutils,
+		networkClient: m.network,
+		k8sClient:     m.k8sClient,
+		primaryIP:     make(map[string]string),
+		terminating:   int32(0),
+	}
+	mockContext.dataStoreAccess = testDatastore()
+
+	// Add primary ENI
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(primaryENIid, primaryDevice, true, false, false, networkutils.CalculateRouteTableId(primaryDevice, 0), "")
+	testAddr1 := net.IPNet{IP: net.ParseIP(ipaddr01), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddIPv4CidrToStore(primaryENIid, testAddr1, false)
+
+	// Add secondary ENI with one IP
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(secENIid, secDevice, false, false, false, networkutils.CalculateRouteTableId(secDevice, 0), "")
+	testAddr11 := net.IPNet{IP: net.ParseIP(ipaddr11), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddIPv4CidrToStore(secENIid, testAddr11, false)
+	mockContext.primaryIP[secENIid] = ipaddr11
+
+	// Wait for ENI to pass minENILifeTime (1m) so it becomes deletable
+	time.Sleep(61 * time.Second)
+
+	// Expect FreeENI and DeleteRulesBySrc to succeed
+	m.awsutils.EXPECT().FreeENI(gomock.Any(), secENIid).Return(nil)
+	m.network.EXPECT().DeleteRulesBySrc(ipaddr11, false).Return(nil)
+
+	mockContext.tryFreeENI(context.Background(), defaultNetworkCard)
+
+	// Verify ENI is removed from datastore
+	eniInfos := mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).GetENIInfos()
+	_, eniInDatastore := eniInfos.ENIs[secENIid]
+	assert.False(t, eniInDatastore, "freed ENI should be removed from datastore")
+
+	// Verify primaryIP entry was deleted
+	_, exists := mockContext.primaryIP[secENIid]
+	assert.False(t, exists, "primaryIP entry for freed ENI should be deleted")
+}
+
+func TestTryFreeENI_DeletesPrimaryIPEntryOnRuleFailure(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:     m.awsutils,
+		networkClient: m.network,
+		k8sClient:     m.k8sClient,
+		primaryIP:     make(map[string]string),
+		terminating:   int32(0),
+	}
+	mockContext.dataStoreAccess = testDatastore()
+
+	// Add primary ENI
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(primaryENIid, primaryDevice, true, false, false, networkutils.CalculateRouteTableId(primaryDevice, 0), "")
+	testAddr1 := net.IPNet{IP: net.ParseIP(ipaddr01), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddIPv4CidrToStore(primaryENIid, testAddr1, false)
+
+	// Add secondary ENI with one IP
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(secENIid, secDevice, false, false, false, networkutils.CalculateRouteTableId(secDevice, 0), "")
+	testAddr11 := net.IPNet{IP: net.ParseIP(ipaddr11), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddIPv4CidrToStore(secENIid, testAddr11, false)
+	mockContext.primaryIP[secENIid] = ipaddr11
+
+	// Wait for ENI to pass minENILifeTime (1m) so it becomes deletable
+	time.Sleep(61 * time.Second)
+
+	// FreeENI succeeds but DeleteRulesBySrc fails
+	m.awsutils.EXPECT().FreeENI(gomock.Any(), secENIid).Return(nil)
+	m.network.EXPECT().DeleteRulesBySrc(ipaddr11, false).Return(errors.New("transient netlink failure"))
+
+	mockContext.tryFreeENI(context.Background(), defaultNetworkCard)
+
+	// Verify ENI is removed from datastore
+	eniInfos := mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).GetENIInfos()
+	_, eniInDatastore := eniInfos.ENIs[secENIid]
+	assert.False(t, eniInDatastore, "freed ENI should be removed from datastore")
+
+	// Verify primaryIP entry was still deleted despite rule deletion failure
+	_, exists := mockContext.primaryIP[secENIid]
+	assert.False(t, exists, "primaryIP entry for freed ENI should be deleted even when DeleteRulesBySrc fails")
+}
+
 func TestTryAddIPToENI(t *testing.T) {
 	_ = os.Unsetenv(envCustomNetworkCfg)
 	m := setup(t)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug, cleanup

<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
We store the ENI -> Primary IP data which is used while configuring the ENI network and verifying this primary IP is not assigned to the Pod. However, when the ENI is freed, it is not deleted from this store. 
This is a harmless as we do not check this store when this ENI appears as a secondary IP on a different ENI, so overall there is no impact, just cleans up the logs

**What does this PR do / Why do we need it?**:
No-op mostly, but just removes all the entry so that it doesn't keep listing


**Testing done on this change**: N/A
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**: N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
