### PR TITLE
Fix Helm v4 WaitStrategy missing on UninstallRelease

### DIFF
--- a/test/framework/helm/release_manager.go
+++ b/test/framework/helm/release_manager.go
@@ -102,6 +102,7 @@ func (d *defaultReleaseManager) UninstallRelease(namespace string, releaseName s
 	actionConfig := d.obtainActionConfig(namespace)
 
 	uninstallAction := action.NewUninstall(actionConfig)
+	uninstallAction.WaitStrategy = kube.StatusWatcherStrategy
 	return uninstallAction.Run(releaseName)
 }
 


### PR DESCRIPTION
Helm v4 requires WaitStrategy to be set on all actions. The install path was updated but uninstall was missed, causing "wait strategy not set" errors during test cleanup (AfterSuite).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->
testing
**Which issue does this PR fix?**:
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->
to fix it failures

**What does this PR do / Why do we need it?**:


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->
ran IT tests successfully on dev cluster  

```
[AfterSuite] 
/local/home/kaposmee/cni/amazon-vpc-cni-k8s/test/integration/metrics-helper/metrics_helper_suite_test.go:159
  STEP: uninstalling cni-metrics-helper using helm @ 07/06/26 06:18:04.226
  STEP: detaching role policy from the node IAM Role @ 07/06/26 06:18:04.413
  STEP: removing the environment variables from the ds map[SOME_NON_EXISTENT_VAR:{}] @ 07/06/26 06:18:04.677
  STEP: getting the aws-node daemon set in namespace kube-system @ 07/06/26 06:18:04.677
  STEP: updating the daemon set with new environment variable @ 07/06/26 06:18:04.677
  STEP: deleting test namespace @ 07/06/26 06:18:14.692
[AfterSuite] PASSED [20.579 seconds]
------------------------------

Ran 1 of 1 Specs in 424.401 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 7m16.876679672s
Test Suite Passed

```
<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
N/A
**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
N/A

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
N/A
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
N/A
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
