### PR TITLE
test: add CNI scale and soak workloads

### DIFF
--- a/scripts/run-cni-scale-cleanup.sh
+++ b/scripts/run-cni-scale-cleanup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Deletes the workload left running by run-cni-scale-tests.sh so the caller can
+# capture full-load metrics before cleanup and recovery metrics afterwards.
+
+set -euo pipefail
+
+SCALE_TEST_NAMESPACE_PREFIX=${SCALE_TEST_NAMESPACE_PREFIX:-cni-scale}
+SCALE_TEST_TIMEOUT_SECONDS=${SCALE_TEST_TIMEOUT_SECONDS:-1800}
+namespace="${SCALE_TEST_NAMESPACE_PREFIX}-1"
+
+if [[ -n ${KUBE_CONFIG_PATH:-} && -z ${KUBECONFIG:-} ]]; then
+  export KUBECONFIG=$KUBE_CONFIG_PATH
+fi
+KUBECONFIG=${KUBECONFIG:-"${HOME:?HOME must be set}/.kube/config"}
+export KUBECONFIG
+
+if [[ ! $SCALE_TEST_TIMEOUT_SECONDS =~ ^[1-9][0-9]*$ ]]; then
+  printf 'SCALE_TEST_TIMEOUT_SECONDS must be a positive integer; got %q\n' \
+    "$SCALE_TEST_TIMEOUT_SECONDS" >&2
+  exit 2
+fi
+command -v kubectl >/dev/null 2>&1 || {
+  printf 'kubectl is required\n' >&2
+  exit 127
+}
+
+printf 'Deleting CNI scale workload namespace %s\n' "$namespace"
+kubectl --kubeconfig "$KUBECONFIG" delete namespace "$namespace" \
+  --ignore-not-found=true \
+  --wait=true \
+  --timeout="${SCALE_TEST_TIMEOUT_SECONDS}s"
+
+if kubectl --kubeconfig "$KUBECONFIG" get namespace "$namespace" >/dev/null 2>&1; then
+  printf 'Namespace %s still exists after cleanup\n' "$namespace" >&2
+  exit 1
+fi
+
+printf 'CNI scale workload cleanup completed\n'

--- a/scripts/run-cni-scale-tests.sh
+++ b/scripts/run-cni-scale-tests.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+# Exercises CNI ADD/DEL and secondary-ENI allocation on an existing cluster.
+# Cluster creation, CNI installation, metric capture, and cluster deletion are
+# owned by the caller.
+
+set -euo pipefail
+
+NAMESPACE=${SCALE_TEST_NAMESPACE:-cni-scale-test}
+TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-617930562442.dkr.ecr.us-west-2.amazonaws.com}
+NGINX_IMAGE=${NGINX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/nginx:1.25.2}
+BUSYBOX_IMAGE=${BUSYBOX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/busybox:latest}
+SCALE_TEST_PODS=${SCALE_TEST_PODS:-20}
+SCALE_TEST_STEP_PODS=${SCALE_TEST_STEP_PODS:-5}
+SCALE_TEST_CYCLES=${SCALE_TEST_CYCLES:-3}
+SCALE_TEST_TIMEOUT_SECONDS=${SCALE_TEST_TIMEOUT_SECONDS:-600}
+SCALE_TEST_PROBE_TIMEOUT_SECONDS=${SCALE_TEST_PROBE_TIMEOUT_SECONDS:-5}
+NG_LABEL_KEY=${NG_LABEL_KEY:-kubernetes.io/os}
+NG_LABEL_VAL=${NG_LABEL_VAL:-linux}
+
+if [[ -n ${KUBE_CONFIG_PATH:-} && -z ${KUBECONFIG:-} ]]; then
+  export KUBECONFIG=$KUBE_CONFIG_PATH
+fi
+KUBECONFIG=${KUBECONFIG:-"${HOME:?HOME must be set}/.kube/config"}
+export KUBECONFIG
+
+KUBECTL=(kubectl --kubeconfig "$KUBECONFIG")
+
+validate_positive_integer() {
+  local name=$1
+  local value=$2
+  if [[ ! $value =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s must be a positive integer; got %q\n' "$name" "$value" >&2
+    exit 2
+  fi
+}
+
+print_diagnostics() {
+  "${KUBECTL[@]}" get all --namespace "$NAMESPACE" --output wide || true
+  "${KUBECTL[@]}" get events --namespace "$NAMESPACE" --sort-by=.lastTimestamp || true
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if ((status != 0)); then
+    printf 'CNI scale test failed; collecting diagnostics\n' >&2
+    print_diagnostics
+  fi
+  if ! "${KUBECTL[@]}" delete namespace "$NAMESPACE" \
+    --ignore-not-found=true \
+    --wait=true \
+    --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"; then
+    printf 'Failed to delete namespace %s\n' "$NAMESPACE" >&2
+    status=1
+  fi
+  exit "$status"
+}
+
+wait_for_zero_target_pods() {
+  local deadline=$((SECONDS + SCALE_TEST_TIMEOUT_SECONDS))
+  local pods
+  while ((SECONDS < deadline)); do
+    pods=$("${KUBECTL[@]}" get pods \
+      --namespace "$NAMESPACE" \
+      --selector app=cni-scale-target \
+      --output name)
+    if [[ -z $pods ]]; then
+      return
+    fi
+    sleep 2
+  done
+  printf 'Target pods did not scale to zero within %ss\n' "$SCALE_TEST_TIMEOUT_SECONDS" >&2
+  return 1
+}
+
+verify_target_ready() {
+  local expected=$1
+  local ready
+  "${KUBECTL[@]}" rollout status deployment/cni-scale-target \
+    --namespace "$NAMESPACE" \
+    --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
+  ready=$("${KUBECTL[@]}" get deployment cni-scale-target \
+    --namespace "$NAMESPACE" \
+    --output jsonpath='{.status.readyReplicas}')
+  if [[ ${ready:-0} != "$expected" ]]; then
+    printf 'Expected %s ready target pods, found %s\n' \
+      "$expected" "${ready:-0}" >&2
+    return 1
+  fi
+}
+
+scale_up_target() {
+  local replicas=0
+  local next
+  while ((replicas < SCALE_TEST_PODS)); do
+    next=$((replicas + SCALE_TEST_STEP_PODS))
+    if ((next > SCALE_TEST_PODS)); then
+      next=$SCALE_TEST_PODS
+    fi
+    printf 'Scaling target workload to %s replicas\n' "$next"
+    "${KUBECTL[@]}" scale deployment/cni-scale-target \
+      --namespace "$NAMESPACE" \
+      --replicas "$next"
+    verify_target_ready "$next"
+    replicas=$next
+  done
+}
+
+probe_target() {
+  "${KUBECTL[@]}" exec \
+    --namespace "$NAMESPACE" \
+    deployment/cni-scale-probe \
+    -- wget -q -T "$SCALE_TEST_PROBE_TIMEOUT_SECONDS" -O /dev/null http://cni-scale-target/
+}
+
+for name in SCALE_TEST_PODS SCALE_TEST_STEP_PODS SCALE_TEST_CYCLES SCALE_TEST_TIMEOUT_SECONDS SCALE_TEST_PROBE_TIMEOUT_SECONDS; do
+  validate_positive_integer "$name" "${!name}"
+done
+command -v kubectl >/dev/null 2>&1 || {
+  printf 'kubectl is required\n' >&2
+  exit 127
+}
+
+TARGET_NODE=${SCALE_TEST_NODE:-$("${KUBECTL[@]}" get nodes \
+  --field-selector spec.unschedulable!=true \
+  --selector "${NG_LABEL_KEY}=${NG_LABEL_VAL}" \
+  --output jsonpath='{.items[0].metadata.name}')}
+if [[ -z $TARGET_NODE ]]; then
+  printf 'No schedulable node matched %s=%s\n' "$NG_LABEL_KEY" "$NG_LABEL_VAL" >&2
+  exit 1
+fi
+
+"${KUBECTL[@]}" delete namespace "$NAMESPACE" \
+  --ignore-not-found=true \
+  --wait=true \
+  --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
+"${KUBECTL[@]}" create namespace "$NAMESPACE"
+trap cleanup EXIT
+
+"${KUBECTL[@]}" apply --filename - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-scale-target
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: cni-scale-target
+  template:
+    metadata:
+      labels:
+        app: cni-scale-target
+    spec:
+      nodeName: ${TARGET_NODE}
+      containers:
+        - name: nginx
+          image: ${NGINX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 2
+            timeoutSeconds: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-scale-probe
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cni-scale-probe
+  template:
+    metadata:
+      labels:
+        app: cni-scale-probe
+    spec:
+      containers:
+        - name: busybox
+          image: ${BUSYBOX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["sleep", "604800"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cni-scale-target
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: cni-scale-target
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+
+"${KUBECTL[@]}" rollout status deployment/cni-scale-probe \
+  --namespace "$NAMESPACE" \
+  --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
+
+printf 'Running %s CNI scale cycles with %s pods pinned to %s\n' \
+  "$SCALE_TEST_CYCLES" "$SCALE_TEST_PODS" "$TARGET_NODE"
+for ((cycle = 1; cycle <= SCALE_TEST_CYCLES; cycle++)); do
+  printf 'Scale cycle %s/%s: 0 -> %s -> 0\n' \
+    "$cycle" "$SCALE_TEST_CYCLES" "$SCALE_TEST_PODS"
+  scale_up_target
+  probe_target
+  "${KUBECTL[@]}" scale deployment/cni-scale-target \
+    --namespace "$NAMESPACE" \
+    --replicas 0
+  wait_for_zero_target_pods
+done
+
+printf 'CNI scale test completed successfully\n'

--- a/scripts/run-cni-scale-tests.sh
+++ b/scripts/run-cni-scale-tests.sh
@@ -1,30 +1,24 @@
 #!/usr/bin/env bash
 
-# Exercises CNI ADD/DEL and secondary-ENI allocation on an existing cluster.
-# Cluster creation, CNI installation, metric capture, and cluster deletion are
-# owned by the caller.
+# Creates a paced, scheduler-distributed CNI scale workload on an existing
+# cluster. The caller owns cluster creation, CNI installation, metric capture,
+# workload cleanup, and cluster deletion.
 
 set -euo pipefail
 
-NAMESPACE=${SCALE_TEST_NAMESPACE:-cni-scale-test}
+CL2_BIN=${CL2_BIN:-clusterloader2}
+SCALE_TEST_NAMESPACE_PREFIX=${SCALE_TEST_NAMESPACE_PREFIX:-cni-scale}
+SCALE_TEST_PODS=${SCALE_TEST_PODS:-2000}
+SCALE_TEST_POD_THROUGHPUT=${SCALE_TEST_POD_THROUGHPUT:-20}
+SCALE_TEST_TIMEOUT_SECONDS=${SCALE_TEST_TIMEOUT_SECONDS:-1800}
 TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-617930562442.dkr.ecr.us-west-2.amazonaws.com}
-NGINX_IMAGE=${NGINX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/nginx:1.25.2}
-BUSYBOX_IMAGE=${BUSYBOX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/busybox:latest}
-SCALE_TEST_PODS=${SCALE_TEST_PODS:-20}
-SCALE_TEST_STEP_PODS=${SCALE_TEST_STEP_PODS:-5}
-SCALE_TEST_CYCLES=${SCALE_TEST_CYCLES:-3}
-SCALE_TEST_TIMEOUT_SECONDS=${SCALE_TEST_TIMEOUT_SECONDS:-600}
-SCALE_TEST_PROBE_TIMEOUT_SECONDS=${SCALE_TEST_PROBE_TIMEOUT_SECONDS:-5}
-NG_LABEL_KEY=${NG_LABEL_KEY:-kubernetes.io/os}
-NG_LABEL_VAL=${NG_LABEL_VAL:-linux}
+SCALE_TEST_POD_IMAGE=${SCALE_TEST_POD_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/busybox:latest}
 
 if [[ -n ${KUBE_CONFIG_PATH:-} && -z ${KUBECONFIG:-} ]]; then
   export KUBECONFIG=$KUBE_CONFIG_PATH
 fi
 KUBECONFIG=${KUBECONFIG:-"${HOME:?HOME must be set}/.kube/config"}
 export KUBECONFIG
-
-KUBECTL=(kubectl --kubeconfig "$KUBECONFIG")
 
 validate_positive_integer() {
   local name=$1
@@ -35,186 +29,63 @@ validate_positive_integer() {
   fi
 }
 
-print_diagnostics() {
-  "${KUBECTL[@]}" get all --namespace "$NAMESPACE" --output wide || true
-  "${KUBECTL[@]}" get events --namespace "$NAMESPACE" --sort-by=.lastTimestamp || true
-}
+for name in SCALE_TEST_PODS SCALE_TEST_POD_THROUGHPUT SCALE_TEST_TIMEOUT_SECONDS; do
+  validate_positive_integer "$name" "${!name}"
+done
+for command in "$CL2_BIN" kubectl sha256sum; do
+  command -v "$command" >/dev/null 2>&1 || {
+    printf '%s is required\n' "$command" >&2
+    exit 127
+  }
+done
 
-cleanup() {
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+clusterloader_path=$(command -v "$CL2_BIN")
+clusterloader_sha256=$(sha256sum "$clusterloader_path")
+clusterloader_sha256=${clusterloader_sha256%% *}
+safe_cluster_name=${CLUSTER_NAME:-local}
+safe_cluster_name=${safe_cluster_name//[^a-zA-Z0-9_.-]/-}
+report_dir=${SCALE_TEST_REPORT_DIR:-"log/clusterloader2-${safe_cluster_name}"}
+mkdir -p "$report_dir"
+
+print_diagnostics_on_failure() {
   local status=$?
   trap - EXIT
   if ((status != 0)); then
-    printf 'CNI scale test failed; collecting diagnostics\n' >&2
-    print_diagnostics
-  fi
-  if ! "${KUBECTL[@]}" delete namespace "$NAMESPACE" \
-    --ignore-not-found=true \
-    --wait=true \
-    --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"; then
-    printf 'Failed to delete namespace %s\n' "$NAMESPACE" >&2
-    status=1
+    printf 'ClusterLoader2 scale workload failed; collecting pod diagnostics\n' >&2
+    kubectl --kubeconfig "$KUBECONFIG" get pods \
+      --all-namespaces \
+      --selector group=cni-scale \
+      --output wide || true
   fi
   exit "$status"
 }
+trap print_diagnostics_on_failure EXIT
 
-wait_for_zero_target_pods() {
-  local deadline=$((SECONDS + SCALE_TEST_TIMEOUT_SECONDS))
-  local pods
-  while ((SECONDS < deadline)); do
-    pods=$("${KUBECTL[@]}" get pods \
-      --namespace "$NAMESPACE" \
-      --selector app=cni-scale-target \
-      --output name)
-    if [[ -z $pods ]]; then
-      return
-    fi
-    sleep 2
-  done
-  printf 'Target pods did not scale to zero within %ss\n' "$SCALE_TEST_TIMEOUT_SECONDS" >&2
-  return 1
-}
-
-verify_target_ready() {
-  local expected=$1
-  local ready
-  "${KUBECTL[@]}" rollout status deployment/cni-scale-target \
-    --namespace "$NAMESPACE" \
-    --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
-  ready=$("${KUBECTL[@]}" get deployment cni-scale-target \
-    --namespace "$NAMESPACE" \
-    --output jsonpath='{.status.readyReplicas}')
-  if [[ ${ready:-0} != "$expected" ]]; then
-    printf 'Expected %s ready target pods, found %s\n' \
-      "$expected" "${ready:-0}" >&2
-    return 1
-  fi
-}
-
-scale_up_target() {
-  local replicas=0
-  local next
-  while ((replicas < SCALE_TEST_PODS)); do
-    next=$((replicas + SCALE_TEST_STEP_PODS))
-    if ((next > SCALE_TEST_PODS)); then
-      next=$SCALE_TEST_PODS
-    fi
-    printf 'Scaling target workload to %s replicas\n' "$next"
-    "${KUBECTL[@]}" scale deployment/cni-scale-target \
-      --namespace "$NAMESPACE" \
-      --replicas "$next"
-    verify_target_ready "$next"
-    replicas=$next
-  done
-}
-
-probe_target() {
-  "${KUBECTL[@]}" exec \
-    --namespace "$NAMESPACE" \
-    deployment/cni-scale-probe \
-    -- wget -q -T "$SCALE_TEST_PROBE_TIMEOUT_SECONDS" -O /dev/null http://cni-scale-target/
-}
-
-for name in SCALE_TEST_PODS SCALE_TEST_STEP_PODS SCALE_TEST_CYCLES SCALE_TEST_TIMEOUT_SECONDS SCALE_TEST_PROBE_TIMEOUT_SECONDS; do
-  validate_positive_integer "$name" "${!name}"
-done
-command -v kubectl >/dev/null 2>&1 || {
-  printf 'kubectl is required\n' >&2
-  exit 127
-}
-
-TARGET_NODE=${SCALE_TEST_NODE:-$("${KUBECTL[@]}" get nodes \
-  --field-selector spec.unschedulable!=true \
-  --selector "${NG_LABEL_KEY}=${NG_LABEL_VAL}" \
-  --output jsonpath='{.items[0].metadata.name}')}
-if [[ -z $TARGET_NODE ]]; then
-  printf 'No schedulable node matched %s=%s\n' "$NG_LABEL_KEY" "$NG_LABEL_VAL" >&2
-  exit 1
-fi
-
-"${KUBECTL[@]}" delete namespace "$NAMESPACE" \
-  --ignore-not-found=true \
-  --wait=true \
-  --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
-"${KUBECTL[@]}" create namespace "$NAMESPACE"
-trap cleanup EXIT
-
-"${KUBECTL[@]}" apply --filename - <<EOF
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cni-scale-target
-  namespace: ${NAMESPACE}
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      app: cni-scale-target
-  template:
-    metadata:
-      labels:
-        app: cni-scale-target
-    spec:
-      nodeName: ${TARGET_NODE}
-      containers:
-        - name: nginx
-          image: ${NGINX_IMAGE}
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
-            periodSeconds: 2
-            timeoutSeconds: 2
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cni-scale-probe
-  namespace: ${NAMESPACE}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: cni-scale-probe
-  template:
-    metadata:
-      labels:
-        app: cni-scale-probe
-    spec:
-      containers:
-        - name: busybox
-          image: ${BUSYBOX_IMAGE}
-          imagePullPolicy: IfNotPresent
-          command: ["sleep", "604800"]
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: cni-scale-target
-  namespace: ${NAMESPACE}
-spec:
-  selector:
-    app: cni-scale-target
-  ports:
-    - port: 80
-      targetPort: 80
+cat >"${report_dir}/metadata.txt" <<EOF
+clusterloader2_path=${clusterloader_path}
+clusterloader2_sha256=${clusterloader_sha256}
+pod_count=${SCALE_TEST_PODS}
+pod_throughput=${SCALE_TEST_POD_THROUGHPUT}
+namespace=${SCALE_TEST_NAMESPACE_PREFIX}-1
 EOF
 
-"${KUBECTL[@]}" rollout status deployment/cni-scale-probe \
-  --namespace "$NAMESPACE" \
-  --timeout "${SCALE_TEST_TIMEOUT_SECONDS}s"
+export NAMESPACE_PREFIX=$SCALE_TEST_NAMESPACE_PREFIX
+export OPERATION_TIMEOUT="${SCALE_TEST_TIMEOUT_SECONDS}s"
+export POD_COUNT=$SCALE_TEST_PODS
+export POD_IMAGE=$SCALE_TEST_POD_IMAGE
+export POD_THROUGHPUT=$SCALE_TEST_POD_THROUGHPUT
 
-printf 'Running %s CNI scale cycles with %s pods pinned to %s\n' \
-  "$SCALE_TEST_CYCLES" "$SCALE_TEST_PODS" "$TARGET_NODE"
-for ((cycle = 1; cycle <= SCALE_TEST_CYCLES; cycle++)); do
-  printf 'Scale cycle %s/%s: 0 -> %s -> 0\n' \
-    "$cycle" "$SCALE_TEST_CYCLES" "$SCALE_TEST_PODS"
-  scale_up_target
-  probe_target
-  "${KUBECTL[@]}" scale deployment/cni-scale-target \
-    --namespace "$NAMESPACE" \
-    --replicas 0
-  wait_for_zero_target_pods
-done
+printf 'Creating %s CNI scale pods at %s pods/s with ClusterLoader2 %s\n' \
+  "$SCALE_TEST_PODS" "$SCALE_TEST_POD_THROUGHPUT" "$clusterloader_sha256"
 
-printf 'CNI scale test completed successfully\n'
+"$CL2_BIN" \
+  -v=2 \
+  --testconfig="${script_dir}/scale/cl2-config.yaml" \
+  --provider=eks \
+  --enable-exec-service=false \
+  --report-dir="$report_dir" \
+  --kubeconfig="$KUBECONFIG" \
+  2>&1 | tee "${report_dir}/clusterloader2.log"
+
+printf 'CNI scale workload reached %s RunningAndReady pods\n' "$SCALE_TEST_PODS"

--- a/scripts/run-cni-soak-tests.sh
+++ b/scripts/run-cni-soak-tests.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+
+# Runs sustained CNI ADD/DEL and IP-allocation churn on an existing cluster.
+# Cluster creation, CNI installation, metric capture, and cluster deletion are
+# owned by the caller.
+
+set -euo pipefail
+
+NAMESPACE=${SOAK_TEST_NAMESPACE:-cni-soak-test}
+TEST_IMAGE_REGISTRY=${TEST_IMAGE_REGISTRY:-617930562442.dkr.ecr.us-west-2.amazonaws.com}
+NGINX_IMAGE=${NGINX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/nginx:1.25.2}
+BUSYBOX_IMAGE=${BUSYBOX_IMAGE:-${TEST_IMAGE_REGISTRY}/networking-e2e-test-images/busybox:latest}
+SOAK_DURATION_MINUTES=${SOAK_DURATION_MINUTES:-120}
+SOAK_BASE_PODS=${SOAK_BASE_PODS:-6}
+SOAK_CHURN_PODS=${SOAK_CHURN_PODS:-1}
+SOAK_IP_PRESSURE_PODS=${SOAK_IP_PRESSURE_PODS:-20}
+SOAK_IP_PRESSURE_STEP_PODS=${SOAK_IP_PRESSURE_STEP_PODS:-5}
+SOAK_CYCLE_INTERVAL_SECONDS=${SOAK_CYCLE_INTERVAL_SECONDS:-300}
+SOAK_HEALTH_INTERVAL_SECONDS=${SOAK_HEALTH_INTERVAL_SECONDS:-60}
+SOAK_TIMEOUT_SECONDS=${SOAK_TIMEOUT_SECONDS:-600}
+SOAK_PROBE_TIMEOUT_SECONDS=${SOAK_PROBE_TIMEOUT_SECONDS:-5}
+NG_LABEL_KEY=${NG_LABEL_KEY:-kubernetes.io/os}
+NG_LABEL_VAL=${NG_LABEL_VAL:-linux}
+
+if [[ -n ${KUBE_CONFIG_PATH:-} && -z ${KUBECONFIG:-} ]]; then
+  export KUBECONFIG=$KUBE_CONFIG_PATH
+fi
+KUBECONFIG=${KUBECONFIG:-"${HOME:?HOME must be set}/.kube/config"}
+export KUBECONFIG
+
+KUBECTL=(kubectl --kubeconfig "$KUBECONFIG")
+IP_PRESSURE_REPLICAS=0
+
+validate_positive_integer() {
+  local name=$1
+  local value=$2
+  if [[ ! $value =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s must be a positive integer; got %q\n' "$name" "$value" >&2
+    exit 2
+  fi
+}
+
+print_diagnostics() {
+  "${KUBECTL[@]}" get all --namespace "$NAMESPACE" --output wide || true
+  "${KUBECTL[@]}" get events --namespace "$NAMESPACE" --sort-by=.lastTimestamp || true
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if ((status != 0)); then
+    printf 'CNI soak test failed; collecting diagnostics\n' >&2
+    print_diagnostics
+  fi
+  if ! "${KUBECTL[@]}" delete namespace "$NAMESPACE" \
+    --ignore-not-found=true \
+    --wait=true \
+    --timeout "${SOAK_TIMEOUT_SECONDS}s"; then
+    printf 'Failed to delete namespace %s\n' "$NAMESPACE" >&2
+    status=1
+  fi
+  exit "$status"
+}
+
+verify_deployment_ready() {
+  local deployment=$1
+  local expected=$2
+  local deadline=$((SECONDS + SOAK_TIMEOUT_SECONDS))
+  local ready
+  while ((SECONDS < deadline)); do
+    ready=$("${KUBECTL[@]}" get deployment "$deployment" \
+      --namespace "$NAMESPACE" \
+      --output jsonpath='{.status.readyReplicas}')
+    if [[ ${ready:-0} == "$expected" ]]; then
+      return
+    fi
+    sleep 2
+  done
+  printf 'Deployment %s has %s ready replicas, want %s\n' \
+    "$deployment" "${ready:-0}" "$expected" >&2
+  return 1
+}
+
+verify_ip_pressure() {
+  verify_deployment_ready cni-soak-ip-pressure "$IP_PRESSURE_REPLICAS"
+}
+
+wait_for_ip_pressure_pod_count() {
+  local expected=$1
+  local deadline=$((SECONDS + SOAK_TIMEOUT_SECONDS))
+  local pods
+  local count
+  while ((SECONDS < deadline)); do
+    pods=$("${KUBECTL[@]}" get pods \
+      --namespace "$NAMESPACE" \
+      --selector app=cni-soak-ip-pressure \
+      --output name)
+    if [[ -z $pods ]]; then
+      count=0
+    else
+      count=$(printf '%s\n' "$pods" | wc -l)
+    fi
+    if ((count == expected)); then
+      return
+    fi
+    sleep 2
+  done
+  printf 'IP-pressure workload has %s pods, want %s\n' "$count" "$expected" >&2
+  return 1
+}
+
+probe_target() {
+  "${KUBECTL[@]}" exec \
+    --namespace "$NAMESPACE" \
+    deployment/cni-soak-probe \
+    -- wget -q -T "$SOAK_PROBE_TIMEOUT_SECONDS" -O /dev/null http://cni-soak-target/
+}
+
+health_check() {
+  verify_deployment_ready cni-soak-target "$SOAK_BASE_PODS"
+  verify_deployment_ready cni-soak-probe 1
+  verify_ip_pressure
+  probe_target
+}
+
+restart_base_pods() {
+  local pods=()
+  local pod
+  while IFS= read -r pod; do
+    [[ -n $pod ]] && pods+=("$pod")
+  done < <("${KUBECTL[@]}" get pods \
+    --namespace "$NAMESPACE" \
+    --selector app=cni-soak-target \
+    --output jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
+    head -n "$SOAK_CHURN_PODS")
+  if ((${#pods[@]} != SOAK_CHURN_PODS)); then
+    printf 'Found %s base pods to restart, want %s\n' \
+      "${#pods[@]}" "$SOAK_CHURN_PODS" >&2
+    return 1
+  fi
+  "${KUBECTL[@]}" delete pod "${pods[@]}" \
+    --namespace "$NAMESPACE" \
+    --wait=false
+  for pod in "${pods[@]}"; do
+    "${KUBECTL[@]}" wait "pod/$pod" \
+      --namespace "$NAMESPACE" \
+      --for delete \
+      --timeout "${SOAK_TIMEOUT_SECONDS}s"
+  done
+  verify_deployment_ready cni-soak-target "$SOAK_BASE_PODS"
+}
+
+toggle_ip_pressure() {
+  local target=0
+  local next
+  local previous
+  if ((IP_PRESSURE_REPLICAS == 0)); then
+    target=$SOAK_IP_PRESSURE_PODS
+  fi
+
+  while ((IP_PRESSURE_REPLICAS != target)); do
+    previous=$IP_PRESSURE_REPLICAS
+    if ((IP_PRESSURE_REPLICAS < target)); then
+      next=$((IP_PRESSURE_REPLICAS + SOAK_IP_PRESSURE_STEP_PODS))
+      if ((next > target)); then
+        next=$target
+      fi
+    else
+      next=$((IP_PRESSURE_REPLICAS - SOAK_IP_PRESSURE_STEP_PODS))
+      if ((next < target)); then
+        next=$target
+      fi
+    fi
+
+    printf 'Scaling IP-pressure workload to %s replicas\n' "$next"
+    "${KUBECTL[@]}" scale deployment/cni-soak-ip-pressure \
+      --namespace "$NAMESPACE" \
+      --replicas "$next"
+    IP_PRESSURE_REPLICAS=$next
+    verify_ip_pressure
+    if ((next < previous)); then
+      wait_for_ip_pressure_pod_count "$next"
+    fi
+  done
+}
+
+for name in \
+  SOAK_DURATION_MINUTES \
+  SOAK_BASE_PODS \
+  SOAK_CHURN_PODS \
+  SOAK_IP_PRESSURE_PODS \
+  SOAK_IP_PRESSURE_STEP_PODS \
+  SOAK_CYCLE_INTERVAL_SECONDS \
+  SOAK_HEALTH_INTERVAL_SECONDS \
+  SOAK_TIMEOUT_SECONDS \
+  SOAK_PROBE_TIMEOUT_SECONDS; do
+  validate_positive_integer "$name" "${!name}"
+done
+if ((SOAK_CHURN_PODS > SOAK_BASE_PODS)); then
+  printf 'SOAK_CHURN_PODS must not exceed SOAK_BASE_PODS\n' >&2
+  exit 2
+fi
+command -v kubectl >/dev/null 2>&1 || {
+  printf 'kubectl is required\n' >&2
+  exit 127
+}
+
+TARGET_NODE=${SOAK_TEST_NODE:-$("${KUBECTL[@]}" get nodes \
+  --field-selector spec.unschedulable!=true \
+  --selector "${NG_LABEL_KEY}=${NG_LABEL_VAL}" \
+  --output jsonpath='{.items[0].metadata.name}')}
+if [[ -z $TARGET_NODE ]]; then
+  printf 'No schedulable node matched %s=%s\n' "$NG_LABEL_KEY" "$NG_LABEL_VAL" >&2
+  exit 1
+fi
+
+"${KUBECTL[@]}" delete namespace "$NAMESPACE" \
+  --ignore-not-found=true \
+  --wait=true \
+  --timeout "${SOAK_TIMEOUT_SECONDS}s"
+"${KUBECTL[@]}" create namespace "$NAMESPACE"
+trap cleanup EXIT
+
+"${KUBECTL[@]}" apply --filename - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-soak-target
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${SOAK_BASE_PODS}
+  selector:
+    matchLabels:
+      app: cni-soak-target
+  template:
+    metadata:
+      labels:
+        app: cni-soak-target
+    spec:
+      containers:
+        - name: nginx
+          image: ${NGINX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 2
+            timeoutSeconds: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-soak-probe
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cni-soak-probe
+  template:
+    metadata:
+      labels:
+        app: cni-soak-probe
+    spec:
+      containers:
+        - name: busybox
+          image: ${BUSYBOX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["sleep", "604800"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-soak-ip-pressure
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: cni-soak-ip-pressure
+  template:
+    metadata:
+      labels:
+        app: cni-soak-ip-pressure
+    spec:
+      nodeName: ${TARGET_NODE}
+      containers:
+        - name: busybox
+          image: ${BUSYBOX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["sleep", "604800"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cni-soak-target
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: cni-soak-target
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+
+health_check
+
+DURATION_SECONDS=$((SOAK_DURATION_MINUTES * 60))
+DEADLINE=$((SECONDS + DURATION_SECONDS))
+NEXT_CYCLE=$SECONDS
+NEXT_HEALTH=$SECONDS
+printf 'Running CNI soak workload for %s minutes; pressure node=%s\n' \
+  "$SOAK_DURATION_MINUTES" "$TARGET_NODE"
+
+while ((SECONDS < DEADLINE)); do
+  if ((SECONDS >= NEXT_CYCLE)); then
+    restart_base_pods
+    toggle_ip_pressure
+    NEXT_CYCLE=$((SECONDS + SOAK_CYCLE_INTERVAL_SECONDS))
+  fi
+  if ((SECONDS >= NEXT_HEALTH)); then
+    health_check
+    NEXT_HEALTH=$((SECONDS + SOAK_HEALTH_INTERVAL_SECONDS))
+  fi
+
+  NEXT_EVENT=$NEXT_CYCLE
+  if ((NEXT_HEALTH < NEXT_EVENT)); then
+    NEXT_EVENT=$NEXT_HEALTH
+  fi
+  if ((DEADLINE < NEXT_EVENT)); then
+    NEXT_EVENT=$DEADLINE
+  fi
+  SLEEP_SECONDS=$((NEXT_EVENT - SECONDS))
+  if ((SLEEP_SECONDS > 0)); then
+    sleep "$SLEEP_SECONDS"
+  fi
+done
+
+if ((IP_PRESSURE_REPLICAS > 0)); then
+  toggle_ip_pressure
+fi
+health_check
+printf 'CNI soak test completed successfully\n'

--- a/scripts/scale/cl2-config.yaml
+++ b/scripts/scale/cl2-config.yaml
@@ -1,0 +1,52 @@
+{{$NAMESPACE_PREFIX := DefaultParam .NAMESPACE_PREFIX "cni-scale"}}
+{{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "1800s"}}
+{{$POD_COUNT := DefaultParam .POD_COUNT 2000}}
+{{$POD_IMAGE := DefaultParam .POD_IMAGE "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"}}
+{{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 20}}
+
+name: cni-pod-scale
+namespace:
+  number: 1
+  prefix: {{$NAMESPACE_PREFIX}}
+  deleteStaleNamespaces: true
+  deleteAutomanagedNamespaces: false
+tuningSets:
+- name: UniformQPS
+  qpsLoad:
+    qps: {{$POD_THROUGHPUT}}
+steps:
+- name: Start pod startup measurement
+  measurements:
+  - Identifier: CNIPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: group = cni-scale
+      threshold: 24h
+- name: Create CNI scale pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$POD_COUNT}}
+    tuningSet: UniformQPS
+    objectBundle:
+    - basename: cni-scale-pod
+      objectTemplatePath: pod.yaml
+      templateFillMap:
+        Image: {{$POD_IMAGE}}
+- name: Wait for every CNI scale pod to be RunningAndReady
+  measurements:
+  - Identifier: WaitForCNIScalePods
+    Method: WaitForRunningPods
+    Params:
+      action: gather
+      desiredPodCount: {{$POD_COUNT}}
+      labelSelector: group = cni-scale
+      timeout: {{$OPERATION_TIMEOUT}}
+- name: Collect pod startup measurement
+  measurements:
+  - Identifier: CNIPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather

--- a/scripts/scale/pod.yaml
+++ b/scripts/scale/pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.Name}}
+  labels:
+    group: cni-scale
+spec:
+  automountServiceAccountToken: false
+  nodeSelector:
+    kubernetes.io/os: linux
+  terminationGracePeriodSeconds: 0
+  topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        group: cni-scale
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+  containers:
+  - name: workload
+    image: {{.Image}}
+    imagePullPolicy: IfNotPresent
+    command:
+    - sleep
+    - "604800"
+    resources:
+      requests:
+        cpu: 5m
+        memory: 8Mi


### PR DESCRIPTION
## Summary

- add a CNI scale workload that ramps pods on one node, verifies readiness and service reachability, and drains each cycle completely
- add a bounded soak workload with steady churn plus periodic IP pressure
- keep cluster creation, CNI installation, metric collection, and verdict policy outside the open-source workload scripts
- collect diagnostics and clean up owned namespaces on failure or interruption

## Validation

- shell syntax and executable checks passed for both scripts
- the scale workload path was exercised manually on Kubernetes 1.34 with three c5.xlarge nodes and candidate CNI v1.23.1
- all blocking lifecycle assertions passed, including node coverage, zero throttles, recovery, and bounded containerd error rate
- post-run infrastructure cleanup was verified