### PR TITLE
test: install kubectl node-shell in mixed-os-snat-cron job

### DIFF
--- a/.github/workflows/weekly-cron-tests.yaml
+++ b/.github/workflows/weekly-cron-tests.yaml
@@ -91,6 +91,11 @@ jobs:
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin/
+          # The SNAT/kube-proxy specs exec on-node commands via `kubectl node-shell`; install the
+          # plugin (pinned to a release tag) so kubectl discovers it on PATH.
+          curl --silent --location --fail -o /tmp/kubectl-node_shell https://raw.githubusercontent.com/kvaps/kubectl-node-shell/v1.11.0/kubectl-node_shell
+          chmod +x /tmp/kubectl-node_shell
+          sudo mv /tmp/kubectl-node_shell /usr/local/bin/kubectl-node_shell
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # refs/tags/v6.2.2
         with:


### PR DESCRIPTION
## What

Install the `kubectl node-shell` plugin in the `mixed-os-snat-cron` job's "Set up tools" step (pinned to release tag `v1.11.0`).

## Why

The mixed-OS SNAT/kube-proxy suite (`test/integration/cni/snat_kube_proxy_test.go`) gates every spec on `checkNodeShellPlugin()` in `BeforeEach`, and uses `kubectl node-shell <node>` to exec on-node commands (`nft list table ip aws-cni`, `iptables-legacy -t nat -L PREROUTING`) to verify SNAT rules across kube-proxy modes.

The `mixed-os-snat-cron` job's "Set up tools" step installs only `ginkgo` and `eksctl` — never the node-shell plugin. So on the `ubuntu-latest` runner `kubectl plugin list` has no `node_shell`, and every spec fails in `BeforeEach`:

```
[FAILED] in [BeforeEach] - snat_kube_proxy_test.go:44
  kubectl node-shell plugin not present
...
Ran 3 of 33 Specs -- 0 Passed | 3 Failed | 30 Skipped
```

The cluster comes up fine (`BeforeSuite` passes); the failure is purely the missing plugin, so no SNAT behavior is actually exercised. Example failing run:
https://github.com/aws/amazon-vpc-cni-k8s/actions/runs/30210265635/job/89815182256

## Fix

Add the plugin install to that job's setup. `kubectl-node-shell` is a shell-script plugin (its releases carry no binary asset), so it is fetched from the raw script at the pinned tag `v1.11.0`. `kubectl` then discovers `kubectl-node_shell` on PATH as the `node_shell` plugin, so `checkNodeShellPlugin()` passes.

## Testing

- Verified the pinned URL resolves (200) and, once on PATH, `kubectl plugin list` reports `node_shell` — the exact substring `checkNodeShellPlugin()` checks.
- Scope: `run-mixed-os-snat-kube-proxy-test.sh` is invoked only by this job, so no other workflow is affected.
