### PR TITLE
test: read connmark rules via aws-node exec to fix flaky snat kube-proxy test

### DIFF
--- a/test/integration/cni/snat_kube_proxy_test.go
+++ b/test/integration/cni/snat_kube_proxy_test.go
@@ -276,21 +276,33 @@ func restartKubeProxyPods() error {
 	return nil
 }
 
-// detectIptablesBackend determines if the node uses iptables-legacy or nftables
-func detectIptablesBackend(nodeName string) string {
+// awsNodeExec runs a command in the aws-node container on the given node and returns stdout.
+// It reads host firewall state by exec-ing into the long-lived, hostNetwork aws-node pod rather
+// than via `kubectl node-shell`: node-shell spawns a throwaway pod per call and attaches to it,
+// and `kubectl run -i` races the sub-second command against the container exiting, intermittently
+// returning empty stdout with exit 0. aws-node is already running, so exec streams reliably, and it
+// ships nft/iptables-legacy/iptables-nft (v1.8.8).
+func awsNodeExec(nodeName string, command ...string) (string, error) {
 	pods, err := f.K8sResourceManagers.PodManager().GetPodsWithLabelSelector("k8s-app", "aws-node")
 	if err != nil {
-		fmt.Fprintf(GinkgoWriter, "Failed to find aws-node pod: %v\n", err)
-		return ""
+		return "", fmt.Errorf("failed to list aws-node pods: %w", err)
 	}
 	pod, found := lo.Find(pods.Items, func(p v1.Pod) bool {
 		return p.Spec.NodeName == nodeName
 	})
 	if !found {
-		fmt.Fprintf(GinkgoWriter, "Failed to find aws-node pod on node %s\n", nodeName)
-		return ""
+		return "", fmt.Errorf("no aws-node pod found on node %s", nodeName)
 	}
-	stdout, _, err := f.K8sResourceManagers.PodManager().PodExecInContainer(pod.Namespace, pod.Name, "aws-node", []string{"iptables", "--version"})
+	stdout, stderr, err := f.K8sResourceManagers.PodManager().PodExecInContainer(pod.Namespace, pod.Name, "aws-node", command)
+	if err != nil {
+		return stdout, fmt.Errorf("aws-node exec %v on %s failed: %w (stderr: %s)", command, nodeName, err, stderr)
+	}
+	return stdout, nil
+}
+
+// detectIptablesBackend determines if the node uses iptables-legacy or nftables
+func detectIptablesBackend(nodeName string) string {
+	stdout, err := awsNodeExec(nodeName, "iptables", "--version")
 	if err != nil {
 		fmt.Fprintf(GinkgoWriter, "Failed to run iptables --version: %v\n", err)
 		return ""
@@ -303,24 +315,28 @@ func detectIptablesBackend(nodeName string) string {
 	return ""
 }
 
-// verifyConnmarkRules checks that CNI connmark rules exist ONLY in the appropriate backend
+// verifyConnmarkRules checks that CNI connmark rules exist ONLY in the appropriate backend.
+// Reads are done via aws-node exec (see awsNodeExec) so they are not subject to the node-shell
+// attach race that can return empty output for a rule that is actually present.
 func verifyConnmarkRules(nodeName, backend string) {
 	if backend == "nftables" {
-		out, err := execNodeShell(nodeName, "nft list table ip aws-cni")
-		fmt.Fprintf(GinkgoWriter, "nftables rules:\n%s\n", string(out))
+		out, err := awsNodeExec(nodeName, "nft", "list", "table", "ip", "aws-cni")
+		fmt.Fprintf(GinkgoWriter, "nftables rules:\n%s\n", out)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(string(out)).To(ContainSubstring("chain nat-prerouting"))
-		Expect(string(out)).To(ContainSubstring("chain snat-mark"))
+		Expect(out).To(ContainSubstring("chain nat-prerouting"))
+		Expect(out).To(ContainSubstring("chain snat-mark"))
 
-		out, _ = execNodeShell(nodeName, "iptables-legacy -t nat -L PREROUTING -n")
-		Expect(string(out)).ToNot(ContainSubstring("AWS-CONNMARK"))
+		out, _ = awsNodeExec(nodeName, "iptables-legacy", "-t", "nat", "-L", "PREROUTING", "-n")
+		Expect(out).ToNot(ContainSubstring("AWS-CONNMARK"))
 	} else {
-		out, err := execNodeShell(nodeName, "iptables-legacy -t nat -L PREROUTING -n")
-		fmt.Fprintf(GinkgoWriter, "iptables-legacy:\n%s\n", string(out))
+		out, err := awsNodeExec(nodeName, "iptables-legacy", "-t", "nat", "-L", "PREROUTING", "-n")
+		fmt.Fprintf(GinkgoWriter, "iptables-legacy:\n%s\n", out)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(string(out)).To(ContainSubstring("AWS-CONNMARK"))
+		Expect(out).To(ContainSubstring("AWS-CONNMARK"))
 
-		_, err = execNodeShell(nodeName, "nft list table ip aws-cni")
-		Expect(err).To(HaveOccurred())
+		// The nft table must be absent; assert on nft's specific "No such file or directory"
+		// so an infra/exec error can't pass this check for the wrong reason.
+		_, err = awsNodeExec(nodeName, "nft", "list", "table", "ip", "aws-cni")
+		Expect(err).To(MatchError(ContainSubstring("No such file or directory")))
 	}
 }


### PR DESCRIPTION
## What

`snat_kube_proxy_test.go`'s `verifyConnmarkRules` intermittently failed with:

```
[FAILED] Expected <string>:  to contain substring <string>: chain nat-prerouting
```

on an empty read, even though the CNI connmark rule was present.

## Root cause

The connmark rule is **not** absent — the *read* was flaky. `verifyConnmarkRules` read node firewall state via `execNodeShell` → `kubectl node-shell` → `kubectl run -i`. For a sub-second command (`nft list ...`), kubectl's attach races the container exit: it can return **empty stdout with exit code 0**, because the logs-fallback only fires when attach *errors* (`kubectl/pkg/cmd/run/run.go` `handleAttachPod`). The test then asserted `ContainSubstring` on an empty string.

Confirmed on a live EKS 1.36 cluster:
- A resident hostNetwork monitor sampling the table every 2s showed it present in **832/832** samples, including at the exact instant of a test failure.
- Replaying the test's exact read on an idle node returned empty **~40%** of the time (rc=0, stderr showed the nsenter pod spawned and deleted with no attach).
- The unfixed suite gave non-deterministic results run-to-run (3/0, then 2/1, then 1/2 — different entries failing), the signature of a flaky read rather than a real regression.

## Fix

Read via `kubectl exec` into the node's long-lived, hostNetwork `aws-node` pod (new `awsNodeExec` helper) instead of `kubectl node-shell`. `aws-node` is already running, so the exec stream is not subject to the attach-vs-exit race, and it ships `nft`/`iptables-legacy`/`iptables-nft`. This extends the mechanism `detectIptablesBackend` already used for `iptables --version` to the connmark reads. No retry/`Eventually` is needed — the read is reliable by construction.

## Testing

On a live EKS 1.36 cluster (VPC CNI v1.23.0):
- Fixed suite: **10/10** SNAT runs green (iptables/nftables/ipvs).
- Unfixed suite on the same cluster: 3/0, 2/1, 1/2 (flaky).
- `go vet ./test/integration/cni/...` passes.

Test-only change; no production code affected.
