### PR TITLE
fix: handle pod-not-found error in DelNetwork

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -2336,7 +2337,7 @@ func (c *IPAMContext) GetPod(podName, namespace string) (*corev1.Pod, error) {
 	}
 	err := c.k8sClient.Get(ctx, podKey, &pod)
 	if err != nil {
-		return nil, fmt.Errorf("error while trying to retrieve pod info: %s", err.Error())
+		return nil, err
 	}
 	return &pod, nil
 }
@@ -2353,9 +2354,8 @@ func (c *IPAMContext) AnnotatePod(podName string, podNamespace string, key strin
 			if err == nil && pod == nil {
 				log.Warnf("get a nil pod for pod name %s and namespace %s", podName, podNamespace)
 			}
-			// since the GetPod() error has been decorated, we have to check key words
 			// releasedIP is not empty meaning del path
-			if releasedIP != "" && err != nil && strings.Contains(err.Error(), "not found") {
+			if releasedIP != "" && err != nil && k8serror.IsNotFound(err) {
 				return nil
 			}
 			return err

--- a/pkg/ipamd/rpc_handler_test.go
+++ b/pkg/ipamd/rpc_handler_test.go
@@ -34,7 +34,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestServer_VersionCheck(t *testing.T) {
@@ -872,4 +875,67 @@ func TestServer_DelNetwork_PodENI_InvalidAnnotation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServer_DelNetwork_PodNotFound(t *testing.T) {
+	// Reset the counter for this test
+	prometheusmetrics.DelIPCnt = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "awscni_del_ip_req_count",
+			Help: "Number of delete IP address requests",
+		},
+		[]string{"reason"},
+	)
+
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	// Create a k8s client that will return NotFound for the pod
+	k8sSchema := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sSchema)
+
+	// Create a test client that doesn't have the pod (will return NotFound on Get)
+	k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+	// Create an empty datastore to simulate pod not in datastore (will return ErrUnknownPod)
+	dsAccess := datastore.InitializeDataStores([]bool{false}, "test", false, log)
+
+	mockContext := &IPAMContext{
+		awsClient:       m.awsutils,
+		maxIPsPerENI:    14,
+		maxENI:          4,
+		warmENITarget:   1,
+		warmIPTarget:    3,
+		networkClient:   m.network,
+		dataStoreAccess: dsAccess,
+		k8sClient:       k8sClient,
+		enablePodENI:    true, // Enable pod ENI to trigger the GetPod call in DelNetwork
+	}
+
+	m.awsutils.EXPECT().GetVPCIPv4CIDRs().Return([]string{}, nil).AnyTimes()
+	m.awsutils.EXPECT().GetVPCIPv6CIDRs().Return([]string{}, nil).AnyTimes()
+	m.network.EXPECT().UseExternalSNAT().Return(true).AnyTimes()
+
+	rpcServer := server{
+		version:     "1.2.3",
+		ipamContext: mockContext,
+	}
+
+	delReq := &pb.DelNetworkRequest{
+		ClientVersion:     "1.2.3",
+		NetworkName:       "net0",
+		ContainerID:       "cid",
+		IfName:            "eni",
+		K8S_POD_NAME:      "test-pod",
+		K8S_POD_NAMESPACE: "default",
+		K8S_POD_UID:       "test-uid",
+		Reason:            "test-reason",
+	}
+
+	resp, err := rpcServer.DelNetwork(context.TODO(), delReq)
+
+	// Verify DelNetwork returns success when pod has already been deleted from Kubernetes.
+	// The fix in GetPod() returns raw Kubernetes errors so k8serror.IsNotFound() works correctly.
+	assert.NoError(t, err)
+	assert.True(t, resp.Success, "DelNetwork should return success when pod is not found")
 }


### PR DESCRIPTION
**What type of PR is this?**:
bug

**Which issue does this PR fix?**:
#3777

**What does this PR do / Why do we need it?**:
When a pod has already been deleted from the cluster, the `DelNetwork()` flow does not correctly recognize the Kubernetes `NotFound` error.

`GetPod()` was converting the original Kubernetes error into a formatted string, which prevented `k8serror.IsNotFound()` from identifying the error correctly.

This change preserves the original Kubernetes error and updates the related pod annotation handling to use `k8serror.IsNotFound()`.

A dedicated unit test is also added to verify that `DelNetwork()` gracefully succeeds when the requested pod is no longer present.

**Testing done on this change**:
- Added a unit test covering the `DelNetwork()` pod-not-found scenario.
- Ran `gofmt`.
- Ran `git diff --check`.
- Verified the changes are limited to the required production code and unit test.

**Will this PR introduce any new dependencies?**:
No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:
No. The change only improves error handling and does not change configuration, APIs, or upgrade behavior.

**Does this change require updates to the CNI daemonset config files to work?**:
No.

**Does this PR introduce any user-facing change?**:
No.
