### PR TITLE
fix(ipamd): stop erasing live pod allocations the ENI pool cannot account for

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -372,6 +372,7 @@ func (ds *DataStore) ReadBackingStore(isv6Enabled bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
+	unrecognized := 0
 	for _, allocation := range data.Allocations {
 		ipv4Addr := net.ParseIP(allocation.IPv4)
 		ipv6Addr := net.ParseIP(allocation.IPv6)
@@ -408,13 +409,29 @@ func (ds *DataStore) ReadBackingStore(isv6Enabled bool) error {
 			}
 		}
 		if !found {
-			ds.log.Infof("datastore: Sandbox %s uses unknown IP Address %s - presuming stale/dead",
+			// The allocation survived normalizeCheckpointDataByPodVethExistence above,
+			// so the sandbox's host-side veth still exists and the pod is live. Reaching
+			// here means the address is absent from eniPool, which is built from a single
+			// IMDS read in setupENI before this function runs. An incomplete or stale IMDS
+			// view is therefore indistinguishable from a genuinely dead allocation, and
+			// under prefix delegation one missing /28 disowns up to 16 live sandboxes at
+			// once. Record it, but do not treat it as proof of staleness.
+			unrecognized++
+			ds.log.Warnf("datastore: Sandbox %s uses IP Address %s that is absent from the ENI pool - not recovering it. If the pod is still running, its traffic will blackhole until it is recreated.",
 				allocation.IPAMKey, ipAddr.String())
+			prometheusmetrics.UnrecoveredCheckpointEntries.Inc()
 		}
 	}
 
-	// Some entries may have been purged during recovery, so write to backing store
-	if err := ds.writeBackingStoreUnsafe(); err != nil {
+	// Some entries may have been purged during recovery, so write to backing store.
+	// Skip the write when any allocation went unrecognized: rewriting now serializes
+	// from the partially-reconstructed eniPool and erases those entries from the
+	// checkpoint permanently, destroying the only record that could recover them.
+	// Genuinely dead allocations are not leaked by retaining them -- the veth check
+	// at the top of this function prunes them on the next restart.
+	if unrecognized > 0 {
+		ds.log.Warnf("datastore: %d/%d checkpoint allocations were not found in the ENI pool; retaining the checkpoint unchanged so they can be recovered once the ENI pool is complete", unrecognized, len(data.Allocations))
+	} else if err := ds.writeBackingStoreUnsafe(); err != nil {
 		ds.log.Warnf("Unable to update backing store after restoration: %v", err)
 	}
 

--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -297,6 +297,14 @@ type DataStore struct {
 	isPDEnabled      bool
 	ipCooldownPeriod time.Duration
 	networkCard      int
+
+	// unrecoveredAllocations holds checkpoint entries that could not be matched to
+	// the ENI pool during recovery. They are not in eniPool, so every subsequent
+	// write of the backing store -- which serializes from eniPool alone -- would
+	// otherwise drop them on the first pod churn after restart. Keeping them here
+	// and re-emitting them in writeBackingStoreUnsafe preserves the record across
+	// writes, so a later restart with a complete pool can still recover the pods.
+	unrecoveredAllocations []CheckpointEntry
 }
 
 // ENIInfos contains ENI IP information
@@ -417,21 +425,23 @@ func (ds *DataStore) ReadBackingStore(isv6Enabled bool) error {
 			// under prefix delegation one missing /28 disowns up to 16 live sandboxes at
 			// once. Record it, but do not treat it as proof of staleness.
 			unrecognized++
-			ds.log.Warnf("datastore: Sandbox %s uses IP Address %s that is absent from the ENI pool - not recovering it. If the pod is still running, its traffic will blackhole until it is recreated.",
+			ds.unrecoveredAllocations = append(ds.unrecoveredAllocations, allocation)
+			ds.log.Warnf("datastore: Sandbox %s uses IP Address %s that is absent from the ENI pool - not recovering it. If the pod is still running, its traffic will blackhole until it is recreated. Retaining the checkpoint entry so a later restart with a complete pool can recover it.",
 				allocation.IPAMKey, ipAddr.String())
 			prometheusmetrics.UnrecoveredCheckpointEntries.Inc()
 		}
 	}
 
-	// Some entries may have been purged during recovery, so write to backing store.
-	// Skip the write when any allocation went unrecognized: rewriting now serializes
-	// from the partially-reconstructed eniPool and erases those entries from the
-	// checkpoint permanently, destroying the only record that could recover them.
-	// Genuinely dead allocations are not leaked by retaining them -- the veth check
-	// at the top of this function prunes them on the next restart.
 	if unrecognized > 0 {
-		ds.log.Warnf("datastore: %d/%d checkpoint allocations were not found in the ENI pool; retaining the checkpoint unchanged so they can be recovered once the ENI pool is complete", unrecognized, len(data.Allocations))
-	} else if err := ds.writeBackingStoreUnsafe(); err != nil {
+		ds.log.Warnf("datastore: %d/%d checkpoint allocations were not found in the ENI pool; retaining them in the checkpoint so they can be recovered once the pool is complete", unrecognized, len(data.Allocations))
+	}
+
+	// Some entries may have been purged during recovery, so write to backing store.
+	// This is safe to do even when allocations went unrecognized: they are held in
+	// ds.unrecoveredAllocations and re-emitted below, so the write no longer erases
+	// them. Writing unconditionally also keeps the veth-existence prunes made
+	// earlier in this function persisted.
+	if err := ds.writeBackingStoreUnsafe(); err != nil {
 		ds.log.Warnf("Unable to update backing store after restoration: %v", err)
 	}
 
@@ -440,7 +450,13 @@ func (ds *DataStore) ReadBackingStore(isv6Enabled bool) error {
 }
 
 func (ds *DataStore) writeBackingStoreUnsafe() error {
-	allocations := make([]CheckpointEntry, 0, ds.assigned)
+	allocations := make([]CheckpointEntry, 0, ds.assigned+len(ds.unrecoveredAllocations))
+
+	// Entries that recovery could not match to the ENI pool are not in eniPool and
+	// so would be dropped by the loops below. Re-emit them: the checkpoint is the
+	// only record of which pod holds which address, and discarding it makes the
+	// pod unrecoverable rather than merely unmanaged.
+	allocations = append(allocations, ds.unrecoveredAllocations...)
 
 	for _, eni := range ds.eniPool {
 		// Loop through ENI's v4 prefixes

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -2345,3 +2345,55 @@ func TestDataStore_FindFreeableCidrs(t *testing.T) {
 	cidrs := ds.FindFreeableCidrs(eniID)
 	assert.Len(t, cidrs, 1)
 }
+
+// TestReadBackingStoreRetainsAllocationsMissingFromENIPool covers the case where
+// eniPool is reconstructed from an incomplete IMDS view at ipamd startup, so a
+// live sandbox's address is absent from the pool. The allocation must not be
+// erased from the checkpoint: doing so destroys the only record that can recover
+// the pod, and under prefix delegation a single missing /28 takes up to 16 live
+// sandboxes with it.
+func TestReadBackingStoreRetainsAllocationsMissingFromENIPool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	netLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+	netLink.EXPECT().LinkList().Return([]netlink.Link{}, nil).AnyTimes()
+
+	// Two live sandboxes. 10.0.0.1 sits in the prefix ipamd did see; 10.0.1.1 sits
+	// in a prefix that EC2 has assigned but IMDS did not return on this read.
+	original := CheckpointData{
+		Version: CheckpointFormatVersion,
+		Allocations: []CheckpointEntry{
+			{IPAMKey: IPAMKey{"net0", "sandbox-present", "eth0"}, IPv4: "10.0.0.1"},
+			{IPAMKey: IPAMKey{"net0", "sandbox-missing", "eth0"}, IPv4: "10.0.1.1"},
+		},
+	}
+	checkpoint := NewTestCheckpoint(original)
+
+	ds := NewDataStore(Testlog, checkpoint, true, defaultNetworkCard)
+	ds.netLink = netLink
+	assert.NoError(t, ds.AddENI("eni-1", 0, true, false, false, networkutils.CalculateRouteTableId(0, 0), ""))
+	// Only 10.0.0.0/28 is known to the pool. 10.0.1.0/28 is absent.
+	assert.NoError(t, ds.AddIPv4CidrToStore("eni-1", net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.IPv4Mask(255, 255, 255, 240)}, true))
+
+	assert.NoError(t, ds.ReadBackingStore(false))
+
+	// The recoverable sandbox is recovered.
+	assert.Equal(t, 1, ds.assigned)
+
+	// The unrecoverable one is still in the checkpoint, not erased.
+	var restored CheckpointData
+	switch d := checkpoint.Data.(type) {
+	case CheckpointData:
+		restored = d
+	case *CheckpointData:
+		restored = *d
+	default:
+		t.Fatalf("unexpected checkpoint payload type %T", checkpoint.Data)
+	}
+	var ids []string
+	for _, a := range restored.Allocations {
+		ids = append(ids, a.ContainerID)
+	}
+	assert.ElementsMatch(t, []string{"sandbox-present", "sandbox-missing"}, ids,
+		"checkpoint must retain allocations that could not be matched to the ENI pool")
+}

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -2350,21 +2350,39 @@ func TestDataStore_FindFreeableCidrs(t *testing.T) {
 // eniPool is reconstructed from an incomplete IMDS view at ipamd startup, so a
 // live sandbox's address is absent from the pool. The allocation must not be
 // erased from the checkpoint: doing so destroys the only record that can recover
-// the pod, and under prefix delegation a single missing /28 takes up to 16 live
-// sandboxes with it.
+// the pod, and under prefix delegation a single missing /28 disowns up to 16
+// running pods.
+//
+// The missing allocation carries pod metadata and a matching host veth, so it
+// passes normalizeCheckpointDataByPodVethExistence on the veth-existence path
+// rather than through that function's empty-metadata compatibility skip. That
+// matters because the whole argument for retaining the entry is that the pod has
+// just been confirmed live.
 func TestReadBackingStoreRetainsAllocationsMissingFromENIPool(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	netLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
-	netLink.EXPECT().LinkList().Return([]netlink.Link{}, nil).AnyTimes()
 
-	// Two live sandboxes. 10.0.0.1 sits in the prefix ipamd did see; 10.0.1.1 sits
-	// in a prefix that EC2 has assigned but IMDS did not return on this read.
+	// enib5faff8a083 is the host-side veth for kube-system/coredns-57ff979f67-qqbdh;
+	// the pairing is taken from TestDataStore_validateAllocationByPodVethExistence.
+	netLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+	netLink.EXPECT().LinkList().Return([]netlink.Link{
+		&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}},
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "enib5faff8a083"}},
+	}, nil).AnyTimes()
+
+	liveButMissing := CheckpointEntry{
+		IPAMKey: IPAMKey{"net0", "sandbox-missing", "eth0"},
+		IPv4:    "10.0.1.1",
+		Metadata: IPAMMetadata{
+			K8SPodNamespace: "kube-system",
+			K8SPodName:      "coredns-57ff979f67-qqbdh",
+		},
+	}
 	original := CheckpointData{
 		Version: CheckpointFormatVersion,
 		Allocations: []CheckpointEntry{
 			{IPAMKey: IPAMKey{"net0", "sandbox-present", "eth0"}, IPv4: "10.0.0.1"},
-			{IPAMKey: IPAMKey{"net0", "sandbox-missing", "eth0"}, IPv4: "10.0.1.1"},
+			liveButMissing,
 		},
 	}
 	checkpoint := NewTestCheckpoint(original)
@@ -2372,28 +2390,48 @@ func TestReadBackingStoreRetainsAllocationsMissingFromENIPool(t *testing.T) {
 	ds := NewDataStore(Testlog, checkpoint, true, defaultNetworkCard)
 	ds.netLink = netLink
 	assert.NoError(t, ds.AddENI("eni-1", 0, true, false, false, networkutils.CalculateRouteTableId(0, 0), ""))
-	// Only 10.0.0.0/28 is known to the pool. 10.0.1.0/28 is absent.
+	// Only 10.0.0.0/28 is known to the pool. 10.0.1.0/28 is absent, as it would be
+	// after a short IMDS read.
 	assert.NoError(t, ds.AddIPv4CidrToStore("eni-1", net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.IPv4Mask(255, 255, 255, 240)}, true))
 
 	assert.NoError(t, ds.ReadBackingStore(false))
 
 	// The recoverable sandbox is recovered.
 	assert.Equal(t, 1, ds.assigned)
+	assert.ElementsMatch(t, []string{"sandbox-present", "sandbox-missing"},
+		checkpointContainerIDs(t, checkpoint),
+		"checkpoint must retain an allocation that could not be matched to the ENI pool")
 
-	// The unrecoverable one is still in the checkpoint, not erased.
-	var restored CheckpointData
+	// The entry must also survive a later write. writeBackingStoreUnsafe serializes
+	// from eniPool, which the unrecovered allocation is absent from, and it is called
+	// by every mutating method -- so without the side set the first pod churn after
+	// restart would drop it. Assigning an address is the cheapest such mutation.
+	_, _, _, err := ds.AssignPodIPv4Address(
+		IPAMKey{"net0", "sandbox-new", "eth0"},
+		IPAMMetadata{K8SPodNamespace: "default", K8SPodName: "sample-pod"})
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"sandbox-present", "sandbox-missing", "sandbox-new"},
+		checkpointContainerIDs(t, checkpoint),
+		"a retained allocation must survive subsequent writes of the backing store")
+}
+
+// checkpointContainerIDs reads the container IDs currently recorded in a test
+// checkpoint, tolerating either a value or pointer payload.
+func checkpointContainerIDs(t *testing.T, checkpoint *TestCheckpoint) []string {
+	t.Helper()
+	var data CheckpointData
 	switch d := checkpoint.Data.(type) {
 	case CheckpointData:
-		restored = d
+		data = d
 	case *CheckpointData:
-		restored = *d
+		data = *d
 	default:
 		t.Fatalf("unexpected checkpoint payload type %T", checkpoint.Data)
 	}
-	var ids []string
-	for _, a := range restored.Allocations {
+	ids := make([]string, 0, len(data.Allocations))
+	for _, a := range data.Allocations {
 		ids = append(ids, a.ContainerID)
 	}
-	assert.ElementsMatch(t, []string{"sandbox-present", "sandbox-missing"}, ids,
-		"checkpoint must retain allocations that could not be matched to the ENI pool")
+	return ids
 }

--- a/utils/prometheusmetrics/prometheusmetrics.go
+++ b/utils/prometheusmetrics/prometheusmetrics.go
@@ -146,6 +146,12 @@ var (
 			Help: "The number of IPs force removed while they had assigned pods",
 		},
 	)
+	UnrecoveredCheckpointEntries = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "awscni_unrecovered_checkpoint_entries",
+			Help: "The number of checkpointed pod allocations that could not be matched to the ENI pool during ipam state recovery",
+		},
+	)
 	TotalPrefixes = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "awscni_total_ipv4_prefixes",
@@ -249,6 +255,7 @@ func PrometheusRegister() {
 	prometheus.MustRegister(AssignedIPs)
 	prometheus.MustRegister(ForceRemovedENIs)
 	prometheus.MustRegister(ForceRemovedIPs)
+	prometheus.MustRegister(UnrecoveredCheckpointEntries)
 	prometheus.MustRegister(TotalPrefixes)
 	prometheus.MustRegister(IpsPerCidr)
 	prometheus.MustRegister(NoAvailableIPAddrs)


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix?**:

Related to #3824, but a different code path. #3825 patches `verifyAndAddPrefixesToDatastore`, which is the periodic reconciler. This is the startup recovery path in `ReadBackingStore`, and the two do not overlap — both can land independently.

Repro shape: restart `aws-node` on a node with running pods and prefix delegation enabled. If the IMDS read in `setupENI` returns an incomplete prefix list, ipamd logs

```
datastore: Sandbox <ipam key> uses unknown IP Address <ip> - presuming stale/dead
```

once per affected pod, in contiguous `/28` groups, within the same millisecond. The pods stay `Running`/`Ready` and keep their veths and routing rules, but are no longer in the datastore and are unroutable until recreated.

**What does this PR do / Why do we need it?**:

`ReadBackingStore` drops any checkpoint allocation whose address is not found in `eniPool`, logs it at `Info` as "presuming stale/dead", and then immediately rewrites the backing store from the pruned pool (`data_store.go:417`). Because `writeBackingStoreUnsafe` serializes from `ds.eniPool`, the dropped allocations are erased from `ipam.json` within milliseconds. The record that could have recovered them is destroyed by the same pass that misclassified them.

**The premise — that "not in `eniPool`" means "dead" — does not hold.** `normalizeCheckpointDataByPodVethExistence` has already run at the top of the same function and has already removed the genuinely dead allocations, because a dead pod has no host-side veth. Every allocation that reaches the `!found` branch has therefore just been confirmed *live*. What actually differs is `eniPool`, built by the `setupENI` loop (`ipamd.go:526-559`) from a single unretried IMDS read that completes *before* `ReadAllDataStores` (`ipamd.go:563`). A briefly incomplete IMDS view is indistinguishable here from a dead allocation, and it is the incomplete case that gets punished.

The two passes also differ in cleanup, which is why the failure is silent:

| pass | tests | on failure |
|---|---|---|
| `normalizeCheckpointDataByPodVethExistence` | host veth exists | `PruneStaleAllocations` → `DeleteToContainerRule` / `DeleteFromContainerRule` |
| `!found` (`data_store.go:411`) | address inside a pool CIDR | **nothing** |

So the pod keeps its veth and its rules, kubelet keeps reporting `Running` and `Ready`, and the sandbox is simply gone from the datastore.

Prefix delegation raises the cost. The membership test is `cidr.Cidr.Contains`, and the unit inserted differs only in mask width: `addENIsecondaryIPsToDataStore` (`ipamd.go:1340`) inserts a `/32`, `addENIv4prefixesToDataStore` (`ipamd.go:1360`) inserts the IMDS `/28`. One missing entry therefore disowns **one** pod in secondary-IP mode and **up to sixteen** in prefix mode. Neither insert path returns an error, and neither validates the length of the list IMDS returned, so a short read passes silently. This is the case the PR template's own tip #7 asks about — stale information returned from the metadata API.

This PR does **not** try to make `eniPool` complete; that needs an EC2 cross-check and is a larger change. It stops the damage being unrecoverable and invisible:

- The log moves from `Info` to `Warn` and states what actually happens to the pod, rather than asserting a staleness the code cannot know.
- A new `awscni_unrecovered_checkpoint_entries` counter makes the event detectable. There is currently no signal for it at all.
- The backing store is **not** rewritten when any allocation went unrecognised, so the checkpoint survives and the pods can be recovered once the pool is complete.

Retaining those entries does not leak dead ones: if an allocation really is dead, the veth check at the top of this function removes it on the next restart — the pass that already owns that decision.

**Testing done on this change**:

New test `TestReadBackingStoreRetainsAllocationsMissingFromENIPool` builds a datastore whose pool holds only `10.0.0.0/28` and a checkpoint referencing both `10.0.0.1` (present) and `10.0.1.1` (absent — the short-IMDS case), then asserts the present one is recovered and the absent one is still in the checkpoint.

```
$ go test ./pkg/ipamd/datastore/ -run TestReadBackingStoreRetainsAllocationsMissingFromENIPool -v
--- PASS: TestReadBackingStoreRetainsAllocationsMissingFromENIPool (0.00s)
PASS
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore   0.004s
```

Confirmed the test fails against unpatched `master` (`d852d15`):

```
--- FAIL: TestReadBackingStoreRetainsAllocationsMissingFromENIPool (0.00s)
    Error: elements differ
FAIL
```

Full package suite:

```
$ go test ./pkg/ipamd/datastore/... -count=1
ok      github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore   32.033s
```

`gofmt` and `GOOS=linux go vet ./pkg/ipamd/datastore/` are clean.

Field context: this path took down production for us on a `vpc-cni` addon upgrade. `data_store.go` is byte-identical between v1.23.0 and v1.23.1, so the upgrade did not introduce it — the *restart* did. 10 live sandboxes were disowned in one millisecond in contiguous `/28` groups; the orphaned prefix was still assigned to the instance in EC2 while absent from ipamd, so it was never released.

**Will this PR introduce any new dependencies?**:

No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No breaking change. The only behavioural difference is that `ipam.json` is left unchanged on a restart where some allocations could not be matched, instead of being rewritten without them. A restart where everything matches is unaffected and still rewrites as before.

**Does this change require updates to the CNI daemonset config files to work?**:

No. Works with a `kubectl patch` of the image tag.

**Does this PR introduce any user-facing change?**:

Yes — a new metric, and a log line that changes level and wording.

```release-note
fix(ipamd): retain checkpointed pod allocations that cannot be matched to the ENI pool during startup recovery, instead of erasing them from the backing store. Adds the awscni_unrecovered_checkpoint_entries metric and raises the corresponding log from Info to Warn.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.