### PR TITLE
AL23 cherry pick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ endif
 
 GOLANG_VERSION ?= $(shell cat .go-version)
 # GOLANG_IMAGE is the building golang container image used.
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 # BASE_IMAGE_CNI is the base layer image for the primary AWS VPC CNI plugin container
-BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+BASE_IMAGE_CNI ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 # BASE_IMAGE_CNI_INIT is the base layer image for the AWS VPC CNI init container
-BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_INIT ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 # BASE_IMAGE_CNI_METRICS is the base layer image for the AWS VPC CNI metrics publisher sidecar container
-BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+BASE_IMAGE_CNI_METRICS ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 
 # DESTDIR is where distribution output (container images) is placed.
 DESTDIR = .

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,7 +232,7 @@ The symptom for this issue is the presence of routing table 30200 or 30400.
 
 ## CNI Compatibility
 
-The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2 as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:
+The [CNI image](../scripts/dockerfiles/Dockerfile.release) built for the `aws-node` manifest uses Amazon Linux 2023 (AL23) as the base image. Support for other Linux distributions (custom AMIs) is best-effort. Known issues with other Linux distributions are captured here:
 
 - **iptables**
   Prior to v1.12.1, the VPC CNI image only contained `iptables-legacy`. Newer distributions of RHEL (RHEL 8.x+), Ubuntu (Ubuntu 21.x+), etc. have moved to using `nftables`. This leads to issues such as [this](https://github.com/aws/amazon-vpc-cni-k8s/issues/1847) when running IPAMD.

--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
     -a -o snat-utils cmd/snat-utils/main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 
 WORKDIR /
 COPY --from=builder /workspace/ .

--- a/test/agent/Makefile
+++ b/test/agent/Makefile
@@ -18,7 +18,7 @@ PUBLIC_REPO_IMAGE=public.ecr.aws/$(REGISTRY_ID)/${IMAGE_NAME}:$(VERSION)
 PRIVATE_REPO_IMAGE=$(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME):$(VERSION)
 
 GOLANG_VERSION ?= $(shell cat ../../.go-version)
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
What type of PR is this?
improvement

Which issue does this PR fix?:
Fixes #3657 
Cherry-pick of #3661 to release-1.22 branch.

What does this PR do / Why do we need it?:
Migrates CNI, init, and metrics-helper base images from Amazon Linux 2 to Amazon Linux 2023 (AL23) on the release-1.22 branch.

migrate to al23 base images.
AL2 reaches end of standard support. AL23 provides updated userspace libraries and security patches.

Testing done on this change:

IPv4 stack validated across— K8s 1.31 through 1.36, on AL2/AL2023 (mixed), AL2023-only, and Bottlerocket,
spanning kernels 5.10, 6.1, 6.12.88, and 6.18.30.
IPv6 stack validated on K8s 1.35, AL2023-only, kernel 6.1.
Tested with Cyclonus network policy conformance suite (112 test cases).

Will this PR introduce any new dependencies?:
No. Only base image layer changes.

Will this break upgrades or downgrades? Has updating a running cluster been tested?:
No. Tested upgrade on running cluster with mixed AL2/AL2023 nodes — no disruption.

Does this change require updates to the CNI daemonset config files to work?:
No. Works with standard kubectl patch of image tag.

Does this PR introduce any user-facing change?:

Base container images migrated from Amazon Linux 2 to Amazon Linux 2023.