### PR TITLE
Move gRPC server to Unix socket and scrub introspection data

### DIFF
--- a/charts/aws-vpc-cni/values.yaml
+++ b/charts/aws-vpc-cni/values.yaml
@@ -169,7 +169,7 @@ livenessProbe:
   exec:
     command:
       - /app/grpc-health-probe
-      - '-addr=:50051'
+      - '-addr=unix:///var/run/aws-node/ipamd.sock'
       - '-connect-timeout=5s'
       - '-rpc-timeout=5s'
   initialDelaySeconds: 60
@@ -180,7 +180,7 @@ readinessProbe:
   exec:
     command:
       - /app/grpc-health-probe
-      - '-addr=:50051'
+      - '-addr=unix:///var/run/aws-node/ipamd.sock'
       - '-connect-timeout=5s'
       - '-rpc-timeout=5s'
   initialDelaySeconds: 1

--- a/cmd/aws-vpc-cni/main.go
+++ b/cmd/aws-vpc-cni/main.go
@@ -181,7 +181,7 @@ type Range struct {
 // Wait for IPAMD health check to pass. Note that if IPAMD fails to start, wait happens indefinitely until liveness probe kills pod
 func waitForIPAM() bool {
 	for {
-		cmd := exec.Command("./grpc-health-probe", "-addr", "127.0.0.1:50051", ">", "/dev/null", "2>&1")
+		cmd := exec.Command("./grpc-health-probe", "-addr", "unix:///var/run/aws-node/ipamd.sock")
 		if err := cmd.Run(); err == nil {
 			return true
 		}

--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	ipamdAddress            = "127.0.0.1:50051"
+	ipamdSocketPath         = "/var/run/aws-node/ipamd.sock"
 	dummyInterfacePrefix    = "dummy"
 	npAgentConnTimeout      = 2
 	npaSocketPath           = "/var/run/aws-node/npa.sock"
@@ -136,6 +136,15 @@ func LoadNetConf(bytes []byte) (*NetConf, logger.Logger, error) {
 	return &conf, log, nil
 }
 
+func dialIPAMD(grpcClient grpcwrapper.GRPC, log logger.Logger, socketPath string) (*grpc.ClientConn, error) {
+	conn, err := grpcClient.Dial("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Connected to IPAMD via Unix socket: %s", socketPath)
+	return conn, nil
+}
+
 func cmdAdd(args *skel.CmdArgs) error {
 	return add(args, typeswrapper.New(), grpcwrapper.New(), rpcwrapper.New(), driver.New())
 }
@@ -177,8 +186,8 @@ func add(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 
 	log.Debugf("pod requires multi-nic attachment: %t", requiresMultiNICAttachment)
 
-	// Set up a connection to the ipamD server.
-	conn, err := grpcClient.Dial(ipamdAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// Set up a connection to the ipamD server via Unix socket.
+	conn, err := dialIPAMD(grpcClient, log, ipamdSocketPath)
 	if err != nil {
 		log.Errorf("Failed to connect to backend server for container %s: %v",
 			args.ContainerID, err)
@@ -395,8 +404,8 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	}
 
 	// notify local IP address manager to free secondary IP
-	// Set up a connection to the server.
-	conn, err := grpcClient.Dial(ipamdAddress, grpc.WithInsecure())
+	// Set up a connection to the server via Unix socket.
+	conn, err := dialIPAMD(grpcClient, log, ipamdSocketPath)
 	if err != nil {
 		log.Errorf("Failed to connect to backend server for container %s: %v",
 			args.ContainerID, err)

--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -99,7 +99,7 @@ func TestCmdAdd(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -144,7 +144,7 @@ func TestCmdAddWithNPenabled(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -189,7 +189,7 @@ func TestCmdAddWithNPenabledWithErr(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -232,7 +232,7 @@ func TestCmdAddNetworkErr(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -265,7 +265,7 @@ func TestCmdAddErrSetupPodNetwork(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -303,7 +303,7 @@ func TestCmdAddWithNetworkPolicyModeUnset(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -346,7 +346,7 @@ func TestCmdAddForMultiNICAttachment(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -426,7 +426,7 @@ func TestCmdDel(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -563,7 +563,7 @@ func TestCmdDelWhenIPAMIsDown(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, errors.New("IPAM is down"))
 
 	mocksNetwork.EXPECT().TeardownPodNetwork(gomock.Any(), gomock.Any()).Return(nil)
@@ -623,7 +623,7 @@ func TestCmdDelWhenIPAMIsDownAndPrevResultDeletionFails(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, errors.New("IPAM is down"))
 
 	mocksNetwork.EXPECT().TeardownPodNetwork(gomock.Any(), gomock.Any()).Return(errors.New("error on TeardownPodNetwork"))
@@ -645,7 +645,7 @@ func TestCmdDelErrDelNetwork(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -679,7 +679,7 @@ func TestCmdDelErrTeardown(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -714,7 +714,7 @@ func TestCmdAddForPodENINetwork(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -759,7 +759,7 @@ func TestCmdDelForPodENINetwork(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -802,7 +802,7 @@ func TestCmdDelWithNetworkPolicyModeUnset(t *testing.T) {
 
 	mocksTypes.EXPECT().LoadArgs(gomock.Any(), gomock.Any()).Return(nil)
 
-	conn, _ := grpc.Dial(ipamdAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial("unix://"+ipamdSocketPath, grpc.WithInsecure())
 
 	mocksGRPC.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(conn, nil)
 	mockC := mock_rpc.NewMockCNIBackendClient(ctrl)
@@ -1832,4 +1832,33 @@ func TestLoadNetConf(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDialIPAMD_ConnectsViaUnixSocket(t *testing.T) {
+	ctrl, _, mocksGRPC, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	log := logger.New(&logger.Configuration{LogLevel: "DEBUG"})
+
+	socketPath := t.TempDir() + "/ipamd.sock"
+	conn, _ := grpc.Dial("unix://"+socketPath, grpc.WithInsecure())
+	mocksGRPC.EXPECT().Dial("unix://"+socketPath, gomock.Any()).Return(conn, nil)
+
+	result, err := dialIPAMD(mocksGRPC, log, socketPath)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestDialIPAMD_ReturnsErrorWhenDialFails(t *testing.T) {
+	ctrl, _, mocksGRPC, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	log := logger.New(&logger.Configuration{LogLevel: "DEBUG"})
+
+	socketPath := t.TempDir() + "/ipamd.sock"
+	mocksGRPC.EXPECT().Dial("unix://"+socketPath, gomock.Any()).Return(nil, errors.New("connection refused"))
+
+	result, err := dialIPAMD(mocksGRPC, log, socketPath)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/config/master/aws-k8s-cni-cn.yaml
+++ b/config/master/aws-k8s-cni-cn.yaml
@@ -218,7 +218,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 60
@@ -227,7 +227,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 1

--- a/config/master/aws-k8s-cni-us-gov-east-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-east-1.yaml
@@ -218,7 +218,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 60
@@ -227,7 +227,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 1

--- a/config/master/aws-k8s-cni-us-gov-west-1.yaml
+++ b/config/master/aws-k8s-cni-us-gov-west-1.yaml
@@ -218,7 +218,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 60
@@ -227,7 +227,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 1

--- a/config/master/aws-k8s-cni.yaml
+++ b/config/master/aws-k8s-cni.yaml
@@ -218,7 +218,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 60
@@ -227,7 +227,7 @@ spec:
             exec:
               command:
               - /app/grpc-health-probe
-              - -addr=:50051
+              - -addr=unix:///var/run/aws-node/ipamd.sock
               - -connect-timeout=5s
               - -rpc-timeout=5s
             initialDelaySeconds: 1

--- a/pkg/ipamd/introspect.go
+++ b/pkg/ipamd/introspect.go
@@ -128,6 +128,24 @@ func eniV1RequestHandler(ipam *IPAMContext) func(http.ResponseWriter, *http.Requ
 		for _, ds := range ipam.dataStoreAccess.DataStores {
 			eniInfos[ds.GetNetworkCard()] = ds.GetENIInfos()
 		}
+		// Scrub sensitive fields that could be used to construct malicious gRPC calls.
+		// ContainerID and IfName are attack prerequisites for DelNetwork.
+		for _, info := range eniInfos {
+			for _, eni := range info.ENIs {
+				for _, cidr := range eni.AvailableIPv4Cidrs {
+					for _, addr := range cidr.IPAddresses {
+						addr.IPAMKey.ContainerID = ""
+						addr.IPAMKey.IfName = ""
+					}
+				}
+				for _, cidr := range eni.IPv6Cidrs {
+					for _, addr := range cidr.IPAddresses {
+						addr.IPAMKey.ContainerID = ""
+						addr.IPAMKey.IfName = ""
+					}
+				}
+			}
+		}
 		responseJSON, err := json.Marshal(eniInfos)
 		if err != nil {
 			log.Errorf("Failed to marshal ENI data: %v", err)

--- a/pkg/ipamd/introspect_test.go
+++ b/pkg/ipamd/introspect_test.go
@@ -1,0 +1,116 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ipamd
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEniV1RequestHandler_ScrubsSensitiveFields(t *testing.T) {
+	// Set up a datastore with a pod assigned
+	ds := datastore.NewDataStore(log, datastore.NullCheckpoint{}, false, 0)
+	ds.AddENI("eni-test-001", 0, true, false, false, 254, "subnet-abc")
+	ipv4Addr := net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	ds.AddIPv4CidrToStore("eni-test-001", ipv4Addr, false)
+
+	// Assign an IP to a pod
+	key := datastore.IPAMKey{
+		NetworkName: "aws-cni",
+		ContainerID: "abc123-secret-container-id",
+		IfName:      "eth0",
+	}
+	metadata := datastore.IPAMMetadata{
+		K8SPodNamespace: "default",
+		K8SPodName:      "my-pod",
+	}
+	_, _, _, _, err := ds.AssignPodIPAddress(key, metadata, true, false)
+	require.NoError(t, err)
+
+	// Build IPAMContext
+	dsAccess := &datastore.DataStoreAccess{DataStores: []*datastore.DataStore{ds}}
+	ipamCtx := &IPAMContext{
+		dataStoreAccess: dsAccess,
+	}
+
+	// Call the handler
+	handler := eniV1RequestHandler(ipamCtx)
+	req := httptest.NewRequest(http.MethodGet, "/v1/enis", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Parse response and verify sensitive fields are scrubbed
+	body := rec.Body.String()
+	assert.NotEmpty(t, body)
+
+	// The response should NOT contain the container ID or interface name
+	assert.NotContains(t, body, "abc123-secret-container-id",
+		"ContainerID should be scrubbed from introspection response")
+	assert.NotContains(t, body, `"ifName":"eth0"`,
+		"IfName should be scrubbed from introspection response")
+
+	// But should still contain useful non-sensitive info
+	assert.Contains(t, body, "eni-test-001", "ENI ID should still be present")
+	assert.Contains(t, body, "10.0.0.5", "IP address should still be present")
+
+	// Verify the JSON structure is valid
+	var result map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &result)
+	assert.NoError(t, err, "Response should be valid JSON")
+}
+
+func TestEniV1RequestHandler_ScrubsIPv6Fields(t *testing.T) {
+	// Set up a datastore with an IPv6 prefix
+	ds := datastore.NewDataStore(log, datastore.NullCheckpoint{}, true, 0)
+	ds.AddENI("eni-v6-001", 0, true, false, false, 254, "subnet-v6")
+	_, ipv6Net, _ := net.ParseCIDR("2001:db8::/64")
+	ds.AddIPv6CidrToStore("eni-v6-001", *ipv6Net, true)
+
+	// Assign an IPv6 address to a pod
+	key := datastore.IPAMKey{
+		NetworkName: "aws-cni",
+		ContainerID: "v6-container-secret-id",
+		IfName:      "eth0",
+	}
+	metadata := datastore.IPAMMetadata{
+		K8SPodNamespace: "default",
+		K8SPodName:      "v6-pod",
+	}
+	_, _, _, _, err := ds.AssignPodIPAddress(key, metadata, false, true)
+	require.NoError(t, err)
+
+	dsAccess := &datastore.DataStoreAccess{DataStores: []*datastore.DataStore{ds}}
+	ipamCtx := &IPAMContext{
+		dataStoreAccess: dsAccess,
+	}
+
+	handler := eniV1RequestHandler(ipamCtx)
+	req := httptest.NewRequest(http.MethodGet, "/v1/enis", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, "v6-container-secret-id",
+		"IPv6 ContainerID should be scrubbed from introspection response")
+}

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -43,7 +44,7 @@ import (
 )
 
 const (
-	ipamdgRPCaddress      = "127.0.0.1:50051"
+	ipamdGRPCSocketPath   = "/var/run/aws-node/ipamd.sock"
 	grpcHealthServiceName = "grpc.health.v1.aws-node"
 
 	vpccniPodIPKey = "vpc.amazonaws.com/pod-ips"
@@ -469,28 +470,50 @@ func (s *server) GetNetworkPolicyConfigs(ctx context.Context, e *emptypb.Empty) 
 
 // RunRPCHandler handles request from gRPC
 func (c *IPAMContext) RunRPCHandler(version string) error {
-	log.Infof("Serving RPC Handler version %s on %s", version, ipamdgRPCaddress)
-	listener, err := net.Listen("tcp", ipamdgRPCaddress)
-	if err != nil {
-		log.Errorf("Failed to listen gRPC port: %v", err)
-		return errors.Wrap(err, "ipamd: failed to listen to gRPC port")
+	return c.runRPCHandlerWithSocketPath(version, ipamdGRPCSocketPath)
+}
+
+func (c *IPAMContext) runRPCHandlerWithSocketPath(version string, socketPath string) error {
+	log.Infof("Serving RPC Handler version %s on unix:%s", version, socketPath)
+
+	// Ensure the parent directory exists
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		return errors.Wrap(err, "ipamd: failed to create socket directory")
 	}
+
+	// Remove stale socket file from a previous run
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "ipamd: failed to remove stale socket")
+	}
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Errorf("Failed to listen on Unix socket %s: %v", socketPath, err)
+		return errors.Wrap(err, "ipamd: failed to listen on Unix socket")
+	}
+
+	// Restrict socket to root:root 0660. The CNI plugin runs as root (invoked by kubelet).
+	if err := os.Chmod(socketPath, 0660); err != nil {
+		listener.Close()
+		_ = os.Remove(socketPath)
+		return errors.Wrap(err, "ipamd: failed to set socket permissions")
+	}
+
 	grpcServer := grpc.NewServer()
 	rpc.RegisterCNIBackendServer(grpcServer, &server{version: version, ipamContext: c})
 	rpc.RegisterConfigServerBackendServer(grpcServer, &server{version: version, ipamContext: c})
 	healthServer := health.NewServer()
-	// If ipamd can talk to the API server and to the EC2 API, the pod is healthy.
-	// No need to ever change this to HealthCheckResponse_NOT_SERVING since it's a local service only
 	healthServer.SetServingStatus(grpcHealthServiceName, healthpb.HealthCheckResponse_SERVING)
 	healthpb.RegisterHealthServer(grpcServer, healthServer)
 
 	// Register reflection service on gRPC server.
 	reflection.Register(grpcServer)
+
 	// Add shutdown hook
 	go c.shutdownListener()
 	if err := grpcServer.Serve(listener); err != nil {
-		log.Errorf("Failed to start server on gRPC port: %v", err)
-		return errors.Wrap(err, "ipamd: failed to start server on gPRC port")
+		log.Errorf("Failed to start server on Unix socket: %v", err)
+		return errors.Wrap(err, "ipamd: failed to start server on Unix socket")
 	}
 	return nil
 }

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -16,7 +16,9 @@ package ipamd
 import (
 	"context"
 	"net"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
@@ -29,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer_VersionCheck(t *testing.T) {
@@ -575,4 +578,133 @@ func TestServer_GetNetworkPolicyConfigs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "standard", resp.NetworkPolicyMode)
 	assert.True(t, resp.MultiNICEnabled)
+}
+
+func TestRunRPCHandler_UnixSocket(t *testing.T) {
+	socketPath := t.TempDir() + "/ipamd.sock"
+
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		networkClient:   m.network,
+		dataStoreAccess: datastore.InitializeDataStores([]bool{false}, "test", false, log),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mockContext.runRPCHandlerWithSocketPath("1.0.0", socketPath)
+	}()
+
+	// Wait for the socket to appear
+	timeout := time.After(5 * time.Second)
+	for {
+		info, err := os.Stat(socketPath)
+		if err == nil {
+			assert.Equal(t, os.FileMode(0660), info.Mode().Perm(), "Socket should have 0660 permissions")
+
+			conn, err := net.Dial("unix", socketPath)
+			assert.NoError(t, err, "Should be able to connect to Unix socket")
+			if conn != nil {
+				conn.Close()
+			}
+			// Clean up: close the listener to stop the gRPC server goroutine
+			t.Cleanup(func() {
+				os.Remove(socketPath)
+			})
+			return
+		}
+		select {
+		case e := <-errCh:
+			t.Fatalf("Server failed to start: %v", e)
+		case <-timeout:
+			t.Fatalf("Timed out waiting for socket to appear")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestRunRPCHandler_RemovesStaleSocket(t *testing.T) {
+	socketPath := t.TempDir() + "/ipamd.sock"
+
+	// Create a stale regular file to simulate leftover from a previous run
+	require.NoError(t, os.WriteFile(socketPath, []byte("stale"), 0600))
+
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		networkClient:   m.network,
+		dataStoreAccess: datastore.InitializeDataStores([]bool{false}, "test", false, log),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mockContext.runRPCHandlerWithSocketPath("1.0.0", socketPath)
+	}()
+
+	// Wait for the socket to appear — proves the stale file was removed and replaced
+	timeout := time.After(5 * time.Second)
+	for {
+		info, err := os.Stat(socketPath)
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			conn, err := net.Dial("unix", socketPath)
+			assert.NoError(t, err, "Should be able to connect after stale socket removal")
+			if conn != nil {
+				conn.Close()
+			}
+			t.Cleanup(func() {
+				os.Remove(socketPath)
+			})
+			return
+		}
+		select {
+		case e := <-errCh:
+			t.Fatalf("Server failed to start: %v", e)
+		case <-timeout:
+			t.Fatalf("Timed out waiting for socket to appear")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestRunRPCHandler_CreatesSocketDirectory(t *testing.T) {
+	socketPath := t.TempDir() + "/sub/dir/ipamd.sock"
+
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		networkClient:   m.network,
+		dataStoreAccess: datastore.InitializeDataStores([]bool{false}, "test", false, log),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mockContext.runRPCHandlerWithSocketPath("1.0.0", socketPath)
+	}()
+
+	// Wait for the socket to appear — proves MkdirAll created intermediate directories
+	timeout := time.After(5 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			t.Cleanup(func() {
+				os.Remove(socketPath)
+			})
+			return
+		}
+		select {
+		case e := <-errCh:
+			t.Fatalf("Server failed to start: %v", e)
+		case <-timeout:
+			t.Fatalf("Timed out waiting for socket to appear")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
bug
**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
IPAMD IP Hijack issue, more detail in internal docs.

**What does this PR do / Why do we need it?**:
  1. Moves gRPC server to Unix domain socket (/var/run/aws-node/ipamd.sock, permissions 0660). The CNI plugin runs as root (invoked by kubelet) and can connect; unprivileged
  hostNetwork pods cannot access the socket due to filesystem permissions and container mount namespace isolation.
  2. Scrubs ContainerID and IfName from the /v1/enis introspection response to block the reconnaissance step. The endpoint remains functional for debugging (ENI IDs, IP
  addresses, pod names) but no longer exposes the fields required to construct a valid DelNetwork call.

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->
  **Unit tests**
```
  $ go test ./pkg/ipamd/... ./cmd/routed-eni-cni-plugin/... -count=1
  ok   github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd          0.332s
  ok   github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore    32.032s
  ok   github.com/aws/amazon-vpc-cni-k8s/cmd/routed-eni-cni-plugin  0.017s
  ok   github.com/aws/amazon-vpc-cni-k8s/cmd/routed-eni-cni-plugin/driver  0.019s
```
  **New tests added**
```
  - TestRunRPCHandler_UnixSocket — verifies socket creation and 0660 permissions
  - TestRunRPCHandler_RemovesStaleSocket — verifies stale socket file is cleaned up before binding
  - TestRunRPCHandler_CreatesSocketDirectory — verifies parent directory is created if missing
  - TestEniV1RequestHandler_ScrubsSensitiveFields — verifies ContainerID/IfName removed from IPv4 introspection response
  - TestEniV1RequestHandler_ScrubsIPv6Fields — verifies ContainerID/IfName removed from IPv6 introspection response
  - TestDialIPAMD_ConnectsViaUnixSocket — verifies client connects to IPAMD via Unix socket
  - TestDialIPAMD_ReturnsErrorWhenDialFails — verifies error is propagated when socket dial fails
```
  **Integration tests (IPAMD suite, EKS v1.35.5, m5.xlarge nodes)**
```
  Ran 26 of 26 Specs in 2491.022 seconds
  26 Passed | 0 Failed | 0 Pending | 0 Skipped
```
  **Manual verification on live cluster (VPC CNI sec-fix.v0.2)**
 1. Unix socket health probe passes:
 ```
  $ kubectl exec -n kube-system aws-node-hzcgl -c aws-node -- /app/grpc-health-probe -addr=unix:///var/run/aws-node/ipamd.sock
  {"level":"info","msg":"status: SERVING"}
```

  2. TCP port 50051 is no longer listening:
 ```
  $ kubectl exec -n kube-system aws-node-hzcgl -c aws-node -- /app/grpc-health-probe -addr=:50051
  {"level":"info","msg":"timeout: failed to connect service \":50051\" within 1s"}
  (exit code 2)
```
  3. Pods healthy with Unix socket probes (0 restarts):
  ```
  $ kubectl get pods -n kube-system -l k8s-app=aws-node
  NAME             READY   STATUS    RESTARTS   AGE
  aws-node-hzcgl   2/2     Running   0          3m12s
  aws-node-wtw44   2/2     Running   0          3m8s
```
  4. IPAMD logs confirm socket-only startup:
  ```
  {"level":"info","caller":"ipamd/rpc_handler.go:473","msg":"Serving RPC Handler version  on unix:/var/run/aws-node/ipamd.sock"}
```

5.DaemonSet rollout completed successfully with no pod disruption.
**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
Not for cx inheriting eks addon/charts default values, for cx who supplying their own default values, they should update livenessProbe and readinessProbe config to use the unix socket path `-addr=unix:///var/run/aws-node/ipamd.sock`

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
Yes
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes, daemonset config change to use `-addr=unix:///var/run/aws-node/ipamd.sock`
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
