### PR TITLE
test/eni-subnet-discovery: size replicas by instance ENI capacity and harden cleanup

### DIFF
--- a/scripts/run-ginkgo-integration-suite.sh
+++ b/scripts/run-ginkgo-integration-suite.sh
@@ -37,7 +37,7 @@ function load_test_parameters(){
 }
 
 function run_ginkgo_test() {
-  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v --timeout 60m --no-color --fail-on-pending $GINKGO_TEST_BUILD/$SUITE_NAME.test -- \
+  (CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS -v --timeout 80m --no-color --fail-on-pending $GINKGO_TEST_BUILD/$SUITE_NAME.test -- \
     --cluster-kubeconfig="$KUBECONFIG" \
     --cluster-name="$CLUSTER_NAME" \
     --aws-region="$REGION" \

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
@@ -130,7 +130,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(30). // Enough to require secondary ENIs
+					Replicas(podsPerENI(string(primaryInstance.InstanceType))). // One ENI's worth; primary subnet is excluded so all pods land on a secondary ENI
 					PodLabel(enhancedPodLabelKey, enhancedPodLabelVal).
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()
@@ -277,7 +277,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(30). // Enough to require secondary ENIs
+					Replicas(computeReplicasForBothSubnets(string(primaryInstance.InstanceType))). // Must overflow onto a secondary ENI (primary subnet not excluded here)
 					PodLabel(enhancedPodLabelKey, enhancedPodLabelVal).
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_enhanced_test.go
@@ -130,7 +130,7 @@ var _ = Describe("ENI Subnet Discovery Enhanced Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(podsPerENI(string(primaryInstance.InstanceType))). // One ENI's worth; primary subnet is excluded so all pods land on a secondary ENI
+					Replicas(computeReplicasForBothSubnets(string(primaryInstance.InstanceType))). // Overflow past one ENI so a secondary ENI is forced; it must land in the discovered subnet.
 					PodLabel(enhancedPodLabelKey, enhancedPodLabelVal).
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_primary_exclusion_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_primary_exclusion_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Primary ENI Exclusion Tests", func() {
 				validatePrimaryENIExclusionInDatastore(primaryENIID)
 
 				By("Scaling deployment to force new ENI creation")
-				scaledDeployment := scaleDeployment(initialDeployment, 20) // Force secondary ENI creation
+				scaledDeployment := scaleDeployment(initialDeployment, podsPerENI(string(primaryInstance.InstanceType))) // Scale up; primary subnet is excluded so new pods land on a secondary ENI
 
 				By("Waiting for new pods to be scheduled")
 				time.Sleep(30 * time.Second)
@@ -208,7 +208,7 @@ var _ = Describe("Primary ENI Exclusion Tests", func() {
 				time.Sleep(30 * time.Second)
 
 				By("Scaling deployment to test prefix delegation with exclusion")
-				scaledDeployment := scaleDeployment(initialDeployment, 15)
+				scaledDeployment := scaleDeployment(initialDeployment, podsPerENI(string(primaryInstance.InstanceType)))
 
 				By("Verifying new pods use secondary subnet with prefix delegation")
 				validateNewPodsOnSecondarySubnet(scaledDeployment, secondarySubnetCIDR)

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
@@ -455,16 +455,25 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 					GinkgoWriter.Printf("Warning: Failed to exclude test subnet: %v\n", err)
 				}
 
-				By("Resetting WARM_ENI_TARGET to 0 to release ENIs")
+				// Force the CNI to reclaim the now-unused ENIs in the excluded test subnet.
+				// WARM_ENI_TARGET=0 alone does not: excluding the subnet (cni=0) drops its IPs
+				// from the warm pool, which shuts the ENI-reclaim path. Setting WARM_IP_TARGET
+				// keeps that path always evaluating extra ENIs for deletion.
+				By("Forcing ENI reclaim so the test subnet's ENIs are released")
 				k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
-					utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
-				time.Sleep(90 * time.Second)
+					utils.AwsNodeName, map[string]string{"WARM_IP_TARGET": "2", "WARM_ENI_TARGET": "0"})
 
-				By("Deleting test subnet")
-				err = f.CloudServices.EC2().DeleteSubnet(context.TODO(), secondarySubnetWithOldTagID)
-				if err != nil {
-					GinkgoWriter.Printf("Warning: Failed to delete subnet %s: %v\n", secondarySubnetWithOldTagID, err)
-				}
+				// Delete only once the ENIs are gone, retrying to avoid a DependencyViolation
+				// that would leak the subnet into later specs.
+				By("Deleting test subnet once its ENIs are released")
+				Eventually(func() error {
+					return f.CloudServices.EC2().DeleteSubnet(context.TODO(), secondarySubnetWithOldTagID)
+				}, 3*time.Minute, 20*time.Second).Should(Succeed(), "test subnet should delete once its ENIs are released")
+
+				// Restore WARM_IP_TARGET to its prior (unset) state so the next spec starts clean.
+				By("Restoring WARM_IP_TARGET to its prior unset value")
+				k8sUtils.RemoveVarFromDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+					utils.AwsNodeName, map[string]struct{}{"WARM_IP_TARGET": {}})
 			})
 
 			It("should include subnet with cni=1 even if old cluster tag is present (old prefix is ignored)", func() {

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_secondary_exclusion_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(15). // Enough to force secondary ENI creation
+					Replicas(computeReplicasForBothSubnets(string(primaryInstance.InstanceType))). // Spread pods across primary + secondary subnets
 					PodLabel(secondaryExclusionPodLabelKey, secondaryExclusionPodLabelVal).
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()
@@ -194,7 +194,9 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 				validateSecondaryENIExclusionInDatastore()
 
 				By("Scaling deployment to test new pod allocation behavior")
-				scaledDeployment := scaleDeployment(initialDeployment, 25) // Add more pods
+				// Scale above the initial both-subnets count so new pods are created; after the
+				// secondary subnet is excluded these new pods must land in the primary subnet.
+				scaledDeployment := scaleDeployment(initialDeployment, computeReplicasForBothSubnets(string(primaryInstance.InstanceType))+2) // Add more pods
 
 				By("Waiting for new pods to be scheduled")
 				time.Sleep(45 * time.Second)
@@ -219,7 +221,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 				time.Sleep(30 * time.Second)
 
 				By("Scaling deployment to test prefix delegation with secondary exclusion")
-				scaledDeployment := scaleDeployment(initialDeployment, 20)
+				scaledDeployment := scaleDeployment(initialDeployment, computeReplicasForBothSubnets(string(primaryInstance.InstanceType))+2)
 
 				By("Verifying new pods use primary subnet with prefix delegation")
 				validateNewPodsAvoidExcludedSecondaryENI(scaledDeployment, primarySubnetCIDR, secondarySubnetCIDR)
@@ -299,7 +301,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(15). // Enough to force secondary ENI creation
+					Replicas(computeReplicasForBothSubnets(string(primaryInstance.InstanceType))). // Overflow onto a secondary ENI so the gating (untagged subnet skipped) is actually exercised
 					PodLabel(secondaryExclusionPodLabelKey, "no-cni-tag-gating").
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()
@@ -539,7 +541,7 @@ var _ = Describe("Secondary ENI Exclusion Tests", func() {
 
 				deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 					Container(container).
-					Replicas(15).
+					Replicas(computeReplicasForBothSubnets(string(primaryInstance.InstanceType))). // Overflow onto a secondary ENI so cluster-isolation (different-cluster subnet skipped) is actually exercised
 					PodLabel(secondaryExclusionPodLabelKey, "different-cluster-isolation").
 					NodeName(*primaryInstance.PrivateDnsName).
 					Build()

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
@@ -59,9 +59,8 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 				Args([]string{"3600"}).
 				Build()
 
-			// Size to the node's ENI capacity (replicas are pinned to one node) rather than a
-			// hardcoded count that overruns smaller instance types.
-			replicas := podsPerENI(string(primaryInstance.InstanceType))
+			// Overflow past one ENI so a secondary ENI is forced into the discovered subnet.
+			replicas := computeReplicasForBothSubnets(string(primaryInstance.InstanceType))
 
 			deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Container(container).

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
@@ -24,6 +24,7 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/vpc"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
@@ -58,9 +59,13 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 				Args([]string{"3600"}).
 				Build()
 
+			// Size to the node's ENI capacity (replicas are pinned to one node) rather than a
+			// hardcoded count that overruns smaller instance types.
+			replicas := podsPerENI(string(primaryInstance.InstanceType))
+
 			deploymentBuilder := manifest.NewBusyBoxDeploymentBuilder(f.Options.TestImageRegistry).
 				Container(container).
-				Replicas(50).
+				Replicas(replicas).
 				PodLabel(podLabelKey, podLabelVal).
 				NodeName(*primaryInstance.PrivateDnsName).
 				Build()
@@ -132,6 +137,9 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 				Context("missing ec2:DescribeSubnets permission,", func() {
 					var role string
 					var EKSCNIPolicyV4ARN string
+					// Unique per-run name: IAM policy names are account-global, so a fixed name
+					// collides with a leftover policy from a prior run (CreatePolicy -> 409).
+					eksCNIPolicyV4Name := fmt.Sprintf("AmazonEKS_CNI_Policy_V4-%d", time.Now().Unix())
 					BeforeEach(func() {
 						By("getting the iam role")
 						podList, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector(AwsNodeLabelKey, utils.AwsNodeName)
@@ -157,8 +165,8 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 
 						eksCNIPolicyV4Data := string(eksCNIPolicyV4Bytes)
 
-						By("Creating and attaching policy AmazonEKS_CNI_Policy_V4")
-						output, err := f.CloudServices.IAM().CreatePolicy(context.TODO(), "AmazonEKS_CNI_Policy_V4", eksCNIPolicyV4Data)
+						By(fmt.Sprintf("Creating and attaching policy %s", eksCNIPolicyV4Name))
+						output, err := f.CloudServices.IAM().CreatePolicy(context.TODO(), eksCNIPolicyV4Name, eksCNIPolicyV4Data)
 						Expect(err).ToNot(HaveOccurred())
 						EKSCNIPolicyV4ARN = *output.Policy.Arn
 						err = f.CloudServices.IAM().AttachRolePolicy(context.TODO(), EKSCNIPolicyV4ARN, role)
@@ -175,12 +183,15 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 						err = f.CloudServices.IAM().AttachRolePolicy(context.TODO(), EKSCNIPolicyARN, role)
 						Expect(err).ToNot(HaveOccurred())
 
-						By("Detaching and deleting policy AmazonEKS_CNI_Policy_V4")
-						err = f.CloudServices.IAM().DetachRolePolicy(context.TODO(), EKSCNIPolicyV4ARN, role)
-						Expect(err).ToNot(HaveOccurred())
-
-						err = f.CloudServices.IAM().DeletePolicy(context.TODO(), EKSCNIPolicyV4ARN)
-						Expect(err).ToNot(HaveOccurred())
+						// Best-effort cleanup: a leaked unique policy is harmless, and failing here
+						// would mask the actual test result.
+						By(fmt.Sprintf("Detaching and deleting policy %s", eksCNIPolicyV4Name))
+						if err := f.CloudServices.IAM().DetachRolePolicy(context.TODO(), EKSCNIPolicyV4ARN, role); err != nil {
+							GinkgoWriter.Printf("WARNING: failed to detach policy %s: %v\n", eksCNIPolicyV4Name, err)
+						}
+						if err := f.CloudServices.IAM().DeletePolicy(context.TODO(), EKSCNIPolicyV4ARN); err != nil {
+							GinkgoWriter.Printf("WARNING: failed to delete policy %s: %v\n", eksCNIPolicyV4Name, err)
+						}
 
 						// Sleep to allow time for CNI policy detachment
 						time.Sleep(10 * time.Second)
@@ -286,6 +297,24 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 		})
 	})
 })
+
+// podsPerENI returns the usable pod IPs on one ENI for the instance type (IPv4Limit-1;
+// the ENI's primary IP is not assigned to pods), read from the CNI's static limits DB.
+func podsPerENI(instanceType string) int {
+	ipv4Limit, err := vpc.GetIPv4Limit(instanceType)
+	Expect(err).ToNot(HaveOccurred(), "no IPv4 limit in CNI limits DB for instance type %q", instanceType)
+	Expect(ipv4Limit).To(BeNumerically(">", 1), "IPv4 limit for instance type %q must be > 1", instanceType)
+	return ipv4Limit - 1
+}
+
+// computeReplicasForBothSubnets returns 1.5x one ENI's worth of pods, so they fill the
+// primary ENI and overflow onto a secondary ENI (pods are assigned from the primary ENI
+// first). This distributes pods across both the primary and discovered subnets with a
+// margin beyond the exact one-ENI boundary.
+func computeReplicasForBothSubnets(instanceType string) int {
+	perENI := podsPerENI(instanceType)
+	return (3*perENI + 1) / 2 // ceil(1.5 * perENI)
+}
 
 func checkSecondaryENISubnets(expectNewCidr bool) {
 	instance, err := f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix?**:
N/A. Stabilizes the existing `eni-subnet-discovery` integration suite.

**What does this PR do / Why do we need it?**:
Fixes three sources of flakiness in the `eni-subnet-discovery` suite.

1. Hardcoded replica counts. Specs pinned deployments to one node with fixed counts (`Replicas(50)`/`(30)`/`(15)`, `scaleDeployment(20/25)`) that exceed pod capacity on smaller instance types (`m5.large` has maxPods 29 and 9 usable pods per ENI), so pods got stuck in `OutOfpods` and deployments timed out. Replica counts now come from the CNI's per-instance-type limits DB (`pkg/vpc.GetIPv4Limit`) through two helpers:
   - `podsPerENI` returns `IPv4Limit - 1` (one ENI's worth of pods).
   - `computeReplicasForBothSubnets` returns `ceil(1.5 * podsPerENI)`, which fills the primary ENI and overflows onto a secondary ENI. Used by specs that need to populate a secondary ENI without excluding the primary subnet.

   Both fail loudly if the instance type is missing from the limits DB.

2. ENI leak across specs. The "old cluster tag" spec tagged its test subnet `cni=0` then waited a fixed 90s before `DeleteSubnet`. Excluding the subnet drops its IPs from the warm pool, which stops the CNI's ENI-reclaim path, so the ENIs were never released and `DeleteSubnet` failed with `DependencyViolation`. The leaked subnet and its excluded ENIs then left the next spec without usable ENIs: both secondary ENIs were excluded, there was no room for a new one, and pods could not get IPs. The cleanup now sets `WARM_IP_TARGET` to force reclaim, polls `DeleteSubnet` until the ENIs are gone, and restores `WARM_IP_TARGET` so the next spec starts clean.

3. Hardcoded IAM policy name. The fixed, account-global name collided with leftover policies from prior runs (`CreatePolicy` returned `EntityAlreadyExists`). It now uses a unique per-run name with best-effort cleanup.

This also raises the ginkgo suite timeout from 60m to 80m in `scripts/run-ginkgo-integration-suite.sh`. The full suite runs close to an hour, since each spec does ENI allocation plus 60 to 90 second CNI-settle and cleanup sleeps, so it was hitting the 60m limit and failing with `[TIMEDOUT]`.

**Testing done on this change**:
Ran the affected specs against an `m5.large` EKS cluster. Without the fix the run reproduced the original failure (`1 Passed | 1 Failed`, deployment timeout); with the fix it passed (`2 Passed | 0 Failed`) on the same clean baseline. `go vet` and compile pass.

**Will this PR introduce any new dependencies?**:
No. Uses the existing in-repo `pkg/vpc` limits DB.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No. Test-only change.

**Does this change require updates to the CNI daemonset config files to work?**:
No.

**Does this PR introduce any user-facing change?**:
No.

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
