### PR TITLE
test: pin busybox and curl image

### DIFF
--- a/test/framework/utils/const.go
+++ b/test/framework/utils/const.go
@@ -25,10 +25,10 @@ const (
 
 	// See https://gallery.ecr.aws/eks/aws-vpc-cni-test-helper
 	TestAgentImage = "networking-e2e-test-images/aws-vpc-cni-test-helper:20231212"
-	BusyBoxImage   = "networking-e2e-test-images/busybox:latest"
+	BusyBoxImage   = "networking-e2e-test-images/busybox:1.38.0"
 	NginxImage     = "networking-e2e-test-images/nginx:1.31.2"
 	NetCatImage    = "networking-e2e-test-images/netcat-openbsd:v1.0"
-	CurlImage      = "networking-e2e-test-images/curlimages/curl:latest"
+	CurlImage      = "networking-e2e-test-images/curlimages/curl:8.21.0"
 
 	PollIntervalShort  = time.Second * 2
 	PollIntervalMedium = time.Second * 5


### PR DESCRIPTION
**What type of PR is this?**
testing

**Which issue does this PR fix?**:
N/A

**What does this PR do / Why do we need it?**:
`busybox:latest` and `curlimages/curl:latest` in the test registry were last pushed years ago and have accumulated critical CVEs — nothing referenced a version, so nothing ever refreshed them. Pins both to current versions (`busybox:1.38.0`, `curlimages/curl:8.21.0`), matching how every other image in this file is already pinned (`nginx:1.31.2`, `netcat-openbsd:v1.0`). Both tags are published as multi-arch image indexes (linux/amd64 + linux/arm64).

**Testing done on this change**:
- `docker buildx imagetools inspect` confirms both tags are image indexes with linux/amd64 + linux/arm64

**Will this PR introduce any new dependencies?**: No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**: No — test-only.

**Does this change require updates to the CNI daemonset config files to work?**: No.

**Does this PR introduce any user-facing change?**: No.

```release-note
NONE