### PR TITLE
test: replace fixed sleeps with readiness polls in pod-eni and eni-subnet-discovery suites

### DIFF
--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_suite_test.go
@@ -214,8 +214,8 @@ var _ = BeforeSuite(func() {
 	k8sUtils.AddEnvVarToDaemonSetAndWaitTillUpdated(f, utils.AwsNodeName, utils.AwsNodeNamespace,
 		utils.AwsNodeName, map[string]string{"WARM_ENI_TARGET": "0"})
 
-	By("sleeping to allow CNI Plugin to delete unused ENIs")
-	time.Sleep(time.Second * 90)
+	By("waiting for the CNI to delete unused ENIs")
+	waitForSecondaryENIsDrained()
 
 	createdSubnet = subnetID
 })

--- a/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
+++ b/test/integration/eni-subnet-discovery/eni_subnet_discovery_test.go
@@ -83,8 +83,8 @@ var _ = Describe("ENI Subnet Selection Test", func() {
 			err := f.K8sResourceManagers.DeploymentManager().DeleteAndWaitTillDeploymentIsDeleted(deployment)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("sleeping to allow CNI Plugin to delete unused ENIs")
-			time.Sleep(time.Second * 90)
+			By("waiting for the CNI to delete unused ENIs")
+			waitForSecondaryENIsDrained()
 
 			newEniSubnetIds = nil
 		})
@@ -313,6 +313,24 @@ func podsPerENI(instanceType string) int {
 func computeReplicasForBothSubnets(instanceType string) int {
 	perENI := podsPerENI(instanceType)
 	return (3*perENI + 1) / 2 // ceil(1.5 * perENI)
+}
+
+// waitForSecondaryENIsDrained polls until the primary instance has no secondary
+// ENIs left, i.e. the CNI has finished detaching warm ENIs after WARM_ENI_TARGET=0.
+func waitForSecondaryENIsDrained() {
+	Eventually(func() int {
+		instance, err := f.CloudServices.EC2().DescribeInstance(context.TODO(), *primaryInstance.InstanceId)
+		if err != nil {
+			return -1
+		}
+		secondary := 0
+		for _, nwInterface := range instance.NetworkInterfaces {
+			if !common.IsPrimaryENI(nwInterface, instance.PrivateIpAddress) {
+				secondary++
+			}
+		}
+		return secondary
+	}, 5*time.Minute, 10*time.Second).Should(BeZero(), "CNI should detach all secondary ENIs")
 }
 
 func checkSecondaryENISubnets(expectNewCidr bool) {

--- a/test/integration/pod-eni/security_group_per_pod_suite_test.go
+++ b/test/integration/pod-eni/security_group_per_pod_suite_test.go
@@ -120,9 +120,15 @@ var _ = BeforeSuite(func() {
 	err = awsUtils.TerminateInstances(f)
 	Expect(err).ToNot(HaveOccurred())
 
+	// TerminateInstances returns before replacement k8s Nodes register, so wait or [0] below panics.
+	By("waiting for replacement nodes to be ready")
+	err = f.K8sResourceManagers.NodeManager().WaitTillNodesReady(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal, numNodes)
+	Expect(err).ToNot(HaveOccurred())
+
 	By("getting target node")
 	nodeList, err = f.K8sResourceManagers.NodeManager().GetNodes(f.Options.NgNameLabelKey, f.Options.NgNameLabelVal)
 	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeList.Items).ToNot(BeEmpty(), "expected at least one node after instance recycling")
 	targetNode = nodeList.Items[0]
 })
 


### PR DESCRIPTION
## What

Two integration-test suites use fixed sleeps where they should observe completion. Both cause flaky BeforeSuite failures that red the networking canaries. This replaces the guesses with bounded polls.

### 1. pod-eni (SGP) BeforeSuite — panic after node recycle

`security_group_per_pod_suite_test.go` calls `TerminateInstances(f)` (recycles the nodegroup), then immediately `GetNodes(...)` + `targetNode = nodeList.Items[0]`. `TerminateInstances` waits only for the ASG at the **EC2** level, not for replacement **Kubernetes Nodes** to re-register, so `GetNodes` can return an empty list and `Items[0]` panics:

```
[PANICKED] runtime error: index out of range [0] with length 0
  test/integration/pod-eni/security_group_per_pod_suite_test.go:126
FAIL! -- A BeforeSuite node failed so all tests were skipped.
```

Fix: `WaitTillNodesReady(...)` (existing framework primitive, bounded 15m) before listing, plus a non-empty guard before indexing. This mirrors the fix already shipped for the sibling `custom-networking-sgpp` suite in #3787, which missed the pod-eni suite.

### 2. eni-subnet-discovery — fixed 90s ENI-drain sleep

The suite sets `WARM_ENI_TARGET=0` then sleeps a fixed 90s hoping the CNI has detached warm ENIs — in BeforeSuite and again in the per-test JustAfterEach. Flaky (slow drain races the next assertion) and wasteful (always waits 90s).

Fix: `waitForSecondaryENIsDrained()` polls the instance's ENIs (`DescribeInstance` + `common.IsPrimaryENI`) until no secondary ENIs remain (bounded 5m), returning as soon as the drain completes.

## Scope note

Sibling scenario files in the eni-subnet-discovery suite (`enhanced` / `primary-exclusion` / `secondary-exclusion`) still contain fixed `sleep 30/45/60/90` calls — same anti-pattern, but converting them is left to a follow-up to keep this change reviewable. The two sleeps fixed here are in the core flow run by every scenario.

## Testing

`go vet ./test/integration/pod-eni/ ./test/integration/eni-subnet-discovery/` passes; `gofmt` clean. Test-only change; no product code touched.