### PR TITLE
Fix misleading duration format in DAD-wait timeout error message

### DIFF
--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -69,7 +69,7 @@ func WaitForAddressesToBeStable(netLink netlinkwrapper.NetLink, ifName string, t
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("link %s still has tentative addresses after %d seconds",
+			return fmt.Errorf("link %s still has tentative addresses after %s",
 				ifName,
 				timeout)
 		}


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix?**:

No separate issue. Cosmetic logging bug in the IPv6 DAD-wait timeout error message. Repro is in the Testing section.

**What does this PR do / Why do we need it?**:

`WaitForAddressesToBeStable` formats the timeout `time.Duration` with `%d` and then appends the literal word `seconds`:

```go
return fmt.Errorf("link %s still has tentative addresses after %d seconds", ifName, timeout)
```

`%d` on a `time.Duration` prints its raw underlying value, which is **nanoseconds**. With the current `v6DADTimeout = 10 * time.Second`, the message renders as:

```
link eth0 still has tentative addresses after 10000000000 seconds
```

i.e. it prints the nanosecond count (10,000,000,000) with the word "seconds" tacked on — reading as ~317 years instead of the actual 10 seconds. This is misleading when debugging IPv6 pod-setup failures (the error shows up verbatim in `kubectl describe pod` events).

Fix: use `%s`, which invokes `Duration.String()` and renders the value with the correct, auto-adjusted unit:

```go
return fmt.Errorf("link %s still has tentative addresses after %s", ifName, timeout)
```

Now the message reads `link eth0 still has tentative addresses after 10s`, and it stays correct if the timeout constant ever changes (e.g. `30s`, `2m0s`).

**Testing done on this change**:

- `go build ./pkg/utils/cniutils/` — passes
- `go vet ./pkg/utils/cniutils/` — passes
- `go test ./pkg/utils/cniutils/` — passes
- Verified `Duration.String()` formatting picks the correct unit:

```
10 * time.Second        -> 10s
500 * time.Millisecond  -> 500ms
90 * time.Second        -> 1m30s
```

No test asserted the previous (buggy) message string, so no test changes required.

**Will this PR introduce any new dependencies?**:

No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No. Error-message text only; no behavior change.

**Does this change require updates to the CNI daemonset config files to work?**:

No.

**Does this PR introduce any user-facing change?**:

Only the text of an error/event message. No release note needed.

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
