### PR TITLE
fix(ipamd): retain prefix tracking in seenIPs and defer cooldown evic…

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1888,8 +1888,6 @@ func (c *IPAMContext) verifyAndAddPrefixesToDatastore(ctx context.Context, eni s
 				if needEC2Reconcile {
 					// IMDS data might be stale
 					log.Debugf("This IP was recently freed, but is now out of cooldown. We need to verify with EC2 control plane.")
-					// Only call EC2 once for this ENI and post GA fix this logic for both prefixes
-					// and secondary IPs as per "split the loop" comment
 					if ec2VerifiedAddresses == nil {
 						var err error
 						// Call EC2 to verify Prefixes on this ENI
@@ -1915,9 +1913,6 @@ func (c *IPAMContext) verifyAndAddPrefixesToDatastore(ctx context.Context, eni s
 						continue
 					}
 				}
-				// The IP can be removed from the cooldown cache
-				// TODO: Here we could check if the Prefix is still used by a pod stuck in Terminating state. (Issue #1091)
-				c.reconcileCooldownCache.Remove(strPrivateIPv4Cidr)
 			}
 		}
 
@@ -1925,10 +1920,13 @@ func (c *IPAMContext) verifyAndAddPrefixesToDatastore(ctx context.Context, eni s
 		if err != nil && err.Error() != datastore.IPAlreadyInStoreError {
 			log.Errorf("Failed to reconcile Prefix %s on ENI %s", strPrivateIPv4Cidr, eni)
 			ipamdErrInc("prefixReconcileAdd")
-			// Continue to check the other Prefixs instead of bailout due to one wrong IP
+			// Preserve in seenIPs on datastore error to prevent accidental deallocation
+			seenIPs[strPrivateIPv4Cidr] = true
 			continue
-
 		}
+
+		// Remove from cooldown cache ONLY after successful verification & datastore write
+		c.reconcileCooldownCache.Remove(strPrivateIPv4Cidr)
 		// Mark action
 		seenIPs[strPrivateIPv4Cidr] = true
 		prometheusmetrics.ReconcileCnt.With(prometheus.Labels{"fn": "eniDataStorePoolReconcileAdd"}).Inc()


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix?**:
Fixes #3824

**What does this PR do / Why do we need it?**:
This PR resolves an issue in prefix reconciliation where active `/28` prefixes were being evicted from the cooldown cache prematurely and lost from tracking in `seenIPs`, causing `ipamd` to classify live sandboxes as `stale/dead` and unassign in-use prefixes from the primary ENI.

1. **Deferred Cooldown Eviction:** In `verifyAndAddPrefixesToDatastore`, `c.reconcileCooldownCache.Remove(strPrivateIPv4Cidr)` was previously called before verifying/persisting the prefix to the datastore. If `AddIPv4CidrToStore` encountered errors or non-fatal states, the cache was already cleared, leading to missing reconciliation states. The eviction call is now deferred until after the prefix is successfully processed and saved.
2. **Preserved Tracking in `seenIPs`:** When datastore errors or retry loops occur during prefix reconciliation, the prefix is now explicitly tracked in `seenIPs[strPrivateIPv4Cidr] = true` to prevent the `ipamd` reconciler from falsely assuming the prefix is missing or unassigned, which previously led to releasing in-use ENI prefixes.

**Testing done on this change**:
- Verified logic flow against `verifyAndAddIPsToDatastore` reference pattern.
- Executed `go vet ./pkg/ipamd/...` across the package with zero compilation or static analysis errors.

**Will this PR introduce any new dependencies?**:
No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No breaking changes. This only corrects the internal IPAM datastore state reconciliation for prefix delegation.

**Does this change require updates to the CNI daemonset config files to work?**:
No.

**Does this PR introduce any user-facing change?**:
```release-note
fix(ipamd): retain prefix tracking in seenIPs and defer cooldown eviction until datastore write completes (#3824)