### PR TITLE
fix(networkutils): avoid transient prefix routes

### DIFF
--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -1009,7 +1009,10 @@ func setupENINetwork(eniIP string, eniMac string, networkCard int, eniSubnetCIDR
 	}
 
 	log.Debugf("Adding IP address %s", eniAddr.String())
-	if err = netLink.AddrAdd(link, &netlink.Addr{IPNet: eniAddr}); err != nil {
+	// Avoid the kernel's implicit connected prefix route in the main table.
+	// The CNI programs the per-ENI route table explicitly, and we do not want
+	// a temporary main-table route to influence source selection during setup.
+	if err = netLink.AddrAdd(link, &netlink.Addr{IPNet: eniAddr, Flags: unix.IFA_F_NOPREFIXROUTE}); err != nil {
 		return errors.Wrap(err, "setupENINetwork: failed to add IP addr to ENI")
 	}
 

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -115,7 +115,7 @@ func TestSetupENINetwork(t *testing.T) {
 		Mask: testEniSubnetIPNet.Mask,
 	}
 	mockNetLink.EXPECT().AddrList(gomock.Any(), unix.AF_INET).Return([]netlink.Addr{}, nil)
-	mockNetLink.EXPECT().AddrAdd(gomock.Any(), &netlink.Addr{IPNet: testEniAddr}).Return(nil)
+	mockNetLink.EXPECT().AddrAdd(gomock.Any(), &netlink.Addr{IPNet: testEniAddr, Flags: unix.IFA_F_NOPREFIXROUTE}).Return(nil)
 
 	mockNetLink.EXPECT().RouteDel(gomock.Any())
 	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)
@@ -172,7 +172,7 @@ func TestSetupENIV6Network(t *testing.T) {
 		Mask: testEniV6SubnetIPNet.Mask,
 	}
 	mockNetLink.EXPECT().AddrList(gomock.Any(), unix.AF_INET6).Return([]netlink.Addr{}, nil)
-	mockNetLink.EXPECT().AddrAdd(gomock.Any(), &netlink.Addr{IPNet: testEniAddr}).Return(nil)
+	mockNetLink.EXPECT().AddrAdd(gomock.Any(), &netlink.Addr{IPNet: testEniAddr, Flags: unix.IFA_F_NOPREFIXROUTE}).Return(nil)
 
 	mockNetLink.EXPECT().RouteDel(gomock.Any())
 	mockNetLink.EXPECT().RouteReplace(gomock.Any()).Return(nil)


### PR DESCRIPTION
Fixes #3857

This change prevents the kernel from creating the implicit prefix route when an ENI address is added, which removes the timing window where traffic can briefly select the wrong ENI path before CNI route cleanup completes.

What changed:
- Add `IFA_F_NOPREFIXROUTE` to the ENI address programmed in `setupENINetwork()`.
- Update the unit test expectations in `pkg/networkutils/network_test.go` to assert the flag is present for IPv4 and IPv6.

Why this is the right place:
- The CNI already explicitly programs the per-ENI route table.
- The existing delete-after-add flow leaves a race window; suppressing the implicit kernel route avoids that window entirely.
- This is per-address behavior, so Bottlerocket/kernel sysctls are not the right lever.

Validation:
- `git diff --check` passes.
- I attempted `go test ./pkg/networkutils -run TestSetupENINetwork -count=1` in this container, but the local environment fails in unrelated dependency/toolchain resolution before the package can finish compiling; CI should be the authoritative verification run.