### PR TITLE
bug(routed-eni): reject invalid vlan ids

### DIFF
--- a/cmd/routed-eni-cni-plugin/driver/driver.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver.go
@@ -45,6 +45,14 @@ const (
 	//to move to stable state before error'ing out.
 	v6DADTimeout                = 10 * time.Second
 	MAX_MAC_GENERATION_ATTEMPTS = 10
+
+	// maxVlanID is the largest valid 802.1Q VLAN id. Branch ENI VLAN ids arrive
+	// via vpc.amazonaws.com/pod-eni annotation
+	maxVlanID = 4094
+
+	// vlanRouteTableOffset is added to a branch ENI VLAN id to derive the policy
+	// route table used for that pod's traffic.
+	vlanRouteTableOffset = 100
 )
 
 type VirtualInterfaceMetadata struct {
@@ -324,6 +332,19 @@ func (n *linuxNetwork) TeardownPodNetwork(vethMetadata []VirtualInterfaceMetadat
 	return nil
 }
 
+// vlanIDToRouteTable validates a branch ENI VLAN id and returns the policy
+// route table it maps to (vlanID + vlanRouteTableOffset).
+func vlanIDToRouteTable(vlanID int) (int, error) {
+	if vlanID < 1 || vlanID > maxVlanID {
+		return 0, errors.Errorf("invalid vlanID %d", vlanID)
+	}
+	rtTable := vlanID + vlanRouteTableOffset
+	if rtTable >= unix.RT_TABLE_DEFAULT && rtTable <= unix.RT_TABLE_LOCAL {
+		return 0, errors.Errorf("vlanID %d maps to reserved table %d", vlanID, rtTable)
+	}
+	return rtTable, nil
+}
+
 // SetupBranchENIPodNetwork sets up the network ns for pods requesting its own security group
 // we expect v4Addr and v6Addr to have correct IPAddress Family.
 func (n *linuxNetwork) SetupBranchENIPodNetwork(vethMetadata VirtualInterfaceMetadata, netnsPath string,
@@ -354,7 +375,11 @@ func (n *linuxNetwork) SetupBranchENIPodNetwork(vethMetadata VirtualInterfaceMet
 		return errors.Wrapf(err, "SetupBranchENIPodNetwork: failed to delete hostVeth rule for %s", vethMetadata.HostVethName)
 	}
 
-	rtTable := vlanID + 100
+	rtTable, err := vlanIDToRouteTable(vlanID)
+	if err != nil {
+		return errors.Wrap(err, "SetupBranchENIPodNetwork")
+	}
+
 	vlanLink, err := n.setupVlan(vlanID, eniMAC, subnetGW, parentIfIndex, rtTable, log)
 	if err != nil {
 		return errors.Wrapf(err, "SetupBranchENIPodNetwork: failed to setup vlan")
@@ -377,6 +402,13 @@ func (n *linuxNetwork) SetupBranchENIPodNetwork(vethMetadata VirtualInterfaceMet
 func (n *linuxNetwork) TeardownBranchENIPodNetwork(vethMetadata VirtualInterfaceMetadata, vlanID int, _ sgpp.EnforcingMode, log logger.Logger) error {
 	log.Debugf("TeardownBranchENIPodNetwork: containerAddr=%s, vlanID=%d", vethMetadata.IPAddress.String(), vlanID)
 
+	// Validate the VLAN id -> route table mapping before issuing any deletes.
+	rtTable, err := vlanIDToRouteTable(vlanID)
+	if err != nil {
+		log.Errorf("TeardownBranchENIPodNetwork: skipping teardown, %v", err)
+		return nil
+	}
+
 	if err := n.teardownVlan(vlanID, log); err != nil {
 		return errors.Wrapf(err, "TeardownBranchENIPodNetwork: failed to teardown vlan")
 	}
@@ -386,7 +418,6 @@ func (n *linuxNetwork) TeardownBranchENIPodNetwork(vethMetadata VirtualInterface
 		ipFamily = unix.AF_INET6
 	}
 	// to handle the migration between different enforcingMode, we try to clean up rules under both mode since the pod might be setup with a different mode.
-	rtTable := vlanID + 100
 	if err := n.teardownIIFBasedContainerRouteRules(rtTable, ipFamily, log); err != nil {
 		return errors.Wrapf(err, "TeardownBranchENIPodNetwork: unable to teardown IIF based container routes and rules")
 	}

--- a/cmd/routed-eni-cni-plugin/driver/driver_test.go
+++ b/cmd/routed-eni-cni-plugin/driver/driver_test.go
@@ -1370,6 +1370,124 @@ func Test_linuxNetwork_SetupBranchENIPodNetwork(t *testing.T) {
 			},
 			wantErr: errors.New("SetupBranchENIPodNetwork: unable to setup IIF based container routes and rules: failed to setup container route, containerAddr=192.168.100.42/32, hostVeth=eni8ea2c11fe35, rtTable=107: some error"),
 		},
+		{
+			name: "vlanID below the valid range is rejected",
+			fields: fields{
+				linkByNameCalls: []linkByNameCall{
+					{
+						linkName: "eni8ea2c11fe35",
+						err:      errors.New("not exists"),
+					},
+					{
+						linkName: "eni8ea2c11fe35",
+						link:     hostVethWithIndex9,
+					},
+				},
+				ruleDelCalls: []ruleDelCall{
+					{
+						rule: oldFromHostVethRule,
+						err:  syscall.ENOENT,
+					},
+				},
+				withNetNSPathCalls: []withNetNSPathCall{
+					{
+						netNSPath: "/proc/42/ns/net",
+					},
+				},
+			},
+			args: args{
+				hostVethName:       "eni8ea2c11fe35",
+				contVethName:       "eth0",
+				netnsPath:          "/proc/42/ns/net",
+				ipAddr:             containerAddr,
+				vlanID:             0,
+				eniMAC:             eniMac,
+				subnetGW:           subnetGW,
+				parentIfIndex:      parentIfIndex,
+				mtu:                9001,
+				podSGEnforcingMode: sgpp.EnforcingModeStandard,
+			},
+			wantErr: errors.New("SetupBranchENIPodNetwork: invalid vlanID 0"),
+		},
+		{
+			name: "vlanID above the valid range is rejected",
+			fields: fields{
+				linkByNameCalls: []linkByNameCall{
+					{
+						linkName: "eni8ea2c11fe35",
+						err:      errors.New("not exists"),
+					},
+					{
+						linkName: "eni8ea2c11fe35",
+						link:     hostVethWithIndex9,
+					},
+				},
+				ruleDelCalls: []ruleDelCall{
+					{
+						rule: oldFromHostVethRule,
+						err:  syscall.ENOENT,
+					},
+				},
+				withNetNSPathCalls: []withNetNSPathCall{
+					{
+						netNSPath: "/proc/42/ns/net",
+					},
+				},
+			},
+			args: args{
+				hostVethName:       "eni8ea2c11fe35",
+				contVethName:       "eth0",
+				netnsPath:          "/proc/42/ns/net",
+				ipAddr:             containerAddr,
+				vlanID:             4095,
+				eniMAC:             eniMac,
+				subnetGW:           subnetGW,
+				parentIfIndex:      parentIfIndex,
+				mtu:                9001,
+				podSGEnforcingMode: sgpp.EnforcingModeStandard,
+			},
+			wantErr: errors.New("SetupBranchENIPodNetwork: invalid vlanID 4095"),
+		},
+		{
+			name: "vlanID mapping to a reserved route table is rejected",
+			fields: fields{
+				linkByNameCalls: []linkByNameCall{
+					{
+						linkName: "eni8ea2c11fe35",
+						err:      errors.New("not exists"),
+					},
+					{
+						linkName: "eni8ea2c11fe35",
+						link:     hostVethWithIndex9,
+					},
+				},
+				ruleDelCalls: []ruleDelCall{
+					{
+						rule: oldFromHostVethRule,
+						err:  syscall.ENOENT,
+					},
+				},
+				withNetNSPathCalls: []withNetNSPathCall{
+					{
+						netNSPath: "/proc/42/ns/net",
+					},
+				},
+			},
+			args: args{
+				hostVethName: "eni8ea2c11fe35",
+				contVethName: "eth0",
+				netnsPath:    "/proc/42/ns/net",
+				ipAddr:       containerAddr,
+				// vlanID 154 maps to rtTable 254 (RT_TABLE_MAIN), which is reserved.
+				vlanID:             154,
+				eniMAC:             eniMac,
+				subnetGW:           subnetGW,
+				parentIfIndex:      parentIfIndex,
+				mtu:                9001,
+				podSGEnforcingMode: sgpp.EnforcingModeStandard,
+			},
+			wantErr: errors.New("SetupBranchENIPodNetwork: vlanID 154 maps to reserved table 254"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1437,6 +1555,39 @@ func Test_linuxNetwork_SetupBranchENIPodNetwork(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func Test_vlanIDToRouteTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		vlanID    int
+		wantTable int
+		wantErr   bool
+	}{
+		{name: "smallest valid vlanID", vlanID: 1, wantTable: 101},
+		{name: "typical vlanID", vlanID: 7, wantTable: 107},
+		{name: "largest vlanID below reserved range", vlanID: 152, wantTable: 252},
+		{name: "smallest vlanID above reserved range", vlanID: 156, wantTable: 256},
+		{name: "largest valid vlanID", vlanID: 4094, wantTable: 4194},
+		{name: "zero vlanID rejected", vlanID: 0, wantErr: true},
+		{name: "negative vlanID rejected", vlanID: -1, wantErr: true},
+		{name: "above max vlanID rejected", vlanID: 4095, wantErr: true},
+		{name: "maps to RT_TABLE_DEFAULT (253) rejected", vlanID: 153, wantErr: true},
+		{name: "maps to RT_TABLE_MAIN (254) rejected", vlanID: 154, wantErr: true},
+		{name: "maps to RT_TABLE_LOCAL (255) rejected", vlanID: 155, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vlanIDToRouteTable(tt.vlanID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, 0, got)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantTable, got)
 		})
 	}
 }
@@ -1788,6 +1939,36 @@ func Test_linuxNetwork_TeardownBranchENIPodNetwork(t *testing.T) {
 				podSGEnforcingMode: sgpp.EnforcingModeStandard,
 			},
 			wantErr: errors.New("TeardownBranchENIPodNetwork: unable to teardown IP based container routes and rules: failed to delete toContainer rule, containerAddr=192.168.100.42/32, rtTable=main: some error"),
+		},
+		{
+			name:   "reserved vlanID mapping to main table (254) issues no deletes",
+			fields: fields{},
+			args: args{
+				containerAddr:      containerAddr,
+				vlanID:             154,
+				podSGEnforcingMode: sgpp.EnforcingModeStrict,
+			},
+		},
+		{
+			// vlanID 155 maps to table 255 (RT_TABLE_LOCAL).
+			name:   "reserved vlanID mapping to local table (255) issues no deletes",
+			fields: fields{},
+			args: args{
+				containerAddr:      containerAddr,
+				vlanID:             155,
+				podSGEnforcingMode: sgpp.EnforcingModeStandard,
+			},
+		},
+		{
+			// Out-of-range ids are skipped as well, and teardown still returns
+			// success so pod deletion is never blocked.
+			name:   "invalid vlanID (0) issues no deletes and does not error",
+			fields: fields{},
+			args: args{
+				containerAddr:      containerAddr,
+				vlanID:             0,
+				podSGEnforcingMode: sgpp.EnforcingModeStandard,
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

/kind bug


**What does this PR do / Why do we need it?**:

Adds validation to the vlan id passed in via vpc.amazonaws.com/pod-eni

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

Validated with unit tests; also in my real cluster I observed that the pod with malformed eni annotation value stays in ContainerCreating state:

```
lv-atk-154                       0/1     ContainerCreating   0              86s   <none>            ip-192-168-107-145.ec2.internal   <none>           <none>
```

and but is able to be deleted without any negative effects on the host:
```
nixozach@80a997300bd5 amazon-vpc-cni-k8s % kubectl delete po lv-atk-154                  
nixozach@80a997300bd5 amazon-vpc-cni-k8s % kubectl get po lv-atk-154
Error from server (NotFound): pods "lv-atk-154" not found
```

**Will this PR introduce any new dependencies?**:

no

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

no

**Does this change require updates to the CNI daemonset config files to work?**:

no

**Does this PR introduce any user-facing change?**:

no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
