### PR TITLE
fix: ESD fail open on DescribeSubnets call failure

### DIFF
--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -1292,10 +1292,12 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 		c.primaryIP[eni] = eniMetadata.PrimaryIPv4Address()
 	}
 
-	// Check if this ENI (primary or secondary) is in an excluded subnet and mark it for exclusion
+	// Check if this ENI (primary or secondary) is in an excluded subnet and mark it for exclusion.
+	// Fail open on error: aborting here would leave the ENI in the datastore with allocatable IPs
+	// but never wired up via SetupENINetwork, black-holing any pod that gets one of those IPs.
 	if c.useSubnetDiscovery {
 		if _, err := c.excludedENIBasedOnSubnetTags(ctx, eni, eniMetadata); err != nil {
-			return fmt.Errorf("checking to excluded configured subnet, error: %w", err)
+			log.Warnf("setupENI: subnet-exclusion check failed for ENI %s (subnet %s), treating as not excluded: %v", eni, eniMetadata.SubnetID, err)
 		}
 	}
 

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -46,6 +46,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/networkutils"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/cniutils"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/eventrecorder"
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/utils/logger"
 	"github.com/aws/amazon-vpc-cni-k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/utils/prometheusmetrics"
@@ -1297,7 +1298,12 @@ func (c *IPAMContext) setupENI(ctx context.Context, eni string, eniMetadata awsu
 	// but never wired up via SetupENINetwork, black-holing any pod that gets one of those IPs.
 	if c.useSubnetDiscovery {
 		if _, err := c.excludedENIBasedOnSubnetTags(ctx, eni, eniMetadata); err != nil {
-			log.Warnf("setupENI: subnet-exclusion check failed for ENI %s (subnet %s), treating as not excluded: %v", eni, eniMetadata.SubnetID, err)
+			msg := fmt.Sprintf("subnet-exclusion check failed for ENI %s (subnet %s), treating as not excluded: %v", eni, eniMetadata.SubnetID, err)
+			if eventRecorder := eventrecorder.Get(); eventRecorder != nil {
+				eventRecorder.SendPodEvent(corev1.EventTypeWarning, "SubnetExclusionCheckFailed", "SetupENI", msg)
+			} else {
+				log.Warnf("setupENI: %s", msg)
+			}
 		}
 	}
 

--- a/pkg/ipamd/ipamd_test.go
+++ b/pkg/ipamd/ipamd_test.go
@@ -2348,6 +2348,40 @@ func TestIPAMContext_setupENIwithPDenabled(t *testing.T) {
 	assert.Equal(t, 1, len(mockContext.primaryIP))
 }
 
+// TestIPAMContext_setupENISubnetExclusionThrottled verifies that when the subnet-exclusion
+// check errors, setupENI still wires up the ENI via SetupENINetwork instead of returning
+// early and leaving a half-configured ENI in the datastore.
+func TestIPAMContext_setupENISubnetExclusionThrottled(t *testing.T) {
+	m := setup(t)
+	defer m.ctrl.Finish()
+
+	mockContext := &IPAMContext{
+		awsClient:          m.awsutils,
+		networkClient:      m.network,
+		primaryIP:          make(map[string]string),
+		terminating:        int32(0),
+		maxENI:             4,
+		numNetworkCards:    1,
+		useSubnetDiscovery: true,
+	}
+
+	mockContext.dataStoreAccess = testDatastore()
+
+	newENIMetadata := getSecondaryENIMetadata()
+	newENIMetadata.SubnetID = "subnet-throttled"
+
+	m.awsutils.EXPECT().GetPrimaryENI().Return(primaryENIid).AnyTimes()
+	m.network.EXPECT().GetRouteTableNumberForENI(defaultNetworkCard, gomock.Any(), secDevice, mockContext.maxENI, false).Return(0, false, nil).Times(1)
+	m.awsutils.EXPECT().IsSubnetExcluded(gomock.Any(), "subnet-throttled").Return(false, errors.New("RequestLimitExceeded: Request limit exceeded")).Times(1)
+	// SetupENINetwork must still be called even though the exclusion check errored.
+	m.network.EXPECT().SetupENINetwork(gomock.Any(), secMAC, defaultNetworkCard, secSubnet, maxENIPerNIC, false, gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	err := mockContext.setupENI(context.Background(), newENIMetadata.ENIID, newENIMetadata, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mockContext.primaryIP))
+	assert.False(t, mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).IsENIExcludedForPodIPs(newENIMetadata.ENIID))
+}
+
 func TestIPAMContext_enableSecurityGroupsForPods(t *testing.T) {
 	m := setup(t)
 	defer m.ctrl.Finish()
@@ -4187,9 +4221,9 @@ func TestSetupENI_HyperPod_SubnetNotFound(t *testing.T) {
 	assert.Equal(t, 1, len(mockContext.primaryIP))
 }
 
-// TestSetupENI_HyperPod_SubnetDiscoveryError verifies that even if IsSubnetExcluded
-// returns an error (e.g., API failure), primaryIP is still recorded before the error
-// propagates. This ensures the safety of the reconcile path.
+// TestSetupENI_HyperPod_SubnetDiscoveryError verifies that when IsSubnetExcluded errors
+// (e.g., DescribeSubnets throttled), setupENI fails open: it logs a warning and completes
+// setup rather than aborting and leaving a half-configured ENI.
 func TestSetupENI_HyperPod_SubnetDiscoveryError(t *testing.T) {
 	m := setup(t)
 	defer m.ctrl.Finish()
@@ -4229,14 +4263,9 @@ func TestSetupENI_HyperPod_SubnetDiscoveryError(t *testing.T) {
 	m.awsutils.EXPECT().IsSubnetExcluded(gomock.Any(), "subnet-unreachable").Return(false, errors.New("API error"))
 
 	err := mockContext.setupENI(context.Background(), primaryENIMetadata.ENIID, primaryENIMetadata, false, false)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "checking to excluded configured subnet")
-
-	// Even though setupENI returned an error, primaryIP was recorded before the
-	// subnet check. This is critical: if nodeInit retries and eventually succeeds,
-	// or if the ENI remains in the datastore, the reconcile path will correctly
-	// skip the primary IP.
+	assert.NoError(t, err)
 	assert.Equal(t, ipaddr01, mockContext.primaryIP[primaryENIid])
+	assert.False(t, mockContext.dataStoreAccess.GetDataStore(defaultNetworkCard).IsENIExcludedForPodIPs(primaryENIid))
 }
 
 // TestReconcile_HyperPod_PrimaryIPSkipped verifies that the reconcile path correctly


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** bug
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

**Which issue does this PR fix?**: Fail open on describe subnets call failure rather than setting up ENI halfway. There are potential security concerns here if the ENI was supposed to be excluded, will continue discussion with the team.
<!-- If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue -->


**What does this PR do / Why do we need it?**:


**Testing done on this change**: Reproduced the black-hole bug on the unpatched mainline image, then verified this branch
fixes it — same cluster, same injected fault.

**Environment:** throwaway EKS cluster, `ENABLE_SUBNET_DISCOVERY=true`, IPv4, EKS Pod Identity for the CNI role. Test node has a primary ENI plus one attached secondary ENI (`eni-…0021`, primary IP `172.31.110.47`, route table `2`).

### Why not reproduce throttling directly

`setupENI` aborts on **any** error from the subnet-exclusion check (`excludedENIBasedOnSubnetTags` → `IsSubnetExcluded` → `GetVpcSubnets` → `ec2:DescribeSubnets`), not only on `RequestLimitExceeded`. So instead of forcing real throttling, I forced a deterministic `DescribeSubnets` failure with a scoped IAM `Deny` — it exercises the exact same error path.

### Fault injection

Temporary inline `Deny` on the CNI Pod Identity role, scoped to this cluster only via the EKS Pod Identity session tag so no other cluster sharing the role is affected:

```json
{
  "Version": "2012-10-17",
  "Statement": [{
    "Sid": "DenyDescribeSubnetsForBlackholeTest",
    "Effect": "Deny",
    "Action": "ec2:DescribeSubnets",
    "Resource": "*",
    "Condition": { "StringEquals": { "aws:PrincipalTag/eks-cluster-name": "peculiar-rock-dolphin" } }
  }]
}
```

With the deny in place, restart the node's `aws-node` pod so `nodeInit` re-runs `setupENI` on the already-attached ENIs while `DescribeSubnets` is failing.

> **Host-routing note:** the source-routing rule + route table for a secondary ENI persist on the
> host across an `aws-node` restart. To prove an *on-host* black-hole (not just a stale wiring left
> over from a good run), flush the secondary ENI's rule/table first, so the CNI has to recreate it:
> ```
> ip rule del from 172.31.110.47 lookup 2
> ip route flush table 2
> ```
> Inspect host routing from a `kubectl debug node/<node>` pod via `chroot /host ip ...`.

### Result — before / after / recovery

| Scenario (`DescribeSubnets` denied) | `setupENI` | Secondary ENI wiring | `aws-node` | Pod on that IP |
|---|---|---|---|---|
| **Mainline `v1.23.0-eksbuild.1` (no fix)** | aborts → retry loop → `Reached max retry (6/5)` | not wired — rule/table absent | `0/2 CrashLoopBackOff` | **black-holed** |
| **This branch (fail-open)** | `treating as not excluded` → `ENI … set up.` | wired — `from …47 lookup 2`, table 2 populated | `2/2 Ready` | routes normally |
| **Recovery (permission restored)** | completes normally | re-wired automatically on reconcile | `2/2 Ready` | routes normally |

### Evidence — mainline (bug)

`ipamd.log` on the unpatched image: `setupENI` returns the error and the init retry loop spins until it gives up; `SetupENINetwork` never runs.

```text
warn  Error trying to set up ENI eni-00210ab561eb42a8c: checking to excluded configured subnet,
      error: failed to get VPC subnets: AllocENI: unable to describe subnets: ... 403
      UnauthorizedOperation ... ec2:DescribeSubnets with an explicit deny in an identity-based policy
...(repeats every ~10s)...
warn  Reached max retry: Unable to discover attached IPs for ENI from metadata service
      (attempted 6/5): checking to excluded configured subnet, error: ...
# no "ENI eni-00210ab561eb42a8c set up." — setupENI never completes
```

Host routing after a fresh init from the flushed state — **not recreated** (black-hole):

```text
$ ip rule show | grep 'lookup 2'      # (no output — rule absent)
$ ip route show table 2               # (empty)
```

### Evidence — this branch (fix)

`ipamd.log`: the exclusion-check failure is logged and `setupENI` continues; `SetupENINetwork` runs and the ENI is wired.

```text
warn  setupENI: failed to check subnet exclusion for ENI eni-00210ab561eb42a8c
      (subnet subnet-0b045048389a1ba95): failed to get VPC subnets: ... UnauthorizedOperation ...
warn  setupENI: subnet-exclusion check failed for ENI eni-00210ab561eb42a8c
      (subnet subnet-0b045048389a1ba95), treating as not excluded: ...
info  ENI eni-00210ab561eb42a8c set up.        # completed, no retry loop, no max-retry
```

Host routing — secondary ENI wired (`SetupENINetwork` ran):

```text
$ ip rule show
32765:  from 172.31.110.47 lookup 2            # secondary ENI's source-routing rule present

$ ip route show table 2
default via 172.31.96.1 dev ens6               # secondary ENI's route table populated
```

`aws-node` came up `2/2 Ready`; node reported `Ready=True`, `NetworkingReady=True`.

### Cleanup / recovery

Deleted the temporary inline `Deny` policy. With `DescribeSubnets` permission restored, the CNI reconciles and re-wires the secondary ENI automatically (verified `2/2 Ready` and routing restored), so the node recovers even on the unpatched image once the fault is gone.

<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
