### PR TITLE
fix: hyperpod ESD issue (cherry-pick of #3754 to release-1.22)

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -2682,7 +2682,7 @@ func (cache *EC2InstanceMetadataCache) IsSubnetExcluded(ctx context.Context, sub
 		}
 	}
 
-	// Subnet not found in VPC
-	log.Warnf("IsSubnetExcluded: subnet %s not found in VPC", subnetID)
-	return false, fmt.Errorf("subnet %s not found in VPC", subnetID)
+	// Subnet not found in VPC — treat as not excluded (e.g. HyperPod cross-account subnets)
+	log.Warnf("IsSubnetExcluded: subnet %s not found in VPC, treating as not excluded", subnetID)
+	return false, nil
 }

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -2889,10 +2889,10 @@ func TestIsSubnetExcluded(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "subnet not found in VPC - should error",
+			name:       "subnet not found in VPC - not excluded (HyperPod cross-account topology)",
 			subnetTags: []ec2types.Tag{},
 			want:       false,
-			wantErr:    true,
+			wantErr:    false,
 		},
 	}
 
@@ -2907,7 +2907,7 @@ func TestIsSubnetExcluded(t *testing.T) {
 			if tt.describeError != nil {
 				// Mock DescribeSubnets to return error
 				mockEC2.EXPECT().DescribeSubnets(gomock.Any(), gomock.Any()).Return(nil, tt.describeError)
-			} else if tt.name == "subnet not found in VPC - should error" {
+			} else if tt.name == "subnet not found in VPC - not excluded (HyperPod cross-account topology)" {
 				// Mock DescribeSubnets to return empty subnet list (subnet not found)
 				subnetResult := &ec2.DescribeSubnetsOutput{
 					Subnets: []ec2types.Subnet{},

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1280,18 +1280,18 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 		return errors.Wrapf(err, "failed to add ENI %s to data store", eni)
 	}
 
-	// Check if this ENI (primary or secondary) is in an excluded subnet and mark it for exclusion
-	if c.useSubnetDiscovery {
-		if _, err := c.excludedENIBasedOnSubnetTags(ctx, eni, eniMetadata); err != nil {
-			return fmt.Errorf("checking to excluded configured subnet, error: %w", err)
-		}
-	}
-
 	// Store the addressable IP for the ENI
 	if c.enableIPv6 {
 		c.primaryIP[eni] = eniMetadata.PrimaryIPv6Address()
 	} else {
 		c.primaryIP[eni] = eniMetadata.PrimaryIPv4Address()
+	}
+
+	// Check if this ENI (primary or secondary) is in an excluded subnet and mark it for exclusion
+	if c.useSubnetDiscovery {
+		if _, err := c.excludedENIBasedOnSubnetTags(ctx, eni, eniMetadata); err != nil {
+			return fmt.Errorf("checking to excluded configured subnet, error: %w", err)
+		}
 	}
 
 	if c.enableIPv6 {

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -4003,6 +4003,209 @@ func TestContainsPrivateIPAddressLimitExceededError(t *testing.T) {
 	}
 }
 
+// TestSetupENI_HyperPod_SubnetNotFound verifies that on HyperPod nodes where the ENI's
+// subnet cannot be resolved by DescribeSubnets (cross-account topology), setupENI still
+// correctly records primaryIP for the ENI. This prevents the reconcile path from later
+// adding the primary IP to the pod IP pool.
+func TestSetupENI_HyperPod_SubnetNotFound(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:          m.awsutils,
+		networkClient:      m.network,
+		primaryIP:          make(map[string]string),
+		terminating:        int32(0),
+		maxENI:             4,
+		numNetworkCards:    1,
+		enableIPv4:         true,
+		useSubnetDiscovery: true,
+	}
+	mockContext.dataStoreAccess = testDatastore()
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+	primaryENIMetadata := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		SubnetID:       "subnet-hyperpod-cross-account",
+		NetworkCard:    defaultNetworkCard,
+		IPv4Addresses: []ec2types.NetworkInterfacePrivateIpAddress{
+			{PrivateIpAddress: &testAddr1, Primary: &primary},
+			{PrivateIpAddress: &testAddr2, Primary: &notPrimary},
+		},
+	}
+
+	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid).AnyTimes()
+	m.network.EXPECT().GetRouteTableNumberForENI(defaultNetworkCard, gomock.Any(), primaryDevice, mockContext.maxENI, false).Times(1)
+	// Simulate HyperPod: subnet not found in VPC returns not excluded, no error
+	m.awsutils.EXPECT().IsSubnetExcluded(gomock.Any(), "subnet-hyperpod-cross-account").Return(false, nil)
+
+	err := mockContext.setupENI(context.Background(), primaryENIMetadata.ENIID, primaryENIMetadata, false, false)
+	assert.NoError(t, err)
+
+	// The critical assertion: primaryIP must be recorded even when subnet can't be resolved
+	assert.Equal(t, ipaddr01, mockContext.primaryIP[primaryENIid])
+	assert.Equal(t, 1, len(mockContext.primaryIP))
+}
+
+// TestSetupENI_HyperPod_SubnetDiscoveryError verifies that even if IsSubnetExcluded
+// returns an error (e.g., API failure), primaryIP is still recorded before the error
+// propagates. This ensures the safety of the reconcile path.
+func TestSetupENI_HyperPod_SubnetDiscoveryError(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:          m.awsutils,
+		networkClient:      m.network,
+		primaryIP:          make(map[string]string),
+		terminating:        int32(0),
+		maxENI:             4,
+		numNetworkCards:    1,
+		enableIPv4:         true,
+		useSubnetDiscovery: true,
+	}
+	mockContext.dataStoreAccess = testDatastore()
+
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+	primaryENIMetadata := awsutils.ENIMetadata{
+		ENIID:          primaryENIid,
+		MAC:            primaryMAC,
+		DeviceNumber:   primaryDevice,
+		SubnetIPv4CIDR: primarySubnet,
+		SubnetID:       "subnet-unreachable",
+		NetworkCard:    defaultNetworkCard,
+		IPv4Addresses: []ec2types.NetworkInterfacePrivateIpAddress{
+			{PrivateIpAddress: &testAddr1, Primary: &primary},
+			{PrivateIpAddress: &testAddr2, Primary: &notPrimary},
+		},
+	}
+
+	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid).AnyTimes()
+	m.network.EXPECT().GetRouteTableNumberForENI(defaultNetworkCard, gomock.Any(), primaryDevice, mockContext.maxENI, false).Times(1)
+	// Simulate subnet discovery API failure
+	m.awsutils.EXPECT().IsSubnetExcluded(gomock.Any(), "subnet-unreachable").Return(false, errors.New("API error"))
+
+	err := mockContext.setupENI(context.Background(), primaryENIMetadata.ENIID, primaryENIMetadata, false, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "checking to excluded configured subnet")
+
+	// Even though setupENI returned an error, primaryIP was recorded before the
+	// subnet check. This is critical: if nodeInit retries and eventually succeeds,
+	// or if the ENI remains in the datastore, the reconcile path will correctly
+	// skip the primary IP.
+	assert.Equal(t, ipaddr01, mockContext.primaryIP[primaryENIid])
+}
+
+// TestReconcile_HyperPod_PrimaryIPSkipped verifies that the reconcile path correctly
+// skips the primary IP when c.primaryIP[eni] is properly set. This is the end-to-end
+// scenario for HyperPod: after setupENI records the primary IP (even with subnet
+// excluded), the reconcile path must not add it to the datastore.
+func TestReconcile_HyperPod_PrimaryIPSkipped(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+	ctx := context.Background()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		networkClient:   m.network,
+		primaryIP:       make(map[string]string),
+		terminating:     int32(0),
+		numNetworkCards: 1,
+	}
+	mockContext.reconcileCooldownCache.cache = make(map[string]time.Time)
+	mockContext.dataStoreAccess = testDatastore()
+
+	// Set up the datastore with the ENI registered
+	_ = mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(primaryENIid, primaryDevice, true, false, false, 0, "")
+
+	// Simulate HyperPod fix: primaryIP is correctly recorded
+	mockContext.primaryIP[primaryENIid] = ipaddr01
+
+	// Add a secondary IP to the datastore (normal operation)
+	secondaryIP := net.IPNet{IP: net.ParseIP(ipaddr02), Mask: net.IPv4Mask(255, 255, 255, 255)}
+	_ = mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddIPv4CidrToStore(primaryENIid, secondaryIP, false)
+
+	// IMDS returns both primary and secondary IPs for the ENI
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+	attachedIPs := []ec2types.NetworkInterfacePrivateIpAddress{
+		{PrivateIpAddress: &testAddr1, Primary: &primary},
+		{PrivateIpAddress: &testAddr2, Primary: &notPrimary},
+	}
+
+	// Run the reconcile function
+	seenIPs := mockContext.verifyAndAddIPsToDatastore(ctx, primaryENIid, attachedIPs, false, defaultNetworkCard)
+
+	// Primary IP should NOT be in seenIPs (it was skipped)
+	assert.False(t, seenIPs[ipaddr01], "Primary IP should be skipped during reconcile")
+	// Secondary IP should be in seenIPs
+	assert.True(t, seenIPs[ipaddr02], "Secondary IP should be seen during reconcile")
+
+	// Verify datastore only has the secondary IP, not the primary
+	curENIs := mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).GetENIInfos()
+	assert.Equal(t, 1, curENIs.TotalIPs, "Only secondary IP should be in the datastore")
+}
+
+// TestReconcile_HyperPod_PrimaryIPNotSet_WithoutFix simulates the pre-fix behavior
+// where primaryIP was empty due to setupENI failing before recording it. Without the
+// fix, the reconcile path would add the primary IP to the pool. This test documents
+// the bug behavior and verifies the fix prevents it.
+func TestReconcile_HyperPod_PrimaryIPNotSet_WithoutFix(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+	ctx := context.Background()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		networkClient:   m.network,
+		primaryIP:       make(map[string]string),
+		terminating:     int32(0),
+		numNetworkCards: 1,
+	}
+	mockContext.reconcileCooldownCache.cache = make(map[string]time.Time)
+	mockContext.dataStoreAccess = testDatastore()
+
+	// Set up the datastore with the ENI registered
+	_ = mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).AddENI(primaryENIid, primaryDevice, true, false, false, 0, "")
+
+	// Simulate the BUG scenario: primaryIP is NOT set (empty string)
+	// This happened pre-fix when setupENI returned error before recording primaryIP
+	// mockContext.primaryIP[primaryENIid] is intentionally NOT set
+
+	// IMDS returns both primary and secondary IPs
+	primary := true
+	notPrimary := false
+	testAddr1 := ipaddr01
+	testAddr2 := ipaddr02
+	attachedIPs := []ec2types.NetworkInterfacePrivateIpAddress{
+		{PrivateIpAddress: &testAddr1, Primary: &primary},
+		{PrivateIpAddress: &testAddr2, Primary: &notPrimary},
+	}
+
+	// Run reconcile - with primaryIP[eni] == "", the string comparison
+	// `strPrivateIPv4 == c.primaryIP[eni]` won't match for "10.10.10.11"
+	seenIPs := mockContext.verifyAndAddIPsToDatastore(ctx, primaryENIid, attachedIPs, false, defaultNetworkCard)
+
+	// Without primaryIP set, BOTH IPs get added (this is the bug the fix prevents)
+	assert.True(t, seenIPs[ipaddr01], "Without primaryIP set, primary IP is incorrectly treated as a regular IP")
+	assert.True(t, seenIPs[ipaddr02])
+
+	// This documents the bug: TotalIPs is 2 (primary + secondary) instead of 1
+	curENIs := mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).GetENIInfos()
+	assert.Equal(t, 2, curENIs.TotalIPs, "Bug: primary IP was added to pool because primaryIP map was empty")
+}
+
 func TestIPAMContext_InInsufficientCidrCoolingPeriod(t *testing.T) {
 	tests := []struct {
 		name                      string


### PR DESCRIPTION
**What type of PR is this?** bug

Backport / cherry-pick of #3754 onto `release-1.22` (targeting the v1.22.4 release line).

**Which issue does this PR fix?**: #3753

**What does this PR do / Why do we need it?**:
HyperPod nodes can have ENIs whose subnet is not in the customer's account, which breaks an assumption made in the Excludable Subnet Discovery (ESD) flow for subnet exclusion. When `DescribeSubnets` cannot resolve such a subnet, the code previously returned an error and failed to record the ENI's primary IP, causing the reconcile path to incorrectly add the primary IP to the pod IP pool.

This change makes `IsSubnetExcluded` treat a subnet that is not found in the VPC as "not excluded" (returning `false, nil` instead of an error), and reorders `setupENI` so the primary IP is recorded before the subnet-exclusion check. Unit tests cover the HyperPod cross-account subnet scenario, the subnet-discovery API error path, and the reconcile path that skips the primary IP.

This is a clean cherry-pick of the change merged to `master` in #3754 — the net diff is identical to upstream `master` (verified via `git patch-id`).

**Testing done on this change**: Original change (#3754) validated on a HyperPod cluster comparing VPC CNI `v1.22.2` against the fixed image:

#### v1.22.2 (10.2.101.235 is ENI primary IP — incorrectly added to pool)
```
    "TotalIPs": 15,
...        "AvailableIPv4Cidrs": {
          "10.2.101.235/32": {
            "Cidr": { "IP": "10.2.101.235", "Mask": "/////w==" },
```
#### fixed image (primary IP correctly excluded)
```
{
  "0": {
    "TotalIPs": 14,
    "AssignedIPs": 3,
          "10.2.144.185/32": {
            "Cidr": { "IP": "10.2.144.185", "Mask": "/////w==" },
            "IPAddresses": {},
            "IsPrefix": false,
            "AddressFamily": ""
```

**Will this PR introduce any new dependencies?**: no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**: no / yes

**Does this change require updates to the CNI daemonset config files to work?**: no

**Does this PR introduce any user-facing change?**:

```release-note
fix: hyperpod compatibility for esd exclusion
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
