### PR TITLE
tests: update eksctl for CI to not use default addon PDBs

### DIFF
--- a/scripts/test/config/bottlerocket.yaml
+++ b/scripts/test/config/bottlerocket.yaml
@@ -6,6 +6,17 @@ metadata:
   name: CLUSTER_NAME_PLACEHOLDER
   region: us-west-2
 
+autoModeConfig:
+  enabled: false
+
+addons:
+  - name: vpc-cni
+  - name: kube-proxy
+  - name: coredns
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+  - name: metrics-server
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+
 nodeGroups:
   - name: ng-bottlerocket
     instanceType: m5.large

--- a/scripts/test/config/perf-cluster.yml
+++ b/scripts/test/config/perf-cluster.yml
@@ -9,6 +9,17 @@ metadata:
   name: CLUSTER_NAME_PLACEHOLDER
   region: us-west-2
 
+autoModeConfig:
+  enabled: false
+
+addons:
+  - name: vpc-cni
+  - name: kube-proxy
+  - name: coredns
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+  - name: metrics-server
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+
 managedNodeGroups:
   - name: cni-test-single-node-mng
     ami: AMI_ID_PLACEHOLDER

--- a/scripts/test/config/test-cluster.yaml
+++ b/scripts/test/config/test-cluster.yaml
@@ -8,6 +8,17 @@ metadata:
   region: us-west-2
   version: "K8S_VERSION_PLACEHOLDER"
 
+autoModeConfig:
+  enabled: false
+
+addons:
+  - name: vpc-cni
+  - name: kube-proxy
+  - name: coredns
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+  - name: metrics-server
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+
 iam:
    serviceRoleARN: "ROLE_ARN_PLACEHOLDER"
 managedNodeGroups:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** testing
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: n/a/
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**: Remove CoreDNS, metrics-server PDB so that custom networking tests don't timeout in CI. The `autoModeConfig` set to `enabled: false` was going to be needed in the future anyway as seen in CI outputs, so may as well do it now



**Testing done on this change**: Local cluster created with `eksctl create cluster -f test-cluster.yaml`, confirmed PDBs are disabled
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
