### PR TITLE
chore: fix flaky SNAT test

### DIFF
--- a/test/integration/cni/pod_traffic_test.go
+++ b/test/integration/cni/pod_traffic_test.go
@@ -337,7 +337,37 @@ func execNodeShellWithTimeout(nodeName string, command string, timeout time.Dura
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "kubectl", "node-shell", nodeName, "--", "bash", "-c", command)
-	return cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+	// Surface the context deadline: CombinedOutput reports a killed process
+	// as "signal: killed", which hides that the timeout fired.
+	if err != nil && ctx.Err() != nil {
+		err = fmt.Errorf("%w: %v", ctx.Err(), err)
+	}
+	return output, err
+}
+
+// execNodeShellWithRetries is execNodeShellWithTimeout plus retries on any
+// failure for up to ~5 minutes. This absorbs node-shell scaffolding flakes
+// (e.g. attach racing the nsenter container startup on a busy node) as well
+// as remote commands whose success depends on the node converging. Callers
+// must therefore pass commands that are idempotent and expected to succeed.
+func execNodeShellWithRetries(nodeName string, command string, attemptTimeout time.Duration) ([]byte, error) {
+	const (
+		retryFor      = 5 * time.Minute
+		retryInterval = 10 * time.Second
+	)
+	deadline := time.Now().Add(retryFor)
+	var output []byte
+	var err error
+	for {
+		output, err = execNodeShellWithTimeout(nodeName, command, attemptTimeout)
+		if err == nil || time.Now().After(deadline) {
+			return output, err
+		}
+		fmt.Fprintf(GinkgoWriter, "node-shell on %s failed, retrying in %s: %v (output: %s)\n",
+			nodeName, retryInterval, err, output)
+		time.Sleep(retryInterval)
+	}
 }
 
 // sets requested policy in drop file and restarts udev

--- a/test/integration/cni/snat_kube_proxy_test.go
+++ b/test/integration/cni/snat_kube_proxy_test.go
@@ -253,8 +253,12 @@ func cleanupIPVSLeftovers() error {
 	}
 	cleanup := "ipvsadm --clear 2>/dev/null; ip link del kube-ipvs0 2>/dev/null; " +
 		"[ ! -e /sys/class/net/kube-ipvs0 ] && ! grep -qE \"^(TCP|UDP|SCTP)\" /proc/net/ip_vs 2>/dev/null"
+	// execNodeShellWithRetries retries any failure for ~5 minutes, which covers
+	// both node-shell scaffolding flakes and a kube-proxy pod that restarted
+	// with a stale (still ipvs) config recreating the interface and virtual
+	// services between cleanup and check: re-running the command re-cleans.
 	for _, node := range nodes.Items {
-		if out, err := execNodeShellWithTimeout(node.Name, cleanup, 30*time.Second); err != nil {
+		if out, err := execNodeShellWithRetries(node.Name, cleanup, 2*time.Minute); err != nil {
 			return fmt.Errorf("ipvs cleanup on node %s left interface or virtual services behind: %w (output: %s)", node.Name, err, out)
 		}
 	}
@@ -306,21 +310,23 @@ func detectIptablesBackend(nodeName string) string {
 // verifyConnmarkRules checks that CNI connmark rules exist ONLY in the appropriate backend
 func verifyConnmarkRules(nodeName, backend string) {
 	if backend == "nftables" {
-		out, err := execNodeShell(nodeName, "nft list table ip aws-cni")
+		out, err := execNodeShellWithRetries(nodeName, "nft list table ip aws-cni", 2*time.Minute)
 		fmt.Fprintf(GinkgoWriter, "nftables rules:\n%s\n", string(out))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(out)).To(ContainSubstring("chain nat-prerouting"))
 		Expect(string(out)).To(ContainSubstring("chain snat-mark"))
 
-		out, _ = execNodeShell(nodeName, "iptables-legacy -t nat -L PREROUTING -n")
+		out, _ = execNodeShellWithRetries(nodeName, "iptables-legacy -t nat -L PREROUTING -n", 2*time.Minute)
 		Expect(string(out)).ToNot(ContainSubstring("AWS-CONNMARK"))
 	} else {
-		out, err := execNodeShell(nodeName, "iptables-legacy -t nat -L PREROUTING -n")
+		out, err := execNodeShellWithRetries(nodeName, "iptables-legacy -t nat -L PREROUTING -n", 2*time.Minute)
 		fmt.Fprintf(GinkgoWriter, "iptables-legacy:\n%s\n", string(out))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(out)).To(ContainSubstring("AWS-CONNMARK"))
 
-		_, err = execNodeShell(nodeName, "nft list table ip aws-cni")
-		Expect(err).To(HaveOccurred())
+		// Inverted so that success means the aws-cni nftables table is absent,
+		// keeping the retry-on-failure semantics of execNodeShellWithRetries.
+		out, err = execNodeShellWithRetries(nodeName, "! nft list table ip aws-cni", 2*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "aws-cni nftables table should not exist with %s backend (output: %s)", backend, out)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

/kind bug

**Which issue does this PR fix?**:

N/A


**What does this PR do / Why do we need it?**:

Fixes a flake in the SNAT kube-proxy mode tests caused by kubectl node-shell scaffolding failures being reported as test failures.

Root cause: kubectl node-shell spawns a fresh nsenter pod per invocation and attaches to it. When the node is busy (this test bounces kube-proxy on every node and restarts aws-node twice), the attach can race the container startup and fail with container "nsenter" ... is not available before the remote command ever runs. The single-shot exec in cleanupIPVSLeftovers (30s timeout, no retry) then failed the DeferCleanup with a misleading "left interface or virtual services behind" error. Worse, a failed cleanup genuinely leaks kube-ipvs0 and the IPVS table on that node, which black-holes ClusterIP traffic (including kubernetes.default) and cascades into connectivity failures in the iptables/nftables entries on later runs — which is why the flake appeared to move between modes.


**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

Ran SNAT tests overnight, observed no failures with this change:
```
=== Run 1/7 started at Tue Sep  8 20:58:26 PDT 2026 ===
=== Run 1 PASSED ===
=== Run 2/7 started at Tue Sep  8 21:16:26 PDT 2026 ===
=== Run 2 PASSED ===
=== Run 3/7 started at Tue Sep  8 21:35:06 PDT 2026 ===
=== Run 3 PASSED ===
=== Run 4/7 started at Tue Sep  8 21:53:53 PDT 2026 ===
=== Run 4 PASSED ===
=== Run 5/7 started at Tue Sep  8 22:12:24 PDT 2026 ===
=== Run 5 PASSED ===
=== Run 6/7 started at Tue Sep  8 22:34:58 PDT 2026 ===
=== Run 6 PASSED ===
=== Run 7/7 started at Tue Sep  8 22:57:04 PDT 2026 ===
```


<!-- 
If adding a new integration test to any of the CNI release test suites, determine if the test can run against the latest VPC CNI image or if it is dependent on a future version release. If dependent, please call `Skip()` in the test to prevent it from running before the future version is available.
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

No

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
