### PR TITLE
test: make SGPP assertions enforcing-mode aware

### DIFF
--- a/test/agent/cmd/networking/main.go
+++ b/test/agent/cmd/networking/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/cmd/networking/tester"
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
 )
@@ -33,11 +34,14 @@ func main() {
 	var shouldTestCleanup bool
 	// per pod security group
 	var ppsg bool
+	var podSGEnforcingMode string
 
 	flag.StringVar(&podNetworkingValidationInputString, "pod-networking-validation-input", "", "json string containing the array of pods whose networking needs to be validated")
 	flag.BoolVar(&shouldTestCleanup, "test-cleanup", false, "bool flag when set to true tests that networking is teared down after pod has been deleted")
 	flag.BoolVar(&shouldTestSetup, "test-setup", false, "bool flag when set to true tests the networking is setup correctly after pod is running")
 	flag.BoolVar(&ppsg, "test-ppsg", false, "bool flag when set to true tests the networking setup for pods using security groups")
+	flag.StringVar(&podSGEnforcingMode, "pod-sg-enforcing-mode", string(sgpp.DefaultEnforcingMode),
+		"security groups for pods enforcing mode")
 
 	flag.Parse()
 
@@ -54,13 +58,15 @@ func main() {
 
 	if ppsg && shouldTestSetup {
 		log.Print("testing networking is setup for pods using security groups")
-		err := tester.TestNetworkingSetupForPodsUsingSecurityGroup(podNetworkingValidationInput)
+		err := tester.TestNetworkingSetupForPodsUsingSecurityGroup(
+			podNetworkingValidationInput, sgpp.EnforcingMode(podSGEnforcingMode))
 		if err != nil {
 			log.Fatalf("found 1 or more pod setup validation failure: %v", err)
 		}
 	} else if ppsg && shouldTestCleanup {
 		log.Print("testing networking is teared down for pods using security groups")
-		err := tester.TestNetworkTearedDownForPodsUsingSecurityGroup(podNetworkingValidationInput)
+		err := tester.TestNetworkTearedDownForPodsUsingSecurityGroup(
+			podNetworkingValidationInput, sgpp.EnforcingMode(podSGEnforcingMode))
 		if err != nil {
 			log.Fatalf("found 1 or more pod setup validation failure: %v", err)
 		}

--- a/test/agent/cmd/networking/tester/network.go
+++ b/test/agent/cmd/networking/tester/network.go
@@ -22,9 +22,17 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/netlinkwrapper"
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+)
+
+const (
+	// Keep these values aligned with networkutils.ToContainerRulePriority and
+	// networkutils.FromPodRulePriority in the CNI datapath.
+	standardToContainerRulePriority = 512
+	standardFromPodRulePriority     = 1536
 )
 
 // TestNetworkingSetupForRegularPod tests networking set by the CNI Plugin for a list of Pod is as
@@ -187,7 +195,18 @@ func TestNetworkingSetupForRegularPod(podNetworkingValidationInput input.PodNetw
 }
 
 // TestNetworkingSetupForPods using security groups
-func TestNetworkingSetupForPodsUsingSecurityGroup(podNetworkingValidationInput input.PodNetworkingValidationInput) []error {
+func TestNetworkingSetupForPodsUsingSecurityGroup(
+	podNetworkingValidationInput input.PodNetworkingValidationInput,
+	enforcingMode sgpp.EnforcingMode,
+) []error {
+	switch enforcingMode {
+	case sgpp.EnforcingModeStandard:
+		return testNetworkingSetupForPodsUsingSecurityGroupStandard(podNetworkingValidationInput)
+	case sgpp.EnforcingModeStrict:
+	default:
+		return []error{fmt.Errorf("unsupported pod security group enforcing mode %q", enforcingMode)}
+	}
+
 	var validationErrors []error
 	var podIP net.IP
 	interfaceToVlanTableMap := make(map[string]int)
@@ -314,6 +333,163 @@ func TestNetworkingSetupForPodsUsingSecurityGroup(podNetworkingValidationInput i
 	return validationErrors
 }
 
+func testNetworkingSetupForPodsUsingSecurityGroupStandard(
+	podNetworkingValidationInput input.PodNetworkingValidationInput,
+) []error {
+	ipFamily := ipFamilyForValidation(podNetworkingValidationInput.IPFamily)
+	nl := netlinkwrapper.NewNetLink()
+	ruleList, err := nl.RuleList(ipFamily)
+	if err != nil {
+		return []error{fmt.Errorf("failed to list ip rules: %v", err)}
+	}
+	linkList, err := nl.LinkList()
+	if err != nil {
+		return []error{fmt.Errorf("failed to list links: %v", err)}
+	}
+	linksByIndex := make(map[int]netlink.Link, len(linkList))
+	for _, link := range linkList {
+		linksByIndex[link.Attrs().Index] = link
+	}
+
+	var validationErrors []error
+	for _, pod := range podNetworkingValidationInput.PodList {
+		podIP := podIPForValidation(pod, podNetworkingValidationInput.IPFamily)
+		log.Printf("testing standard-mode networking for Pod name: %s Namespace: %s, IP: %s",
+			pod.PodName, pod.PodNamespace, podIP)
+		if podIP == nil {
+			validationErrors = append(validationErrors, fmt.Errorf(
+				"failed to parse IP for pod %s/%s", pod.PodNamespace, pod.PodName))
+			continue
+		}
+
+		hostVethName := getHostVethPairName(pod, podNetworkingValidationInput.VethPrefix)
+		hostVeth, linkErrors := validateStandardHostVeth(nl, podNetworkingValidationInput, pod, hostVethName)
+		validationErrors = append(validationErrors, linkErrors...)
+		if hostVeth == nil {
+			continue
+		}
+
+		// Standard mode routes to-pod traffic through the main table and from-pod traffic through the branch table according to rule priority.
+		branchTable, ruleErrors := validateStandardPodRules(ruleList, podIP)
+		validationErrors = append(validationErrors, ruleErrors...)
+		validationErrors = append(validationErrors,
+			validateStandardMainRoute(ipFamily, podIP, hostVeth, hostVethName)...)
+		if branchTable == 0 {
+			continue
+		}
+		validationErrors = append(validationErrors,
+			validateStandardBranchTable(ipFamily, branchTable, linksByIndex)...)
+	}
+
+	return validationErrors
+}
+
+func validateStandardHostVeth(
+	nl netlinkwrapper.NetLink,
+	validationInput input.PodNetworkingValidationInput,
+	pod input.Pod,
+	hostVethName string,
+) (netlink.Link, []error) {
+	link, err := nl.LinkByName(hostVethName)
+	if err != nil {
+		return nil, []error{fmt.Errorf("failed to find netlink %s: %v", hostVethName, err)}
+	}
+
+	var validationErrors []error
+	if validationInput.ValidateMTU && link.Attrs().MTU != validationInput.MTU {
+		validationErrors = append(validationErrors, fmt.Errorf(
+			"MTU value %v for pod: %s on veth pair: %s failed to match the expected value: %v",
+			link.Attrs().MTU, pod.PodName, hostVethName, validationInput.MTU))
+	}
+	if !strings.Contains(link.Attrs().Flags.String(), "up") {
+		validationErrors = append(validationErrors,
+			fmt.Errorf("veth pair on host side is not up %s", link.Attrs().Flags.String()))
+	}
+	return link, validationErrors
+}
+
+func validateStandardPodRules(ruleList []netlink.Rule, podIP net.IP) (int, []error) {
+	toMainRules, fromBranchRules := standardPodRouteRules(ruleList, podIP)
+	var validationErrors []error
+	if len(toMainRules) != 1 {
+		validationErrors = append(validationErrors, fmt.Errorf(
+			"expected one standard-mode rule to pod %s in main table, found: %+v",
+			podIP, toMainRules))
+	}
+	if len(fromBranchRules) != 1 {
+		validationErrors = append(validationErrors, fmt.Errorf(
+			"expected one standard-mode rule from pod %s to branch table, found: %+v",
+			podIP, fromBranchRules))
+		return 0, validationErrors
+	}
+	return fromBranchRules[0].Table, validationErrors
+}
+
+func validateStandardMainRoute(
+	ipFamily int,
+	podIP net.IP,
+	hostVeth netlink.Link,
+	hostVethName string,
+) []error {
+	routes, err := netlink.RouteListFiltered(ipFamily,
+		&netlink.Route{Dst: podIPNet(podIP)}, netlink.RT_FILTER_DST)
+	if err != nil {
+		return []error{fmt.Errorf("failed to find route with destination %s: %v", podIP, err)}
+	}
+
+	mainRouteCount := 0
+	for _, route := range routes {
+		if route.Table == unix.RT_TABLE_MAIN && route.LinkIndex == hostVeth.Attrs().Index {
+			mainRouteCount++
+		}
+	}
+	if mainRouteCount != 1 {
+		return []error{fmt.Errorf(
+			"expected one main-table route to pod %s through veth %s, found: %+v",
+			podIP, hostVethName, routes)}
+	}
+	return nil
+}
+
+func validateStandardBranchTable(
+	ipFamily int,
+	branchTable int,
+	linksByIndex map[int]netlink.Link,
+) []error {
+	routes, err := netlink.RouteListFiltered(ipFamily,
+		&netlink.Route{Table: branchTable}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return []error{fmt.Errorf("failed to list routes for branch table %d: %v", branchTable, err)}
+	}
+	if len(routes) != 2 {
+		return []error{fmt.Errorf(
+			"expected two routes in standard-mode branch table %d, found: %+v",
+			branchTable, routes)}
+	}
+
+	branchLink, ok := linksByIndex[routes[0].LinkIndex]
+	if !ok || !strings.HasPrefix(branchLink.Attrs().Name, "vlan.eth") {
+		return []error{fmt.Errorf(
+			"branch table %d does not route through a vlan branch interface: %+v",
+			branchTable, routes)}
+	}
+
+	var validationErrors []error
+	if !strings.Contains(branchLink.Attrs().Flags.String(), "up") {
+		validationErrors = append(validationErrors, fmt.Errorf(
+			"branch eni %s is not up %s",
+			branchLink.Attrs().Name, branchLink.Attrs().Flags.String()))
+	}
+	for _, route := range routes {
+		if route.LinkIndex != branchLink.Attrs().Index {
+			validationErrors = append(validationErrors, fmt.Errorf(
+				"branch table %d contains route through unexpected link: %+v",
+				branchTable, route))
+		}
+	}
+	return validationErrors
+}
+
 // TestNetworkTearedDownForRegularPods test pod networking is correctly teared down by the CNI Plugin
 // The test assumes that the IP assigned to the older Pod is not assigned to a new Pod while this test
 // is being executed
@@ -401,7 +577,18 @@ func TestNetworkTearedDownForRegularPods(podNetworkingValidationInput input.PodN
 }
 
 // TestNetworkingForPods using security groups is teared down correctly
-func TestNetworkTearedDownForPodsUsingSecurityGroup(podNetworkingValidationInput input.PodNetworkingValidationInput) []error {
+func TestNetworkTearedDownForPodsUsingSecurityGroup(
+	podNetworkingValidationInput input.PodNetworkingValidationInput,
+	enforcingMode sgpp.EnforcingMode,
+) []error {
+	switch enforcingMode {
+	case sgpp.EnforcingModeStandard:
+		return testNetworkTearedDownForPodsUsingSecurityGroupStandard(podNetworkingValidationInput)
+	case sgpp.EnforcingModeStrict:
+	default:
+		return []error{fmt.Errorf("unsupported pod security group enforcing mode %q", enforcingMode)}
+	}
+
 	var validationErrors []error
 	var podIP net.IP
 	interfaceToVlanTableMap := make(map[string]int)
@@ -481,6 +668,66 @@ func TestNetworkTearedDownForPodsUsingSecurityGroup(podNetworkingValidationInput
 	}
 
 	return validationErrors
+}
+
+func testNetworkTearedDownForPodsUsingSecurityGroupStandard(
+	podNetworkingValidationInput input.PodNetworkingValidationInput,
+) []error {
+	validationErrors := TestNetworkTearedDownForRegularPods(podNetworkingValidationInput)
+
+	nl := netlinkwrapper.NewNetLink()
+	linkList, err := nl.LinkList()
+	if err != nil {
+		return append(validationErrors, fmt.Errorf("failed to list links: %v", err))
+	}
+	for _, link := range linkList {
+		if strings.HasPrefix(link.Attrs().Name, "vlan.eth") {
+			validationErrors = append(validationErrors,
+				fmt.Errorf("found leaked branch ENI %s", link.Attrs().Name))
+		}
+	}
+	return validationErrors
+}
+
+func standardPodRouteRules(ruleList []netlink.Rule, podIP net.IP) (
+	toMainRules []netlink.Rule,
+	fromBranchRules []netlink.Rule,
+) {
+	for _, rule := range ruleList {
+		if rule.Dst != nil && rule.Dst.IP.Equal(podIP) &&
+			rule.Table == unix.RT_TABLE_MAIN &&
+			rule.Priority == standardToContainerRulePriority {
+			toMainRules = append(toMainRules, rule)
+		}
+		if rule.Src != nil && rule.Src.IP.Equal(podIP) &&
+			rule.Table != unix.RT_TABLE_MAIN &&
+			rule.Priority == standardFromPodRulePriority {
+			fromBranchRules = append(fromBranchRules, rule)
+		}
+	}
+	return toMainRules, fromBranchRules
+}
+
+func podIPNet(podIP net.IP) *net.IPNet {
+	maskSize := 32
+	if podIP.To4() == nil {
+		maskSize = 128
+	}
+	return &net.IPNet{IP: podIP, Mask: net.CIDRMask(maskSize, maskSize)}
+}
+
+func ipFamilyForValidation(ipFamily string) int {
+	if ipFamily == "IPv6" {
+		return netlink.FAMILY_V6
+	}
+	return netlink.FAMILY_V4
+}
+
+func podIPForValidation(pod input.Pod, ipFamily string) net.IP {
+	if ipFamily == "IPv6" {
+		return net.ParseIP(pod.PodIPv6Address)
+	}
+	return net.ParseIP(pod.PodIPv4Address)
 }
 
 func isRuleToOrFromIP(rule netlink.Rule, ip net.IP) bool {

--- a/test/agent/cmd/networking/tester/network_test.go
+++ b/test/agent/cmd/networking/tester/network_test.go
@@ -1,0 +1,81 @@
+package tester
+
+import (
+	"net"
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
+	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestPPSGValidationRejectsUnsupportedMode(t *testing.T) {
+	invalidMode := sgpp.EnforcingMode("invalid")
+	if errs := TestNetworkingSetupForPodsUsingSecurityGroup(
+		input.PodNetworkingValidationInput{}, invalidMode); len(errs) != 1 {
+		t.Fatalf("setup errors = %d, want 1: %+v", len(errs), errs)
+	}
+	if errs := TestNetworkTearedDownForPodsUsingSecurityGroup(
+		input.PodNetworkingValidationInput{}, invalidMode); len(errs) != 1 {
+		t.Fatalf("cleanup errors = %d, want 1: %+v", len(errs), errs)
+	}
+}
+
+func TestStandardPodRouteRules(t *testing.T) {
+	podIP := net.ParseIP("10.0.0.10")
+	podNet := podIPNet(podIP)
+	otherNet := podIPNet(net.ParseIP("10.0.0.11"))
+
+	rules := []netlink.Rule{
+		{
+			Dst:      podNet,
+			Table:    unix.RT_TABLE_MAIN,
+			Priority: standardToContainerRulePriority,
+		},
+		{
+			Src:      podNet,
+			Table:    101,
+			Priority: standardFromPodRulePriority,
+		},
+		{
+			Dst:      otherNet,
+			Table:    unix.RT_TABLE_MAIN,
+			Priority: standardToContainerRulePriority,
+		},
+		{
+			Src:      podNet,
+			Table:    unix.RT_TABLE_MAIN,
+			Priority: standardFromPodRulePriority,
+		},
+	}
+
+	toMain, fromBranch := standardPodRouteRules(rules, podIP)
+	if len(toMain) != 1 {
+		t.Fatalf("to-main rules = %d, want 1: %+v", len(toMain), toMain)
+	}
+	if len(fromBranch) != 1 {
+		t.Fatalf("from-branch rules = %d, want 1: %+v", len(fromBranch), fromBranch)
+	}
+	if fromBranch[0].Table != 101 {
+		t.Fatalf("from-branch table = %d, want 101", fromBranch[0].Table)
+	}
+}
+
+func TestPodIPNet(t *testing.T) {
+	tests := []struct {
+		ip       string
+		wantMask int
+	}{
+		{ip: "10.0.0.10", wantMask: 32},
+		{ip: "2001:db8::10", wantMask: 128},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			ones, _ := podIPNet(net.ParseIP(tt.ip)).Mask.Size()
+			if ones != tt.wantMask {
+				t.Fatalf("mask size = %d, want %d", ones, tt.wantMask)
+			}
+		})
+	}
+}

--- a/test/integration/common/sgpp_mode.go
+++ b/test/integration/common/sgpp_mode.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
+)
+
+const (
+	podSGEnforcingModeEnv = "POD_SECURITY_GROUP_ENFORCING_MODE"
+	vethPrefixEnv         = "AWS_VPC_K8S_CNI_VETHPREFIX"
+	defaultVethPrefix     = "eni"
+)
+
+// SGPPTestConfig captures the mode-dependent host networking expectations.
+type SGPPTestConfig struct {
+	EnforcingMode  sgpp.EnforcingMode
+	HostVethPrefix string
+}
+
+// ResolveSGPPTestConfig derives SGPP test expectations from the live aws-node environment.
+func ResolveSGPPTestConfig(awsNodeEnv map[string]string) (SGPPTestConfig, error) {
+	enforcingMode := sgpp.DefaultEnforcingMode
+	if configuredMode := awsNodeEnv[podSGEnforcingModeEnv]; configuredMode != "" {
+		enforcingMode = sgpp.EnforcingMode(configuredMode)
+	}
+	if enforcingMode != sgpp.EnforcingModeStrict && enforcingMode != sgpp.EnforcingModeStandard {
+		return SGPPTestConfig{}, fmt.Errorf("unsupported %s value %q",
+			podSGEnforcingModeEnv, enforcingMode)
+	}
+
+	configuredVethPrefix := awsNodeEnv[vethPrefixEnv]
+	if configuredVethPrefix == "" {
+		configuredVethPrefix = defaultVethPrefix
+	}
+
+	return SGPPTestConfig{
+		EnforcingMode:  enforcingMode,
+		HostVethPrefix: sgpp.BuildHostVethNamePrefix(configuredVethPrefix, enforcingMode),
+	}, nil
+}

--- a/test/integration/common/sgpp_mode_test.go
+++ b/test/integration/common/sgpp_mode_test.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
+)
+
+func TestResolveSGPPTestConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        map[string]string
+		wantMode   sgpp.EnforcingMode
+		wantPrefix string
+	}{
+		{
+			name:       "defaults to strict mode and vlan prefix",
+			env:        map[string]string{},
+			wantMode:   sgpp.EnforcingModeStrict,
+			wantPrefix: "vlan",
+		},
+		{
+			name: "standard mode uses default veth prefix",
+			env: map[string]string{
+				podSGEnforcingModeEnv: string(sgpp.EnforcingModeStandard),
+			},
+			wantMode:   sgpp.EnforcingModeStandard,
+			wantPrefix: defaultVethPrefix,
+		},
+		{
+			name: "standard mode uses configured veth prefix",
+			env: map[string]string{
+				podSGEnforcingModeEnv: string(sgpp.EnforcingModeStandard),
+				vethPrefixEnv:         "abcd",
+			},
+			wantMode:   sgpp.EnforcingModeStandard,
+			wantPrefix: "abcd",
+		},
+		{
+			name: "strict mode ignores configured veth prefix",
+			env: map[string]string{
+				podSGEnforcingModeEnv: string(sgpp.EnforcingModeStrict),
+				vethPrefixEnv:         "abcd",
+			},
+			wantMode:   sgpp.EnforcingModeStrict,
+			wantPrefix: "vlan",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveSGPPTestConfig(tt.env)
+			if err != nil {
+				t.Fatalf("ResolveSGPPTestConfig() returned error: %v", err)
+			}
+			if got.EnforcingMode != tt.wantMode {
+				t.Errorf("enforcing mode = %q, want %q", got.EnforcingMode, tt.wantMode)
+			}
+			if got.HostVethPrefix != tt.wantPrefix {
+				t.Errorf("host veth prefix = %q, want %q", got.HostVethPrefix, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestResolveSGPPTestConfigRejectsInvalidMode(t *testing.T) {
+	_, err := ResolveSGPPTestConfig(map[string]string{
+		podSGEnforcingModeEnv: "invalid",
+	})
+	if err == nil {
+		t.Fatal("ResolveSGPPTestConfig() returned no error")
+	}
+}

--- a/test/integration/common/util.go
+++ b/test/integration/common/util.go
@@ -257,7 +257,7 @@ func AssertSpanningENIsPreconditions(f *framework.Framework, node coreV1.Node) i
 	netInfo := NetworkInfoForNode(f, node)
 	replicas, err := SpanningENIsReplicaCount(netInfo)
 	Expect(err).ToNot(HaveOccurred(), "instance type cannot support a spanning ENI deployment")
-	awsNodeEnv := getAWSNodeEnv(f)
+	awsNodeEnv := GetAWSNodeEnv(f)
 
 	Expect(parseBoolEnv(awsNodeEnv["ENABLE_PREFIX_DELEGATION"])).To(BeFalse(),
 		"prefix delegation is enabled: per-ENI capacity is prefix-based, so the "+
@@ -275,9 +275,9 @@ func AssertSpanningENIsPreconditions(f *framework.Framework, node coreV1.Node) i
 	return replicas
 }
 
-// getAWSNodeEnv reads the environment variables on the live aws-node container so
+// GetAWSNodeEnv reads the environment variables on the live aws-node container so
 // preconditions reflect the current node state, including mid-suite toggles.
-func getAWSNodeEnv(f *framework.Framework) map[string]string {
+func GetAWSNodeEnv(f *framework.Framework) map[string]string {
 	ds, err := f.K8sResourceManagers.DaemonSetManager().
 		GetDaemonSet(utils.AwsNodeNamespace, utils.AwsNodeName)
 	Expect(err).ToNot(HaveOccurred())
@@ -297,6 +297,15 @@ func getAWSNodeEnv(f *framework.Framework) map[string]string {
 	Expect(found).To(BeTrue(), "daemonset %s/%s has no %q container",
 		utils.AwsNodeNamespace, utils.AwsNodeName, utils.AwsNodeName)
 	return env
+}
+
+// CurrentSGPPTestConfig reads and validates the live aws-node SGPP configuration.
+func CurrentSGPPTestConfig(f *framework.Framework) SGPPTestConfig {
+	testConfig, err := ResolveSGPPTestConfig(GetAWSNodeEnv(f))
+	Expect(err).ToNot(HaveOccurred())
+	fmt.Fprintf(GinkgoWriter, "SGPP enforcing mode is %s; expected host veth prefix is %s\n",
+		testConfig.EnforcingMode, testConfig.HostVethPrefix)
+	return testConfig
 }
 
 func parseBoolEnv(val string) bool {

--- a/test/integration/custom-networking-sgpp/custom_networking_sgpp_test.go
+++ b/test/integration/custom-networking-sgpp/custom_networking_sgpp_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/agent"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	vpcControllerFW "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
@@ -254,6 +255,7 @@ var _ = Describe("Custom Networking + Security Groups for Pods Test", func() {
 })
 
 func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingValidationInput {
+	testConfig := common.CurrentSGPPTestConfig(f)
 	var ipFamily string
 	if isIPv4Cluster {
 		ipFamily = "IPv4"
@@ -262,7 +264,7 @@ func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingVali
 	}
 	ip := input.PodNetworkingValidationInput{
 		IPFamily:    ipFamily,
-		VethPrefix:  "vlan",
+		VethPrefix:  testConfig.HostVethPrefix,
 		PodList:     []input.Pod{},
 		ValidateMTU: true,
 		MTU:         9001,
@@ -288,8 +290,10 @@ func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingVali
 }
 
 func ValidateHostNetworking(testType TestType, podValidationInputString string) {
+	testConfig := common.CurrentSGPPTestConfig(f)
 	testerArgs := []string{fmt.Sprintf("-pod-networking-validation-input=%s",
-		podValidationInputString)}
+		podValidationInputString),
+		fmt.Sprintf("-pod-sg-enforcing-mode=%s", testConfig.EnforcingMode)}
 
 	if NetworkingSetupSucceeds == testType {
 		testerArgs = append(testerArgs, "-test-setup=true", "-test-ppsg=true")

--- a/test/integration/pod-eni/security_group_per_pod_test.go
+++ b/test/integration/pod-eni/security_group_per_pod_test.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
 	"github.com/aws/amazon-vpc-cni-k8s/test/agent/pkg/input"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/agent"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/manifest"
 	k8sUtils "github.com/aws/amazon-vpc-cni-k8s/test/framework/resources/k8s/utils"
 	"github.com/aws/amazon-vpc-cni-k8s/test/framework/utils"
+	"github.com/aws/amazon-vpc-cni-k8s/test/integration/common"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	vpcControllerFW "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
@@ -176,7 +178,13 @@ var _ = Describe("Security Group for Pods Test", func() {
 			branchPodLabelVal = []string{serverPodLabelVal}
 		})
 
-		It("should have 0% success rate", func() {
+		It("applies the closed-port expectation for the active enforcing mode", func() {
+			testConfig := common.CurrentSGPPTestConfig(f)
+			if testConfig.EnforcingMode == sgpp.EnforcingModeStandard {
+				Skip("same-node traffic in standard mode does not traverse the branch ENI; " +
+					"this mixed-topology test has no deterministic aggregate success rate")
+			}
+
 			t := agent.TrafficTest{
 				Framework:                      f,
 				TrafficServerDeploymentBuilder: serverDeploymentBuilder,
@@ -204,9 +212,6 @@ var _ = Describe("Security Group for Pods Test", func() {
 			initialDelay = 10
 			periodSecond = 10
 			failureCount = 3
-			// If liveliness probe will fail then the container would have
-			// restarted
-			containerRestartCount = 0
 			// Value for the Environment variable DISABLE_TCP_EARLY_DEMUX
 			disableTCPEarlyDemux string
 		)
@@ -259,9 +264,15 @@ var _ = Describe("Security Group for Pods Test", func() {
 			pod, err = f.K8sResourceManagers.PodManager().GetPod(pod.Namespace, pod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("verifying the container restarted %d times", containerRestartCount))
-			Expect(int(pod.Status.ContainerStatuses[0].RestartCount)).
-				To(Equal(containerRestartCount))
+			testConfig := common.CurrentSGPPTestConfig(f)
+			restartCount := int(pod.Status.ContainerStatuses[0].RestartCount)
+			if expectTCPEarlyDemuxRestart(testConfig.EnforcingMode, disableTCPEarlyDemux) {
+				By("verifying the container restarted after the liveness probe failed")
+				Expect(restartCount).To(BeNumerically(">", 0))
+			} else {
+				By("verifying the liveness probe succeeded without restarting the container")
+				Expect(restartCount).To(Equal(0))
+			}
 		})
 
 		JustAfterEach(func() {
@@ -272,15 +283,13 @@ var _ = Describe("Security Group for Pods Test", func() {
 
 		Context("when disabling DISABLE_TCP_EARLY_DEMUX", func() {
 			BeforeEach(func() {
-				containerRestartCount = 1
 				disableTCPEarlyDemux = "false"
 			})
-			It("TCP liveness probe will fail", func() {})
+			It("uses the mode-specific TCP liveness probe behavior", func() {})
 		})
 
 		Context("when enabling DISABLE_TCP_EARLY_DEMUX", func() {
 			BeforeEach(func() {
-				containerRestartCount = 0
 				disableTCPEarlyDemux = "true"
 			})
 			It("TCP liveness probe will succeed", func() {})
@@ -333,6 +342,7 @@ var _ = Describe("Security Group for Pods Test", func() {
 })
 
 func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingValidationInput {
+	testConfig := common.CurrentSGPPTestConfig(f)
 	var ipFamily string
 	if isIPv4Cluster {
 		ipFamily = "IPv4"
@@ -341,7 +351,7 @@ func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingVali
 	}
 	ip := input.PodNetworkingValidationInput{
 		IPFamily:    ipFamily,
-		VethPrefix:  "vlan",
+		VethPrefix:  testConfig.HostVethPrefix,
 		PodList:     []input.Pod{},
 		ValidateMTU: true,
 		MTU:         9001,
@@ -367,8 +377,10 @@ func GetPodNetworkingValidationInput(podList v1.PodList) input.PodNetworkingVali
 }
 
 func ValidateHostNetworking(testType TestType, podValidationInputString string) {
+	testConfig := common.CurrentSGPPTestConfig(f)
 	testerArgs := []string{fmt.Sprintf("-pod-networking-validation-input=%s",
-		podValidationInputString)}
+		podValidationInputString),
+		fmt.Sprintf("-pod-sg-enforcing-mode=%s", testConfig.EnforcingMode)}
 
 	if NetworkingSetupSucceeds == testType {
 		testerArgs = append(testerArgs, "-test-setup=true", "-test-ppsg=true")
@@ -403,6 +415,10 @@ func ValidateHostNetworking(testType TestType, podValidationInputString string) 
 	err = f.K8sResourceManagers.PodManager().
 		DeleteAndWaitTillPodDeleted(testPod)
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func expectTCPEarlyDemuxRestart(enforcingMode sgpp.EnforcingMode, disableTCPEarlyDemux string) bool {
+	return enforcingMode == sgpp.EnforcingModeStrict && disableTCPEarlyDemux == "false"
 }
 
 func ValidatePodsHaveBranchENI(podList v1.PodList) error {

--- a/test/integration/pod-eni/sgpp_mode_test.go
+++ b/test/integration/pod-eni/sgpp_mode_test.go
@@ -1,0 +1,50 @@
+package pod_eni
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
+)
+
+func TestExpectTCPEarlyDemuxRestart(t *testing.T) {
+	tests := []struct {
+		name                 string
+		mode                 sgpp.EnforcingMode
+		disableTCPEarlyDemux string
+		want                 bool
+	}{
+		{
+			name:                 "strict mode with early demux enabled",
+			mode:                 sgpp.EnforcingModeStrict,
+			disableTCPEarlyDemux: "false",
+			want:                 true,
+		},
+		{
+			name:                 "strict mode with early demux disabled",
+			mode:                 sgpp.EnforcingModeStrict,
+			disableTCPEarlyDemux: "true",
+			want:                 false,
+		},
+		{
+			name:                 "standard mode with early demux enabled",
+			mode:                 sgpp.EnforcingModeStandard,
+			disableTCPEarlyDemux: "false",
+			want:                 false,
+		},
+		{
+			name:                 "standard mode with early demux disabled",
+			mode:                 sgpp.EnforcingModeStandard,
+			disableTCPEarlyDemux: "true",
+			want:                 false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expectTCPEarlyDemuxRestart(tt.mode, tt.disableTCPEarlyDemux); got != tt.want {
+				t.Errorf("expectTCPEarlyDemuxRestart(%q, %q) = %t, want %t",
+					tt.mode, tt.disableTCPEarlyDemux, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

testing

**Which issue does this PR fix?**:

The SGPP integration assertions assumed the strict enforcing-mode datapath, so valid standard-mode routing and host-network behavior could fail the tests.

**What does this PR do / Why do we need it?**:

Makes the SGPP integration tests read the active enforcing mode and apply mode-specific assertions. It also passes the mode to the networking helper and centralizes the shared test configuration lookup. The CNI datapath is unchanged.

**Testing done on this change**:

- Unit tests for the networking helper and SGPP mode/config handling.
- Existing-cluster SGPP integration coverage for `pod-eni` and `custom-networking-sgpp` in both strict and standard modes.

**Will this PR introduce any new dependencies?**:

No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No. This only changes integration-test code and the test helper.

**Does this change require updates to the CNI daemonset config files to work?**:

No.

**Does this PR introduce any user-facing change?**:

No.

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
