### PR TITLE
(bug) Return error if the parsing fails and UT

### DIFF
--- a/cmd/routed-eni-cni-plugin/cni.go
+++ b/cmd/routed-eni-cni-plugin/cni.go
@@ -374,11 +374,10 @@ func del(args *skel.CmdArgs, cniTypes typeswrapper.CNITYPES, grpcClient grpcwrap
 	driverClient driver.NetworkAPIs) error {
 
 	conf, log, err := LoadNetConf(args.StdinData)
-	log.Debugf("Prev Result: %v\n", conf.PrevResult)
-
 	if err != nil {
 		return errors.Wrap(err, "del cmd: error loading config from args")
 	}
+	log.Debugf("Prev Result: %v\n", conf.PrevResult)
 
 	log.Infof("Received CNI del request: ContainerID(%s) Netns(%s) IfName(%s) Args(%s) Path(%s) argsStdinData(%s)",
 		args.ContainerID, args.Netns, args.IfName, args.Args, args.Path, args.StdinData)

--- a/cmd/routed-eni-cni-plugin/cni_test.go
+++ b/cmd/routed-eni-cni-plugin/cni_test.go
@@ -1862,3 +1862,39 @@ func TestDialIPAMD_ReturnsErrorWhenDialFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
+
+// del must return the config-loading error rather than panicking. LoadNetConf returns
+// (nil, nil, err) on failure, so touching conf or log before checking err is a nil deref.
+func TestCmdDelErrLoadNetConf(t *testing.T) {
+	ctrl, mocksTypes, mocksGRPC, mocksRPC, mocksNetwork := setup(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name      string
+		stdinData []byte
+	}{
+		{
+			name:      "malformed JSON config",
+			stdinData: []byte("{invalid-json}"),
+		},
+		{
+			// ParsePrevResult fails on a cniVersion the plugin cannot parse, e.g. after a
+			// CNI downgrade. LoadNetConf returns before the logger is constructed.
+			name:      "unparsable prevResult",
+			stdinData: []byte(`{"cniVersion":"0.4.0","name":"aws-cni","type":"aws-cni","prevResult":{"cniVersion":"9.9.9"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdArgs := &skel.CmdArgs{ContainerID: containerID,
+				Netns:     netNS,
+				IfName:    ifName,
+				StdinData: tt.stdinData}
+
+			err := del(cmdArgs, mocksTypes, mocksGRPC, mocksRPC, mocksNetwork)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "del cmd: error loading config from args")
+		})
+	}
+}

--- a/pkg/ipamd/rpc_handler.go
+++ b/pkg/ipamd/rpc_handler.go
@@ -403,8 +403,14 @@ func (s *server) DelNetwork(ctx context.Context, in *rpc.DelNetworkRequest) (*rp
 					// Parse JSON data
 					var podENIData []PodENIData
 					err := json.Unmarshal([]byte(val), &podENIData)
-					if err != nil || len(podENIData) < 1 {
+					if err != nil {
 						log.Errorf("Failed to unmarshal PodENIData JSON: %v", err)
+						return &rpc.DelNetworkReply{Success: false}, err
+					}
+					if len(podENIData) < 1 {
+						err = fmt.Errorf("parsed PodENIData is empty")
+						log.Errorf("Failed to parse PodENIData: %v", err)
+						return &rpc.DelNetworkReply{Success: false}, err
 					}
 					return &rpc.DelNetworkReply{
 						Success:              true,

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestServer_VersionCheck(t *testing.T) {
@@ -706,5 +709,111 @@ func TestRunRPCHandler_CreatesSocketDirectory(t *testing.T) {
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
+	}
+}
+
+func TestServer_DelNetwork_PodENI_InvalidAnnotation(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		k8sClient:       m.k8sClient,
+		enablePodENI:    true,
+		enableIPv4:      true,
+		networkClient:   m.network,
+		dataStoreAccess: datastore.InitializeDataStores([]bool{false}, "test", false, log),
+	}
+
+	tests := []struct {
+		name       string
+		podName    string
+		podUID     string
+		requestUID string
+		annotation string
+		wantErr    bool
+		wantMsg    string
+	}{
+		{
+			name:       "malformed JSON annotation returns error",
+			podName:    "test-pod-malformed-json",
+			podUID:     "test-uid",
+			requestUID: "test-uid",
+			annotation: "not-valid-json",
+			wantErr:    true,
+		},
+		{
+			name:       "empty JSON array annotation returns error",
+			podName:    "test-pod-empty-array",
+			podUID:     "test-uid",
+			requestUID: "test-uid",
+			annotation: "[]",
+			wantErr:    true,
+			wantMsg:    "parsed PodENIData is empty",
+		},
+		{
+			name:       "pod UID mismatch returns error",
+			podName:    "test-pod-uid-mismatch",
+			podUID:     "actual-uid",
+			requestUID: "wrong-uid",
+			annotation: `[{"eniId":"eni-abc","ifAddress":"01:23:45:67:89:ab","privateIp":"10.0.0.1","vlanID":1,"subnetCidr":"10.0.0.0/24"}]`,
+			wantErr:    true,
+			wantMsg:    "pod UID mismatch",
+		},
+		{
+			name:       "valid annotation succeeds",
+			podName:    "test-pod-valid",
+			podUID:     "test-uid",
+			requestUID: "test-uid",
+			annotation: `[{"eniId":"eni-abc","ifAddress":"01:23:45:67:89:ab","privateIp":"10.0.0.1","vlanID":1,"subnetCidr":"10.0.0.0/24"}]`,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a pod with the given annotation
+			pod := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.podName,
+					Namespace: "default",
+					UID:       types.UID(tt.podUID),
+					Annotations: map[string]string{
+						"vpc.amazonaws.com/pod-eni": tt.annotation,
+					},
+				},
+			}
+			err := m.k8sClient.Create(context.TODO(), &pod)
+			require.NoError(t, err)
+
+			rpcServer := server{
+				version:     "1.0.0",
+				ipamContext: mockContext,
+			}
+
+			delReq := &pb.DelNetworkRequest{
+				ClientVersion:     "1.0.0",
+				K8S_POD_NAME:      pod.Name,
+				K8S_POD_NAMESPACE: pod.Namespace,
+				K8S_POD_UID:       tt.requestUID,
+				NetworkName:       "net0",
+				ContainerID:       "container-id",
+				IfName:            "eth0",
+				Reason:            "PodDeleted",
+			}
+
+			resp, err := rpcServer.DelNetwork(context.TODO(), delReq)
+
+			if tt.wantErr {
+				assert.False(t, resp.Success)
+				assert.Error(t, err)
+				if tt.wantMsg != "" {
+					assert.Contains(t, err.Error(), tt.wantMsg)
+				}
+			} else {
+				assert.True(t, resp.Success)
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -88,6 +88,16 @@ type cloudWatchPublisher struct {
 	log                  logger.Logger
 }
 
+// regionFromIMDS returns the region reported by IMDS. GetRegion returns a nil output
+// alongside the error, so the error must be checked before the output is dereferenced.
+func regionFromIMDS(ctx context.Context, client ec2metadatawrapper.EC2MetadataClient) (string, error) {
+	output, err := client.GetRegion(ctx, &ec2metadata.GetRegionInput{})
+	if err != nil {
+		return "", errors.Wrap(err, "publisher: unable to obtain region from instance metadata")
+	}
+	return output.Region, nil
+}
+
 // Logic to fetch Region and CLUSTER_ID
 // Case 1: Cx not using IRSA, we need to get region and clusterID using IMDS
 // Case 2: Cx using IRSA but not specified clusterID, we can still get this info if IMDS is not blocked
@@ -116,8 +126,7 @@ func New(ctx context.Context, region string, clusterID string, log logger.Logger
 		if err != nil {
 			return nil, err
 		}
-		output, err := ec2Metadataclient.GetRegion(ctx, &ec2metadata.GetRegionInput{})
-		region = output.Region
+		region, err = regionFromIMDS(ctx, ec2Metadataclient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -21,10 +21,13 @@ import (
 
 	"github.com/pkg/errors"
 
+	mock_ec2metadatawrapper "github.com/aws/amazon-vpc-cni-k8s/pkg/ec2metadatawrapper/mocks"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2metadata "github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -272,4 +275,33 @@ func getCloudWatchPublisher(t *testing.T) *cloudWatchPublisher {
 		localMetricData:  make([]types.MetricDatum, 0, localMetricDataSize),
 		log:              getCloudWatchLog(),
 	}
+}
+
+// GetRegion returns a nil output together with its error, so the error must be checked
+// before output.Region is read. Reachable in cni-metrics-helper when AWS_REGION is unset
+// (non-IRSA) and IMDS is unreachable, throttled, or blocked by the hop limit.
+func TestRegionFromIMDSError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetadata := mock_ec2metadatawrapper.NewMockEC2MetadataClient(ctrl)
+	mockMetadata.EXPECT().GetRegion(gomock.Any(), gomock.Any()).Return(nil, errors.New("IMDS unreachable"))
+
+	region, err := regionFromIMDS(context.TODO(), mockMetadata)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to obtain region from instance metadata")
+	assert.Empty(t, region)
+}
+
+func TestRegionFromIMDSSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetadata := mock_ec2metadatawrapper.NewMockEC2MetadataClient(ctrl)
+	mockMetadata.EXPECT().GetRegion(gomock.Any(), gomock.Any()).Return(
+		&ec2metadata.GetRegionOutput{Region: "us-west-2"}, nil)
+
+	region, err := regionFromIMDS(context.TODO(), mockMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, "us-west-2", region)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** 
bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: If annotation is malformed, we do not handle the failure and return. 

<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:
SGP pod deletion is always handled by Prev Result stored. However in the rare cases where the Prev Result is not present, CNI falls back to IPAMD to get the VlanID and other metadata about SGP pod on delete flow. 
If the annotation present on the SGP pod is invalid or malformed, we are not returning an error which can cause other issues

Fixed similar issues in other parts of the code where the result gets used before checking the error


**Testing done on this change**: N/A. This is rare condition to get triggered as we block that annotation to get created from webhook and Prev Result deletion has to fail due to some reason. 

<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**: No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
