### PR TITLE
fix: resolve ci account vpc leaking during ITs

### DIFF
--- a/test/framework/resources/aws/services/ec2.go
+++ b/test/framework/resources/aws/services/ec2.go
@@ -43,7 +43,8 @@ type EC2 interface {
 	DescribeRouteTablesWithVPCID(ctx context.Context, vpcID string) (*ec2.DescribeRouteTablesOutput, error)
 	CreateSecurityGroup(ctx context.Context, groupName string, description string, vpcID string) (*ec2.CreateSecurityGroupOutput, error)
 	DeleteSecurityGroup(ctx context.Context, groupID string) error
-	AssociateRouteTableToSubnet(ctx context.Context, routeTableId string, subnetID string) error
+	AssociateRouteTableToSubnet(ctx context.Context, routeTableId string, subnetID string) (string, error)
+	DisassociateRouteTable(ctx context.Context, associationID string) error
 	CreateKey(ctx context.Context, keyName string) (*ec2.CreateKeyPairOutput, error)
 	DeleteKey(ctx context.Context, keyName string) error
 	DescribeKey(ctx context.Context, keyName string) (*ec2.DescribeKeyPairsOutput, error)
@@ -329,12 +330,22 @@ func (d *defaultEC2) DescribeRouteTables(ctx context.Context, subnetID string) (
 	return d.client.DescribeRouteTables(ctx, describeRouteTableInput)
 }
 
-func (d *defaultEC2) AssociateRouteTableToSubnet(ctx context.Context, routeTableId string, subnetID string) error {
+func (d *defaultEC2) AssociateRouteTableToSubnet(ctx context.Context, routeTableId string, subnetID string) (string, error) {
 	associateRouteTableInput := &ec2.AssociateRouteTableInput{
 		RouteTableId: aws.String(routeTableId),
 		SubnetId:     aws.String(subnetID),
 	}
-	_, err := d.client.AssociateRouteTable(ctx, associateRouteTableInput)
+	output, err := d.client.AssociateRouteTable(ctx, associateRouteTableInput)
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(output.AssociationId), nil
+}
+
+func (d *defaultEC2) DisassociateRouteTable(ctx context.Context, associationID string) error {
+	_, err := d.client.DisassociateRouteTable(ctx, &ec2.DisassociateRouteTableInput{
+		AssociationId: aws.String(associationID),
+	})
 	return err
 }
 

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
@@ -49,9 +49,9 @@ var (
 	cidrRange              *net.IPNet
 	cidrBlockAssociationID string
 	// Security Group that will be used in ENIConfig
-	customNetworkingSGID         string
-	customNetworkingSubnetIDList       []string
-	customNetworkingRTAssociationIDs   []string
+	customNetworkingSGID             string
+	customNetworkingSubnetIDList     []string
+	customNetworkingRTAssociationIDs []string
 	// List of ENIConfig per Availability Zone
 	eniConfigList        []*v1alpha1.ENIConfig
 	eniConfigBuilderList []*manifest.ENIConfigBuilder

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
@@ -50,7 +50,8 @@ var (
 	cidrBlockAssociationID string
 	// Security Group that will be used in ENIConfig
 	customNetworkingSGID         string
-	customNetworkingSubnetIDList []string
+	customNetworkingSubnetIDList       []string
+	customNetworkingRTAssociationIDs   []string
 	// List of ENIConfig per Availability Zone
 	eniConfigList        []*v1alpha1.ENIConfig
 	eniConfigBuilderList []*manifest.ENIConfigBuilder
@@ -121,7 +122,7 @@ var _ = BeforeSuite(func() {
 		subnetID := *createSubnetOutput.Subnet.SubnetId
 
 		By("associating the route table with the newly created subnet")
-		err = f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
+		rtAssociationID, err := f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
 		Expect(err).ToNot(HaveOccurred())
 
 		eniConfigBuilder := manifest.NewENIConfigBuilder().
@@ -133,6 +134,7 @@ var _ = BeforeSuite(func() {
 
 		// For updating/deleting later
 		customNetworkingSubnetIDList = append(customNetworkingSubnetIDList, subnetID)
+		customNetworkingRTAssociationIDs = append(customNetworkingRTAssociationIDs, rtAssociationID)
 		eniConfigBuilderList = append(eniConfigBuilderList, eniConfigBuilder)
 		eniConfigList = append(eniConfigList, eniConfig.DeepCopy())
 
@@ -207,6 +209,11 @@ var _ = AfterSuite(func() {
 
 	By("deleting pod ENI security group")
 	errs.Append(f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), podEniSGID))
+
+	for _, associationID := range customNetworkingRTAssociationIDs {
+		By(fmt.Sprintf("disassociating route table association %s", associationID))
+		errs.Append(f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), associationID))
+	}
 
 	for _, subnet := range customNetworkingSubnetIDList {
 		By(fmt.Sprintf("deleting the subnet %s", subnet))

--- a/test/integration/custom-networking/custom_networking_suite_test.go
+++ b/test/integration/custom-networking/custom_networking_suite_test.go
@@ -51,14 +51,14 @@ var (
 	cidrRange              *net.IPNet
 	cidrBlockAssociationID string
 	// Security Group that will be used in ENIConfig
-	customNetworkingSGID         string
-	customNetworkingSGOpenPort   = 8080
-	customNetworkingSubnetIDList       []string
-	customNetworkingRTAssociationIDs   []string
-	corednsSGOpenPort            = 53
-	primaryENISGID               string
-	primaryENISGList             []string
-	clusterSGID                  string
+	customNetworkingSGID             string
+	customNetworkingSGOpenPort       = 8080
+	customNetworkingSubnetIDList     []string
+	customNetworkingRTAssociationIDs []string
+	corednsSGOpenPort                = 53
+	primaryENISGID                   string
+	primaryENISGList                 []string
+	clusterSGID                      string
 	// List of ENIConfig per Availability Zone
 	eniConfigList        []*v1alpha1.ENIConfig
 	eniConfigBuilderList []*manifest.ENIConfigBuilder

--- a/test/integration/custom-networking/custom_networking_suite_test.go
+++ b/test/integration/custom-networking/custom_networking_suite_test.go
@@ -53,7 +53,8 @@ var (
 	// Security Group that will be used in ENIConfig
 	customNetworkingSGID         string
 	customNetworkingSGOpenPort   = 8080
-	customNetworkingSubnetIDList []string
+	customNetworkingSubnetIDList       []string
+	customNetworkingRTAssociationIDs   []string
 	corednsSGOpenPort            = 53
 	primaryENISGID               string
 	primaryENISGList             []string
@@ -168,7 +169,7 @@ var _ = BeforeSuite(func() {
 		subnetID := *createSubnetOutput.Subnet.SubnetId
 
 		By("associating the route table with the newly created subnet")
-		err = f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
+		rtAssociationID, err := f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
 		Expect(err).ToNot(HaveOccurred())
 
 		eniConfigBuilder := manifest.NewENIConfigBuilder().
@@ -180,6 +181,7 @@ var _ = BeforeSuite(func() {
 
 		// For updating/deleting later
 		customNetworkingSubnetIDList = append(customNetworkingSubnetIDList, subnetID)
+		customNetworkingRTAssociationIDs = append(customNetworkingRTAssociationIDs, rtAssociationID)
 		eniConfigBuilderList = append(eniConfigBuilderList, eniConfigBuilder)
 		eniConfigList = append(eniConfigList, eniConfig.DeepCopy())
 
@@ -235,6 +237,11 @@ var _ = AfterSuite(func() {
 
 	By("deleting security group")
 	errs.Append(f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), customNetworkingSGID))
+
+	for _, associationID := range customNetworkingRTAssociationIDs {
+		By(fmt.Sprintf("disassociating route table association %s", associationID))
+		errs.Append(f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), associationID))
+	}
 
 	for _, subnet := range customNetworkingSubnetIDList {
 		By(fmt.Sprintf("deleting the subnet %s", subnet))

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -49,6 +49,7 @@ var (
 	cidrRange              *net.IPNet
 	cidrBlockAssociationID string
 	createdSubnet          string
+	rtAssociationID        string
 	primaryInstance        ec2types.Instance
 	useIPv6                bool
 )
@@ -205,7 +206,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("associating the route table with the newly created subnet")
-	err = f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
+	rtAssociationID, err = f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("try detaching all ENIs by setting WARM_ENI_TARGET to 0")
@@ -231,6 +232,13 @@ var _ = AfterSuite(func() {
 		utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "1"})
 
 	var errs prometheus.MultiError
+
+	if rtAssociationID != "" {
+		By(fmt.Sprintf("disassociating route table association %s", rtAssociationID))
+		if err := f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), rtAssociationID); err != nil {
+			errs.Append(err)
+		}
+	}
 
 	By(fmt.Sprintf("deleting the subnet %s", createdSubnet))
 	if err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), createdSubnet); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** Testing
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: n/a
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**: Integration tests are failing in GH CI due to hitting the region VPC limit. Custom networking tests (custom-networking, custom-networking-sgpp, eni-subnet-discovery) create subnets in a secondary CIDR and associate them with the cluster's PublicRouteTable, but never disassociate them during cleanup. When AfterSuite deletes the subnets (or fails to due to lingering ENIs), the route table associations remain. This blocks CloudFormation from deleting the PublicRouteTable, causing the entire cluster stack to get stuck in DELETE_FAILED, leaking the vpc (leading to where we ended up)


**Testing done on this change**: Locally ran ITs, no leakage, verfied in CI account
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: no
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**: No/Yes


**Does this change require updates to the CNI daemonset config files to work?**: no
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
