### PR TITLE
fix(awsutils): reconcile ENI metadata against EC2 instead of only logging drift

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1788,13 +1788,27 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		// Under prefix delegation the unit is a /28, so a single prefix missing here
 		// disowns up to 16 running pods.
 		//
-		// EC2 is the authority, as logOutOfSyncState already notes. Union rather
-		// than replace: this can only ever add addresses IMDS had not caught up on,
-		// never remove one it reported, so the pool cannot shrink because of this
-		// call. Anything EC2 has genuinely released is handled by reconciliation
-		// later, which is where that decision belongs.
+		// Union rather than replace: this can only add prefixes IMDS had not caught
+		// up on, never remove one it reported, so the pool cannot shrink here.
+		//
+		// Deliberately scoped to PREFIXES ONLY. The symmetric fix for secondary IPs
+		// is not safe by the same argument, because trusting EC2 in one direction
+		// cuts both ways: logOutOfSyncState detects staleness in BOTH directions,
+		// including IMDS addresses absent from DescribeNetworkInterfaces. An address
+		// released shortly before this restart can still appear in an eventually
+		// consistent EC2 response; adding it would let ipamd assign it to a pod that
+		// cannot communicate -- the same blackholed-pod symptom this change exists to
+		// prevent, reintroduced by another route.
+		//
+		// That risk is acceptable to carry for prefixes and not for addresses:
+		//   - prefixes are allocated and released as whole /28 units and churn far
+		//     less than individual secondary IPs, so the stale window is rarer;
+		//   - the cost of getting it wrong is asymmetric. A missing prefix disowns
+		//     up to 16 running pods; a missing secondary IP disowns one;
+		//   - secondary-IP mode already has a backstop that prefix mode lacks, the
+		//     len(IPv4Addresses) == 0 check below. There is no prefix-count
+		//     equivalent anywhere.
 		eniMetadata.IPv4Prefixes = unionIPv4Prefixes(eniID, eniMetadata.IPv4Prefixes, ec2res.Ipv4Prefixes)
-		eniMetadata.IPv4Addresses = unionIPv4Addresses(eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
 		eniMap[eniID] = eniMetadata
 
 		tagMap[eniMetadata.ENIID] = convertSDKTagsToTags(ec2res.TagSet)
@@ -1905,26 +1919,6 @@ func unionIPv4Prefixes(eniID string, imdsPrefixes, ec2Prefixes []ec2types.Ipv4Pr
 	if len(added) > 0 {
 		log.Warnf("DescribeAllENIs: IMDS did not report IPv4 prefixes %s on ENI %s that DescribeNetworkInterfaces lists. Using the EC2 view; pods holding addresses in those prefixes would otherwise be treated as stale.",
 			strings.Join(added, ","), eniID)
-	}
-	return result
-}
-
-// unionIPv4Addresses is the secondary-IP counterpart of unionIPv4Prefixes. The
-// divergence it covers is already detected by logOutOfSyncState, which only
-// logs it.
-func unionIPv4Addresses(imdsIPv4s, ec2IPv4s []ec2types.NetworkInterfacePrivateIpAddress) []ec2types.NetworkInterfacePrivateIpAddress {
-	seen := sets.String{}
-	for _, ip := range imdsIPv4s {
-		seen.Insert(aws.ToString(ip.PrivateIpAddress))
-	}
-	result := imdsIPv4s
-	for _, ip := range ec2IPv4s {
-		addr := aws.ToString(ip.PrivateIpAddress)
-		if addr == "" || seen.Has(addr) {
-			continue
-		}
-		seen.Insert(addr)
-		result = append(result, ip)
 	}
 	return result
 }

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1727,12 +1727,6 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		return DescribeAllENIsResult{}, err
 	}
 
-	// Collect the verified ENIs
-	var verifiedENIs []ENIMetadata
-	for _, eniMetadata := range eniMap {
-		verifiedENIs = append(verifiedENIs, eniMetadata)
-	}
-
 	// Collect ENI response into ENI metadata and tags.
 	var trunkENI string
 	efaENIs := make(map[string]bool, 0)
@@ -1786,8 +1780,33 @@ func (cache *EC2InstanceMetadataCache) DescribeAllENIs(ctx context.Context) (Des
 		if len(eniMetadata.IPv4Addresses) > 0 {
 			logOutOfSyncState(eniID, eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
 		}
+		// IMDS and EC2 are queried independently and IMDS can lag, which matters
+		// because everything downstream treats this metadata as the complete set
+		// of addresses the ENI owns. ipamd builds its datastore pool from it, and
+		// ReadBackingStore then drops any checkpointed pod allocation whose address
+		// is not in that pool, treating a short IMDS read as proof the pod is dead.
+		// Under prefix delegation the unit is a /28, so a single prefix missing here
+		// disowns up to 16 running pods.
+		//
+		// EC2 is the authority, as logOutOfSyncState already notes. Union rather
+		// than replace: this can only ever add addresses IMDS had not caught up on,
+		// never remove one it reported, so the pool cannot shrink because of this
+		// call. Anything EC2 has genuinely released is handled by reconciliation
+		// later, which is where that decision belongs.
+		eniMetadata.IPv4Prefixes = unionIPv4Prefixes(eniID, eniMetadata.IPv4Prefixes, ec2res.Ipv4Prefixes)
+		eniMetadata.IPv4Addresses = unionIPv4Addresses(eniMetadata.IPv4Addresses, ec2res.PrivateIpAddresses)
+		eniMap[eniID] = eniMetadata
+
 		tagMap[eniMetadata.ENIID] = convertSDKTagsToTags(ec2res.TagSet)
 	}
+
+	// Collect the verified ENIs. This runs after the loop above so that the
+	// reconciled metadata is what callers receive.
+	var verifiedENIs []ENIMetadata
+	for _, eniMetadata := range eniMap {
+		verifiedENIs = append(verifiedENIs, eniMetadata)
+	}
+
 	return DescribeAllENIsResult{
 		ENIMetadata:             verifiedENIs,
 		TagMap:                  tagMap,
@@ -1864,6 +1883,52 @@ func badENIID(errMsg string) string {
 }
 
 // logOutOfSyncState compares the IP and metadata returned by IMDS and the EC2 API DescribeNetworkInterfaces calls
+// unionIPv4Prefixes returns the IMDS prefixes plus any the EC2 response lists
+// that IMDS had not reported yet. There is no prefix equivalent of
+// logOutOfSyncState, so a short prefix list is otherwise entirely silent.
+func unionIPv4Prefixes(eniID string, imdsPrefixes, ec2Prefixes []ec2types.Ipv4PrefixSpecification) []ec2types.Ipv4PrefixSpecification {
+	seen := sets.String{}
+	for _, p := range imdsPrefixes {
+		seen.Insert(aws.ToString(p.Ipv4Prefix))
+	}
+	result := imdsPrefixes
+	var added []string
+	for _, p := range ec2Prefixes {
+		cidr := aws.ToString(p.Ipv4Prefix)
+		if cidr == "" || seen.Has(cidr) {
+			continue
+		}
+		seen.Insert(cidr)
+		result = append(result, p)
+		added = append(added, cidr)
+	}
+	if len(added) > 0 {
+		log.Warnf("DescribeAllENIs: IMDS did not report IPv4 prefixes %s on ENI %s that DescribeNetworkInterfaces lists. Using the EC2 view; pods holding addresses in those prefixes would otherwise be treated as stale.",
+			strings.Join(added, ","), eniID)
+	}
+	return result
+}
+
+// unionIPv4Addresses is the secondary-IP counterpart of unionIPv4Prefixes. The
+// divergence it covers is already detected by logOutOfSyncState, which only
+// logs it.
+func unionIPv4Addresses(imdsIPv4s, ec2IPv4s []ec2types.NetworkInterfacePrivateIpAddress) []ec2types.NetworkInterfacePrivateIpAddress {
+	seen := sets.String{}
+	for _, ip := range imdsIPv4s {
+		seen.Insert(aws.ToString(ip.PrivateIpAddress))
+	}
+	result := imdsIPv4s
+	for _, ip := range ec2IPv4s {
+		addr := aws.ToString(ip.PrivateIpAddress)
+		if addr == "" || seen.Has(addr) {
+			continue
+		}
+		seen.Insert(addr)
+		result = append(result, ip)
+	}
+	return result
+}
+
 func logOutOfSyncState(eniID string, imdsIPv4s, ec2IPv4s []ec2types.NetworkInterfacePrivateIpAddress) {
 	// Comparing the IMDS IPv4 addresses attached to the ENI with the DescribeNetworkInterfaces AWS API call, which
 	// technically should be the source of truth and contain the freshest information. Let's just do a quick scan here

--- a/pkg/awsutils/awsutils_test.go
+++ b/pkg/awsutils/awsutils_test.go
@@ -3860,3 +3860,58 @@ func TestGetAttachedENIsIPv6OnlyENIInIPv4Cluster(t *testing.T) {
 		assert.Empty(t, ens[1].IPv4Addresses)
 	}
 }
+
+// TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS covers the case where
+// IMDS has not caught up with a prefix EC2 has already assigned. Everything
+// downstream treats this metadata as the complete set of addresses the ENI
+// owns, and ipamd's datastore drops checkpointed pod allocations that fall
+// outside it, so a short IMDS read here disowns up to 16 running pods per
+// missing /28.
+func TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS(t *testing.T) {
+	ctrl, mockEC2 := setup(t)
+	defer ctrl.Finish()
+
+	// IMDS reports one prefix; EC2 reports that one plus a second.
+	imdsPrefix := eni1Prefix
+	lateEC2Prefix := eni2Prefix
+
+	mockMetadata := testMetadata(map[string]interface{}{
+		metadataMACPath + primaryMAC + metadataIPv4Prefixes: imdsPrefix,
+	})
+
+	result := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []ec2types.NetworkInterface{{
+			NetworkInterfaceId: aws.String(primaryeniID),
+			Attachment: &ec2types.NetworkInterfaceAttachment{
+				DeviceIndex:      aws.Int32(0),
+				NetworkCardIndex: aws.Int32(0),
+			},
+			PrivateIpAddresses: []ec2types.NetworkInterfacePrivateIpAddress{
+				{PrivateIpAddress: aws.String(eni1PrivateIP), Primary: aws.Bool(true)},
+			},
+			Ipv4Prefixes: []ec2types.Ipv4PrefixSpecification{
+				{Ipv4Prefix: aws.String(imdsPrefix)},
+				{Ipv4Prefix: aws.String(lateEC2Prefix)},
+			},
+		}},
+	}
+
+	mockEC2.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(result, nil)
+	vpc.SetInstance("test", 4, 10, 0, []vpc.NetworkCard{{MaximumNetworkInterfaces: 4, NetworkCardIndex: 0}}, "nitro", false)
+
+	cache := &EC2InstanceMetadataCache{imds: TypedIMDS{mockMetadata}, ec2SVC: mockEC2, instanceType: "test"}
+	metaData, err := cache.DescribeAllENIs(context.Background())
+	assert.NoError(t, err)
+
+	var got []string
+	for _, eni := range metaData.ENIMetadata {
+		if eni.ENIID != primaryeniID {
+			continue
+		}
+		for _, p := range eni.IPv4Prefixes {
+			got = append(got, aws.ToString(p.Ipv4Prefix))
+		}
+	}
+	assert.ElementsMatch(t, []string{imdsPrefix, lateEC2Prefix}, got,
+		"a prefix EC2 lists but IMDS has not reported must survive into the ENI metadata")
+}


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix?**:

Root cause behind #3824. Complementary to #3876, which I opened for the same incident — that one stops `ReadBackingStore` destroying the evidence when the pool is incomplete; this one stops the pool being incomplete in the first place. They touch different files (`pkg/awsutils/awsutils.go` vs `pkg/ipamd/datastore/data_store.go`) and are independently useful, but this is the actual fix.

**What does this PR do / Why do we need it?**:

`DescribeAllENIs` already fetches both views — IMDS via `GetAttachedENIs`, then EC2 via `DescribeNetworkInterfaces`. It even compares them for secondary IPs in `logOutOfSyncState`, whose own comment says:

> Comparing the IMDS IPv4 addresses attached to the ENI with the DescribeNetworkInterfaces AWS API call, **which technically should be the source of truth and contain the freshest information**.

and then only logs the difference. The `ENIMetadata` returned to callers still carries the IMDS view.

**For IPv4 prefixes there is no comparison at all.** Nothing validates the length of the prefix list IMDS returned, and `addENIv4prefixesToDataStore` has no error return, so a short prefix read is entirely silent — no log, no metric, no error.

That matters because callers treat this metadata as the complete set of addresses the ENI owns:

1. `nodeInit` calls `DescribeAllENIs`, then the `setupENI` loop (`ipamd.go:527`) builds the datastore pool from it via `addENIv4prefixesToDataStore` / `addENIsecondaryIPsToDataStore`.
2. `ReadAllDataStores` runs *after* that (`ipamd.go:563`).
3. `ReadBackingStore` drops any checkpointed allocation whose address is not inside a pool CIDR, logging `presuming stale/dead`.

The pod in question is not dead. `normalizeCheckpointDataByPodVethExistence` ran immediately above and confirmed its host veth exists — a dead pod has no veth. It is holding an address from a prefix IMDS had not caught up on. And unlike the veth path, the `!found` branch calls no cleanup, so the pod keeps its veth and routing rules while no longer being in the datastore: `Running`, `Ready`, and unroutable.

Under prefix delegation the membership test is `cidr.Cidr.Contains` against a `/28`, so **one missing prefix disowns up to 16 running pods**.

**The fix costs nothing extra.** The `DescribeNetworkInterfaces` response was already being used only for tags, trunk and EFA detection. This reconciles the metadata against the response the function already has — no new API call, no new IAM permission, no change to call rate.

**The merge is a union, not a replacement.** It can only add addresses IMDS had not caught up on, never remove one it reported, so this call cannot shrink the pool — which is the failure mode being fixed. Anything EC2 has genuinely released is handled by reconciliation later, which is where that decision belongs.

This also fixes an ordering bug that would have silently discarded the reconciliation: `verifiedENIs` was collected from `eniMap` *before* the loop over the EC2 response ran, so any update made inside that loop never reached the caller. It is now collected after the loop.

**Testing done on this change**:

New test `TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS`: IMDS reports one prefix, EC2 reports that one plus a second, and the returned `ENIMetadata` must contain both.

```
=== RUN   TestDescribeAllENIs
--- PASS: TestDescribeAllENIs (0.71s)
=== RUN   TestDescribeAllENIsConnectionTracking
--- PASS: TestDescribeAllENIsConnectionTracking (0.00s)
=== RUN   TestDescribeAllENIsNoConnectionTracking
--- PASS: TestDescribeAllENIsNoConnectionTracking (0.00s)
=== RUN   TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS
--- PASS: TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS (0.00s)
PASS
```

Confirmed the new test fails against unpatched `master` (`d852d15`):

```
--- FAIL: TestDescribeAllENIsReconcilesPrefixesMissingFromIMDS (0.04s)
    Error: elements differ
           extra elements in list A:
FAIL
```

Full `pkg/awsutils` suite passes. `gofmt` and `GOOS=linux go vet ./pkg/awsutils/` clean.

Field context: this took down production for us on a `vpc-cni` addon upgrade. `data_store.go` is byte-identical between v1.23.0 and v1.23.1, so the upgrade did not introduce it — the *restart* did. 10 live sandboxes were disowned within one millisecond in contiguous `/28` groups. The orphaned prefix was still assigned to the instance in EC2 while absent from ipamd — exactly the divergence this reconciles — so ipamd had no record of it and never released it.

**Will this PR introduce any new dependencies?**:

No.

**Will this break upgrades or downgrades? Has updating a running cluster been tested?**:

No breaking change. `ENABLE_IMDS_ONLY_MODE` returns before this code and is unaffected. When IMDS and EC2 agree — the normal case — the union is identical to today's value and nothing changes.

**Does this change require updates to the CNI daemonset config files to work?**:

No. Works with a `kubectl patch` of the image tag.

**Does this PR introduce any user-facing change?**:

A new warning log when EC2 lists prefixes IMDS has not reported.

```release-note
fix(awsutils): reconcile ENI metadata against the DescribeNetworkInterfaces response so IPv4 prefixes and secondary IPs that IMDS has not yet reported are not treated as absent. Previously a stale IMDS read could cause ipamd to disown running pods -- up to 16 per missing /28 under prefix delegation -- leaving them Running and Ready but unroutable.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.