### PR TITLE
fix: tolerate concurrent NewChain race in egress-cni snat.Add

### DIFF
--- a/cmd/egress-cni-plugin/snat/snat.go
+++ b/cmd/egress-cni-plugin/snat/snat.go
@@ -15,6 +15,7 @@ package snat
 
 import (
 	"net"
+	"strings"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils"
@@ -72,7 +73,7 @@ func Add(ipt iptableswrapper.IPTablesIface, nodeIP, src net.IP, multicastRange, 
 	for _, rule := range rules {
 		_chain := rule[0]
 		if !existingChains[_chain] {
-			if err = ipt.NewChain("nat", _chain); err != nil {
+			if err = ipt.NewChain("nat", _chain); err != nil && !chainExistErr(err) {
 				return err
 			}
 			existingChains[_chain] = true
@@ -87,6 +88,14 @@ func Add(ipt iptableswrapper.IPTablesIface, nodeIP, src net.IP, multicastRange, 
 	}
 
 	return nil
+}
+
+// chainExistErr returns true if the error indicates an iptables chain already exists.
+// This can occur as a benign race when multiple CNI invocations run concurrently on the
+// same node (e.g. many pods starting simultaneously at a cron tick) and both attempt to
+// create the same chain at the same instant.
+func chainExistErr(err error) bool {
+	return strings.Contains(err.Error(), "Chain already exists")
 }
 
 // Del removes rules added by snat

--- a/cmd/egress-cni-plugin/snat/snat.go
+++ b/cmd/egress-cni-plugin/snat/snat.go
@@ -15,7 +15,6 @@ package snat
 
 import (
 	"net"
-	"strings"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils"
@@ -73,7 +72,13 @@ func Add(ipt iptableswrapper.IPTablesIface, nodeIP, src net.IP, multicastRange, 
 	for _, rule := range rules {
 		_chain := rule[0]
 		if !existingChains[_chain] {
-			if err = ipt.NewChain("nat", _chain); err != nil && !chainExistErr(err) {
+			// Tolerate "Chain already exists" from a concurrent invocation that won
+			// the race. On a node with many pods starting simultaneously (e.g. at a
+			// cron tick), multiple egress-cni processes snapshot ListChains before
+			// any has called NewChain and all race to create the same chain. The
+			// second caller gets this error, but the chain is already in the desired
+			// state — it is safe to proceed. See https://github.com/aws/amazon-vpc-cni-k8s/pull/3782.
+			if err = ipt.NewChain("nat", _chain); err != nil && !cniutils.IsChainExistErr(err) {
 				return err
 			}
 			existingChains[_chain] = true
@@ -88,14 +93,6 @@ func Add(ipt iptableswrapper.IPTablesIface, nodeIP, src net.IP, multicastRange, 
 	}
 
 	return nil
-}
-
-// chainExistErr returns true if the error indicates an iptables chain already exists.
-// This can occur as a benign race when multiple CNI invocations run concurrently on the
-// same node (e.g. many pods starting simultaneously at a cron tick) and both attempt to
-// create the same chain at the same instant.
-func chainExistErr(err error) bool {
-	return strings.Contains(err.Error(), "Chain already exists")
 }
 
 // Del removes rules added by snat

--- a/cmd/egress-cni-plugin/snat/snat.go
+++ b/cmd/egress-cni-plugin/snat/snat.go
@@ -97,18 +97,29 @@ func Add(ipt iptableswrapper.IPTablesIface, nodeIP, src net.IP, multicastRange, 
 
 // Del removes rules added by snat
 func Del(ipt iptableswrapper.IPTablesIface, src net.IP, chain, comment string) (err error) {
+	// Tolerate "rule does not exist" — a concurrent DEL invocation may have
+	// already removed this POSTROUTING jump rule before we reached this point.
+	// The desired end state (rule absent) is already achieved; proceed.
 	err = ipt.Delete("nat", "POSTROUTING", "-s", src.String(), "-j", chain, "-m", "comment", "--comment", comment)
-	if err != nil && !cniutils.IsIptableTargetNotExist(err) {
+	if err != nil && !cniutils.IsChainNotExistErr(err) {
 		return err
 	}
 
+	// Tolerate "No chain/target/match" — a concurrent DEL invocation may have
+	// already cleared and deleted this chain. ClearChain internally calls
+	// NewChain; if the chain was already removed it will be re-created as an
+	// empty chain, so a genuine "not exist" return here would be unexpected.
+	// Guard defensively for any implementation that does return it.
 	err = ipt.ClearChain("nat", chain)
-	if err != nil && !cniutils.IsIptableTargetNotExist(err) {
+	if err != nil && !cniutils.IsChainNotExistErr(err) {
 		return err
 	}
 
+	// Tolerate "No chain/target/match" — a concurrent DEL invocation may have
+	// already deleted the chain (after we cleared it or before we got here).
+	// Either way the chain is gone, which is the desired post-DEL state.
 	err = ipt.DeleteChain("nat", chain)
-	if err != nil && !cniutils.IsIptableTargetNotExist(err) {
+	if err != nil && !cniutils.IsChainNotExistErr(err) {
 		return err
 	}
 

--- a/cmd/egress-cni-plugin/snat/snat_test.go
+++ b/cmd/egress-cni-plugin/snat/snat_test.go
@@ -170,3 +170,61 @@ func setupDelExpect(ipt iptableswrapper.IPTablesIface, actualClearChain, actualD
 		*actualRule = append(*actualRule, rule)
 	}).Return(nil).AnyTimes()
 }
+
+// TestDelV4_ClearChainNotExist verifies the teardown DEL+DEL race fix: when
+// ClearChain returns "No chain/target/match by that name" (because a concurrent
+// DEL invocation already removed the chain), Del() must succeed rather than
+// propagating the error.
+func TestDelV4_ClearChainNotExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ipt := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	// The POSTROUTING jump rule is already gone (concurrent DEL won the race).
+	ipt.EXPECT().Delete("nat", "POSTROUTING", gomock.Any()).Return(
+		fmt.Errorf("No chain/target/match by that name"),
+	).AnyTimes()
+
+	// ClearChain also finds the chain already gone.
+	ipt.EXPECT().ClearChain("nat", chainV4).Return(
+		fmt.Errorf("No chain/target/match by that name"),
+	)
+
+	// DeleteChain succeeds (or is also missing — tested separately).
+	ipt.EXPECT().DeleteChain("nat", chainV4).Return(nil)
+
+	err := Del(ipt, containerIPv4, chainV4, comment)
+	assert.Nil(t, err, "Del() must not fail when ClearChain returns 'No chain/target/match by that name'")
+}
+
+// TestDelV4_DeleteChainNotExist verifies the teardown DEL+DEL race fix: when
+// DeleteChain returns "No chain/target/match by that name" (because a concurrent
+// DEL invocation already deleted the chain after we cleared it), Del() must
+// succeed rather than propagating the error.
+func TestDelV4_DeleteChainNotExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ipt := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	// The POSTROUTING jump rule deletion succeeds normally.
+	ipt.EXPECT().Delete("nat", "POSTROUTING", gomock.Any()).Return(nil).AnyTimes()
+
+	// ClearChain succeeds (empties the chain).
+	ipt.EXPECT().ClearChain("nat", chainV4).Return(nil)
+
+	// DeleteChain finds the chain already gone — concurrent DEL deleted it
+	// between our ClearChain and DeleteChain calls.
+	ipt.EXPECT().DeleteChain("nat", chainV4).Return(
+		fmt.Errorf("No chain/target/match by that name"),
+	)
+
+	err := Del(ipt, containerIPv4, chainV4, comment)
+	assert.Nil(t, err, "Del() must not fail when DeleteChain returns 'No chain/target/match by that name'")
+}
+
+// TestIsChainNotExistErr verifies cniutils.IsChainNotExistErr correctly
+// identifies "No chain/target/match" errors and ignores unrelated errors.
+func TestIsChainNotExistErr(t *testing.T) {
+	assert.True(t, cniutils.IsChainNotExistErr(fmt.Errorf("No chain/target/match by that name")))
+	assert.True(t, cniutils.IsChainNotExistErr(fmt.Errorf("iptables: No chain/target/match by that name.\n")))
+	assert.False(t, cniutils.IsChainNotExistErr(fmt.Errorf("some other error")))
+	assert.False(t, cniutils.IsChainNotExistErr(fmt.Errorf("Chain already exists")))
+}

--- a/cmd/egress-cni-plugin/snat/snat_test.go
+++ b/cmd/egress-cni-plugin/snat/snat_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper"
 	mock_iptables "github.com/aws/amazon-vpc-cni-k8s/pkg/iptableswrapper/mocks"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils"
 )
 
 const (
@@ -87,6 +88,51 @@ func TestDelV4(t *testing.T) {
 	assert.EqualValuesf(t, expectDeleteChain, actualDeleteChain, "iptables chain is expected to be removed")
 
 	assert.EqualValuesf(t, expectRule, actualRule, "iptables rule is expected to be removed")
+}
+
+// TestAddV4_ChainAlreadyExists verifies that Add() succeeds when NewChain
+// returns "Chain already exists". This simulates the production race condition
+// where multiple concurrent egress-cni invocations all snapshot ListChains
+// before any has created the chain, then race to call NewChain — the loser
+// gets this error but the chain is in the desired state, so Add() must not fail.
+// This was the root cause of FailedCreatePodSandBox failures when 10+ pods
+// start simultaneously on the same node.
+func TestAddV4_ChainAlreadyExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ipt := mock_iptables.NewMockIPTablesIface(ctrl)
+
+	// Start with an empty chain list — neither POSTROUTING nor CNI-E4 are
+	// visible from this goroutine's snapshot (the concurrent peer hasn't
+	// created them yet, from our perspective).
+	ipt.EXPECT().ListChains("nat").Return([]string{}, nil)
+	ipt.EXPECT().HasRandomFully().Return(false).AnyTimes()
+
+	// Both chains need to be created; the concurrent peer wins the race and
+	// creates them first — our NewChain calls get "Chain already exists".
+	ipt.EXPECT().NewChain("nat", gomock.Any()).Return(
+		fmt.Errorf("iptables: Chain already exists."),
+	).AnyTimes()
+
+	// AppendUnique must still be called for all rules — the chains exist and
+	// we should proceed normally.
+	ipt.EXPECT().AppendUnique("nat", gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	err := Add(ipt, nodeIPv4, containerIPv4, ipv4MulticastRange, chainV4, comment, rndSNAT)
+	assert.Nil(t, err, "Add() must succeed when NewChain returns 'Chain already exists'")
+}
+
+// TestIsChainExistErr verifies that cniutils.IsChainExistErr correctly
+// identifies "Chain already exists" errors from iptables and does not match
+// unrelated errors.
+func TestIsChainExistErr(t *testing.T) {
+	assert.True(t, cniutils.IsChainExistErr(fmt.Errorf("iptables: Chain already exists.")),
+		"should match 'Chain already exists'")
+	assert.True(t, cniutils.IsChainExistErr(fmt.Errorf("exit status 1: iptables: Chain already exists.")),
+		"should match error containing 'Chain already exists'")
+	assert.False(t, cniutils.IsChainExistErr(fmt.Errorf("some other error")),
+		"should not match unrelated error")
+	assert.False(t, cniutils.IsChainExistErr(fmt.Errorf("exit status 2: iptables: some other failure")),
+		"should not match plain non-chain-exist error")
 }
 
 func setupAddExpect(ipt iptableswrapper.IPTablesIface, actualNewChain, actualNewRule *[]string) {

--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -154,8 +154,7 @@ func IsIptableTargetNotExist(err error) bool {
 //
 // The primary check uses the typed *iptables.Error with exit status 1 (the same
 // sentinel used by ClearChain in github.com/coreos/go-iptables). A string
-// fallback covers test doubles that return plain errors rather than
-// *iptables.Error.
+// fallback covers test doubles that return plain errors rather than *iptables.Error.
 func IsChainExistErr(err error) bool {
 	if e, ok := err.(*iptables.Error); ok {
 		return e.ExitStatus() == 1
@@ -163,6 +162,21 @@ func IsChainExistErr(err error) bool {
 	return strings.Contains(err.Error(), "Chain already exists")
 }
 
+// IsChainNotExistErr returns true if err indicates that an iptables chain or
+// rule does not exist. This is the expected error when a concurrent DEL
+// invocation has already removed the chain or rule before this invocation
+// reaches the same operation — the desired end state (chain gone) is already
+// achieved and it is safe to proceed.
+//
+// The primary check uses the typed *iptables.Error.IsNotExist() which matches
+// "No chain/target/match by that name" and related patterns. A string fallback
+// covers test doubles that return plain errors rather than *iptables.Error.
+func IsChainNotExistErr(err error) bool {
+	if e, ok := err.(*iptables.Error); ok {
+		return e.IsNotExist()
+	}
+	return strings.Contains(err.Error(), "No chain/target/match by that name")
+}
 // PrefixSimilar checks if prefix pool and eni prefix are equivalent.
 func PrefixSimilar(prefixPool []string, eniPrefixes []ec2types.Ipv4PrefixSpecification) bool {
 	if len(prefixPool) != len(eniPrefixes) {

--- a/pkg/utils/cniutils/cni_utils.go
+++ b/pkg/utils/cniutils/cni_utils.go
@@ -147,6 +147,22 @@ func IsIptableTargetNotExist(err error) bool {
 	return e.IsNotExist()
 }
 
+// IsChainExistErr returns true if err indicates that an iptables chain already
+// exists. This is the benign race error returned by NewChain when a concurrent
+// caller has already created the chain — the desired end state is achieved
+// either way.
+//
+// The primary check uses the typed *iptables.Error with exit status 1 (the same
+// sentinel used by ClearChain in github.com/coreos/go-iptables). A string
+// fallback covers test doubles that return plain errors rather than
+// *iptables.Error.
+func IsChainExistErr(err error) bool {
+	if e, ok := err.(*iptables.Error); ok {
+		return e.ExitStatus() == 1
+	}
+	return strings.Contains(err.Error(), "Chain already exists")
+}
+
 // PrefixSimilar checks if prefix pool and eni prefix are equivalent.
 func PrefixSimilar(prefixPool []string, eniPrefixes []ec2types.Ipv4PrefixSpecification) bool {
 	if len(prefixPool) != len(eniPrefixes) {


### PR DESCRIPTION
## Problem

When many pods start simultaneously on the same node (e.g. at a 5-minute cron tick on a jobs node), multiple concurrent invocations of `egress-cni` race to create the same iptables chain. Each invocation snapshots existing chains via `ListChains`, sees the chain absent, then calls `NewChain` — the second concurrent invocation fails with:

```
iptables -t nat -N POSTROUTING --wait: exit status 1: iptables: Chain already exists.
```

This causes the pod sandbox setup to fail entirely, leaving the pod stuck in `Init:0/1`. On busy nodes receiving a burst of simultaneous pod starts (observed with 10+ pods scheduled at the same cron tick), this failure is consistent and reproducible.

The error propagates back to the container runtime as:
```
Failed to create pod sandbox: plugin type=&#34;egress-cni&#34; name=&#34;egress-cni&#34; failed (add):
running [/usr/sbin/iptables -t nat -N POSTROUTING --wait]: exit status 1: iptables: Chain already exists.
```

## Root Cause

In `snat.Add()`, the existing chains check is a non-atomic snapshot+check+create sequence:

```go
// Step 1: snapshot (non-atomic)
chains, _ := ipt.ListChains(&#34;nat&#34;)
existingChains := map[string]bool{...}

// Step 2: create if absent — RACE WINDOW
if !existingChains[_chain] {
    if err = ipt.NewChain(&#34;nat&#34;, _chain); err != nil {
        return err  // ← fails on concurrent second call
    }
}
```

Note: the existing `pkg/networkutils` package already handles this exact race with a `containChainExistErr` helper. This fix applies the same pattern to the egress-cni snat package.

## Fix

Tolerate the `&#34;Chain already exists&#34;` error from `NewChain` — it is benign when caused by a concurrent invocation that won the race and successfully created the chain first. A chain that already exists is exactly what we want.

The chain-exists check is extracted to a new exported helper `IsChainExistErr()` in `pkg/utils/cniutils` (alongside the existing `IsIptableTargetNotExist()`), using a typed `*iptables.Error` check (`ExitStatus() == 1`) — the same sentinel used by `ClearChain` in `github.com/coreos/go-iptables`:

```go
// Tolerate "Chain already exists" from a concurrent invocation that won the race.
if err = ipt.NewChain("nat", _chain); err != nil && !cniutils.IsChainExistErr(err) {
    return err
}
```

The subsequent `AppendUnique` call is already idempotent, so no further changes are needed.

## Testing

This race is observable in production on IPv6 EKS clusters with `ENABLE_IPv4=false` + `egress-cni` enabled, when 10+ pods start simultaneously on the same node. The fix makes `NewChain` idempotent under concurrent execution.

New unit tests added:
- `TestAddV4_ChainAlreadyExists` — `Add()` must succeed when `NewChain` returns `"Chain already exists"` (the exact production race scenario)
- `TestIsChainExistErr` — unit-tests the new `cniutils.IsChainExistErr` helper

## Production Validation

This fix has been applied to an internal fork (`acquia/kaas-aws-vpc-cni`, [PR #150](https://github.com/acquia/kaas-aws-vpc-cni/pull/150)) and is pending production rollout. The race was confirmed via incident prod-saturnc368 (2026-07-15): a kaas-workflow rollback that reduced the per-node concurrency below the race threshold immediately stopped the `FailedCreatePodSandBox` failures, directly confirming the race condition theory. The internal fork PR is open and will adopt the upstream merge once this PR lands.