### PR TITLE
test: pin nginx image to 1.31.2 (nginx:latest tag does not exist)

### DIFF
--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -26,7 +26,7 @@ const (
 	// See https://gallery.ecr.aws/eks/aws-vpc-cni-test-helper
 	TestAgentImage = "networking-e2e-test-images/aws-vpc-cni-test-helper:20231212"
 	BusyBoxImage   = "networking-e2e-test-images/busybox:latest"
-	NginxImage     = "networking-e2e-test-images/nginx:latest"
+	NginxImage     = "networking-e2e-test-images/nginx:1.31.2"
 	NetCatImage    = "networking-e2e-test-images/netcat-openbsd:v1.0"
 	CurlImage      = "networking-e2e-test-images/curlimages/curl:latest"
 


### PR DESCRIPTION
## What

Pin the e2e nginx test image from `nginx:latest` to `nginx:1.31.2`.

```diff
- NginxImage = "networking-e2e-test-images/nginx:latest"
+ NginxImage = "networking-e2e-test-images/nginx:1.31.2"
```

## Why

The `[CANARY] test service connectivity` specs create a 20-replica `http-server` deployment using `networking-e2e-test-images/nginx:latest` and wait for it to become ready. **That tag does not exist** in the shared e2e ECR registry (`617930562442.dkr.ecr.us-west-2.amazonaws.com`). The repo only contains:

```
1.21.4, 1.21.4_amd64, 1.21.4_arm64
1.25.2, 1.25.2_amd64, 1.25.2_arm64
1.31.2, 1.31.2_amd64, 1.31.2_arm64   (pushed 2026-06-24)
```

So every `http-server` pod fails with `ImagePullBackOff`, the deployment never reaches 20/20 available, `CreateAndWaitTillDeploymentIsReady` hits its 300s timeout, all four service-connectivity specs fail (×3 flake attempts), and the ginkgo suite eventually trips its 60m timeout — turning master integration tests red on every run.

### Regression source

Introduced by #3733 (commit `ffc5887`, 2026-06-19, "Bump up ngnix tag to latest"), which changed the tag from the previously-working `1.25.2` to `latest`. The `latest` tag was never pushed to the registry.

### Why `1.31.2`

It is the newest existing tag, so it honors the intent of #3733 ("bump nginx") while using a tag that actually exists. It is a multi-arch OCI index (`linux/amd64` + `linux/arm64`), which is required because the test deployment has no arch nodeSelector and the test cluster runs both `c5.xlarge` (x86) and `c6g.xlarge` (arm64) managed nodegroups.

## Verification

Against the CI account's view of the shared registry:

| Check | `nginx:latest` (before) | `nginx:1.31.2` (after) |
|---|---|---|
| Pull amd64 | ❌ `manifest unknown: image not found` | ✅ pulls |
| Pull arm64 (c6g nodes) | ❌ | ✅ pulls |
| Run + serve HTTP on :80 | n/a | ✅ HTTP 200 |

`go build ./test/framework/utils/` passes.
