### PR TITLE
test: fix custom-networking BeforeSuite ASG scale-to-0 wait

### DIFF
--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -28,6 +28,7 @@ import (
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -390,13 +391,22 @@ func TerminateInstances(f *framework.Framework) error {
 		return fmt.Errorf("failed to set desired capacity to 0 on %s: %v", asgName, err)
 	}
 
-	// Wait until ASG has actually finished terminating its instances before scaling
+	// Wait until the ASG has no InService instances before scaling back up.
+	// Terminating instances linger in the ASG's Instances list (e.g. Terminating,
+	// Terminating:Wait) until fully reaped, so checking len(Instances)==0 can time
+	// out even though the scale-down succeeded. Treat InService as the only
+	// "still up" state.
 	if err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(ctx, asgName)
 		if derr != nil || len(asgs) == 0 {
 			return false, nil
 		}
-		return len(asgs[0].Instances) == 0, nil
+		for _, inst := range asgs[0].Instances {
+			if inst.LifecycleState == autoscalingtypes.LifecycleStateInService {
+				return false, nil
+			}
+		}
+		return true, nil
 	}); err != nil {
 		return fmt.Errorf("timed out waiting for ASG %s to scale to 0: %v", asgName, err)
 	}


### PR DESCRIPTION
### What

Fix the `custom-networking` integration suite `BeforeSuite`, which fails with `timed out waiting for ASG <name> to scale to 0` and aborts before any spec runs (`Ran 0 of 6 Specs`).

### Why

`TerminateInstances` (`test/framework/resources/aws/utils/nodegroup.go`) scales the nodegroup ASG to 0 and then waits for `len(asgs[0].Instances) == 0`. Terminating instances linger in the ASG's `Instances` list (`Terminating`, `Terminating:Wait`) until fully reaped, so that condition can exceed the 10-minute poll even though the scale-down already succeeded.

Evidence from failing Hydra canary runs (`custom-networking-al2023-ipv4-1-36`, beta):

- Hydra log: `[FAILED] in [BeforeSuite] ... timed out waiting for ASG eks-linux-ng-... to scale to 0: context deadline exceeded`, `Ran 0 of 6 Specs`.
- CloudTrail for the same ASG/window: `SetDesiredCapacity desired=0` at T+0, both instances `TerminateInstances` (by AutoScaling) within ~90s, then ~66 `DescribeAutoScalingGroups` polls until the 10-min timeout at T+10m. The scale-down completed quickly; only the wait condition was wrong.

This reproduced on every real run of the suite (systematic, not flaky). Regression from #3668, which replaced the previous terminate+sleep with the ASG scale-to-0 wait.

### Change

Wait until no instance is `InService` (SDK `autoscalingtypes.LifecycleStateInService`) rather than requiring the `Instances` list to be empty, so terminating/terminated instances no longer block the wait.

### Testing

- `go vet ./test/framework/resources/aws/utils/` — clean.
- `go test -c ./test/integration/custom-networking/` — the integration test binary compiles.
- `gofmt` clean.

(Not yet run end-to-end on a live cluster; drafting for review.)
