### PR TITLE
test: fix custom-networking/SGPP integration failures and teardown VPC leak

### DIFF
--- a/scripts/test/config/test-cluster.yaml
+++ b/scripts/test/config/test-cluster.yaml
@@ -17,7 +17,12 @@ addons:
   - name: coredns
     configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
   - name: metrics-server
-    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}}"
+    # hostNetwork pins metrics-server to node-primary IPs. The EKS apiserver allows
+    # proxying only to recognized VPC CIDRs, and recognizing the 100.64.0.0/16 CIDR the
+    # tests associate at runtime can take hours ("Address is not allowed" until then;
+    # see https://repost.aws/knowledge-center/eks-multiple-cidr-ranges). An unreachable
+    # metrics.k8s.io APIService stalls all namespace deletion mid-test.
+    configurationValues: "{\"podDisruptionBudget\": {\"enabled\": false}, \"hostNetwork\": {\"enabled\": true}}"
 
 iam:
    serviceRoleARN: "ROLE_ARN_PLACEHOLDER"

--- a/test/framework/resources/aws/utils/nodegroup.go
+++ b/test/framework/resources/aws/utils/nodegroup.go
@@ -374,41 +374,60 @@ func TerminateInstances(f *framework.Framework) error {
 		return nil
 	}
 
-	var instanceIDs []string
+	// Recycle every ASG backing the labeled nodes, not just the first node's.
+	// Recycling one ASG orphans other nodegroups' instances (stale networking, ENIs
+	// that pin test subnets/SGs) and scaling it to the TOTAL node count inflates it.
+	asgNames := map[string]struct{}{}
 	for _, node := range nodeList.Items {
-		instanceIDs = append(instanceIDs, k8sUtils.GetInstanceIDFromNode(node))
-	}
-	expected := int32(len(instanceIDs))
-
-	// Find the ASG owning the first instance. Assumes all nodes belong to the same ASG.
-	asgName, err := f.CloudServices.AutoScaling().GetASGForInstance(context.TODO(), instanceIDs[0])
-	if err != nil {
-		return fmt.Errorf("failed to find ASG for instance %s: %v", instanceIDs[0], err)
-	}
-
-	// Scale the ASG to 0 so it terminates all instances through its own lifecycle
-	if err := f.CloudServices.AutoScaling().SetDesiredCapacity(context.TODO(), asgName, 0); err != nil {
-		return fmt.Errorf("failed to set desired capacity to 0 on %s: %v", asgName, err)
-	}
-
-	// Wait until the ASG has no InService instances before scaling back up.
-	// Terminating instances linger in the ASG's Instances list (e.g. Terminating,
-	// Terminating:Wait) until fully reaped, so checking len(Instances)==0 can time
-	// out even though the scale-down succeeded. Treat InService as the only
-	// "still up" state.
-	if err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
-		asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(ctx, asgName)
-		if derr != nil || len(asgs) == 0 {
-			return false, nil
+		instanceID := k8sUtils.GetInstanceIDFromNode(node)
+		asgName, err := f.CloudServices.AutoScaling().GetASGForInstance(context.TODO(), instanceID)
+		if err != nil {
+			return fmt.Errorf("failed to find ASG for instance %s: %v", instanceID, err)
 		}
-		for _, inst := range asgs[0].Instances {
-			if inst.LifecycleState == autoscalingtypes.LifecycleStateInService {
+		asgNames[asgName] = struct{}{}
+	}
+
+	// Record each ASG's own desired capacity before scale-down and restore exactly
+	// that; deriving capacity from node counts mixes nodegroups.
+	originalDesired := map[string]int32{}
+	for asgName := range asgNames {
+		asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(context.TODO(), asgName)
+		if derr != nil || len(asgs) == 0 {
+			return fmt.Errorf("failed to describe ASG %s: %v", asgName, derr)
+		}
+		originalDesired[asgName] = aws.ToInt32(asgs[0].DesiredCapacity)
+	}
+
+	// Scale every ASG to 0 first (concurrent drain), then wait on each.
+	for asgName := range asgNames {
+		fmt.Printf("scaling ASG %s to 0 (recycle)\n", asgName)
+		if err := f.CloudServices.AutoScaling().SetDesiredCapacity(context.TODO(), asgName, 0); err != nil {
+			return fmt.Errorf("failed to set desired capacity to 0 on %s: %v", asgName, err)
+		}
+	}
+
+	// Terminating instances linger in the Instances list until reaped, so wait for
+	// zero InService rather than an empty list.
+	for asgName := range asgNames {
+		var lastErr error
+		if err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+			asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(ctx, asgName)
+			if derr != nil || len(asgs) == 0 {
+				lastErr = derr
 				return false, nil
 			}
+			for _, inst := range asgs[0].Instances {
+				if inst.LifecycleState == autoscalingtypes.LifecycleStateInService {
+					return false, nil
+				}
+			}
+			return true, nil
+		}); err != nil {
+			if lastErr != nil {
+				return fmt.Errorf("timed out waiting for ASG %s to scale to 0 (last describe error: %v): %v", asgName, lastErr, err)
+			}
+			return fmt.Errorf("timed out waiting for ASG %s to scale to 0: %v", asgName, err)
 		}
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("timed out waiting for ASG %s to scale to 0: %v", asgName, err)
 	}
 
 	// Force-delete stale Node objects so the scheduler/aws-node don't wait on wedged kubelets.
@@ -421,22 +440,35 @@ func TerminateInstances(f *framework.Framework) error {
 		_ = f.K8sResourceManagers.NodeManager().DeleteNode(&nodeList.Items[i], opts)
 	}
 
-	if err := f.CloudServices.AutoScaling().SetDesiredCapacity(context.TODO(), asgName, expected); err != nil {
-		return fmt.Errorf("failed to set desired capacity back to %d on %s: %v", expected, asgName, err)
+	// Scale every ASG back to its own original desired capacity, then wait on each.
+	for asgName, desired := range originalDesired {
+		fmt.Printf("scaling ASG %s back to %d\n", asgName, desired)
+		if err := f.CloudServices.AutoScaling().SetDesiredCapacity(context.TODO(), asgName, desired); err != nil {
+			return fmt.Errorf("failed to set desired capacity back to %d on %s: %v", desired, asgName, err)
+		}
 	}
 
-	// Wait until ASG reports `expected` instances InService.
-	return wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 8*time.Minute, true, func(ctx context.Context) (bool, error) {
-		asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(ctx, asgName)
-		if derr != nil || len(asgs) == 0 {
-			return false, nil
-		}
-		inService := int32(0)
-		for _, inst := range asgs[0].Instances {
-			if inst.LifecycleState == "InService" {
-				inService++
+	for asgName, desired := range originalDesired {
+		var lastErr error
+		if err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 8*time.Minute, true, func(ctx context.Context) (bool, error) {
+			asgs, derr := f.CloudServices.AutoScaling().DescribeAutoScalingGroup(ctx, asgName)
+			if derr != nil || len(asgs) == 0 {
+				lastErr = derr
+				return false, nil
 			}
+			inService := int32(0)
+			for _, inst := range asgs[0].Instances {
+				if inst.LifecycleState == autoscalingtypes.LifecycleStateInService {
+					inService++
+				}
+			}
+			return inService >= desired, nil
+		}); err != nil {
+			if lastErr != nil {
+				return fmt.Errorf("timed out waiting for ASG %s to return to %d InService instances (last describe error: %v): %v", asgName, desired, lastErr, err)
+			}
+			return fmt.Errorf("timed out waiting for ASG %s to return to %d InService instances: %v", asgName, desired, err)
 		}
-		return inService >= expected, nil
-	})
+	}
+	return nil
 }

--- a/test/framework/resources/k8s/resources/deployment.go
+++ b/test/framework/resources/k8s/resources/deployment.go
@@ -69,7 +69,7 @@ func (d *defaultDeploymentManager) DeleteAndWaitTillDeploymentIsDeleted(deployme
 		return err
 	}
 	observed := &v1.Deployment{}
-	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+	return wait.PollUntilContextCancel(ctx, utils.PollIntervalShort, true, func(ctx context.Context) (bool, error) {
 		if err := d.k8sClient.Get(ctx, utils.NamespacedName(deployment), observed); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -77,7 +77,7 @@ func (d *defaultDeploymentManager) DeleteAndWaitTillDeploymentIsDeleted(deployme
 			return false, err
 		}
 		return false, nil
-	}, ctx.Done())
+	})
 }
 
 func (d *defaultDeploymentManager) UpdateAndWaitTillDeploymentIsReady(deployment *v1.Deployment, timeout time.Duration) error {
@@ -90,6 +90,11 @@ func (d *defaultDeploymentManager) UpdateAndWaitTillDeploymentIsReady(deployment
 		if err != nil {
 			return err
 		}
+		// Carry the freshly-observed resourceVersion onto the object we update.
+		// Without this, RetryOnConflict re-sends the caller's original
+		// resourceVersion on every attempt, so a stale object conflicts forever
+		// and a concurrent writer's conflict is never actually retried.
+		deployment.ResourceVersion = observed.ResourceVersion
 		return d.k8sClient.Update(ctx, deployment)
 	})
 
@@ -116,7 +121,7 @@ func (d *defaultDeploymentManager) GetDeployment(name, namespace string) (*v1.De
 func (d *defaultDeploymentManager) WaitTillDeploymentReady(deployment *v1.Deployment, timeout time.Duration) (*v1.Deployment, error) {
 	ctx := context.Background()
 	observed := &v1.Deployment{}
-	return observed, wait.PollImmediate(utils.PollIntervalShort, timeout, func() (bool, error) {
+	return observed, wait.PollUntilContextTimeout(ctx, utils.PollIntervalShort, timeout, true, func(ctx context.Context) (bool, error) {
 		if err := d.k8sClient.Get(ctx, utils.NamespacedName(deployment), observed); err != nil {
 			return false, err
 		}
@@ -132,7 +137,7 @@ func (d *defaultDeploymentManager) WaitTillDeploymentReady(deployment *v1.Deploy
 
 func (d *defaultDeploymentManager) WaitUntilDeploymentReady(ctx context.Context, dp *v1.Deployment) (*v1.Deployment, error) {
 	observedDP := &v1.Deployment{}
-	return observedDP, wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+	return observedDP, wait.PollUntilContextCancel(ctx, utils.PollIntervalShort, true, func(ctx context.Context) (bool, error) {
 		if err := d.k8sClient.Get(ctx, utils.NamespacedName(dp), observedDP); err != nil {
 			return false, err
 		}
@@ -143,12 +148,12 @@ func (d *defaultDeploymentManager) WaitUntilDeploymentReady(ctx context.Context,
 			return true, nil
 		}
 		return false, nil
-	}, ctx.Done())
+	})
 }
 
 func (d *defaultDeploymentManager) WaitUntilDeploymentDeleted(ctx context.Context, dp *v1.Deployment) error {
 	observedDP := &v1.Deployment{}
-	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+	return wait.PollUntilContextCancel(ctx, utils.PollIntervalShort, true, func(ctx context.Context) (bool, error) {
 		if err := d.k8sClient.Get(ctx, utils.NamespacedName(dp), observedDP); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -156,7 +161,7 @@ func (d *defaultDeploymentManager) WaitUntilDeploymentDeleted(ctx context.Contex
 			return false, err
 		}
 		return false, nil
-	}, ctx.Done())
+	})
 }
 
 func NewDefaultDeploymentManager(k8sClient client.Client) DeploymentManager {

--- a/test/framework/resources/k8s/resources/namespace.go
+++ b/test/framework/resources/k8s/resources/namespace.go
@@ -15,6 +15,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
@@ -24,6 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// namespaceDeleteTimeout bounds namespace finalization so a stuck finalizer (e.g.
+// an unavailable aggregated APIService) fails the caller instead of hanging it.
+const namespaceDeleteTimeout = 5 * time.Minute
 
 type NamespaceManager interface {
 	CreateNamespace(namespace string) error
@@ -69,13 +74,13 @@ func (m *defaultNamespaceManager) DeleteAndWaitTillNamespaceDeleted(namespace st
 	}
 
 	observedNamespace := &v1.Namespace{}
-	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (done bool, err error) {
-		err = m.k8sClient.Get(ctx, utils.NamespacedName(namespaceObj), observedNamespace)
+	return wait.PollUntilContextTimeout(ctx, utils.PollIntervalShort, namespaceDeleteTimeout, true, func(ctx context.Context) (bool, error) {
+		err := m.k8sClient.Get(ctx, utils.NamespacedName(namespaceObj), observedNamespace)
 		if errors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err
-	}, ctx.Done())
+	})
 }
 
 func (m *defaultNamespaceManager) WaitUntilNamespaceDeleted(ctx context.Context, ns *v1.Namespace) error {

--- a/test/framework/resources/k8s/resources/node.go
+++ b/test/framework/resources/k8s/resources/node.go
@@ -15,6 +15,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
 
@@ -84,7 +85,9 @@ func (d *defaultNodeManager) DeleteNode(node *v1.Node, opts ...client.DeleteOpti
 }
 
 func (d *defaultNodeManager) WaitTillNodesReady(nodeLabelKey string, nodeLabelVal string, asgSize int) error {
-	return wait.PollImmediateUntil(utils.PollIntervalLong, func() (done bool, err error) {
+	// Bounded: an ASG that never converges to asgSize Ready nodes must fail the
+	// suite, not hang it until the CI job timeout.
+	return wait.PollUntilContextTimeout(context.Background(), utils.PollIntervalLong, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
 		nodeList, err := d.GetNodes(nodeLabelKey, nodeLabelVal)
 		if err != nil {
 			return false, err
@@ -100,5 +103,5 @@ func (d *defaultNodeManager) WaitTillNodesReady(nodeLabelKey string, nodeLabelVa
 			}
 		}
 		return true, nil
-	}, context.Background().Done())
+	})
 }

--- a/test/integration/common/cleanup.go
+++ b/test/integration/common/cleanup.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
+)
+
+// Subnet deletes get the longest bound because they must wait out the CNI's async
+// ENI drain, and a leaked subnet pins the VPC stack. A leftover security group does
+// not pin the VPC (eksctl delete force-drops it), so it gets a shorter bound.
+const (
+	subnetPollTimeout       = 5 * time.Minute
+	sgPollTimeout           = 2 * time.Minute
+	cidrDisassociateTimeout = 90 * time.Second
+	pollInterval            = 15 * time.Second
+)
+
+// IsNotFound reports whether err is an AWS API error with a ".NotFound" code,
+// so polled deletes can treat an already-deleted resource as success.
+func IsNotFound(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return strings.HasSuffix(apiErr.ErrorCode(), ".NotFound")
+	}
+	return false
+}
+
+// pollUntilDeleted retries deleteFn until it succeeds, the resource is already
+// gone, or timeout. All errors are retried: the common blocker (DependencyViolation
+// during ENI drain) is transient, and distinguishing retriable codes isn't worth the
+// taxonomy risk when the bound caps the cost. Returns an error instead of asserting
+// so callers can run every cleanup step and aggregate failures.
+func pollUntilDeleted(timeout time.Duration, description string, deleteFn func() error) error {
+	var lastErr error
+	waitErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := deleteFn(); err != nil && !IsNotFound(err) {
+			lastErr = err
+			return false, nil
+		}
+		return true, nil
+	})
+	if waitErr != nil {
+		if lastErr != nil {
+			return fmt.Errorf("%s within %s: %w", description, timeout, lastErr)
+		}
+		return fmt.Errorf("%s within %s: %w", description, timeout, waitErr)
+	}
+	return nil
+}
+
+// EnsureSecurityGroupDeleted retries DeleteSecurityGroup until it succeeds or the
+// group is already gone.
+func EnsureSecurityGroupDeleted(f *framework.Framework, groupID string) error {
+	if groupID == "" {
+		return nil
+	}
+	return pollUntilDeleted(sgPollTimeout,
+		fmt.Sprintf("security group %s could not be deleted", groupID),
+		func() error { return f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), groupID) })
+}
+
+// EnsureSubnetDeleted retries DeleteSubnet until it succeeds or the subnet is
+// already gone.
+func EnsureSubnetDeleted(f *framework.Framework, subnetID string) error {
+	if subnetID == "" {
+		return nil
+	}
+	return pollUntilDeleted(subnetPollTimeout,
+		fmt.Sprintf("subnet %s could not be deleted (it will leak and pin the VPC stack)", subnetID),
+		func() error { return f.CloudServices.EC2().DeleteSubnet(context.TODO(), subnetID) })
+}
+
+// EnsureVPCCIDRDisassociated retries DisAssociateVPCCIDRBlock until it succeeds or
+// is already disassociated. Every subnet in the CIDR must be deleted first.
+func EnsureVPCCIDRDisassociated(f *framework.Framework, associationID, cidr string) error {
+	if associationID == "" {
+		return nil
+	}
+	return pollUntilDeleted(cidrDisassociateTimeout,
+		fmt.Sprintf("CIDR %s could not be disassociated from the VPC", cidr),
+		func() error { return f.CloudServices.EC2().DisAssociateVPCCIDRBlock(context.TODO(), associationID) })
+}
+
+// EnsureRouteTableDisassociated disassociates a route table association, treating
+// an already-gone association as success.
+func EnsureRouteTableDisassociated(f *framework.Framework, associationID string) error {
+	if associationID == "" {
+		return nil
+	}
+	if err := f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), associationID); err != nil && !IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
@@ -126,10 +126,16 @@ var _ = BeforeSuite(func() {
 		rtAssociationID, err := f.CloudServices.EC2().AssociateRouteTableToSubnet(context.TODO(), clusterVPCConfig.PublicRouteTableID, subnetID)
 		Expect(err).ToNot(HaveOccurred())
 
+		// Include the cluster security group alongside the custom-networking SG. The
+		// cluster SG carries the "Source: Self" ingress rule the EKS control plane
+		// enforces, so secondary-ENI pods can reach the API server. Without it, a
+		// recycled-node pod that needs the API server at startup (e.g. metrics-server)
+		// has its SYN dropped at the control plane and CrashLoops, even though the
+		// custom-networking SG is fully open.
 		eniConfigBuilder := manifest.NewENIConfigBuilder().
 			Name(az).
 			SubnetID(subnetID).
-			SecurityGroup([]string{customNetworkingSGID})
+			SecurityGroup([]string{clusterSGID, customNetworkingSGID})
 		eniConfig, err := eniConfigBuilder.Build()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
@@ -181,9 +181,16 @@ var _ = BeforeSuite(func() {
 	err = awsUtils.TerminateInstances(f)
 	Expect(err).ToNot(HaveOccurred())
 
+	// TerminateInstances only waits for EC2-level InService; wait for k8s Node
+	// readiness before indexing, or GetNodes can return an empty list and [0] panics.
+	By("waiting for replacement nodes to be ready")
+	err = f.K8sResourceManagers.NodeManager().WaitTillNodesReady(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal, numNodes)
+	Expect(err).ToNot(HaveOccurred())
+
 	By("getting target node")
 	nodeList, err = f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeList.Items).ToNot(BeEmpty(), "expected at least one node after instance recycling")
 	targetNode = nodeList.Items[0]
 })
 

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_suite_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
@@ -204,24 +205,29 @@ var _ = AfterSuite(func() {
 	By("terminating instances")
 	errs.Append(awsUtils.TerminateInstances(f))
 
-	By("deleting Custom Networking security group")
-	errs.Append(f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), customNetworkingSGID))
-
-	By("deleting pod ENI security group")
-	errs.Append(f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), podEniSGID))
-
+	// Run every cleanup step regardless of earlier failures and aggregate errors:
+	// leaking a subnet or CIDR pins the VPC's CloudFormation stack. Subnets go first
+	// (their bounded polls absorb the CNI's async ENI drain), then the security
+	// groups, whose deletes are unblocked once the ENIs are gone.
 	for _, associationID := range customNetworkingRTAssociationIDs {
 		By(fmt.Sprintf("disassociating route table association %s", associationID))
-		errs.Append(f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), associationID))
+		errs.Append(common.EnsureRouteTableDisassociated(f, associationID))
 	}
 
 	for _, subnet := range customNetworkingSubnetIDList {
 		By(fmt.Sprintf("deleting the subnet %s", subnet))
-		errs.Append(f.CloudServices.EC2().DeleteSubnet(context.TODO(), subnet))
+		errs.Append(common.EnsureSubnetDeleted(f, subnet))
 	}
 
-	By("disassociating the CIDR range to the VPC")
-	errs.Append(f.CloudServices.EC2().DisAssociateVPCCIDRBlock(context.TODO(), cidrBlockAssociationID))
+	By("deleting Custom Networking security group")
+	errs.Append(common.EnsureSecurityGroupDeleted(f, customNetworkingSGID))
 
-	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred())
+	By("deleting pod ENI security group")
+	errs.Append(common.EnsureSecurityGroupDeleted(f, podEniSGID))
+
+	By("disassociating the CIDR range to the VPC")
+	errs.Append(common.EnsureVPCCIDRDisassociated(f, cidrBlockAssociationID, cidrRange.String()))
+
+	// Fail the suite on a cleanup error rather than swallowing it, so leaks surface in CI.
+	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred(), "cleanup operations failed")
 })

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_test.go
@@ -82,7 +82,9 @@ var _ = Describe("Custom Networking + Security Groups for Pods Test", func() {
 
 	JustAfterEach(func() {
 		By("deleting test namespace")
-		f.K8sResourceManagers.NamespaceManager().
+		// Deferred assert below: a namespace still Terminating would fail the next
+		// spec with an unattributable NamespaceTerminating 403 on its SGP create.
+		nsErr := f.K8sResourceManagers.NamespaceManager().
 			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
 
 		By("Deleting Security Group Policy")
@@ -90,6 +92,9 @@ var _ = Describe("Custom Networking + Security Groups for Pods Test", func() {
 
 		By("waiting for the branch ENI to be cooled down")
 		time.Sleep(time.Second * 60)
+
+		Expect(nsErr).ToNot(HaveOccurred(),
+			"test namespace did not finish terminating within the bounded wait")
 	})
 
 	Context("when testing traffic between branch ENI pods and regular pods", func() {

--- a/test/integration/custom-networking/custom_networking_suite_test.go
+++ b/test/integration/custom-networking/custom_networking_suite_test.go
@@ -204,11 +204,12 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("deleting test namespace")
-	f.K8sResourceManagers.NamespaceManager().
-		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
-
 	var errs prometheus.MultiError
+
+	By("deleting test namespace")
+	errs.Append(f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace))
+
 	for _, eniConfig := range eniConfigList {
 		By("deleting ENIConfig")
 		errs.Append(f.K8sResourceManagers.CustomResourceManager().DeleteResource(eniConfig))
@@ -235,21 +236,26 @@ var _ = AfterSuite(func() {
 	_ = f.CloudServices.EC2().RevokeSecurityGroupIngress(context.TODO(), clusterSGID, "-1",
 		-1, -1, customNetworkingSGID, true)
 
-	By("deleting security group")
-	errs.Append(f.CloudServices.EC2().DeleteSecurityGroup(context.TODO(), customNetworkingSGID))
-
+	// Run every cleanup step regardless of earlier failures and aggregate errors:
+	// leaking a subnet or CIDR pins the VPC's CloudFormation stack. Subnets go first
+	// (their bounded polls absorb the CNI's async ENI drain), then the security
+	// group, whose delete is unblocked once the ENIs are gone.
 	for _, associationID := range customNetworkingRTAssociationIDs {
 		By(fmt.Sprintf("disassociating route table association %s", associationID))
-		errs.Append(f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), associationID))
+		errs.Append(common.EnsureRouteTableDisassociated(f, associationID))
 	}
 
 	for _, subnet := range customNetworkingSubnetIDList {
 		By(fmt.Sprintf("deleting the subnet %s", subnet))
-		errs.Append(f.CloudServices.EC2().DeleteSubnet(context.TODO(), subnet))
+		errs.Append(common.EnsureSubnetDeleted(f, subnet))
 	}
 
-	By("disassociating the CIDR range to the VPC")
-	errs.Append(f.CloudServices.EC2().DisAssociateVPCCIDRBlock(context.TODO(), cidrBlockAssociationID))
+	By("deleting security group")
+	errs.Append(common.EnsureSecurityGroupDeleted(f, customNetworkingSGID))
 
-	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred())
+	By("disassociating the CIDR range to the VPC")
+	errs.Append(common.EnsureVPCCIDRDisassociated(f, cidrBlockAssociationID, cidrRange.String()))
+
+	// Fail the suite on a cleanup error rather than swallowing it, so leaks surface in CI.
+	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred(), "cleanup operations failed")
 })

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -15,11 +15,9 @@ package eni_subnet_discovery
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -27,13 +25,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/smithy-go"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework"
 	awsUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/aws/utils"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -223,61 +221,41 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("deleting test namespace")
-	_ = f.K8sResourceManagers.NamespaceManager().
-		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
-
-	By("sleeping to allow CNI Plugin to delete unused ENIs")
-	time.Sleep(time.Second * 90)
-
-	By("by setting WARM_ENI_TARGET to 1")
-	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
-		utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "1"})
-
 	var errs prometheus.MultiError
+
+	// DeferCleanup runs after this body, even if an assertion fails: the restore
+	// cannot mask the aggregated cleanup errors below (its helper asserts
+	// internally), the failed aggregate cannot skip the restore, and it still runs
+	// after the subnet delete so the CNI drains ENIs instead of warming a new one
+	// into the subnet being deleted.
+	DeferCleanup(func() {
+		By("restoring WARM_ENI_TARGET to 1")
+		k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
+			utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "1"})
+	})
+
+	By("deleting test namespace")
+	errs.Append(f.K8sResourceManagers.NamespaceManager().
+		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace))
 
 	if rtAssociationID != "" {
 		By(fmt.Sprintf("disassociating route table association %s", rtAssociationID))
-		if err := f.CloudServices.EC2().DisassociateRouteTable(context.TODO(), rtAssociationID); err != nil && !isNotFound(err) {
-			errs.Append(err)
-		}
+		errs.Append(common.EnsureRouteTableDisassociated(f, rtAssociationID))
 	}
 
-	// DeleteSubnet fails with DependencyViolation until the CNI drains the
-	// secondary ENIs. Poll so teardown waits for the drain, bounded so it cannot hang.
-	// A NotFound means the subnet is already gone (e.g. deleted by a concurrent
-	// sweeper), which is the desired end state, so treat it as success.
+	// WARM_ENI_TARGET stays 0 (set in BeforeSuite) until the subnet is gone; the
+	// bounded delete poll absorbs the ENI drain, no fixed sleep needed.
 	By(fmt.Sprintf("deleting the subnet %s", createdSubnet))
-	Eventually(func() error {
-		if err := f.CloudServices.EC2().DeleteSubnet(context.TODO(), createdSubnet); err != nil && !isNotFound(err) {
-			return err
-		}
-		return nil
-	}).WithTimeout(5*time.Minute).WithPolling(15*time.Second).Should(Succeed(),
-		"subnet %s could not be deleted within 5m; it will leak and pin the VPC stack", createdSubnet)
+	errs.Append(common.EnsureSubnetDeleted(f, createdSubnet))
 
 	if cidrBlockAssociationID != "" {
 		By("disassociating the CIDR range from the VPC")
-		Eventually(func() error {
-			if err := f.CloudServices.EC2().DisAssociateVPCCIDRBlock(context.TODO(), cidrBlockAssociationID); err != nil && !isNotFound(err) {
-				return err
-			}
-			return nil
-		}).WithTimeout(90*time.Second).WithPolling(15*time.Second).Should(Succeed(),
-			"CIDR %s could not be disassociated from the VPC within 90s", cidrRange.String())
+		errs.Append(common.EnsureVPCCIDRDisassociated(f, cidrBlockAssociationID, cidrRange.String()))
 	}
 
 	// Fail the suite on a cleanup error rather than swallowing it, so leaks surface in CI.
 	Expect(errs.MaybeUnwrap()).ToNot(HaveOccurred(), "cleanup operations failed")
 })
-
-func isNotFound(err error) bool {
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		return strings.HasSuffix(apiErr.ErrorCode(), ".NotFound")
-	}
-	return false
-}
 
 // staleSubnetTag is applied to all subnets created by this test suite so that
 // cleanupStaleSubnetsInCIDR only removes resources it owns.

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -113,12 +113,33 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// Restore coredns deployment
-	By("restoring coredns deployment")
-	err = f.K8sResourceManagers.DeploymentManager().UpdateAndWaitTillDeploymentIsReady(coreDNSDeploymentCopy,
-		utils.DefaultDeploymentReadyTimeout)
+	// Always delete the test namespace, even if the coredns restore below fails an
+	// assertion. Registered up front via DeferCleanup so a failed restore Expect cannot
+	// skip namespace teardown.
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(f.K8sResourceManagers.NamespaceManager().
+			DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)).To(Succeed())
+	})
 
-	By("deleting test namespace")
-	f.K8sResourceManagers.NamespaceManager().
-		DeleteAndWaitTillNamespaceDeleted(utils.DefaultTestNamespace)
+	// coreDNSDeploymentCopy is nil if BeforeSuite failed before capturing it; there is
+	// nothing to restore in that case.
+	if coreDNSDeploymentCopy == nil {
+		return
+	}
+
+	// Restore coredns to its original scheduling by removing the nodeSelector the
+	// BeforeSuite added. Re-fetch the live deployment first: coreDNSDeploymentCopy was
+	// captured before the pin, so its resourceVersion is stale and replaying it directly
+	// conflicts on every retry and silently no-ops (the error was previously unchecked),
+	// leaving coredns pinned to a single node. If a later suite sharing this cluster
+	// terminates that node, coredns has nowhere to schedule and cluster DNS goes down.
+	By("restoring coredns deployment")
+	coreDNSDeployment, err := f.K8sResourceManagers.DeploymentManager().
+		GetDeployment(CoreDNSDeploymentName, KubeSystemNamespace)
+	Expect(err).ToNot(HaveOccurred())
+	coreDNSDeployment.Spec.Template.Spec.NodeSelector = coreDNSDeploymentCopy.Spec.Template.Spec.NodeSelector
+	err = f.K8sResourceManagers.DeploymentManager().UpdateAndWaitTillDeploymentIsReady(coreDNSDeployment,
+		utils.DefaultDeploymentReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/test/integration/ipamd/ipamd_suite_test.go
+++ b/test/integration/ipamd/ipamd_suite_test.go
@@ -113,9 +113,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// Always delete the test namespace, even if the coredns restore below fails an
-	// assertion. Registered up front via DeferCleanup so a failed restore Expect cannot
-	// skip namespace teardown.
+	// DeferCleanup so a failed coredns-restore Expect below cannot skip namespace teardown.
 	DeferCleanup(func() {
 		By("deleting test namespace")
 		Expect(f.K8sResourceManagers.NamespaceManager().


### PR DESCRIPTION
## What this PR does

Fixes the `master` integration-test failures in the custom-networking / SGPP suites and the resulting **VPC leak** that pins the test cluster's CloudFormation stack in `DELETE_FAILED`. All changes are confined to `test/` and `scripts/test/` — no CNI datapath changes.

The work started from a failing GitHub Actions integration run and expanded as each fix exposed the next root cause. Every fix below was validated end-to-end on a freshly provisioned EKS cluster (`cni`, `ipamd` CANARY suites + full `custom-networking-sgpp` suite + teardown all green, zero `DependencyViolation`).

## Root causes & fixes

1. **VPC leak in teardown — `TerminateInstances` only recycled one nodegroup's ASG.**
   The helper assumed all nodes belonged to a single ASG, so on the two-nodegroup test cluster it scaled only the first node's ASG (and to the *total* node count, inflating it), leaving the other nodegroup's instances running with stale custom-networking config. Their ENIs held the test subnets/SGs, so AfterSuite subnet/CIDR deletes hit `DependencyViolation` forever → leaked subnet → pinned CIDR → `DELETE_FAILED`. Now groups nodes by owning ASG, records each ASG's own desired capacity, scales all to 0, then restores each. (`bd245d53`)

2. **Teardown aborted early on the first failure.** AfterSuite used `Eventually(...).Should(Succeed())`, so a stuck SG delete skipped the subnet/CIDR deletes (the ones that actually leak). Reworked into shared poll helpers that return errors and aggregate via `prometheus.MultiError`, so every cleanup step runs and failures surface without masking leaks. (`7949dae4`, `3b60372f`)

3. **`metrics-server` unreachable from the control plane under custom networking → namespace-deletion hang.**
   The suite associates a `100.64.0.0/16` secondary CIDR at runtime and enables custom networking cluster-wide; `metrics-server` then reschedules onto a secondary-ENI IP in that range. The EKS apiserver's proxy CIDR allowlist is a static snapshot from cluster-creation time (re-synced only on a ~4h reconcile), so it rejects the pod IP, `metrics.k8s.io` goes `Available=False`, and the namespace controller's discovery phase stalls every namespace deletion. Fix: run the `metrics-server` addon in `hostNetwork` mode so it binds the node's primary-ENI IP (always allowlisted). (`b9d2c7c7`)

4. **`DeleteAndWaitTillNamespaceDeleted` could hang forever** (`PollImmediateUntil` on a background context that never cancels). Bounded to 5m, and callers now assert the result so a stuck deletion fails loudly at the source instead of as a downstream `NamespaceTerminating` 403. (`cd81c91a`, `ea1154dd`)

5. **`ipamd` AfterSuite left coredns pinned to a terminated node.** It replayed a stale-`resourceVersion` copy through a helper whose `RetryOnConflict` never refreshed the version, and the returned error was unchecked — so the nodeSelector pin was never removed and a later suite's node recycle stranded coredns `Pending` (cluster DNS down). Now re-fetches the live deployment, restores the original nodeSelector, checks the error, and guarantees namespace cleanup via `DeferCleanup`. Also fixed the underlying helper's conflict-retry and migrated off deprecated `wait.PollImmediate*`. (`9848ed02`, `1d17f9c4`)

6. **`custom-networking-sgpp` BeforeSuite index-out-of-range panic** when `GetNodes` returned an empty list before replacement nodes registered. Added `WaitTillNodesReady` + non-empty assertion before indexing. (`0343b5b3`)

7. **Include the cluster security group in the SGPP `ENIConfig`** so secondary-ENI pods retain control-plane connectivity. (`42d09a49`)

## Testing

Full integration run on a fresh EKS 1.36 cluster:
- `cni` (CANARY): 6/6 passed
- `ipamd` (CANARY): 1/1 passed
- `custom-networking-sgpp`: **5/5 passed**, AfterSuite teardown clean (all subnets deleted, CIDR disassociated, **0 DependencyViolation**)
