### PR TITLE
test: scope instance SG ingress to VPC CIDRs instead of 0.0.0.0/0

### DIFF
--- a/test/integration/cni/pod_traffic_test.go
+++ b/test/integration/cni/pod_traffic_test.go
@@ -81,9 +81,11 @@ var _ = Describe("test pod networking", func() {
 
 	JustBeforeEach(func() {
 		By("authorizing security group ingress on instance security group")
-		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
+		for _, cidr := range vpcCIDRs {
+			err = f.CloudServices.EC2().
+				AuthorizeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, cidr, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("authorizing security group egress on instance security group")
 		err = f.CloudServices.EC2().
@@ -122,9 +124,11 @@ var _ = Describe("test pod networking", func() {
 
 	JustAfterEach(func() {
 		By("revoking security group ingress on instance security group")
-		err = f.CloudServices.EC2().
-			RevokeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
+		for _, cidr := range vpcCIDRs {
+			err = f.CloudServices.EC2().
+				RevokeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, cidr, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("revoking security group egress on instance security group")
 		err = f.CloudServices.EC2().

--- a/test/integration/cni/soak_test.go
+++ b/test/integration/cni/soak_test.go
@@ -61,9 +61,11 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 		serverPort = 2273
 
 		By("Authorize Security Group Ingress on EC2 instance.")
-		err = f.CloudServices.EC2().
-			AuthorizeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
+		for _, cidr := range vpcCIDRs {
+			err = f.CloudServices.EC2().
+				AuthorizeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, cidr, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("Authorize Security Group Egress on EC2 instance.")
 		err = f.CloudServices.EC2().
@@ -75,9 +77,11 @@ var _ = Describe("SOAK Test pod networking", Ordered, func() {
 		fmt.Println("Cleaning SOAK test")
 
 		By("Revoke Security Group Ingress.")
-		err = f.CloudServices.EC2().
-			RevokeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, "0.0.0.0/0", false)
-		Expect(err).ToNot(HaveOccurred())
+		for _, cidr := range vpcCIDRs {
+			err = f.CloudServices.EC2().
+				RevokeSecurityGroupIngress(context.TODO(), instanceSecurityGroupID, protocol, serverPort, serverPort, cidr, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("Revoke Security Group Egress.")
 		err = f.CloudServices.EC2().


### PR DESCRIPTION
## What type of PR is this?
cleanup

## Which issue does this PR fix?
N/A — security hygiene in the integration test framework.

## What does this PR do / Why do we need it?
The cni pod traffic and soak integration tests authorize ingress on the node instance security group with `0.0.0.0/0` for the test server port (2273). The test traffic is pod-to-pod entirely within the cluster VPC, so world-open ingress is unnecessary. Because these suites run continuously in canary/CI accounts, every run briefly creates a wide-open security group rule, which is flagged by security tooling that audits open security groups.

This change scopes the authorize/revoke calls to the VPC CIDR block associations already discovered in the suite BeforeSuite (`vpcCIDRs`), instead of `0.0.0.0/0`. Egress rules are unchanged.

## Testing done on this change
`go vet ./test/integration/cni/` passes. No behavior change for the tests themselves: server pods remain reachable from client pods since all test traffic sources are within the VPC CIDRs.

## Will this PR introduce any new dependencies?
No

## Will this break upgrades or downgrades?
No

## Does this PR introduce any user-facing change?
No