### PR TITLE
test: increase cni integration suite timeout to 120m

### DIFF
--- a/scripts/run-cni-release-tests.sh
+++ b/scripts/run-cni-release-tests.sh
@@ -34,7 +34,7 @@ function run_integration_test() {
 
   echo "Running cni integration tests"
   START=$SECONDS
-  cd $INTEGRATION_TEST_DIR/cni && CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --skip-file=soak_test.go -v -timeout 60m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBECONFIG" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" --test-image-registry=$TEST_IMAGE_REGISTRY || TEST_RESULT=fail
+  cd $INTEGRATION_TEST_DIR/cni && CGO_ENABLED=0 ginkgo $EXTRA_GINKGO_FLAGS --skip-file=soak_test.go -v -timeout 120m --no-color --fail-on-pending -- --cluster-kubeconfig="$KUBECONFIG" --cluster-name="$CLUSTER_NAME" --aws-region="$REGION" --aws-vpc-id="$VPC_ID" --ng-name-label-key="$NG_LABEL_KEY" --ng-name-label-val="$NG_LABEL_VAL" --test-image-registry=$TEST_IMAGE_REGISTRY || TEST_RESULT=fail
   echo "cni test took $((SECONDS - START)) seconds."
 
   if [[ ! -z $PROD_IMAGE_REGISTRY ]]; then


### PR DESCRIPTION
### What type of PR is this?
Bug fix / test infrastructure

### Which issue does this PR fix?
The `cni` integration ginkgo suite (`test/integration/cni`) times out before it finishes. It runs with `-timeout 60m` in `scripts/run-cni-release-tests.sh`, and the suite no longer completes in that window, so it fails with `Suite Timeout Elapsed` partway through and the whole run is reported as failed even when nothing is broken. Our build pipeline that runs this script has been hitting this.

### What does this PR do / why do we need it?
The suite takes longer than it used to. Most of the time goes to the `host_networking` and `pod_traffic` specs, which create deployments large enough to place pods on a second ENI and then wait for each pod's networking to come up. The number of specs has also grown release over release, so there is more to run each time:

| Version | Runnable cni specs |
|---|---|
| v1.21.2 | ~14 |
| v1.22.4 | 18 |
| v1.23   | 21 |

On a full run of the `cni` suite it took about 100 minutes to complete (`Ginkgo ran 1 suite in ~1h40m`). At the current 60m limit it consistently stops after roughly 15-19 specs with `Suite Timeout Elapsed`. Raising the `cni` suite timeout to 120m lets it run to the end.

Only the `cni` suite timeout changes. `ipamd` (90m) and `cni-metrics-helper` (15m) are left as they are.

### Testing done on this change
Ran the `cni` suite against a live EKS cluster with `-timeout 120m`: it finished in about 100 minutes with no `Suite Timeout Elapsed`. The same suite at 60m stops partway through with the timeout.

### Will this PR introduce any new dependencies?
No.

### Will this break upgrades or downgrades? Has updating a dependency led to version bumps or breaking changes?
No. This only changes a test-suite timeout value in a release-test script.

### Does this change require updates to the CNI daemonset config files to work?
No.

### Does this PR introduce any user-facing change?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
