### PR TITLE
Fix cni-metrics-helper integration failure

### DIFF
--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -19,7 +19,7 @@ import (
 )
 
 type InstallationManager interface {
-	InstallCNIMetricsHelper(image string, tag string, clusterId string) error
+	InstallCNIMetricsHelper(image string, tag string, clusterId string, region string) error
 	UnInstallCNIMetricsHelper() error
 	InstallTigeraOperator(version string) error
 	UninstallTigeraOperator() error
@@ -33,7 +33,7 @@ type defaultInstallationManager struct {
 	releaseManager helm.ReleaseManager
 }
 
-func (d *defaultInstallationManager) InstallCNIMetricsHelper(image string, tag string, clusterId string) error {
+func (d *defaultInstallationManager) InstallCNIMetricsHelper(image string, tag string, clusterId string, region string) error {
 	values := map[string]interface{}{
 		"env": map[string]interface{}{
 			"AWS_CLUSTER_ID": clusterId,
@@ -42,6 +42,10 @@ func (d *defaultInstallationManager) InstallCNIMetricsHelper(image string, tag s
 			"repository": image,
 			"tag":        tag,
 		},
+	}
+
+	if region != "" {
+		values["env"].(map[string]interface{})["AWS_REGION"] = region
 	}
 
 	projectRoot := utils.GetProjectRoot()

--- a/test/framework/resources/aws/services/iam.go
+++ b/test/framework/resources/aws/services/iam.go
@@ -110,7 +110,18 @@ func (d *defaultIAM) ListPolicies(ctx context.Context, scope string) (*iam.ListP
 	listPolicyInput := &iam.ListPoliciesInput{
 		Scope: types.PolicyScopeType(scope),
 	}
-	return d.client.ListPolicies(ctx, listPolicyInput)
+	// ListPolicies is paginated (max 100 per page). Accumulate all pages so callers
+	// that scan for a policy by name don't miss matches beyond the first page.
+	aggregated := &iam.ListPoliciesOutput{}
+	paginator := iam.NewListPoliciesPaginator(d.client, listPolicyInput)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		aggregated.Policies = append(aggregated.Policies, page.Policies...)
+	}
+	return aggregated, nil
 }
 
 func NewIAM(cfg aws.Config) IAM {

--- a/test/integration/metrics-helper/metrics_helper_suite_test.go
+++ b/test/integration/metrics-helper/metrics_helper_suite_test.go
@@ -149,7 +149,7 @@ var _ = BeforeSuite(func() {
 		utils.AwsNodeName, map[string]string{"SOME_NON_EXISTENT_VAR": "0"})
 
 	By("installing cni-metrics-helper using helm")
-	err = f.InstallationManager.InstallCNIMetricsHelper(imageRepository, imageTag, ngName)
+	err = f.InstallationManager.InstallCNIMetricsHelper(imageRepository, imageTag, ngName, f.Options.AWSRegion)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("waiting for the metrics helper to publish initial metrics")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
fix 
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
CNI metrics helper test fails if IMDS is disabled or if AWS API returns a limited policies which fails. This adds region env variable for cni-metrics-helper if available and adds paginated call with list-policies

**What does this PR do / Why do we need it?**:
Fix integration test 

**Testing done on this change**: Tested locally on the cluster. 
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: N/A
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**: N/A
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: N/A
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
